### PR TITLE
fix(pulseaudio) use case-insensitive comparison for icon lookup

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -187,8 +187,10 @@ const std::string waybar::modules::Pulseaudio::getPortIcon() const
     "hifi",
     "phone",
   };
+  std::string nameLC = port_name_;
+  std::transform(nameLC.begin(), nameLC.end(), nameLC.begin(), ::tolower);
   for (auto const& port : ports) {
-    if (port_name_.find(port) != std::string::npos) {
+    if (nameLC.find(port) != std::string::npos) {
       return port;
     }
   }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -1,4 +1,5 @@
 #include "modules/pulseaudio.hpp"
+#include <array>
 
 waybar::modules::Pulseaudio::Pulseaudio(const std::string& id, const Json::Value &config)
     : ALabel(config, "{volume}%"),
@@ -174,19 +175,20 @@ void waybar::modules::Pulseaudio::serverInfoCb(pa_context *context,
     sinkInfoCb, data);
 }
 
+static const std::array<std::string, 9> ports = {
+  "headphones",
+  "speaker",
+  "hdmi",
+  "headset",
+  "handsfree",
+  "portable",
+  "car",
+  "hifi",
+  "phone",
+};
+
 const std::string waybar::modules::Pulseaudio::getPortIcon() const
 {
-  std::vector<std::string> ports = {
-    "headphones",
-    "speaker",
-    "hdmi",
-    "headset",
-    "handsfree",
-    "portable",
-    "car",
-    "hifi",
-    "phone",
-  };
   std::string nameLC = port_name_;
   std::transform(nameLC.begin(), nameLC.end(), nameLC.begin(), ::tolower);
   for (auto const& port : ports) {


### PR DESCRIPTION
Pulseaudio ports names in my setup are starting with capital letter:
```
% pacmd list-sinks |grep '\[Out\]'
                [Out] Speaker: Speaker playback (priority 100, latency offset 0 usec, available: no)
                [Out] Headphones: Headphones playback (priority 100, latency offset 0 usec, available: yes)
        active port: <[Out] Headphones>
```
Because of that waybar::modules::Pulseaudio::getPortIcon() fails to select "headphones" icon for "Headphones" port and returns "phone" as the only matching icon.

The second commit is a small optimization: it saves a few CPU cycles per call on allocation of vector and all these strings.