### PR TITLE
Fix crash when monitor unplugged

### DIFF
--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -56,11 +56,12 @@ private:
   const std::string preferred_device_;
   static constexpr int EPOLL_MAX_EVENTS = 16;
 
-  waybar::util::SleeperThread udev_thread_;
-  std::mutex udev_thread_mutex_;
-  std::vector<BacklightDev> devices_;
-
   std::optional<BacklightDev> previous_best_;
   std::string previous_format_;
+
+  std::mutex udev_thread_mutex_;
+  std::vector<BacklightDev> devices_;
+  // thread must destruct before shared data
+  waybar::util::SleeperThread udev_thread_;
 };
 } // namespace waybar::modules

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -149,6 +149,9 @@ waybar::modules::Backlight::Backlight(const std::string &name,
       const int event_count =
           epoll_wait(epoll_fd.get(), events, EPOLL_MAX_EVENTS,
                      std::chrono::milliseconds{interval_}.count());
+      if (!udev_thread_.isRunning()) {
+        break;
+      }
       decltype(devices_) devices;
       {
         std::scoped_lock<std::mutex> lock(udev_thread_mutex_);


### PR DESCRIPTION
`Backlight#devices_` was being destructed before
`Backlight#udev_thread_`. Also check if thread is still running after
`epoll_wait`.

Fixes #188. @jonfin, could you test?