### PR TITLE
Add MPD support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,6 @@
 ---
 BasedOnStyle: Google
-ColumnLimit: '100'
-
+AlignConsecutiveDeclarations: true
+BinPackArguments: false
+ColumnLimit: 100
 ...

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig configuration for Waybar
+# http://EditorConfig.org
+
+# Top-most EditorConfig file
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{build,css}]
+indent_style = space
+indent_size = 4
+
+[*.{hpp,cpp}]
+indent_style = space
+indent_size = 2

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 - Memory
 - Cpu load average
 - Temperature
+- MPD
 - Custom scripts
 - Multiple output configuration
 - And much more customizations
@@ -49,6 +50,7 @@ libpulse [Pulseaudio module]
 libnl [Network module]
 sway [Sway modules]
 libdbusmenu-gtk3 [Tray module]
+libmpdclient [MPD module]
 ```
 
 Contributions welcome! - have fun :)<br>

--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -23,6 +23,9 @@
 #ifdef HAVE_LIBPULSE
 #include "modules/pulseaudio.hpp"
 #endif
+#ifdef HAVE_LIBMPDCLIENT
+#include "modules/mpd.hpp"
+#endif
 #include "modules/temperature.hpp"
 #include "modules/custom.hpp"
 

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -27,7 +27,8 @@ class MPD : public ALabel {
 
     // Not using unique_ptr since we don't manage the pointer
     // (It's either nullptr, or from the config)
-    const char* server;
+    const char* server_;
+    unsigned port_;
 
     unique_connection connection_;
     unique_status     status_;

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -15,6 +15,7 @@ class MPD : public ALabel {
     std::thread worker();
     void setLabel();
     std::string getStateIcon();
+    std::string getOptionIcon(std::string optionName, bool activated);
 
     void tryConnect();
     void checkErrors();
@@ -26,7 +27,7 @@ class MPD : public ALabel {
 
     using unique_connection = std::unique_ptr<mpd_connection, decltype(&mpd_connection_free)>;
     using unique_status     = std::unique_ptr<mpd_status, decltype(&mpd_status_free)>;
-    using unique_song      = std::unique_ptr<mpd_song, decltype(&mpd_song_free)>;
+    using unique_song       = std::unique_ptr<mpd_song, decltype(&mpd_song_free)>;
 
     // Not using unique_ptr since we don't manage the pointer
     // (It's either nullptr, or from the config)

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -14,8 +14,11 @@ class MPD : public ALabel {
   private:
     std::thread worker();
     void setLabel();
+    std::string getStateIcon();
+
     void tryConnect();
     void checkErrors();
+
     void fetchState();
     void waitForEvent();
 
@@ -28,10 +31,11 @@ class MPD : public ALabel {
     // Not using unique_ptr since we don't manage the pointer
     // (It's either nullptr, or from the config)
     const char* server_;
-    unsigned port_;
+    const unsigned port_;
 
     unique_connection connection_;
     unique_status     status_;
+    mpd_state         state_;
     unique_song       song_;
 
     bool stopped_;

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -23,6 +23,8 @@ class MPD : public ALabel {
     void fetchState();
     void waitForEvent();
 
+    bool handlePlayPause(GdkEventButton* const&);
+
     std::thread worker_;
 
     using unique_connection = std::unique_ptr<mpd_connection, decltype(&mpd_connection_free)>;
@@ -35,6 +37,9 @@ class MPD : public ALabel {
     const unsigned port_;
 
     unique_connection connection_;
+    // Use two connections because the main one will be blocking most of the time.
+    // Used to send play/pause events and poll elapsed time.
+    unique_connection alternate_connection_;
     unique_status     status_;
     mpd_state         state_;
     unique_song       song_;

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <thread>
+#include <fmt/format.h>
+#include <mpd/client.h>
+#include "ALabel.hpp"
+
+namespace waybar::modules {
+
+class MPD : public ALabel {
+  public:
+    MPD(const std::string&, const Json::Value&);
+    auto update() -> void;
+  private:
+    std::thread worker();
+    void setLabel();
+    void tryConnect();
+    void checkErrors();
+    void fetchState();
+    void waitForEvent();
+
+    std::thread worker_;
+
+    using unique_connection = std::unique_ptr<mpd_connection, decltype(&mpd_connection_free)>;
+    using unique_status     = std::unique_ptr<mpd_status, decltype(&mpd_status_free)>;
+    using unique_song      = std::unique_ptr<mpd_song, decltype(&mpd_song_free)>;
+
+    // Not using unique_ptr since we don't manage the pointer
+    // (It's either nullptr, or from the config)
+    const char* server;
+
+    unique_connection connection_;
+    unique_status     status_;
+    unique_song       song_;
+
+    bool stopped_;
+};
+
+}  // namespace waybar::modules

--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -36,6 +36,8 @@ class MPD : public ALabel {
   bool stopped();
   bool playing();
 
+  const std::string module_name_;
+
   using unique_connection = std::unique_ptr<mpd_connection, decltype(&mpd_connection_free)>;
   using unique_status = std::unique_ptr<mpd_status, decltype(&mpd_status_free)>;
   using unique_song = std::unique_ptr<mpd_song, decltype(&mpd_song_free)>;

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,7 @@ libnl = dependency('libnl-3.0', required: get_option('libnl'))
 libnlgen = dependency('libnl-genl-3.0', required: get_option('libnl'))
 libpulse = dependency('libpulse', required: get_option('pulseaudio'))
 libudev = dependency('libudev', required: get_option('libudev'))
+libmpdclient = dependency('libmpdclient', required: get_option('mpd'))
 
 src_files = files(
     'src/factory.cpp',
@@ -107,6 +108,11 @@ if libudev.found()
     src_files += 'src/modules/backlight.cpp'
 endif
 
+if libmpdclient.found()
+    add_project_arguments('-DHAVE_LIBMPDCLIENT', language: 'cpp')
+    src_files += 'src/modules/mpd.cpp'
+endif
+
 subdir('protocol')
 
 executable(
@@ -128,7 +134,8 @@ executable(
         libnl,
         libnlgen,
         libpulse,
-        libudev
+        libudev,
+        libmpdclient
     ],
     include_directories: [include_directories('include')],
     install: true,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,4 +2,5 @@ option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl suppo
 option('libudev', type: 'feature', value: 'auto', description: 'Enable libudev support for udev related features')
 option('pulseaudio', type: 'feature', value: 'auto', description: 'Enable support for pulseaudio')
 option('dbusmenu-gtk', type: 'feature', value: 'auto', description: 'Enable support for tray')
+option('mpd', type: 'feature', value: 'auto', description: 'Enable support for the Music Player Daemon')
 option('out', type: 'string', value : '/', description: 'output prefix directory')

--- a/resources/config
+++ b/resources/config
@@ -6,7 +6,7 @@
     // Choose the order of the modules
     "modules-left": ["sway/workspaces", "sway/mode", "custom/media"],
     "modules-center": ["sway/window"],
-    "modules-right": ["idle_inhibitor", "pulseaudio", "network", "cpu", "memory", "temperature", "backlight", "battery", "battery#bat2", "clock", "tray"],
+    "modules-right": ["mpd", "idle_inhibitor", "pulseaudio", "network", "cpu", "memory", "temperature", "backlight", "battery", "battery#bat2", "clock", "tray"],
     // Modules configuration
     // "sway/workspaces": {
     //     "disable-scroll": true,
@@ -26,6 +26,31 @@
     "sway/mode": {
         "format": "<span style=\"italic\">{}</span>"
     },
+    "mpd": {
+        "format": "{stateIcon} {consumeIcon}{randomIcon}{repeatIcon}{singleIcon}{artist} - {album} - {title} ({elapsedTime:%M:%S}/{totalTime:%M:%S}) ",
+        "format-disconnected": "Disconnected ",
+        "format-stopped": "{consumeIcon}{randomIcon}{repeatIcon}{singleIcon}Stopped ",
+        "interval": 2,
+        "consume-icons": {
+            "on": " "
+        },
+        "random-icons": {
+            "off": "<span color=\"#f53c3c\"></span> ",
+            "on": " "
+        },
+        "repeat-icons": {
+            "on": " "
+        },
+        "single-icons": {
+            "on": "1 "
+        },
+        "state-icons": {
+            "paused": "",
+            "playing": ""
+        },
+        "tooltip-format": "MPD (connected)",
+        "tooltip-format-disconnected": "MPD (disconnected)"
+    }
     "idle_inhibitor": {
         "format": "{icon}",
         "format-icons": {

--- a/resources/style.css
+++ b/resources/style.css
@@ -140,7 +140,7 @@ window#waybar.hidded {
 }
 
 #mpd {
-    background-color: #ba2880;
+    background: #ba2880;
 }
 
 #mpd.disconnected {
@@ -150,4 +150,8 @@ window#waybar.hidded {
 #mpd.stopped {
     background: #90b1b1;
     color: #2a5c45;
+}
+
+#mpd.paused {
+    background: #ce68a6;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -140,7 +140,8 @@ window#waybar.hidded {
 }
 
 #mpd {
-    background: #ba2880;
+    background: #66cc99;
+    color: #2a5c45;
 }
 
 #mpd.disconnected {
@@ -149,9 +150,8 @@ window#waybar.hidded {
 
 #mpd.stopped {
     background: #90b1b1;
-    color: #2a5c45;
 }
 
 #mpd.paused {
-    background: #ce68a6;
+    background: #51a37a;
 }

--- a/resources/style.css
+++ b/resources/style.css
@@ -138,3 +138,16 @@ window#waybar.hidded {
     background-color: #ecf0f1;
     color: #2d3436;
 }
+
+#mpd {
+    background-color: #ba2880;
+}
+
+#mpd.disconnected {
+    background: #f53c3c;
+}
+
+#mpd.stopped {
+    background: #90b1b1;
+    color: #2a5c45;
+}

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -56,6 +56,11 @@ waybar::IModule* waybar::Factory::makeModule(const std::string &name) const
       return new waybar::modules::Pulseaudio(id, config_[name]);
     }
     #endif
+    #ifdef HAVE_LIBMPDCLIENT
+    if (ref == "mpd") {
+      return new waybar::modules::MPD(id, config_[name]);
+    }
+    #endif
     if (ref == "temperature") {
       return new waybar::modules::Temperature(id, config_[name]);
     }

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -59,6 +59,14 @@ void waybar::modules::MPD::setLabel() {
     auto format = config_["format-disconnected"].isString() ?
       config_["format-disconnected"].asString() : "disconnected";
     label_.set_markup(format);
+
+    if (tooltipEnabled()) {
+      std::string tooltip_format;
+      tooltip_format = config_["tooltip-format-disconnected"].isString() ?
+        config_["tooltip-format-disconnected"].asString() : "MPD (disconnected)";
+      // Nothing to format
+      label_.set_tooltip_text(tooltip_format);
+    }
     return;
   } else {
     label_.get_style_context()->remove_class("disconnected");
@@ -92,7 +100,7 @@ void waybar::modules::MPD::setLabel() {
   if (tooltipEnabled()) {
     std::string tooltip_format;
     tooltip_format = config_["tooltip-format"].isString() ?
-      config_["tooltip-format"].asString() : "MPD";
+      config_["tooltip-format"].asString() : "MPD (connected)";
     auto tooltip_text = fmt::format(tooltip_format,
         fmt::arg("artist", artist),
         fmt::arg("album-artist", album_artist),

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -104,8 +104,17 @@ void waybar::modules::MPD::setLabel() {
     format =
         config_["format-stopped"].isString() ? config_["format-stopped"].asString() : "stopped";
     label_.get_style_context()->add_class("stopped");
+    label_.get_style_context()->remove_class("playing");
+    label_.get_style_context()->remove_class("paused");
   } else {
     label_.get_style_context()->remove_class("stopped");
+    if (playing()) {
+      label_.get_style_context()->add_class("playing");
+      label_.get_style_context()->remove_class("paused");
+    } else {
+      label_.get_style_context()->add_class("paused");
+      label_.get_style_context()->remove_class("playing");
+    }
 
     stateIcon = getStateIcon();
 

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -38,7 +38,8 @@ auto waybar::modules::MPD::update() -> void {
       if (!wasPlaying && playing()) {
         periodic_updater().detach();
       }
-    } catch (std::exception e) {
+    } catch (const std::exception& e) {
+      std::cerr << module_name_ + ": " + e.what() << std::endl;
       state_ = MPD_STATE_UNKNOWN;
     }
   }
@@ -51,7 +52,11 @@ std::thread waybar::modules::MPD::event_listener() {
     while (true) {
       if (connection_ == nullptr) {
         // Retry periodically if no connection
-        update();
+        try {
+          update();
+        } catch (const std::exception& e) {
+          std::cerr << module_name_ + ": " + e.what() << std::endl;
+        }
         std::this_thread::sleep_for(interval_);
       } else {
         waitForEvent();

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -1,0 +1,164 @@
+#include "modules/mpd.hpp"
+
+#include <iostream>
+
+waybar::modules::MPD::MPD(const std::string& id, const Json::Value &config)
+    : ALabel(config, "{album} - {artist} - {title}", 2),
+      server(nullptr),
+      connection_(nullptr, &mpd_connection_free),
+      status_(nullptr, &mpd_status_free),
+      song_(nullptr, &mpd_song_free) {
+  label_.set_name("mpd");
+  if (!id.empty()) {
+    label_.get_style_context()->add_class(id);
+  }
+
+  if (!config["server"].isNull()) {
+    server = config["server"].asCString();
+  }
+
+  worker_ = worker();
+}
+
+auto waybar::modules::MPD::update() -> void {
+  tryConnect();
+
+  if (connection_ != nullptr) {
+    try {
+      fetchState();
+    } catch (std::exception e) {
+      stopped_ = true;
+    }
+  }
+
+  setLabel();
+}
+
+std::thread waybar::modules::MPD::worker() {
+  return std::thread([this] () {
+      while (true) {
+        if (connection_ == nullptr) {
+          // Retry periodically if no connection
+          update();
+          std::this_thread::sleep_for(std::chrono::seconds(2));
+        } else {
+          // Else, update on any event
+          waitForEvent();
+          update();
+        }
+      }
+  });
+}
+
+void waybar::modules::MPD::setLabel() {
+  if (connection_ == nullptr) {
+    label_.get_style_context()->add_class("disconnected");
+    // In the case connection closed while MPD is stopped
+    label_.get_style_context()->remove_class("stopped");
+
+    auto format = config_["format-disconnected"].isString() ?
+      config_["format-disconnected"].asString() : "disconnected";
+    label_.set_markup(format);
+    return;
+  } else {
+    label_.get_style_context()->remove_class("disconnected");
+  }
+
+  auto format = format_;
+
+  std::string artist, album_artist, album, title, date;
+
+  if (stopped_) {
+    format = config_["format-stopped"].isString() ?
+      config_["format-stopped"].asString() : "stopped";
+    label_.get_style_context()->add_class("stopped");
+  } else {
+    label_.get_style_context()->remove_class("stopped");
+
+    artist       = mpd_song_get_tag(song_.get(), MPD_TAG_ARTIST, 0);
+    album_artist = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM_ARTIST, 0);
+    album        = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM, 0);
+    title        = mpd_song_get_tag(song_.get(), MPD_TAG_TITLE, 0);
+    date         = mpd_song_get_tag(song_.get(), MPD_TAG_DATE, 0);
+  }
+
+  label_.set_markup(fmt::format(format,
+        fmt::arg("artist", artist),
+        fmt::arg("album-artist", album_artist),
+        fmt::arg("album", album),
+        fmt::arg("title", title),
+        fmt::arg("date", date)));
+
+  if (tooltipEnabled()) {
+    std::string tooltip_format;
+    tooltip_format = config_["tooltip-format"].isString() ?
+      config_["tooltip-format"].asString() : "MPD";
+    auto tooltip_text = fmt::format(tooltip_format,
+        fmt::arg("artist", artist),
+        fmt::arg("album-artist", album_artist),
+        fmt::arg("album", album),
+        fmt::arg("title", title),
+        fmt::arg("date", date));
+    label_.set_tooltip_text(tooltip_text);
+  }
+}
+
+void waybar::modules::MPD::tryConnect() {
+  if (connection_ != nullptr) {
+    return;
+  }
+
+  connection_ = unique_connection(
+      mpd_connection_new(server, config_["port"].asUInt(), 5'000),
+      &mpd_connection_free);
+
+  if (connection_ == nullptr) {
+    std::cerr << "Failed to connect to MPD" << std::endl;
+    return;
+  }
+
+  try {
+    checkErrors();
+  } catch (std::runtime_error e) {
+    std::cerr << "Failed to connect to MPD: " << e.what() << std::endl;
+    connection_.reset();
+  }
+
+}
+
+void waybar::modules::MPD::checkErrors() {
+  auto conn = connection_.get();
+
+  switch (mpd_connection_get_error(conn)) {
+    case MPD_ERROR_SUCCESS:
+      return;
+    case MPD_ERROR_CLOSED:
+      std::cerr << "Connection to MPD closed" << std::endl;
+      mpd_connection_clear_error(conn);
+      connection_.reset();
+      return;
+    default:
+      auto error_message = mpd_connection_get_error_message(conn);
+      mpd_connection_clear_error(conn);
+      throw std::runtime_error(std::string(error_message));
+  }
+}
+
+void waybar::modules::MPD::fetchState() {
+    status_ = unique_status(mpd_run_status(connection_.get()), &mpd_status_free);
+    checkErrors();
+    mpd_state state = mpd_status_get_state(status_.get());
+    checkErrors();
+    stopped_ = state == MPD_STATE_UNKNOWN || state == MPD_STATE_STOP;
+
+    mpd_send_current_song(connection_.get());
+    song_ = unique_song(mpd_recv_song(connection_.get()), &mpd_song_free);
+    mpd_response_finish(connection_.get());
+    checkErrors();
+}
+
+void waybar::modules::MPD::waitForEvent() {
+  auto conn = connection_.get();
+  mpd_run_idle_mask(conn, MPD_IDLE_PLAYER /* | MPD_IDLE_OPTIONS */);
+  checkErrors();
+}

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -5,6 +5,7 @@
 
 waybar::modules::MPD::MPD(const std::string& id, const Json::Value& config)
     : ALabel(config, "{album} - {artist} - {title}", 5),
+      module_name_(id.empty() ? "mpd" : "mpd#" + id),
       server_(nullptr),
       port_(config["port"].asUInt()),
       connection_(nullptr, &mpd_connection_free),
@@ -166,12 +167,12 @@ std::string waybar::modules::MPD::getStateIcon() {
   }
 
   if (connection_ == nullptr) {
-    std::cerr << "MPD: Trying to fetch state icon while disconnected" << std::endl;
+    std::cerr << module_name_ << ": Trying to fetch state icon while disconnected" << std::endl;
     return "";
   }
 
   if (stopped()) {
-    std::cerr << "MPD: Trying to fetch state icon while stopped" << std::endl;
+    std::cerr << module_name_ << ": Trying to fetch state icon while stopped" << std::endl;
     return "";
   }
 
@@ -188,7 +189,7 @@ std::string waybar::modules::MPD::getOptionIcon(std::string optionName, bool act
   }
 
   if (connection_ == nullptr) {
-    std::cerr << "MPD: Trying to fetch option icon while disconnected" << std::endl;
+    std::cerr << module_name_ << ": Trying to fetch option icon while disconnected" << std::endl;
     return "";
   }
 
@@ -210,7 +211,7 @@ void waybar::modules::MPD::tryConnect() {
       unique_connection(mpd_connection_new(server_, port_, 5'000), &mpd_connection_free);
 
   if (connection_ == nullptr || alternate_connection_ == nullptr) {
-    std::cerr << "Failed to connect to MPD" << std::endl;
+    std::cerr << module_name_ << ": Failed to connect to MPD" << std::endl;
     connection_.reset();
     alternate_connection_.reset();
     return;
@@ -219,7 +220,7 @@ void waybar::modules::MPD::tryConnect() {
   try {
     checkErrors(connection_.get());
   } catch (std::runtime_error e) {
-    std::cerr << "Failed to connect to MPD: " << e.what() << std::endl;
+    std::cerr << module_name_ << ": Failed to connect to MPD: " << e.what() << std::endl;
     connection_.reset();
     alternate_connection_.reset();
   }
@@ -230,7 +231,7 @@ void waybar::modules::MPD::checkErrors(mpd_connection* conn) {
     case MPD_ERROR_SUCCESS:
       return;
     case MPD_ERROR_CLOSED:
-      std::cerr << "Connection to MPD closed" << std::endl;
+      std::cerr << module_name_ << ": Connection to MPD closed" << std::endl;
       mpd_connection_clear_error(conn);
       connection_.reset();
       alternate_connection_.reset();

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -234,6 +234,7 @@ void waybar::modules::MPD::checkErrors(mpd_connection* conn) {
       mpd_connection_clear_error(conn);
       connection_.reset();
       alternate_connection_.reset();
+      state_ = MPD_STATE_UNKNOWN;
       return;
     default:
       auto error_message = mpd_connection_get_error_message(conn);

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -1,10 +1,9 @@
 #include "modules/mpd.hpp"
 
 #include <fmt/chrono.h>
-
 #include <iostream>
 
-waybar::modules::MPD::MPD(const std::string& id, const Json::Value &config)
+waybar::modules::MPD::MPD(const std::string& id, const Json::Value& config)
     : ALabel(config, "{album} - {artist} - {title}", 5),
       server_(nullptr),
       port_(config["port"].asUInt()),
@@ -24,8 +23,7 @@ waybar::modules::MPD::MPD(const std::string& id, const Json::Value &config)
   event_listener().detach();
 
   event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
-  event_box_.signal_button_press_event().connect(
-      sigc::mem_fun(*this, &MPD::handlePlayPause));
+  event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &MPD::handlePlayPause));
 }
 
 auto waybar::modules::MPD::update() -> void {
@@ -77,14 +75,16 @@ void waybar::modules::MPD::setLabel() {
     // In the case connection closed while MPD is stopped
     label_.get_style_context()->remove_class("stopped");
 
-    auto format = config_["format-disconnected"].isString() ?
-      config_["format-disconnected"].asString() : "disconnected";
+    auto format = config_["format-disconnected"].isString()
+                      ? config_["format-disconnected"].asString()
+                      : "disconnected";
     label_.set_markup(format);
 
     if (tooltipEnabled()) {
       std::string tooltip_format;
-      tooltip_format = config_["tooltip-format-disconnected"].isString() ?
-        config_["tooltip-format-disconnected"].asString() : "MPD (disconnected)";
+      tooltip_format = config_["tooltip-format-disconnected"].isString()
+                           ? config_["tooltip-format-disconnected"].asString()
+                           : "MPD (disconnected)";
       // Nothing to format
       label_.set_tooltip_text(tooltip_format);
     }
@@ -95,67 +95,67 @@ void waybar::modules::MPD::setLabel() {
 
   auto format = format_;
 
-  std::string artist, album_artist, album, title, date;
+  std::string          artist, album_artist, album, title, date;
   std::chrono::seconds elapsedTime, totalTime;
 
   std::string stateIcon = "";
   if (stopped()) {
-    format = config_["format-stopped"].isString() ?
-      config_["format-stopped"].asString() : "stopped";
+    format =
+        config_["format-stopped"].isString() ? config_["format-stopped"].asString() : "stopped";
     label_.get_style_context()->add_class("stopped");
   } else {
     label_.get_style_context()->remove_class("stopped");
 
     stateIcon = getStateIcon();
 
-    artist       = mpd_song_get_tag(song_.get(), MPD_TAG_ARTIST, 0);
+    artist = mpd_song_get_tag(song_.get(), MPD_TAG_ARTIST, 0);
     album_artist = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM_ARTIST, 0);
-    album        = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM, 0);
-    title        = mpd_song_get_tag(song_.get(), MPD_TAG_TITLE, 0);
-    date         = mpd_song_get_tag(song_.get(), MPD_TAG_DATE, 0);
-    elapsedTime  = std::chrono::seconds(mpd_status_get_elapsed_time(status_.get()));
-    totalTime    = std::chrono::seconds(mpd_status_get_total_time(status_.get()));
+    album = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM, 0);
+    title = mpd_song_get_tag(song_.get(), MPD_TAG_TITLE, 0);
+    date = mpd_song_get_tag(song_.get(), MPD_TAG_DATE, 0);
+    elapsedTime = std::chrono::seconds(mpd_status_get_elapsed_time(status_.get()));
+    totalTime = std::chrono::seconds(mpd_status_get_total_time(status_.get()));
   }
 
-  bool consumeActivated = mpd_status_get_consume(status_.get());
+  bool        consumeActivated = mpd_status_get_consume(status_.get());
   std::string consumeIcon = getOptionIcon("consume", consumeActivated);
-  bool randomActivated = mpd_status_get_random(status_.get());
+  bool        randomActivated = mpd_status_get_random(status_.get());
   std::string randomIcon = getOptionIcon("random", randomActivated);
-  bool repeatActivated = mpd_status_get_repeat(status_.get());
+  bool        repeatActivated = mpd_status_get_repeat(status_.get());
   std::string repeatIcon = getOptionIcon("repeat", repeatActivated);
-  bool singleActivated = mpd_status_get_single(status_.get());
+  bool        singleActivated = mpd_status_get_single(status_.get());
   std::string singleIcon = getOptionIcon("single", singleActivated);
 
   // TODO: format can fail
   label_.set_markup(fmt::format(format,
-        fmt::arg("artist", artist),
-        fmt::arg("albumArtist", album_artist),
-        fmt::arg("album", album),
-        fmt::arg("title", title),
-        fmt::arg("date", date),
-        fmt::arg("elapsedTime", elapsedTime),
-        fmt::arg("totalTime", totalTime),
-        fmt::arg("stateIcon", stateIcon),
-        fmt::arg("consumeIcon", consumeIcon),
-        fmt::arg("randomIcon", randomIcon),
-        fmt::arg("repeatIcon", repeatIcon),
-        fmt::arg("singleIcon", singleIcon)));
+                                fmt::arg("artist", artist),
+                                fmt::arg("albumArtist", album_artist),
+                                fmt::arg("album", album),
+                                fmt::arg("title", title),
+                                fmt::arg("date", date),
+                                fmt::arg("elapsedTime", elapsedTime),
+                                fmt::arg("totalTime", totalTime),
+                                fmt::arg("stateIcon", stateIcon),
+                                fmt::arg("consumeIcon", consumeIcon),
+                                fmt::arg("randomIcon", randomIcon),
+                                fmt::arg("repeatIcon", repeatIcon),
+                                fmt::arg("singleIcon", singleIcon)));
 
   if (tooltipEnabled()) {
     std::string tooltip_format;
-    tooltip_format = config_["tooltip-format"].isString() ?
-      config_["tooltip-format"].asString() : "MPD (connected)";
+    tooltip_format = config_["tooltip-format"].isString() ? config_["tooltip-format"].asString()
+                                                          : "MPD (connected)";
     auto tooltip_text = fmt::format(tooltip_format,
-        fmt::arg("artist", artist),
-        fmt::arg("albumArtist", album_artist),
-        fmt::arg("album", album),
-        fmt::arg("title", title),
-        fmt::arg("date", date),
-        fmt::arg("stateIcon", stateIcon),
-        fmt::arg("consumeIcon", consumeIcon),
-        fmt::arg("randomIcon", randomIcon),
-        fmt::arg("repeatIcon", repeatIcon),
-        fmt::arg("singleIcon", singleIcon));
+                                    fmt::arg("artist", artist),
+                                    fmt::arg("albumArtist", album_artist),
+                                    fmt::arg("album", album),
+                                    fmt::arg("title", title),
+                                    fmt::arg("date", date),
+                                    fmt::arg("stateIcon", stateIcon),
+                                    fmt::arg("consumeIcon", consumeIcon),
+                                    fmt::arg("randomIcon", randomIcon),
+                                    fmt::arg("repeatIcon", repeatIcon),
+                                    fmt::arg("singleIcon", singleIcon));
     label_.set_tooltip_text(tooltip_text);
   }
 }
@@ -204,13 +204,10 @@ void waybar::modules::MPD::tryConnect() {
     return;
   }
 
-  connection_ = unique_connection(
-      mpd_connection_new(server_, port_, 5'000),
-      &mpd_connection_free);
+  connection_ = unique_connection(mpd_connection_new(server_, port_, 5'000), &mpd_connection_free);
 
-  alternate_connection_ = unique_connection(
-      mpd_connection_new(server_, port_, 5'000),
-      &mpd_connection_free);
+  alternate_connection_ =
+      unique_connection(mpd_connection_new(server_, port_, 5'000), &mpd_connection_free);
 
   if (connection_ == nullptr || alternate_connection_ == nullptr) {
     std::cerr << "Failed to connect to MPD" << std::endl;
@@ -258,8 +255,10 @@ void waybar::modules::MPD::fetchState() {
 
 void waybar::modules::MPD::waitForEvent() {
   auto conn = alternate_connection_.get();
-  // Wait for a player (play/pause), option (random, shuffle, etc.), or playlist change
-  mpd_run_idle_mask(conn, static_cast<mpd_idle>(MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_PLAYLIST));
+  // Wait for a player (play/pause), option (random, shuffle, etc.), or playlist
+  // change
+  mpd_run_idle_mask(conn,
+                    static_cast<mpd_idle>(MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_PLAYLIST));
   checkErrors(conn);
 }
 
@@ -287,6 +286,4 @@ bool waybar::modules::MPD::stopped() {
   return connection_ == nullptr || state_ == MPD_STATE_UNKNOWN || state_ == MPD_STATE_STOP;
 }
 
-bool waybar::modules::MPD::playing() {
-  return connection_ != nullptr && state_ == MPD_STATE_PLAY;
-}
+bool waybar::modules::MPD::playing() { return connection_ != nullptr && state_ == MPD_STATE_PLAY; }


### PR DESCRIPTION
This adds a basic MPD module, somewhat based on Polybar's implementation.

Also adds a minimal [EditorConfig](https://editorconfig.org/) so editors picks up the codebase's style. ~~(Maybe a `.clang_format` would be nice too but I don't think I should be the one choosing the style. See [here](https://zed0.co.uk/clang-format-configurator/) if you're interested)~~

Clang format configuration added!

**Don't merge now** I'm currently trying to also add support for options (shuffle, repeat, etc.). I'm putting it here now so I pick up on recommendations/reviews as soon as possible ^^

Features:
- artist, album-artist, album, title, and date in the label
- format, format-stopped, and format-disconnected depending on this module's state
- Event driven updates (so fast!)
- Automatic reconnect

Implementation details:
- Uses the official libmpdclient
- Use the `Deleter` feature of `unique_ptr`s to avoid the [rule of 5](https://cpppatterns.com/patterns/rule-of-five.html)

Todo:
- [x] Add support for options (shuffle, repeat, etc.)
- [x] Allow specifying the reconnect interval
- [x] Add support for icons
- [x] Add support for pause/play when clicking
- [x] Add a better sample config with icons in `resources/config`
- [ ] Update the wiki?
- [x] Check error handling ~~(the current implementation can throw an exception in a thread which won't be handled, and can make Waybar crash)~~
- [x] Allow setting a label when disconnected
- [x] Periodically fetch elapsed time when a song is playing

Thanks for the great work on Waybar ^^