### PR TITLE
[bugfix] idle_inhibitor: handle click events correctly

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -28,9 +28,8 @@ protected:
   bool alt_ = false;
   std::string default_format_;
 
-private:
-  bool handleToggle(GdkEventButton *const &ev);
-  bool handleScroll(GdkEventScroll *);
+  virtual bool handleToggle(GdkEventButton *const &ev);
+  virtual bool handleScroll(GdkEventScroll *);
 };
 
 } // namespace waybar

--- a/include/modules/idle_inhibitor.hpp
+++ b/include/modules/idle_inhibitor.hpp
@@ -13,7 +13,7 @@ class IdleInhibitor: public ALabel {
     ~IdleInhibitor();
     auto update() -> void;
   private:
-    bool onClick(GdkEventButton* const& ev);
+    bool handleToggle(GdkEventButton* const& e);
 
     const Bar& bar_;
     std::string status_;


### PR DESCRIPTION
The idle inhibitor module won't work if any click event is specified in the config. Because the click event handler of the idle inhibitor module is not activated. 

- Declare event handler in ALabel virtual so the idle_inhibitor can overriding them
- Handle the left click event in idle_inhibitor and call ALabel handler if needed

It should not conflict with #204.