### PR TITLE
Use SignalStrength for format icons

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -90,7 +90,7 @@ std::string waybar::ALabel::getIcon(uint16_t percentage,
                                     const std::string& alt) {
   auto format_icons = config_["format-icons"];
   if (format_icons.isObject()) {
-    if (!alt.empty() && format_icons[alt].isArray()) {
+    if (!alt.empty() && (format_icons[alt].isString() || format_icons[alt].isArray())) {
       format_icons = format_icons[alt];
     } else {
       format_icons = format_icons["default"];

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -90,7 +90,7 @@ std::string waybar::ALabel::getIcon(uint16_t percentage,
                                     const std::string& alt) {
   auto format_icons = config_["format-icons"];
   if (format_icons.isObject()) {
-    if (!alt.empty() && format_icons[alt].isString()) {
+    if (!alt.empty() && format_icons[alt].isArray()) {
       format_icons = format_icons[alt];
     } else {
       format_icons = format_icons["default"];

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -105,17 +105,21 @@ void waybar::modules::Network::worker()
 auto waybar::modules::Network::update() -> void
 {
   auto format = format_;
+  std::string connectiontype;
   if (ifid_ <= 0 || ipaddr_.empty()) {
     format = config_["format-disconnected"].isString()
       ? config_["format-disconnected"].asString() : format;
     label_.get_style_context()->add_class("disconnected");
+    connectiontype = "disconnected";
   } else {
     if (essid_.empty()) {
       format = config_["format-ethernet"].isString()
         ? config_["format-ethernet"].asString() : format;
+      connectiontype = "ethernet";
     } else {
       format = config_["format-wifi"].isString()
         ? config_["format-wifi"].asString() : format;
+      connectiontype = "wifi";
     }
     label_.get_style_context()->remove_class("disconnected");
   }
@@ -126,7 +130,8 @@ auto waybar::modules::Network::update() -> void
     fmt::arg("ifname", ifname_),
     fmt::arg("netmask", netmask_),
     fmt::arg("ipaddr", ipaddr_),
-    fmt::arg("cidr", cidr_)
+    fmt::arg("cidr", cidr_),
+    fmt::arg("icon", getIcon(signal_strength_, connectiontype))
   ));
 }
 


### PR DESCRIPTION
This adds the ability to set format icons similar to the pulseaudio module.

A config for this could look like this (Needs FontAwesome Pro):
```
"format": "{icon}",
"format-icons": {
  "wifi": ["", "" ,""],
  "ethernet": [""],
  "disconnected": [""] 
}
```

Also if fixes getIcon() in ALabel.