### PR TITLE
Added clock tooltip with optional alternate format

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -38,7 +38,7 @@
         "spacing": 10
     },
     "clock": {
-        "tooltip-format": "{:%Y-%m-%d | %H:%S}"
+        "tooltip-format": "{:%Y-%m-%d | %H:%S}",
         "format-alt": "{:%Y-%m-%d}"
     },
     "cpu": {

--- a/resources/config
+++ b/resources/config
@@ -38,6 +38,8 @@
         "spacing": 10
     },
     "clock": {
+        "tooltip": true,
+        "tooltip-format": "{:%Y-%m-%d | %H:%S}"
         "format-alt": "{:%Y-%m-%d}"
     },
     "cpu": {

--- a/resources/config
+++ b/resources/config
@@ -38,7 +38,6 @@
         "spacing": 10
     },
     "clock": {
-        "tooltip": true,
         "tooltip-format": "{:%Y-%m-%d | %H:%S}"
         "format-alt": "{:%Y-%m-%d}"
     },

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -109,8 +109,7 @@ std::string waybar::ALabel::getIcon(uint16_t percentage, const std::string& alt)
 
 bool waybar::ALabel::tooltipEnabled()
 {
-  return !config_["tooltip"].isBool() ||
-    (config_["tooltip"].isBool() && config_["tooltip"].asBool());
+  return config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true;
 }
 
 waybar::ALabel::operator Gtk::Widget&() { return event_box_; }

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -21,5 +21,16 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 auto waybar::modules::Clock::update() -> void
 {
   auto localtime = fmt::localtime(std::time(nullptr));
-  label_.set_markup(fmt::format(format_, localtime));
+  auto text = fmt::format(format_, localtime);
+  label_.set_markup(text);
+  
+  if (tooltipEnabled()) {
+    if (config_["tooltip-format"].isString()) {
+      auto tooltip_format = config_["tooltip-format"].asString();
+      auto tooltip_text = fmt::format(tooltip_format, localtime);
+      label_.set_tooltip_text(tooltip_text);
+    } else {
+      label_.set_tooltip_text(text);
+    }
+  }
 }


### PR DESCRIPTION
I wanted the ability to see the current date when I hover my mouse over the clock module.

Adds the following settings:
- clock/tooltip
- clock/tooltip-format (default is same as normal format)
