### PR TITLE
Module network ipaddr

### DIFF
--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <net/if.h>
+#include <arpa/inet.h>
+#include <ifaddrs.h>
 #include <netlink/netlink.h>
 #include <netlink/genl/genl.h>
 #include <netlink/genl/ctrl.h>
@@ -24,6 +26,7 @@ class Network : public ALabel {
     void disconnected();
     void initNL80211();
     int getExternalInterface();
+    void getInterfaceAddress();
     void parseEssid(struct nlattr**);
     void parseSignal(struct nlattr**);
     bool associatedOrJoined(struct nlattr**);
@@ -39,6 +42,9 @@ class Network : public ALabel {
 
     std::string essid_;
     std::string ifname_;
+    std::string ipaddr_;
+    std::string netmask_;
+    int cidr_;
     int signal_strength_dbm_;
     uint16_t signal_strength_;
 };

--- a/resources/config
+++ b/resources/config
@@ -59,7 +59,7 @@
     "network": {
         // "interface": "wlp2s0", // (Optional) To force the use of this interface
         "format-wifi": "{essid} ({signalStrength}%) ",
-        "format-ethernet": "{ifname} ",
+        "format-ethernet": "{ifname}: {ipaddr}/{cidr} ",
         "format-disconnected": "Disconnected ⚠"
     },
     "pulseaudio": {

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -269,11 +269,11 @@ void waybar::modules::Network::getInterfaceAddress() {
   int success = getifaddrs(&ifaddr);
   if (success == 0) {
     ifa = ifaddr;
-    while(ifa != NULL && ipaddr_.empty() && netmask_.empty()) {
-      if(ifa->ifa_addr->sa_family == family_) {
-        if(strcmp(ifa->ifa_name, ifname_.c_str()) == 0){
-          ipaddr_=inet_ntoa(((struct sockaddr_in*)ifa->ifa_addr)->sin_addr);
-          netmask_=inet_ntoa(((struct sockaddr_in*)ifa->ifa_netmask)->sin_addr);
+    while (ifa != NULL && ipaddr_.empty() && netmask_.empty()) {
+      if (ifa->ifa_addr->sa_family == family_) {
+        if (strcmp(ifa->ifa_name, ifname_.c_str()) == 0) {
+          ipaddr_ = inet_ntoa(((struct sockaddr_in*)ifa->ifa_addr)->sin_addr);
+          netmask_ = inet_ntoa(((struct sockaddr_in*)ifa->ifa_netmask)->sin_addr);
           cidrRaw = ((struct sockaddr_in *)(ifa->ifa_netmask))->sin_addr.s_addr;
           unsigned int cidr = 0;
           while (cidrRaw) {
@@ -285,8 +285,12 @@ void waybar::modules::Network::getInterfaceAddress() {
       }
       ifa = ifa->ifa_next;
     }
+    freeifaddrs(ifaddr);
+  } else {
+    ipaddr_.clear();
+    netmask_.clear();
+    cidr_ = 0;
   }
-  freeifaddrs(ifaddr);
 }
 
 int waybar::modules::Network::netlinkRequest(int fd, void *req,

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -26,6 +26,7 @@ waybar::modules::Network::Network(const Json::Value& config)
       char ifname[IF_NAMESIZE];
       if_indextoname(ifid_, ifname);
       ifname_ = ifname;
+      getInterfaceAddress();
     }
   }
   initNL80211();
@@ -64,6 +65,7 @@ waybar::modules::Network::Network(const Json::Value& config)
         char ifname[IF_NAMESIZE];
         if_indextoname(ifid_, ifname);
         ifname_ = ifname;
+        getInterfaceAddress();
         need_update = true;
       }
     }
@@ -101,7 +103,10 @@ auto waybar::modules::Network::update() -> void
     fmt::arg("essid", essid_),
     fmt::arg("signaldBm", signal_strength_dbm_),
     fmt::arg("signalStrength", signal_strength_),
-    fmt::arg("ifname", ifname_)
+    fmt::arg("ifname", ifname_),
+    fmt::arg("netmask", netmask_),
+    fmt::arg("ipaddr", ipaddr_),
+    fmt::arg("cidr", cidr_)
   ));
 }
 
@@ -110,6 +115,9 @@ void waybar::modules::Network::disconnected()
   essid_.clear();
   signal_strength_dbm_ = 0;
   signal_strength_ = 0;
+  ipaddr_.clear();
+  netmask_.clear();
+  cidr_ = 0;
   ifname_.clear();
   ifid_ = -1;
 }
@@ -253,6 +261,32 @@ int waybar::modules::Network::getExternalInterface()
 
 out:
   return ifidx;
+}
+
+void waybar::modules::Network::getInterfaceAddress() {
+  unsigned int cidrRaw;
+  struct ifaddrs *ifaddr, *ifa;
+  int success = getifaddrs(&ifaddr);
+  if (success == 0) {
+    ifa = ifaddr;
+    while(ifa != NULL && ipaddr_.empty() && netmask_.empty()) {
+      if(ifa->ifa_addr->sa_family == family_) {
+        if(strcmp(ifa->ifa_name, ifname_.c_str()) == 0){
+          ipaddr_=inet_ntoa(((struct sockaddr_in*)ifa->ifa_addr)->sin_addr);
+          netmask_=inet_ntoa(((struct sockaddr_in*)ifa->ifa_netmask)->sin_addr);
+          cidrRaw = ((struct sockaddr_in *)(ifa->ifa_netmask))->sin_addr.s_addr;
+          unsigned int cidr = 0;
+          while (cidrRaw) {
+              cidr += cidrRaw & 1;
+              cidrRaw >>= 1;
+          }
+          cidr_ = cidr;
+        }
+      }
+      ifa = ifa->ifa_next;
+    }
+  }
+  freeifaddrs(ifaddr);
 }
 
 int waybar::modules::Network::netlinkRequest(int fd, void *req,


### PR DESCRIPTION
This PR adds the ability to display the IP address, as well as the subnet mask (also in CIDR notation).

The following format replacements will get added:

| string      | replacement |
| --- | --- |
| `{ipaddr}`  | The first IP of the interface. |
| `{netmask}` | The subnetmask corresponding to the IP. |
| `{cidr}`    | The subnetmask corresponding to the IP in CIDR notation. |

And while we are at it, the following format replacement is missing from network:

| string      | replacement |
| --- | --- |
| `{signaldBm}`  | Signal strenth of the wireless network in dBm. |
