### PR TITLE
Add module Idle inhibitor

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -7,6 +7,7 @@
 #include <gtkmm/window.h>
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 #include "xdg-output-unstable-v1-client-protocol.h"
+#include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "IModule.hpp"
 
 namespace waybar {

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -24,6 +24,7 @@ class Client {
     struct zwlr_layer_shell_v1 *layer_shell = nullptr;
     struct zxdg_output_manager_v1 *xdg_output_manager = nullptr;
     struct wl_seat *seat = nullptr;
+    struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager = nullptr;
     std::vector<std::unique_ptr<Bar>> bars;
 
   private:

--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -7,6 +7,7 @@
 #include "modules/sway/workspaces.hpp"
 #include "modules/sway/window.hpp"
 #endif
+#include "modules/idle_inhibitor.hpp"
 #include "modules/battery.hpp"
 #include "modules/memory.hpp"
 #include "modules/cpu.hpp"

--- a/include/modules/idle_inhibitor.hpp
+++ b/include/modules/idle_inhibitor.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <fmt/format.h>
+#include "bar.hpp"
+#include "client.hpp"
+#include "ALabel.hpp"
+
+namespace waybar::modules {
+
+class IdleInhibitor: public ALabel {
+  public:
+    IdleInhibitor(const std::string&, const waybar::Bar&, const Json::Value&);
+    ~IdleInhibitor();
+    auto update() -> void;
+  private:
+    bool onClick(GdkEventButton* const& ev);
+
+    const Bar& bar_;
+    std::string status_;
+    struct zwp_idle_inhibitor_v1 *idle_inhibitor_;
+};
+
+}

--- a/meson.build
+++ b/meson.build
@@ -65,6 +65,7 @@ src_files = files(
     'src/modules/clock.cpp',
     'src/modules/custom.cpp',
     'src/modules/cpu.cpp',
+	'src/modules/idle_inhibitor.cpp',
     'src/main.cpp',
     'src/bar.cpp',
     'src/client.cpp'

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -24,6 +24,7 @@ wayland_scanner_client = generator(
 client_protocols = [
 	[wl_protocol_dir, 'stable/xdg-shell/xdg-shell.xml'],
 	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
+	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
 	['wlr-layer-shell-unstable-v1.xml'],
 ]
 

--- a/resources/config
+++ b/resources/config
@@ -6,7 +6,7 @@
     // Choose the order of the modules
     "modules-left": ["sway/workspaces", "sway/mode", "custom/spotify"],
     "modules-center": ["sway/window"],
-    "modules-right": ["pulseaudio", "network", "cpu", "memory", "backlight", "battery", "battery#bat2", "clock", "tray"],
+    "modules-right": ["idle_inhibitor", "pulseaudio", "network", "cpu", "memory", "backlight", "battery", "battery#bat2", "clock", "tray"],
     // Modules configuration
     // "sway/workspaces": {
     //     "disable-scroll": true,
@@ -25,6 +25,13 @@
     // },
     "sway/mode": {
         "format": "<span style=\"italic\">{}</span>"
+    },
+    "idle_inhibitor": {
+        "format": "{icon}",
+        "format-icons": {
+            "activated": "",
+            "deactivated": ""
+        }
     },
     "tray": {
         // "icon-size": 21,

--- a/resources/style.css
+++ b/resources/style.css
@@ -30,7 +30,7 @@ window#waybar {
     border-bottom: 3px solid white;
 }
 
-#clock, #battery, #cpu, #memory, #backlight, #network, #pulseaudio, #custom-spotify, #tray, #mode {
+#clock, #battery, #cpu, #memory, #backlight, #network, #pulseaudio, #custom-spotify, #tray, #mode, #idle_inhibitor {
     padding: 0 10px;
     margin: 0 5px;
 }
@@ -104,4 +104,8 @@ window#waybar {
 
 #tray {
     background-color: #2980b9;
+}
+
+#idle_inhibitor {
+    background-color: #000000;
 }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -55,6 +55,10 @@ void waybar::Client::handleGlobal(void *data, struct wl_registry *registry,
       o->xdg_output_manager = static_cast<struct zxdg_output_manager_v1 *>(
         wl_registry_bind(registry, name,
         &zxdg_output_manager_v1_interface, ZXDG_OUTPUT_V1_NAME_SINCE_VERSION));
+  } else if (strcmp(interface, zwp_idle_inhibit_manager_v1_interface.name) == 0) {
+    o->idle_inhibit_manager = static_cast<struct zwp_idle_inhibit_manager_v1 *>(
+        wl_registry_bind(registry, name,
+        &zwp_idle_inhibit_manager_v1_interface, 1));
   }
 }
 
