### PR TITLE
Add configuration options for widgets on mouse events

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -6,21 +6,28 @@
 namespace waybar {
 
 class ALabel : public IModule {
-  public:
-    ALabel(const Json::Value&, const std::string format);
-    virtual ~ALabel() = default;
-    virtual auto update() -> void;
-    virtual std::string getIcon(uint16_t, const std::string& alt = "");
-    virtual operator Gtk::Widget &();
-  protected:
-    Gtk::EventBox event_box_;
-    Gtk::Label label_;
-    const Json::Value& config_;
-    std::string format_;
-  private:
-    bool handleToggle(GdkEventButton* const& ev);
-    bool alt = false;
-    const std::string default_format_;
+ public:
+  ALabel(const Json::Value&, const std::string format);
+  virtual ~ALabel() = default;
+  virtual auto update() -> void;
+  virtual std::string getIcon(uint16_t, const std::string& alt = "");
+  virtual operator Gtk::Widget&();
+
+ protected:
+  Gtk::EventBox event_box_;
+  Gtk::Label label_;
+  const Json::Value& config_;
+  std::string format_;
+  std::string button_press_cmd_ = "";
+  std::string scroll_up_cmd_ = "";
+  std::string scroll_down_cmd_ = "";
+  std::mutex mutex_;
+
+ private:
+  bool handleToggle(GdkEventButton* const& ev);
+  bool handleScroll(GdkEventScroll*);
+  bool alt = false;
+  const std::string default_format_;
 };
 
-}
+}  // namespace waybar

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -1,7 +1,8 @@
 #pragma once
 
-#include <pulse/pulseaudio.h>
 #include <fmt/format.h>
+#include <pulse/pulseaudio.h>
+#include <pulse/volume.h>
 #include <algorithm>
 #include "ALabel.hpp"
 
@@ -18,6 +19,8 @@ class Pulseaudio : public ALabel {
     static void contextStateCb(pa_context*, void*);
     static void sinkInfoCb(pa_context*, const pa_sink_info*, int, void*);
     static void serverInfoCb(pa_context*, const pa_server_info*, void*);
+    static void volumeModifyCb(pa_context*, int, void*);
+    bool handleScroll(GdkEventScroll* e);
 
     const std::string getPortIcon() const;
 
@@ -26,9 +29,11 @@ class Pulseaudio : public ALabel {
     pa_context* context_;
     uint32_t sink_idx_{0};
     uint16_t volume_;
+    pa_cvolume pa_volume_;
     bool muted_;
     std::string port_name_;
     std::string desc_;
+    bool scrolling_;
 };
 
-}
+}  // namespace waybar::modules

--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -29,7 +29,24 @@ inline struct res exec(const std::string cmd)
     output.erase(output.length()-1);
   }
   int exit_code = WEXITSTATUS(pclose(fp));
-  return { exit_code, output };
+  return {exit_code, output};
 }
 
+inline bool forkExec(std::string cmd) {
+  if (cmd == "") return true;
+
+  printf("fork exec command %s\n", cmd.c_str());
+  int32_t pid = fork();
+
+  if (pid < 0) {
+    printf("Unable to exec cmd %s, error %s", cmd.c_str(), strerror(errno));
+    return false;
+  }
+
+  // Child executes the command
+  if (!pid) execl("/bin/sh", "sh", "-c", cmd.c_str(), (char*)0);
+
+  return true;
 }
+
+}  // namespace waybar::util::command

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -1,4 +1,5 @@
 #include "ALabel.hpp"
+#include <util/command.hpp>
 
 #include <iostream>
 
