### PR TITLE
Added light module (brightness)

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -19,6 +19,9 @@
 #ifdef HAVE_LIBPULSE
 #include "modules/pulseaudio.hpp"
 #endif
+#ifdef HAVE_LIGHT
+#include "modules/light.hpp"
+#endif
 #include "modules/custom.hpp"
 
 namespace waybar {

--- a/include/modules/light.hpp
+++ b/include/modules/light.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <fmt/format.h>
+#include <iostream>
+#include "util/sleeper_thread.hpp"
+#include "util/command.hpp"
+#include "ALabel.hpp"
+
+namespace waybar::modules {
+
+class Light : public ALabel {
+  public:
+    Light(const std::string&, const Json::Value&);
+    ~Light() = default;
+    auto update() -> void;
+  private:
+    static inline const std::string cmd_get_ = "light -G";
+    static inline const std::string cmd_increase_ = "light -A {}";
+    static inline const std::string cmd_decrease_ = "light -U {}";
+
+    void delayWorker();
+    bool handleScroll(GdkEventScroll* e);
+    void updateBrightness();
+
+    uint8_t brightness_level_;
+    bool scrolling_;
+    waybar::util::SleeperThread thread_;
+};
+
+}  // namespace waybar::modules

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,11 @@ if libpulse.found()
     src_files += 'src/modules/pulseaudio.cpp'
 endif
 
+if find_program('light', required: get_option('light')).found()
+    add_project_arguments('-DHAVE_LIGHT', language: 'cpp')
+    src_files += 'src/modules/light.cpp'
+endif
+
 if dbusmenu_gtk.found()
     add_project_arguments('-DHAVE_DBUSMENU', language: 'cpp')
     src_files += files(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl support for network related features')
 option('pulseaudio', type: 'feature', value: 'auto', description: 'Enable support for pulseaudio')
+option('light', type: 'feature', value: 'auto', description: 'Enable support for light')
 option('dbusmenu-gtk', type: 'feature', value: 'auto', description: 'Enable support for tray')
 option('out', type: 'string', value : '/', description: 'output prefix directory')

--- a/resources/config
+++ b/resources/config
@@ -6,7 +6,7 @@
     // Choose the order of the modules
     "modules-left": ["sway/workspaces", "sway/mode", "custom/spotify"],
     "modules-center": ["sway/window"],
-    "modules-right": ["pulseaudio", "network", "cpu", "memory", "battery", "battery#bat2", "clock", "tray"],
+    "modules-right": ["pulseaudio", "light", "network", "cpu", "memory", "battery", "battery#bat2", "clock", "tray"],
     // Modules configuration
     // "sway/workspaces": {
     //     "disable-scroll": true,
@@ -26,19 +26,6 @@
     "sway/mode": {
         "format": "<span style=\"italic\">{}</span>"
     },
-    "tray": {
-        // "icon-size": 21,
-        "spacing": 10
-    },
-    "clock": {
-        "format-alt": "{:%Y-%m-%d}"
-    },
-    "cpu": {
-        "format": "{usage}% "
-    },
-    "memory": {
-        "format": "{}% "
-    },
     "battery": {
         "states": {
             // "good": 95,
@@ -52,6 +39,19 @@
     },
     "battery#bat2": {
         "bat": "BAT2"
+    },
+    "clock": {
+        "format-alt": "{:%Y-%m-%d}"
+    },
+    "cpu": {
+        "format": "{usage}% "
+    },
+    "light": {
+        //"scroll-step": 5,
+        "format": "{}% "
+    },
+    "memory": {
+        "format": "{}% "
     },
     "network": {
         // "interface": "wlp2s0", // (Optional) To force the use of this interface
@@ -74,6 +74,10 @@
             "default": ["", ""]
         },
         "on-click": "pavucontrol"
+    },
+    "tray": {
+        // "icon-size": 21,
+        "spacing": 10
     },
     "custom/spotify": {
         "format": " {}",

--- a/resources/style.css
+++ b/resources/style.css
@@ -30,7 +30,7 @@ window#waybar {
     border-bottom: 3px solid white;
 }
 
-#clock, #battery, #cpu, #memory, #network, #pulseaudio, #custom-spotify, #tray, #mode {
+#clock, #battery, #cpu, #memory, #network, #pulseaudio, #light, #custom-spotify, #tray, #mode {
     padding: 0 10px;
     margin: 0 5px;
 }
@@ -68,7 +68,11 @@ window#waybar {
 
 #cpu {
     background: #2ecc71;
-    color: #000000;
+    color: black;
+}
+
+#light {
+  background: #b70000;
 }
 
 #memory {

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -48,6 +48,11 @@ waybar::IModule* waybar::Factory::makeModule(const std::string &name) const
       return new waybar::modules::Pulseaudio(id, config_[name]);
     }
     #endif
