### PR TITLE
Change scroll-step unit to percent

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -111,7 +111,7 @@
         "format-disconnected": "Disconnected ⚠"
     },
     "pulseaudio": {
-        //"scroll-step": 1,
+        // "scroll-step": 1, // %, can be a float
         "format": "{volume}% {icon}",
         "format-bluetooth": "{volume}% {icon}",
         "format-muted": "",

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -77,7 +77,8 @@ bool waybar::modules::Pulseaudio::handleVolume(GdkEventScroll *e) {
     return false;
   }
   bool       direction_up = false;
-  uint16_t   change = config_["scroll-step"].isUInt() ? config_["scroll-step"].asUInt() * 100 : 100;
+  double volume_tick = (double)PA_VOLUME_NORM / 100;
+  pa_volume_t change = volume_tick;
   pa_cvolume pa_volume = pa_volume_;
   scrolling_ = true;
   if (e->direction == GDK_SCROLL_UP) {
@@ -95,6 +96,11 @@ bool waybar::modules::Pulseaudio::handleVolume(GdkEventScroll *e) {
     } else if (delta_y > 0) {
       direction_up = false;
     }
+  }
+
+  // isDouble returns true for integers as well, just in case
+  if (config_["scroll-step"].isDouble()) {
+    change = round(config_["scroll-step"].asDouble() * volume_tick);
   }
 
   if (direction_up) {


### PR DESCRIPTION
Fixes https://github.com/Alexays/Waybar/issues/301

~~`scroll-step` is probably not what most people want, but kept it for backwards compatibility. `scroll-step-percent = 1` is now effectively the same as `scroll-step = 6.5535`.~~

`scroll-step = 1` ≈ 1% now.

Better alignment with the percentage ticks could be achieved (by calculating the change needed to reach the next tick, instead of adding the same number every time), but eh, negligible, IMO.

Let me know if you're happy with the API, I'll update the wiki.