### PR TITLE
fix(window): Ignore waybar

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -23,9 +23,11 @@ void waybar::modules::sway::Window::worker()
     try {
       auto res = ipc_.handleEvent();
       auto parsed = parser_.parse(res.payload);
+      // Check for waybar prevents flicker when hovering window module
       if ((parsed["change"] == "focus" || parsed["change"] == "title")
         && parsed["container"]["focused"].asBool()) {
-        window_ = Glib::Markup::escape_text(parsed["container"]["name"].asString());
+        window_ = Glib::Markup::escape_text(parsed["container"]["name"].asString()
+        && parsed["container"]["name"].asString() != "waybar");
         windowId_ = parsed["container"]["id"].asInt();
         dp.emit();
       } else if ((parsed["change"] == "close"


### PR DESCRIPTION
With this, the window title `waybar` will be ignored so it won't flicker as decribed in #148.

Regarding the hiding of tooltips, i think this belongs in another pull (together with formating tooltips like module text).