### PR TITLE
refactor: replace all gtkmm.h includes

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -2,6 +2,9 @@
 
 #include <json/json.h>
 #include "IModule.hpp"
+#include <glibmm/markup.h>
+#include <gtkmm/eventbox.h>
+#include <gtkmm/label.h>
 
 namespace waybar {
 

--- a/include/IModule.hpp
+++ b/include/IModule.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <gtkmm.h>
+#include <glibmm/dispatcher.h>
+#include <gtkmm/box.h>
+#include <gtkmm/widget.h>
 
 namespace waybar {
 

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <json/json.h>
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/main.h>
+#include <gtkmm/cssprovider.h>
+#include <gtkmm/window.h>
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "xdg-output-unstable-v1-client-protocol.h"
 #include "IModule.hpp"

--- a/include/modules/sni/host.hpp
+++ b/include/modules/sni/host.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <giomm.h>
 #include <json/json.h>
 #include <tuple>
 #include <dbus-status-notifier-watcher.h>

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <dbus-status-notifier-item.h>
-#include <gtkmm.h>
+#include <glibmm/refptr.h>
+#include <gtkmm/eventbox.h>
+#include <gtkmm/image.h>
+#include <gtkmm/icontheme.h>
+#include <gtkmm/menu.h>
 #include <json/json.h>
 #include <libdbusmenu-gtk/dbusmenu-gtk.h>
 #ifdef FILESYSTEM_EXPERIMENTAL

--- a/include/modules/sni/watcher.hpp
+++ b/include/modules/sni/watcher.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
-#include <gtkmm.h>
+#include <giomm.h>
+#include <glibmm/refptr.h>
 #include <dbus-status-notifier-watcher.h>
 
 namespace waybar::modules::SNI {

--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -7,6 +7,7 @@
 #include "util/json.hpp"
 #include "IModule.hpp"
 #include "modules/sway/ipc/client.hpp"
+#include <gtkmm/button.h>
 
 namespace waybar::modules::sway {
 

--- a/include/util/chrono.hpp
+++ b/include/util/chrono.hpp
@@ -5,7 +5,6 @@
 #include <functional>
 #include <condition_variable>
 #include <thread>
-#include <gtkmm.h>
 
 namespace waybar::chrono {
 

--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <sys/wait.h>
+#include <giomm.h>
 
 namespace waybar::util::command {
 


### PR DESCRIPTION
Replaces all occurences of `#include <gtkmm.h>` with only ne neccesary headers