@@ -14,30 +15,94 @@ waybar::ALabel::ALabel(const Json::Value& config, const std::string format)
   }
   if (config_["format-alt"].isString()) {
     event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
-    event_box_.signal_button_press_event()
-      .connect(sigc::mem_fun(*this, &ALabel::handleToggle));
+    event_box_.signal_button_press_event().connect(
+        sigc::mem_fun(*this, &ALabel::handleToggle));
+  }
+
+  // configure events' user commands
+  if (config_["on-click"].isString()) {
+    std::string cmd = config_["on-click"].asString();
+    event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
+    event_box_.signal_button_press_event().connect(
+      sigc::mem_fun(*this, &ALabel::handleToggle));
+
+    button_press_cmd_ = cmd;
+  }
+  if (config_["on-scroll-up"].isString()) {
+    std::string cmd = config_["on-scroll-up"].asString();
+    event_box_.add_events(Gdk::SCROLL_MASK);
+    event_box_.signal_scroll_event().connect(
+      sigc::mem_fun(*this, &ALabel::handleScroll));
+
+    scroll_up_cmd_ = cmd;
+  }
+  if (config_["on-scroll-down"].isString()) {
+    std::string cmd = config_["on-scroll-down"].asString();
+    event_box_.add_events(Gdk::SCROLL_MASK);
+    event_box_.signal_scroll_event().connect(
+      sigc::mem_fun(*this, &ALabel::handleScroll));
+
+    scroll_down_cmd_ = cmd;
   }
 }
 
-auto waybar::ALabel::update() -> void
-{
+auto waybar::ALabel::update() -> void {
   // Nothing here
 }
 
-bool waybar::ALabel::handleToggle(GdkEventButton* const& /*ev*/)
-{
-  alt = !alt;
-  if (alt) {
-    format_ = config_["format-alt"].asString();
+bool waybar::ALabel::handleToggle(GdkEventButton* const& e) {
+  if (button_press_cmd_ != "" && e->button == 1) {
+    waybar::util::command::forkExec(button_press_cmd_);
   } else {
-    format_ = default_format_;
+    alt = !alt;
+    if (alt) {
+      format_ = config_["format-alt"].asString();
+    } else {
+      format_ = default_format_;
+    }
   }
+
   dp.emit();
   return true;
 }
 
-std::string waybar::ALabel::getIcon(uint16_t percentage, const std::string& alt)
-{
+bool waybar::ALabel::handleScroll(GdkEventScroll* e) {
+
+  // Avoid concurrent scroll event
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    bool direction_up = false;
+
+    if (e->direction == GDK_SCROLL_UP) {
+      direction_up = true;
+    }
+    if (e->direction == GDK_SCROLL_DOWN) {
+      direction_up = false;
+    }
+    if (e->direction == GDK_SCROLL_SMOOTH) {
+      gdouble delta_x, delta_y;
+      gdk_event_get_scroll_deltas(reinterpret_cast<const GdkEvent*>(e),
+                                  &delta_x, &delta_y);
+      if (delta_y < 0) {
+        direction_up = true;
+      } else if (delta_y > 0) {
+        direction_up = false;
+      }
+    }
+
+    if (direction_up)
+      waybar::util::command::forkExec(scroll_up_cmd_);
+    else
+      waybar::util::command::forkExec(scroll_down_cmd_);
+
+    dp.emit();
+  }
+
+  return true;
+}
+
+std::string waybar::ALabel::getIcon(uint16_t percentage,
+                                    const std::string& alt) {
   auto format_icons = config_["format-icons"];
   if (format_icons.isObject()) {
     if (!alt.empty() && format_icons[alt].isString()) {
@@ -57,6 +122,4 @@ std::string waybar::ALabel::getIcon(uint16_t percentage, const std::string& alt)
   return "";
 }
 
-waybar::ALabel::operator Gtk::Widget &() {
-  return event_box_;
-}
+waybar::ALabel::operator Gtk::Widget&() { return event_box_; }


### PR DESCRIPTION
Subscribe for mouse scroll events on the pulseaudio widget
and change volume when event is received.
Scroll up increments the volume and scroll down decrements it.

Signed-off-by: Harish Krupo <harishkrupo@gmail.com>