### PR TITLE
fix(mpd): Escape MPD values in the label

### DIFF
--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -142,19 +142,20 @@ void waybar::modules::MPD::setLabel() {
   std::string singleIcon = getOptionIcon("single", singleActivated);
 
   // TODO: format can fail
-  label_.set_markup(fmt::format(format,
-                                fmt::arg("artist", artist),
-                                fmt::arg("albumArtist", album_artist),
-                                fmt::arg("album", album),
-                                fmt::arg("title", title),
-                                fmt::arg("date", date),
-                                fmt::arg("elapsedTime", elapsedTime),
-                                fmt::arg("totalTime", totalTime),
-                                fmt::arg("stateIcon", stateIcon),
-                                fmt::arg("consumeIcon", consumeIcon),
-                                fmt::arg("randomIcon", randomIcon),
-                                fmt::arg("repeatIcon", repeatIcon),
-                                fmt::arg("singleIcon", singleIcon)));
+  label_.set_markup(
+      fmt::format(format,
+                  fmt::arg("artist", Glib::Markup::escape_text(artist).raw()),
+                  fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist).raw()),
+                  fmt::arg("album", Glib::Markup::escape_text(album).raw()),
+                  fmt::arg("title", Glib::Markup::escape_text(title).raw()),
+                  fmt::arg("date", Glib::Markup::escape_text(date).raw()),
+                  fmt::arg("elapsedTime", elapsedTime),
+                  fmt::arg("totalTime", totalTime),
+                  fmt::arg("stateIcon", stateIcon),
+                  fmt::arg("consumeIcon", consumeIcon),
+                  fmt::arg("randomIcon", randomIcon),
+                  fmt::arg("repeatIcon", repeatIcon),
+                  fmt::arg("singleIcon", singleIcon)));
 
   if (tooltipEnabled()) {
     std::string tooltip_format;


### PR DESCRIPTION
The idea comes from #273 but doesn't fix it (I haven't managed to crash the bar yet)

This still doesn't support the `escape` configuration, the rationale is that:
- Users probably won't modify the song metadata to change the style of Waybar's MPD module
- The rest of the format replacements comes from the configuration and can be escaped there directly