### PR TITLE
Update to new Sway IPC protocol

### DIFF
--- a/src/modules/sway/ipc/client.cpp
+++ b/src/modules/sway/ipc/client.cpp
@@ -122,7 +122,7 @@ struct waybar::modules::sway::Ipc::ipc_response
 void waybar::modules::sway::Ipc::subscribe(const std::string& payload) const
 {
   auto res = send(fd_event_, IPC_SUBSCRIBE, payload);
-  if (res.payload != "{\"success\": true}") {
+  if (res.payload != "{\"success\": true}" && res.payload != "[{\"success\": true}]") {
     throw std::runtime_error("Unable to subscribe ipc event");
   }
 }


### PR DESCRIPTION
Fixes #109 by checking for old and new IPC response formats. Works with swaywm/sway@9d18d81