### PR TITLE
Process tray icon updates

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -50,6 +50,10 @@ public:
 private:
   void proxyReady(Glib::RefPtr<Gio::AsyncResult>& result);
   void setProperty(const Glib::ustring& name, Glib::VariantBase& value);
+  void getUpdatedProperties();
+  void processUpdatedProperties(Glib::RefPtr<Gio::AsyncResult>& result);
+  void onSignal(const Glib::ustring& sender_name, const Glib::ustring& signal_name,
+      const Glib::VariantContainerBase& arguments);
 
   void updateImage();
   Glib::RefPtr<Gdk::Pixbuf> extractPixBuf(GVariant *variant);
@@ -60,6 +64,7 @@ private:
 
   Glib::RefPtr<Gio::Cancellable> cancellable_;
   Glib::RefPtr<Gio::DBus::Proxy> proxy_;
+  bool update_pending_;
 };
 
 } // namespace waybar::modules::SNI

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -2,12 +2,14 @@
 
 #include <dbus-status-notifier-item.h>
 #include <glibmm/refptr.h>
+#include <giomm/dbusproxy.h>
 #include <gtkmm/eventbox.h>
 #include <gtkmm/image.h>
 #include <gtkmm/icontheme.h>
 #include <gtkmm/menu.h>
 #include <json/json.h>
 #include <libdbusmenu-gtk/dbusmenu-gtk.h>
+#include <sigc++/trackable.h>
 #ifdef FILESYSTEM_EXPERIMENTAL
 #include <experimental/filesystem>
 #else
@@ -16,7 +18,7 @@
 
 namespace waybar::modules::SNI {
 
-class Item {
+class Item : public sigc::trackable {
 public:
   Item(std::string, std::string, const Json::Value&);
   ~Item() = default;
@@ -46,8 +48,8 @@ public:
   bool item_is_menu;
 
 private:
-  static void proxyReady(GObject *obj, GAsyncResult *res, gpointer data);
-  static void getAll(GObject *obj, GAsyncResult *res, gpointer data);
+  void proxyReady(Glib::RefPtr<Gio::AsyncResult>& result);
+  void setProperty(const Glib::ustring& name, Glib::VariantBase& value);
 
   void updateImage();
   Glib::RefPtr<Gdk::Pixbuf> extractPixBuf(GVariant *variant);
@@ -56,8 +58,8 @@ private:
   bool makeMenu(GdkEventButton *const &ev);
   bool handleClick(GdkEventButton *const & /*ev*/);
 
-  GCancellable *cancellable_ = nullptr;
-  SnItem *proxy_ = nullptr;
+  Glib::RefPtr<Gio::Cancellable> cancellable_;
+  Glib::RefPtr<Gio::DBus::Proxy> proxy_;
 };
 
 } // namespace waybar::modules::SNI

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -115,6 +115,11 @@ void waybar::modules::SNI::Item::getAll(GObject *obj, GAsyncResult *res,
   // TODO: handle change
 }
 
+static void
+pixbuf_data_deleter(const guint8* data) {
+  g_free((void*) data);
+}
+
 Glib::RefPtr<Gdk::Pixbuf>
 waybar::modules::SNI::Item::extractPixBuf(GVariant *variant) {
   GVariantIter *it;
@@ -158,7 +163,8 @@ waybar::modules::SNI::Item::extractPixBuf(GVariant *variant) {
       array[i + 3] = alpha;
     }
     return Gdk::Pixbuf::create_from_data(array, Gdk::Colorspace::COLORSPACE_RGB,
-                                         true, 8, lwidth, lheight, 4 * lwidth);
+                                         true, 8, lwidth, lheight, 4 * lwidth,
+                                         &pixbuf_data_deleter);
   }
   return Glib::RefPtr<Gdk::Pixbuf>{};
 }


### PR DESCRIPTION
A functional but not quite finished implementation of update signals subscription for SNI::Item. Also changes most of dbus code in the class to use giomm wrappers because raw gdbus API is a pain to use.

I'm still not happy with the way updateImage could be invoked multiple times for each NewIcon signal. Ideally there should be some kind of batch update, and I'm considering if it's better to call GetAll and emulate PropertiesChanged signal. Going to give it a try on the weekend.