### PR TITLE
Custom modules can control tooltip and CSS class

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -15,8 +15,13 @@ class Custom : public ALabel {
   private:
     void delayWorker();
     void continuousWorker();
+    void parseOutput();
 
     const std::string name_;
+    std::string text_;
+    std::string tooltip_;
+    std::string class_;
+    std::string prevclass_;
     waybar::util::SleeperThread thread_;
     waybar::util::command::res output_;
 };

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -72,9 +72,47 @@ auto waybar::modules::Custom::update() -> void
     label_.set_name("");
   } else {
     label_.set_name("custom-" + name_);
-    auto str = fmt::format(format_, output_.out);
+
+    parseOutput();
+    auto str = fmt::format(format_, text_);
     label_.set_text(str);
-    label_.set_tooltip_text(str);
+    if (text_ == tooltip_) {
+      label_.set_tooltip_text(str);
+    } else {
+      label_.set_tooltip_text(tooltip_);
+    }
+    if (class_ != "") {
+      if (prevclass_ != "") {
+        label_.get_style_context()->remove_class(prevclass_);
+      }
+      label_.get_style_context()->add_class(class_);
+      prevclass_ = class_;
+    } else {
+      label_.get_style_context()->remove_class(prevclass_);
+      prevclass_ = "";
+    }
+
     label_.show();
+  }
+}
+
+void waybar::modules::Custom::parseOutput()
+{
+  std::istringstream output(output_.out);
+  std::string line;
+  int i = 0;
+  while (getline(output, line)) {
+    if (i == 0) {
+      text_ = line;
+      tooltip_ = line;
+      class_ = "";
+    } else if (i == 1) {
+      tooltip_ = line;
+    } else if (i == 2) {
+      class_ = line;
+    } else {
+      break;
+    }
+    i++;
   }
 }


### PR DESCRIPTION
This PR enables custom modules to control their own tooltip and CSS class.

Modules can return data similar to [i3blocks](https://github.com/vivien/i3blocks#format):
Line 1: Content (if it's the only line also tooltip)
Line 2: Tooltip
Line 3: CSS class

Every aditional line will be ignored.