### PR TITLE
Add format-icons to custom module

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -19,7 +19,6 @@ class Custom : public ALabel {
     void continuousWorker();
     void parseOutputRaw();
     void parseOutputJson();
-    bool isInteger(const std::string&);
 
     const std::string name_;
     std::string text_;

--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -19,12 +19,14 @@ class Custom : public ALabel {
     void continuousWorker();
     void parseOutputRaw();
     void parseOutputJson();
+    bool isInteger(const std::string&);
 
     const std::string name_;
     std::string text_;
     std::string tooltip_;
     std::string class_;
     std::string prevclass_;
+    int percentage_;
     waybar::util::SleeperThread thread_;
     waybar::util::command::res output_;
     waybar::util::JsonParser parser_;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -132,19 +132,6 @@ void waybar::modules::Custom::parseOutputRaw()
   }
 }
 
-bool waybar::modules::Custom::isInteger(const std::string& n)
-{
-  if (std::isdigit(n[0]) || (n.size() > 1 && (n[0] == '-' || n[0] == '+'))) {
-    for (std::string::size_type i{ 1 }; i < n.size(); ++i) {
-      if (!std::isdigit(n[i])) {
-        return false;
-      }
-    }
-    return true;
-  }
-  return false;
-}
-
 void waybar::modules::Custom::parseOutputJson()
 {
   std::istringstream output(output_.out);
@@ -154,8 +141,8 @@ void waybar::modules::Custom::parseOutputJson()
     text_ = parsed["text"].asString();
     tooltip_ = parsed["tooltip"].asString();
     class_ = parsed["class"].asString();
-    if (!parsed["percentage"].asString().empty() && isInteger(parsed["percentage"].asString())) {
-      percentage_ = std::stoi(parsed["percentage"].asString(), nullptr);
+    if (!parsed["percentage"].asString().empty() && parsed["percentage"].isUInt()) {
+      percentage_ = parsed["percentage"].asUInt();
     } else {
       percentage_ = 0;
     }

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -87,7 +87,9 @@ auto waybar::modules::Custom::update() -> void
       parseOutputRaw();
     }
 
-    auto str = fmt::format(format_, text_);
+    auto str = fmt::format(format_, text_,
+      fmt::arg("icon", getIcon(percentage_)),
+      fmt::arg("percentage", percentage_));
     label_.set_markup(str);
     if (text_ == tooltip_) {
       label_.set_tooltip_text(str);
@@ -130,6 +132,19 @@ void waybar::modules::Custom::parseOutputRaw()
   }
 }
 
+bool waybar::modules::Custom::isInteger(const std::string& n)
+{
+  if (std::isdigit(n[0]) || (n.size() > 1 && (n[0] == '-' || n[0] == '+'))) {
+    for (std::string::size_type i{ 1 }; i < n.size(); ++i) {
+      if (!std::isdigit(n[i])) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
 void waybar::modules::Custom::parseOutputJson()
 {
   std::istringstream output(output_.out);
@@ -139,6 +154,11 @@ void waybar::modules::Custom::parseOutputJson()
     text_ = parsed["text"].asString();
     tooltip_ = parsed["tooltip"].asString();
     class_ = parsed["class"].asString();
+    if (!parsed["percentage"].asString().empty() && isInteger(parsed["percentage"].asString())) {
+      percentage_ = std::stoi(parsed["percentage"].asString(), nullptr);
+    } else {
+      percentage_ = 0;
+    }
     break;
   }
 }


### PR DESCRIPTION
This commit allows custom modules (json only) to set a percentage. This can be displayed either by using `{percentage}` or by using `{icon}` with `format-icons` set.


## Doku:
```
#### Format replacements:

| option           | typeof  | default | description |
| `format`         | string  | `{}`    | The format, how information should be displayed. On `{}` data gets inserted. |
| `format-icons`   | array   |         | Based on the set percentage, the corresponding icon gets selected.<br>The order is *low* to *high*. |

| string | replacement |
| --- | --- |
| `{}` | Output of the script. |
| `{percentage}` | Percentage wich can be set via a json return-type. |
| `{icon}` | An icon from 'format-icons' according to percentage. |
```