### PR TITLE
add option for when filesystem still lives in the experimental namespace

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -1,6 +1,10 @@
 #pragma once
 
-#include <filesystem>
+#ifdef FILESYSTEM_EXPERIMENTAL
+  #include <experimental/filesystem>
+#else
+  #include <filesystem>
+#endif
 #include <fstream>
 #include <iostream>
 #include <fmt/format.h>
@@ -11,7 +15,11 @@
 
 namespace waybar::modules {
 
+#ifdef FILESYSTEM_EXPERIMENTAL
+namespace fs = std::experimental::filesystem;
+#else
 namespace fs = std::filesystem;
+#endif
 
 class Battery : public ALabel {
   public:

--- a/include/modules/sni/sni.hpp
+++ b/include/modules/sni/sni.hpp
@@ -3,7 +3,11 @@
 #include <dbus-status-notifier-item.h>
 #include <gtkmm.h>
 #include <json/json.h>
-#include <filesystem>
+#ifdef FILESYSTEM_EXPERIMENTAL
+  #include <experimental/filesystem>
+#else
+  #include <filesystem>
+#endif
 
 namespace waybar::modules::SNI {
 

--- a/meson.build
+++ b/meson.build
@@ -83,11 +83,9 @@ if dbusmenu_gtk.found()
     )
 endif
 
-test_fs = '''#include <filesystem>
-int main(void){}'''
 compiler = meson.get_compiler('cpp')
 
-if not compiler.compiles(test_fs, name : 'is filesystem still in experimental?')
+if not compiler.has_header('filesystem')
     add_project_arguments('-DFILESYSTEM_EXPERIMENTAL', language: 'cpp')
 endif
 

--- a/meson.build
+++ b/meson.build
@@ -83,6 +83,10 @@ if dbusmenu_gtk.found()
     )
 endif
 
+if get_option('filesystem-experimental')
+    add_project_arguments('-DFILESYSTEM_EXPERIMENTAL', language: 'cpp')
+endif
+
 subdir('protocol')
 
 executable(

--- a/meson.build
+++ b/meson.build
@@ -83,7 +83,11 @@ if dbusmenu_gtk.found()
     )
 endif
 
-if get_option('filesystem-experimental')
+test_fs = '''#include <filesystem>
+int main(void){}'''
+compiler = meson.get_compiler('cpp')
+
+if not compiler.compiles(test_fs, name : 'is filesystem still in experimental?')
     add_project_arguments('-DFILESYSTEM_EXPERIMENTAL', language: 'cpp')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,4 @@ option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl suppo
 option('pulseaudio', type: 'feature', value: 'auto', description: 'Enable support for pulseaudio')
 option('dbusmenu-gtk', type: 'feature', value: 'auto', description: 'Enable support for tray')
 option('out', type: 'string', value : '/', description: 'output prefix directory')
+option('filesystem-experimental', type: 'boolean', value: 'true', description: 'Does filesystem still live in experimental?')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,4 +2,3 @@ option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl suppo
 option('pulseaudio', type: 'feature', value: 'auto', description: 'Enable support for pulseaudio')
 option('dbusmenu-gtk', type: 'feature', value: 'auto', description: 'Enable support for tray')
 option('out', type: 'string', value : '/', description: 'output prefix directory')
-option('filesystem-experimental', type: 'boolean', value: 'true', description: 'Does filesystem still live in experimental?')

--- a/src/modules/sni/sni.cpp
+++ b/src/modules/sni/sni.cpp
@@ -190,7 +190,11 @@ void waybar::modules::SNI::Item::updateImage()
   if (!icon_name.empty()) {
     try {
       // Try to find icons specified by path and filename
+#ifdef FILESYSTEM_EXPERIMENTAL
+      if (std::experimental::filesystem::exists(icon_name)) {
+#else
       if (std::filesystem::exists(icon_name)) {
+#endif
         auto pixbuf = Gdk::Pixbuf::create_from_file(icon_name);
         if (pixbuf->gobj() != nullptr) {
           // An icon specified by path and filename may be the wrong size for


### PR DESCRIPTION
For gcc-7, filesystem still lives in the experimental namespace, thus compilation will fail. I have added an option to meson to fix the header includes and namespaces accordingly. 