### PR TITLE
Ensure no NULL tags are set

### DIFF
--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -15,6 +15,7 @@ class MPD : public ALabel {
 
  private:
   std::thread periodic_updater();
+  std::string getTag(mpd_tag_type type, unsigned idx = 0);
   void        setLabel();
   std::string getStateIcon();
   std::string getOptionIcon(std::string optionName, bool activated);

--- a/resources/config
+++ b/resources/config
@@ -30,6 +30,7 @@
         "format": "{stateIcon} {consumeIcon}{randomIcon}{repeatIcon}{singleIcon}{artist} - {album} - {title} ({elapsedTime:%M:%S}/{totalTime:%M:%S}) ",
         "format-disconnected": "Disconnected ",
         "format-stopped": "{consumeIcon}{randomIcon}{repeatIcon}{singleIcon}Stopped ",
+        "unknown-tag": "N/A",
         "interval": 2,
         "consume-icons": {
             "on": " "

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -75,6 +75,17 @@ std::thread waybar::modules::MPD::periodic_updater() {
   });
 }
 
+std::string waybar::modules::MPD::getTag(mpd_tag_type type, unsigned idx) {
+  std::string result = config_["unknown-tag"].isString() ? config_["unknown-tag"].asString() : "N/A";
+  const char* tag = mpd_song_get_tag(song_.get(), type, idx);
+
+  // mpd_song_get_tag can return NULL, so make sure it's valid before setting
+  if (tag)
+    result = tag;
+
+  return result;
+}
+
 void waybar::modules::MPD::setLabel() {
   if (connection_ == nullptr) {
     label_.get_style_context()->add_class("disconnected");
@@ -123,11 +134,11 @@ void waybar::modules::MPD::setLabel() {
 
     stateIcon = getStateIcon();
 
-    artist = mpd_song_get_tag(song_.get(), MPD_TAG_ARTIST, 0);
-    album_artist = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM_ARTIST, 0);
-    album = mpd_song_get_tag(song_.get(), MPD_TAG_ALBUM, 0);
-    title = mpd_song_get_tag(song_.get(), MPD_TAG_TITLE, 0);
-    date = mpd_song_get_tag(song_.get(), MPD_TAG_DATE, 0);
+    artist = getTag(MPD_TAG_ARTIST);
+    album_artist = getTag(MPD_TAG_ALBUM_ARTIST);
+    album = getTag(MPD_TAG_ALBUM);
+    title = getTag(MPD_TAG_TITLE);
+    date = getTag(MPD_TAG_DATE);
     elapsedTime = std::chrono::seconds(mpd_status_get_elapsed_time(status_.get()));
     totalTime = std::chrono::seconds(mpd_status_get_total_time(status_.get()));
   }

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -245,7 +245,7 @@ void waybar::modules::MPD::tryConnect() {
 
   try {
     checkErrors(connection_.get());
-  } catch (std::runtime_error e) {
+  } catch (std::runtime_error &e) {
     std::cerr << module_name_ << ": Failed to connect to MPD: " << e.what() << std::endl;
     connection_.reset();
     alternate_connection_.reset();


### PR DESCRIPTION
Because `mpd_song_get_tag` from libmpdclient can return NULL, verify the
value of tag is valid. Otherwise, set a default string of "N/A". Also
adds configuration to specify what this default string should be.

Additionally, fix compile-time warning of catch by value.

Closes #273 (I'll file another issue on the segfault at `mpd_status_get_state`,
unless we want to keep conversation there)

P.S. Thoughts appreciated on the config name `"unknown-tag"`; for some
reason it just doesn't jive with me, though it's fairly descriptive of what it does.

I'll update the wiki once this gets merged.

EDIT: It appears you guys are using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0-beta.4/) style (or
something similar). Should I fix my commits to reflect that?