### PR TITLE
fix(backlight) Allow format-alt

### DIFF
--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -61,5 +61,6 @@ private:
   std::vector<BacklightDev> devices_;
 
   std::optional<BacklightDev> previous_best_;
+  std::string previous_format_;
 };
 } // namespace waybar::modules


### PR DESCRIPTION
The backlight modules does not allow the use of `format-alt` prior to this change.