### PR TITLE
fix custom intervals causing cpu to go mental

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -4,7 +4,7 @@ waybar::modules::Clock::Clock(const Json::Value& config)
   : ALabel(config, "{:%H:%M}")
 {
   label_.set_name("clock");
-  uint32_t interval = config_["interval"] ? config_["inveral"].asUInt() : 60;
+  uint32_t interval = config_["interval"] ? config_["interval"].asUInt() : 60;
   thread_ = [this, interval] {
     auto now = waybar::chrono::clock::now();
     dp.emit();

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -4,7 +4,7 @@ waybar::modules::Cpu::Cpu(const Json::Value& config)
   : ALabel(config, "{}%")
 {
   label_.set_name("cpu");
-  uint32_t interval = config_["interval"] ? config_["inveral"].asUInt() : 10;
+  uint32_t interval = config_["interval"] ? config_["interval"].asUInt() : 10;
   thread_ = [this, interval] {
     dp.emit();
     thread_.sleep_for(chrono::seconds(interval));

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -4,7 +4,7 @@ waybar::modules::Memory::Memory(const Json::Value& config)
   : ALabel(config, "{}%")
 {
   label_.set_name("memory");
-  uint32_t interval = config_["interval"] ? config_["inveral"].asUInt() : 30;
+  uint32_t interval = config_["interval"] ? config_["interval"].asUInt() : 30;
   thread_ = [this, interval] {
     dp.emit();
     thread_.sleep_for(chrono::seconds(interval));


### PR DESCRIPTION
```
clock {
  "interval": 1,
  "format": "{:%H:%M:%M"},
  ...
}
```
Caused the Waybar to use 100% CPU.

This was caused by `interval` not being set properly due to a typo.

Possibly also fixes #47 