### PR TITLE
Strip workspace number from name

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -25,7 +25,8 @@ class Workspaces : public IModule {
     std::string getPrevWorkspace();
     std::string getNextWorkspace();
     uint16_t getWorkspaceIndex(const std::string &name);
-    std::string trimWorkspaceName(std::string);
+    std::string getWorkspaceName(const Json::Value&);
+    std::string trimWorkspaceName(const Json::Value&);
 
     const Bar& bar_;
     const Json::Value& config_;


### PR DESCRIPTION
We already have access to the workspace number as {index} in the format string.

I refactored the duplicated code for creating the formatted string into a new method called `getWorkspaceName`. The stripping of workspace number is made in the same was as `strip_workspace_numbers` in swaybar.