### PR TITLE
feat(custom): Add field for additional data to json

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -22,6 +22,7 @@ class Custom : public ALabel {
 
     const std::string name_;
     std::string text_;
+    std::string alt_;
     std::string tooltip_;
     std::string class_;
     std::string prevclass_;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -91,6 +91,7 @@ auto waybar::modules::Custom::update() -> void
     }
 
     auto str = fmt::format(format_, text_,
+      fmt::arg("alt", alt_),
       fmt::arg("icon", getIcon(percentage_)),
       fmt::arg("percentage", percentage_));
     label_.set_markup(str);
@@ -144,6 +145,7 @@ void waybar::modules::Custom::parseOutputJson()
   while (getline(output, line)) {
     auto parsed = parser_.parse(line);
     text_ = Glib::Markup::escape_text(parsed["text"].asString());
+    alt_ = Glib::Markup::escape_text(parsed["alt"].asString());
     tooltip_ = parsed["tooltip"].asString();
     class_ = parsed["class"].asString();
     if (!parsed["percentage"].asString().empty() && parsed["percentage"].isUInt()) {


### PR DESCRIPTION
Just a small change that adds an additional string field to the custom module, so `format-alt` can be utilized better.

Maybe this should be touched again when tackeling #100 