+    #ifdef HAVE_LIGHT
+    if (ref == "light") {
+      return new waybar::modules::Light(id, config_[name]);
+    }
+    #endif
     if (ref.compare(0, 7, "custom/") == 0 && ref.size() > 7) {
       return new waybar::modules::Custom(ref.substr(7), config_[name]);
     }

--- a/src/modules/light.cpp
+++ b/src/modules/light.cpp
@@ -1,0 +1,89 @@
+#include "modules/light.hpp"
+
+waybar::modules::Light::Light(const std::string& id, const Json::Value &config)
+    : ALabel(config, "{brightness}%", 5),
+      brightness_level_(100),
+      scrolling_(false)
+{
+  label_.set_name("light");
+  if (!id.empty()) {
+    label_.get_style_context()->add_class(id);
+  }
+
+  delayWorker();
+
+  event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
+  event_box_.signal_scroll_event().connect(
+    sigc::mem_fun(*this, &Light::handleScroll));
+}
+
+auto waybar::modules::Light::update() -> void
+{
+  auto str = fmt::format(format_, fmt::arg("brightness", brightness_level_));
+  label_.set_markup(str);
+  label_.set_tooltip_text(str); // TODO: Tooltip text
+
+  if (scrolling_) {
+    scrolling_ = false;
+  }
+}
+
+void waybar::modules::Light::delayWorker()
+{
+  thread_ = [this] {
+    updateBrightness();
+    thread_.sleep_for(interval_);
+  };
+}
+
+bool waybar::modules::Light::handleScroll(GdkEventScroll *e) {
+  bool direction_up = false;
+
+  // Avoid concurrent scroll event
+  if (scrolling_) {
+    return false;
+  }
+  scrolling_ = true;
+
+  uint16_t change = config_["scroll-step"].isUInt() ? config_["scroll-step"].asUInt() : 5;
+
+  if (e->direction == GDK_SCROLL_UP) {
+    direction_up = true;
+  }
+  if (e->direction == GDK_SCROLL_DOWN) {
+    direction_up = false;
+  }
+  if (e->direction == GDK_SCROLL_SMOOTH) {
+    gdouble delta_x, delta_y;
+    gdk_event_get_scroll_deltas(reinterpret_cast<const GdkEvent *>(e), &delta_x, &delta_y);
+    if (delta_y < 0) {
+      direction_up = true;
+    } else if (delta_y > 0) {
+      direction_up = false;
+    }
+  }
+
+  if (direction_up) {
+    if (brightness_level_ + 1 < 100)  {
+      auto res = waybar::util::command::exec(fmt::format(cmd_increase_, change));
+    }
+  } else {
+    if (brightness_level_ - 1 > 0) {
+      auto res = waybar::util::command::exec(fmt::format(cmd_decrease_, change));
+    }
+  }
+  updateBrightness();
+  return true;
+}
+
+void waybar::modules::Light::updateBrightness()
+{
+  float temp_float;
+  auto res = waybar::util::command::exec(cmd_get_);
+  if (res.exit_code == 0) {
+    // Convert float to uint8_t
+    sscanf(res.out.c_str(), "%f", &temp_float);
+    brightness_level_ = (uint8_t) (temp_float + 0.5);
+    dp.emit();
+  }
+}


### PR DESCRIPTION
Reference to #177 

I have added a new module called 'light', this supports [light](https://github.com/haikarainen/light) brightness tool.

Features of light module:
- [x] Build option to enable light module
- [x] Show/increase/decrease brightness
- [x] Scroll support
- [x] `scroll-step` to choose brightness change
- [x] Update brightness value on scroll
- [x] Styling
- [ ] Upper and lower brightness limits
- [ ] Format icons
- [ ] On click events
- [ ] Wiki page

<br>

Further improvements:
- Now modules inside `config` are in alphabetic order (except for sway and customs), like `style.css`
- Changed cpu style color to `black` instead of `#000000`