### PR TITLE
feat(pulseaudio): do not restrict format-icon list

### DIFF
--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -22,8 +22,6 @@ class Pulseaudio : public ALabel {
     static void volumeModifyCb(pa_context*, int, void*);
     bool handleScroll(GdkEventScroll* e);
 
-    const std::string getPortIcon() const;
-
     pa_threaded_mainloop* mainloop_;
     pa_mainloop_api* mainloop_api_;
     pa_context* context_;

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "modules/pulseaudio.hpp"
 
 waybar::modules::Pulseaudio::Pulseaudio(const std::string& id, const Json::Value &config)
@@ -174,27 +175,6 @@ void waybar::modules::Pulseaudio::serverInfoCb(pa_context *context,
     sinkInfoCb, data);
 }
 
-const std::string waybar::modules::Pulseaudio::getPortIcon() const
-{
-  std::vector<std::string> ports = {
-    "headphones",
-    "speaker",
-    "hdmi",
-    "headset",
-    "handsfree",
-    "portable",
-    "car",
-    "hifi",
-    "phone",
-  };
-  for (auto const& port : ports) {
-    if (port_name_.find(port) != std::string::npos) {
-      return port;
-    }
-  }
-  return "";
-}
-
 auto waybar::modules::Pulseaudio::update() -> void
 {
   auto format = format_;
@@ -212,7 +192,7 @@ auto waybar::modules::Pulseaudio::update() -> void
   }
   label_.set_markup(
       fmt::format(format, fmt::arg("volume", volume_),
-                  fmt::arg("icon", getIcon(volume_, getPortIcon()))));
+                  fmt::arg("icon", getIcon(volume_, port_name_))));
   label_.set_tooltip_text(desc_);
   if (scrolling_) {
     scrolling_ = false;


### PR DESCRIPTION
Some ports are not in the list, I wanted to add an icon for
"analog-output-lineout" and I had to modify
waybar::modules::Pulseaudio::getPortIcon().

I tried to remove the function and use port_name_ variable directly and it seems
to work. If the string is not in the config file, "default" icon is used. If
there is no "default" entry, no icon is shown.
