### PR TITLE
Fix workspaces not being removed from bar when moved to another output

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -42,7 +42,9 @@ auto waybar::modules::sway::Workspaces::update() -> void
   for (auto it = buttons_.begin(); it != buttons_.end();) {
     auto ws = std::find_if(workspaces_.begin(), workspaces_.end(),
       [it](auto node) -> bool { return node["name"].asString() == it->first; });
-    if (ws == workspaces_.end()) {
+    if (ws == workspaces_.end() ||
+            (!config_["all-outputs"].asBool() &&
+             (*ws)["output"].asString() != bar_.output_name)) {
       it = buttons_.erase(it);
       needReorder = true;
     } else {


### PR DESCRIPTION
And another one :D 
Now only the ordering of the workspaces has to be fixed if all-outputs == true.