### PR TITLE
meson: fix 'gio-unix-2.0' dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -33,6 +33,7 @@ wayland_protos = dependency('wayland-protocols')
 wlroots = dependency('wlroots', fallback: ['wlroots', 'wlroots'])
 gtkmm = dependency('gtkmm-3.0')
 dbusmenu_gtk = dependency('dbusmenu-gtk3-0.4', required: get_option('dbusmenu-gtk'))
+giounix = dependency('gio-unix-2.0', required: get_option('dbusmenu-gtk'))
 jsoncpp = dependency('jsoncpp')
 sigcpp = dependency('sigc++-2.0')
 libnl = dependency('libnl-3.0', required: get_option('libnl'))
@@ -98,6 +99,7 @@ executable(
         wayland_cursor,
         gtkmm,
         dbusmenu_gtk,
+        giounix,
         libnl,
         libnlgen,
         libpulse

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -62,7 +62,7 @@ client_protos_headers += gdbus_header.process('./dbus-menu.xml')
 lib_client_protos = static_library(
 	'client_protos',
 	client_protos_src + client_protos_headers,
-	dependencies: [wayland_client, gtkmm],
+	dependencies: [wayland_client, gtkmm, giounix],
 	include_directories: include_directories('..'),
 ) # for the include directory
 


### PR DESCRIPTION
Add the required `gio-unix-2.0`.

Is it only needed when using dbusmenu?