@@ -138,6 +142,7 @@ int waybar::Client::main(int argc, char* argv[])
   bars.clear();
   zxdg_output_manager_v1_destroy(xdg_output_manager);
   zwlr_layer_shell_v1_destroy(layer_shell);
+  zwp_idle_inhibit_manager_v1_destroy(idle_inhibit_manager);
   wl_registry_destroy(registry);
   wl_seat_destroy(seat);
   wl_display_disconnect(wl_display);

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -24,6 +24,9 @@ waybar::IModule* waybar::Factory::makeModule(const std::string &name) const
       return new waybar::modules::sway::Window(id, bar_, config_[name]);
     }
     #endif
+    if (ref == "idle_inhibitor") {
+      return new waybar::modules::IdleInhibitor(id, bar_, config_[name]);
+    }
     if (ref == "memory") {
       return new waybar::modules::Memory(id, config_[name]);
     }

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -1,0 +1,48 @@
+#include "modules/idle_inhibitor.hpp"
+
+
+waybar::modules::IdleInhibitor::IdleInhibitor(const std::string& id, const Bar& bar, const Json::Value& config)
+  : ALabel(config, "{status}"), bar_(bar), status_("deactivated"), idle_inhibitor_(nullptr)
+{
+  label_.set_name("idle_inhibitor");
+  if (!id.empty()) {
+    label_.get_style_context()->add_class(id);
+  }
+  event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
+  event_box_.signal_button_press_event().connect(
+      sigc::mem_fun(*this, &IdleInhibitor::onClick));
+  dp.emit();
+}
+
+waybar::modules::IdleInhibitor::~IdleInhibitor()
+{
+  if(idle_inhibitor_) {
+    zwp_idle_inhibitor_v1_destroy(idle_inhibitor_);
+    idle_inhibitor_ = nullptr;
+  }
+}
+
+auto waybar::modules::IdleInhibitor::update() -> void
+{
+  label_.set_markup(
+      fmt::format(format_, fmt::arg("status", status_),
+                  fmt::arg("icon", getIcon(0, status_))));
+  label_.set_tooltip_text(status_);
+}
+
+bool waybar::modules::IdleInhibitor::onClick(GdkEventButton* const& e)
+{
+  if(e->button == 1) {
+    if (idle_inhibitor_) {
+      zwp_idle_inhibitor_v1_destroy(idle_inhibitor_);
+      idle_inhibitor_ = nullptr;
+      status_ = "deactivated";
+    } else {
+      idle_inhibitor_ = zwp_idle_inhibit_manager_v1_create_inhibitor(
+          bar_.client.idle_inhibit_manager, bar_.surface);
+      status_ = "activated";
+    }
+  }
+  dp.emit();
+  return true;
+}

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -27,7 +27,9 @@ auto waybar::modules::IdleInhibitor::update() -> void
   label_.set_markup(
       fmt::format(format_, fmt::arg("status", status_),
                   fmt::arg("icon", getIcon(0, status_))));
-  label_.set_tooltip_text(status_);
+  if(tooltipEnabled()) {
+    label_.set_tooltip_text(status_);
+  }
 }
 
 bool waybar::modules::IdleInhibitor::onClick(GdkEventButton* const& e)


### PR DESCRIPTION
This patch adds a module to simulate user action, so the lockscreen won't be started.

I tested it only with swayidle, but it uses the idle inhibit protocol and should work with others programs.