### PR TITLE
Add class for full battery and give option to interpret unknown as full

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -23,7 +23,7 @@ class Battery : public ALabel {
   
     void worker();
     std::tuple<uint16_t, std::string> getInfos();
-    std::string getState(uint16_t, bool);
+    std::string getState(uint16_t);
 
     util::SleeperThread thread_;
     util::SleeperThread threadTimer_;

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -29,6 +29,7 @@ class Battery : public ALabel {
     util::SleeperThread threadTimer_;
     std::vector<fs::path> batteries_;
     int fd_;
+    std::string old_state_;
 };
 
 }

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -29,7 +29,7 @@ class Battery : public ALabel {
     util::SleeperThread threadTimer_;
     std::vector<fs::path> batteries_;
     int fd_;
-    std::string old_state_;
+    std::string old_status_;
 };
 
 }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -74,7 +74,7 @@ std::tuple<uint16_t, std::string> waybar::modules::Battery::getInfos()
       std::ifstream(bat / "status") >> _status;
       if (_status != "Unknown") {
         status = _status;
-      }else if (config_["full-is-unknown"].isString() && config_["full-is-unknown"] == "true") {
+      } else if (config_["full-is-unknown"].isString() && config_["full-is-unknown"] == "true") {
         status = "Full"; //Some notebooks (e.g. Thinkpad T430s) report a full battery as "Unknown".
       }
       total += capacity;
@@ -127,12 +127,12 @@ auto waybar::modules::Battery::update() -> void
     }
   } else {
     label_.get_style_context()->remove_class("charging");
-    if (status == "Full"){
+    if (status == "Full") {
       label_.get_style_context()->add_class("full");
       if (config_["format-full"].isString()) {
         format = config_["format-full"].asString();
       }
-    }else{
+    } else {
       label_.get_style_context()->remove_class("full");
     }
   }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -74,6 +74,8 @@ std::tuple<uint16_t, std::string> waybar::modules::Battery::getInfos()
       std::ifstream(bat / "status") >> _status;
       if (_status != "Unknown") {
         status = _status;
+      }else if (config_["full-is-unknown"].isString() && config_["full-is-unknown"] == "true") {
+        status = "Full"; //Some notebooks (e.g. Thinkpad T430s) report a full battery as "Unknown".
       }
       total += capacity;
     }
@@ -125,8 +127,13 @@ auto waybar::modules::Battery::update() -> void
     }
   } else {
     label_.get_style_context()->remove_class("charging");
-    if (status == "Full" && config_["format-full"].isString()) {
-      format = config_["format-full"].asString();
+    if (status == "Full"){
+      label_.get_style_context()->add_class("full");
+      if (config_["format-full"].isString()) {
+        format = config_["format-full"].asString();
+      }
+    }else{
+      label_.get_style_context()->remove_class("full");
     }
   }
   auto state = getState(capacity, charging);

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -34,7 +34,6 @@ waybar::modules::Battery::Battery(const Json::Value& config)
   for (auto const& bat : batteries_) {
     inotify_add_watch(fd_, (bat / "uevent").c_str(), IN_ACCESS);
   }
-  old_status_ = "";
   worker();
 }
 
@@ -67,7 +66,7 @@ std::tuple<uint16_t, std::string> waybar::modules::Battery::getInfos()
 {
   try {
     uint16_t total = 0;
-    std::string status;
+    std::string status = "Unknown";
     for (auto const& bat : batteries_) {
       uint16_t capacity;
       std::string _status;
@@ -125,9 +124,9 @@ auto waybar::modules::Battery::update() -> void
   old_status_ = status;
   if (!state.empty() && config_["format-" + status + "-" + state].isString()) {
     format = config_["format-" + status + "-" + state].asString();
-  }else if (config_["format-" + status].isString()) {
+  } else if (config_["format-" + status].isString()) {
     format = config_["format-" + status].asString();
-  }else if (!state.empty() && config_["format-" + state].isString()) {
+  } else if (!state.empty() && config_["format-" + state].isString()) {
     format = config_["format-" + state].asString();
   }
   if (format.empty()) {

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -34,6 +34,7 @@ waybar::modules::Battery::Battery(const Json::Value& config)
   for (auto const& bat : batteries_) {
     inotify_add_watch(fd_, (bat / "uevent").c_str(), IN_ACCESS);
   }
+  old_status_ = "";
   worker();
 }
 
@@ -85,7 +86,7 @@ std::tuple<uint16_t, std::string> waybar::modules::Battery::getInfos()
   }
 }
 
-std::string waybar::modules::Battery::getState(uint16_t capacity, bool charging)
+std::string waybar::modules::Battery::getState(uint16_t capacity)
 {
   // Get current state
   std::vector<std::pair<std::string, uint16_t>> states;
@@ -102,7 +103,7 @@ std::string waybar::modules::Battery::getState(uint16_t capacity, bool charging)
   });
   std::string validState = "";
   for (auto state : states) {
-    if (capacity <= state.second && !charging && validState.empty()) {
+    if (capacity <= state.second && validState.empty()) {
       label_.get_style_context()->add_class(state.first);
       validState = state.first;
     } else {
@@ -118,7 +119,7 @@ auto waybar::modules::Battery::update() -> void
   label_.set_tooltip_text(status);
   std::transform(status.begin(), status.end(), status.begin(), ::tolower);
   auto format = format_;
-  auto state = getState(capacity, charging);
+  auto state = getState(capacity);
   label_.get_style_context()->remove_class(old_status_);
   label_.get_style_context()->add_class(status);
   old_status_ = status;


### PR DESCRIPTION
Full battery status should also bet set as a class.
Additionally, users can configure the battery module such that an "Unknown" status is interpreted as "Full", because that's how some notebooks behave (e.g. Thinkpad T430s. Yup, that's the one I use ^^).