### PR TITLE
 fix(sway): ipc client crash when compiled with -D_GLIBCXX_ASSERTIONS 

### DIFF
--- a/src/modules/sway/ipc/client.cpp
+++ b/src/modules/sway/ipc/client.cpp
@@ -64,7 +64,7 @@ struct waybar::modules::sway::Ipc::ipc_response
   waybar::modules::sway::Ipc::recv(int fd) const
 {
   std::string header;
-  header.reserve(ipc_header_size_);
+  header.resize(ipc_header_size_);
   auto data32 = reinterpret_cast<uint32_t *>(header.data() + ipc_magic_.size());
   size_t total = 0;
 
@@ -83,7 +83,7 @@ struct waybar::modules::sway::Ipc::ipc_response
 
   total = 0;
   std::string payload;
-  payload.reserve(data32[0] + 1);
+  payload.resize(data32[0]);
   while (total < data32[0]) {
     auto res = ::recv(fd, payload.data() + total, data32[0] - total, 0);
     if (res < 0) {
@@ -91,7 +91,6 @@ struct waybar::modules::sway::Ipc::ipc_response
     }
     total += res;
   }
-  payload[data32[0]] = 0;
   return { data32[0], data32[1], &payload.front() };
 }
 
@@ -100,7 +99,7 @@ struct waybar::modules::sway::Ipc::ipc_response
   const std::string& payload) const
 {
   std::string header;
-  header.reserve(ipc_header_size_);
+  header.resize(ipc_header_size_);
   auto data32 = reinterpret_cast<uint32_t *>(header.data() + ipc_magic_.size());
   memcpy(header.data(), ipc_magic_.c_str(), ipc_magic_.size());
   data32[0] = payload.size();


### PR DESCRIPTION
Waybar from my Fedora package has been crashing with following assertion:
`/usr/include/c++/8/bits/basic_string.h:1067: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](std::__cxx11:      :basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _All      oc>::reference = char&; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]: Assertion '__pos <= size()' failed.`

The crash happens because std::string.reserve() does not change string size, leaving it as 0. And all further modifications of string.data() are actually happening out of range.
-D_GLIBCXX_ASSERTIONS enforces strict out-of-bounds access checks in stl containers and makes the issue visible.
