### PR TITLE
fix compilation on systems with old gdbus-codegen

### DIFF
--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -38,26 +38,58 @@ endforeach
 
 gdbus_codegen = find_program('gdbus-codegen')
 
-gdbus_code = generator(
-    gdbus_codegen,
-    output: '@BASENAME@.c',
-    arguments: ['--c-namespace', 'Sn', '--body', '--output', '@OUTPUT@', '@INPUT@']
-)
+r = run_command(gdbus_codegen, '--body', '--output', '/dev/null')
+if r.returncode() != 0
+  gdbus_code_dsnw = custom_target(
+      'dbus-status-notifier-watcher.[ch]',
+      output: ['@BASENAME@.c','@BASENAME@.h'],
+      input: './dbus-status-notifier-watcher.xml',
+      command: [gdbus_codegen,'--c-namespace', 'Sn', '--generate-c-code', 'protocol/@BASENAME@', '@INPUT@'],
+  )
 
-gdbus_header = generator(
-    gdbus_codegen,
-    output: '@BASENAME@.h',
-    arguments: ['--c-namespace', 'Sn', '--header', '--output', '@OUTPUT@', '@INPUT@']
-)
+  gdbus_code_dsni = custom_target(
+      'dbus-status-notifier-item.[ch]',
+      output: ['@BASENAME@.c','@BASENAME@.h'],
+      input: './dbus-status-notifier-item.xml',
+      command: [gdbus_codegen,'--c-namespace', 'Sn', '--generate-c-code', 'protocol/@BASENAME@', '@INPUT@'],
+  )
 
-client_protos_src += gdbus_code.process('./dbus-status-notifier-watcher.xml')
-client_protos_headers += gdbus_header.process('./dbus-status-notifier-watcher.xml')
+  gdbus_code_dm = custom_target(
+      'dbus-menu.[ch]',
+      output: ['@BASENAME@.c','@BASENAME@.h'],
+      input: './dbus-menu.xml',
+      command: [gdbus_codegen,'--c-namespace', 'Sn', '--generate-c-code', 'protocol/@BASENAME@', '@INPUT@'],
+  )
 
-client_protos_src += gdbus_code.process('./dbus-status-notifier-item.xml')
-client_protos_headers += gdbus_header.process('./dbus-status-notifier-item.xml')
+  client_protos_src += gdbus_code_dsnw[0]
+  client_protos_headers += gdbus_code_dsnw[1]
+  client_protos_src += gdbus_code_dsni[0]
+  client_protos_headers += gdbus_code_dsni[1]
+  client_protos_src += gdbus_code_dm[0]
+  client_protos_headers += gdbus_code_dm[1]
+else
+  gdbus_code = generator(
+      gdbus_codegen,
+      output: '@BASENAME@.c',
+      arguments: ['--c-namespace', 'Sn', '--body', '--output', '@OUTPUT@', '@INPUT@']
+  )
 
-client_protos_src += gdbus_code.process('./dbus-menu.xml')
-client_protos_headers += gdbus_header.process('./dbus-menu.xml')
+  gdbus_header = generator(
+      gdbus_codegen,
+      output: '@BASENAME@.h',
+      arguments: ['--c-namespace', 'Sn', '--header', '--output', '@OUTPUT@', '@INPUT@']
+  )
+
+  client_protos_src += gdbus_code.process('./dbus-status-notifier-watcher.xml')
+  client_protos_headers += gdbus_header.process('./dbus-status-notifier-watcher.xml')
+
+  client_protos_src += gdbus_code.process('./dbus-status-notifier-item.xml')
+  client_protos_headers += gdbus_header.process('./dbus-status-notifier-item.xml')
+
+  client_protos_src += gdbus_code.process('./dbus-menu.xml')
+  client_protos_headers += gdbus_header.process('./dbus-menu.xml')
+endif
+
 
 lib_client_protos = static_library(
 	'client_protos',


### PR DESCRIPTION
Older versions of gdbus-codegen do not support --body and --header call. On those systems, the old synax --generate-c-code must be used. A simple call to gdbus-codegen find out whether --body and --header are supported and falls back to the old syntax if they are not.