### PR TITLE
Add pkill signals to custom modules

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -22,6 +22,7 @@ class Bar {
     ~Bar() = default;
 
     auto toggle() -> void;
+    void handleSignal(int);
 
     const Client& client;
     Gtk::Window window;

--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 #include <iostream>
+#include <csignal>
 #include "util/sleeper_thread.hpp"
 #include "util/command.hpp"
 #include "util/json.hpp"
@@ -14,6 +15,7 @@ class Custom : public ALabel {
     Custom(const std::string&, const Json::Value&);
     ~Custom();
     auto update() -> void;
+    void refresh(int /*signal*/);
   private:
     void delayWorker();
     void continuousWorker();

--- a/include/util/sleeper_thread.hpp
+++ b/include/util/sleeper_thread.hpp
@@ -21,7 +21,10 @@ public:
   SleeperThread& operator=(std::function<void()> func)
   {
     thread_ = std::thread([this, func] {
-      while (do_run_) func();
+      while (do_run_) {
+        signal_ = false;
+        func();
+      }
     });
     return *this;
   }
@@ -34,18 +37,19 @@ public:
   auto sleep_for(std::chrono::system_clock::duration dur)
   {
     std::unique_lock lk(mutex_);
-    return condvar_.wait_for(lk, dur, [this] { return !do_run_; });
+    return condvar_.wait_for(lk, dur, [this] { return signal_ || !do_run_; });
   }
 
   auto sleep_until(std::chrono::time_point<std::chrono::system_clock,
     std::chrono::system_clock::duration> time_point)
   {
     std::unique_lock lk(mutex_);
-    return condvar_.wait_until(lk, time_point, [this] { return !do_run_; });
+    return condvar_.wait_until(lk, time_point, [this] { return signal_ || !do_run_; });
   }
 
   auto wake_up()
   {
+    signal_ = true;
     condvar_.notify_all();
   }
 
@@ -53,6 +57,7 @@ public:
   {
     {
       std::lock_guard<std::mutex> lck(mutex_);
+      signal_ = true;
       do_run_ = false;
     }
     condvar_.notify_all();
@@ -71,6 +76,7 @@ private:
   std::condition_variable condvar_;
   std::mutex mutex_;
   bool do_run_ = true;
+  bool signal_ = false;
 };
 
 }

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -6,8 +6,9 @@
 waybar::ALabel::ALabel(const Json::Value& config, const std::string format, uint16_t interval)
   : config_(config),
     format_(config_["format"].isString() ? config_["format"].asString() : format),
-    interval_(std::chrono::seconds(config_["interval"].isUInt()
-      ? config_["interval"].asUInt() : interval)), default_format_(format_)
+    interval_(config_["interval"] == "once" ? std::chrono::seconds(100000000) :
+      std::chrono::seconds(config_["interval"].isUInt() ?
+      config_["interval"].asUInt() : interval)), default_format_(format_)
 {
   event_box_.add(label_);
 	if (config_["max-length"].isUInt()) {

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -185,6 +185,22 @@ void waybar::Bar::handleDescription(void* /*data*/,
   // Nothing here
 }
 
+void waybar::Bar::handleSignal(int signal)
+{
+  for (auto& module : modules_left_) {
+    auto* custom = dynamic_cast<waybar::modules::Custom*>(module.get());
+    if(custom) custom->refresh(signal);
+  }
+  for (auto& module : modules_center_) {
+    auto* custom = dynamic_cast<waybar::modules::Custom*>(module.get());
+    if(custom) custom->refresh(signal);
+  }
+  for (auto& module : modules_right_) {
+    auto* custom = dynamic_cast<waybar::modules::Custom*>(module.get());
+    if(custom) custom->refresh(signal);
+  }
+}
+
 void waybar::Bar::layerSurfaceHandleConfigure(void* data,
   struct zwlr_layer_surface_v1* surface, uint32_t serial, uint32_t width,
   uint32_t height)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,6 +19,14 @@ int main(int argc, char* argv[])
       }
     });
 
+    for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
+      std::signal(sig, [] (int sig/*signal*/) {
+        for (auto& bar : waybar::client->bars) {
+          bar->handleSignal(sig);
+        }
+      });
+    }
+
     return c.main(argc, argv);
   } catch (const std::exception& e) {
     std::cerr << e.what() << std::endl;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -78,6 +78,13 @@ void waybar::modules::Custom::continuousWorker()
   };
 }
 
+void waybar::modules::Custom::refresh(int sig /*signal*/)
+{
+  if(sig == SIGRTMIN + config_["signal"].asInt()) {
+    thread_.wake_up();
+  }
+}
+
 auto waybar::modules::Custom::update() -> void
 {
   // Hide label if output is empty


### PR DESCRIPTION
This implements pkill signals for custom modules (see #170). You can define it with `"signal"` in the config and test it with `pkill -RTMIN+8 waybar` (for example signal 8). 
In addition there is now also the setting `"interval": "once"`, to load the module only once at startup.

edit: I already updated the [wiki](https://github.com/Alexays/Waybar/wiki/Module:-Custom) for this PR. I didn't know they were directly live. If you need time for the review, I can reverse it. Just let me know.