### PR TITLE
Allow rotating label contents by specifying a new "rotate" property 

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -18,7 +18,7 @@ waybar::ALabel::ALabel(const Json::Value& config, const std::string& format, uin
   }
 
   if (config_["rotate"].isUInt()) {
-	label_.set_angle(config["rotate"].asUInt());
+    label_.set_angle(config["rotate"].asUInt());
   }
 
   if (config_["format-alt"].isString()) {

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -16,6 +16,11 @@ waybar::ALabel::ALabel(const Json::Value& config, const std::string& format, uin
     label_.set_max_width_chars(config_["max-length"].asUInt());
     label_.set_ellipsize(Pango::EllipsizeMode::ELLIPSIZE_END);
   }
+
+  if (config_["rotate"].isUInt()) {
+	label_.set_angle(config["rotate"].asUInt());
+  }
+
   if (config_["format-alt"].isString()) {
     event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
     event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &ALabel::handleToggle));


### PR DESCRIPTION
This change allows rotation of label contents, which can be useful when using a vertical bar.
See:
![waybar](https://user-images.githubusercontent.com/48644/56767701-b201a980-67ac-11e9-852f-5d18c8544330.png)
