### PR TITLE
Don't call layer_surface.set_size on configure

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -119,8 +119,6 @@ height: {} required by the modules", o->height_, min_height) << std::endl;
       "Bar configured (width: {}, height: {}) for output: {}",
       o->width_, o->height_, o->output_name) << std::endl;
 
-    zwlr_layer_surface_v1_set_exclusive_zone(surface, o->height_);
-    zwlr_layer_surface_v1_set_size(surface, o->width_, o->height_);
     wl_surface_commit(o->surface);
   }
 }


### PR DESCRIPTION
Calling `set_exclusive_zone` and `set_size` with the values provided by the compositor in a configure will actually freeze the bar in the new configuration it requested, as calling those with non-zero values opts-out of autoconfiguration by the compositor.

By removing these calls, waybar can now adapt to dynamic changes in the output dimensions, which can happen for example if the monitor's transform is changed (like for a tablet-like device auto-detecting its orientation).