### PR TITLE
[custom] Allow icon selection based on json alt attribute

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -98,7 +98,7 @@ auto waybar::modules::Custom::update() -> void
 
     auto str = fmt::format(format_, text_,
       fmt::arg("alt", alt_),
-      fmt::arg("icon", getIcon(percentage_)),
+      fmt::arg("icon", getIcon(percentage_, alt_)),
       fmt::arg("percentage", percentage_));
     label_.set_markup(str);
     if (tooltipEnabled()) {


### PR DESCRIPTION
 Because getIcon() has logic to test if format-icon is an array or a dictionary, it is possible to also pass alt_ to this function.