### PR TITLE
fix(mpd): regularly timeout the event listener to prevent timeout

### DIFF
--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -48,6 +48,8 @@ class MPD : public ALabel {
   const char*    server_;
   const unsigned port_;
 
+  unsigned timeout_;
+
   // We need a mutex here because we can trigger updates from multiple thread:
   // the event based updates, the periodic updates needed for the elapsed time,
   // and the click play/pause feature


### PR DESCRIPTION
Finally got to the bottom of this!

Didn't manage to find a way to "unblock" the event listener, so here's what I propose (from the commit message):

The MPD server has a `connection_timeout` that defaults to 60. If no data
is transferred in this time span, the connection is closed. If the
connection is closed while the event listener thread is listening for events,
it will block forever. By timing out the event listening and
re-connecting regularly, we prevent this issue. An option "timeout" has
been added for users that have a lower server `connection_timeout` than
default. Fixes #277