### PR TITLE
fix(battery): change comparison expr. to assignment

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -95,7 +95,7 @@ const std::tuple<uint8_t, uint32_t, std::string> waybar::modules::Battery::getIn
     }
     uint16_t capacity = total / batteries_.size();
     if (status == "Charging" && total_current != 0) {
-      status == "Plugged";
+      status = "Plugged";
     }
     return {capacity, total_current, status};
   } catch (const std::exception& e) {


### PR DESCRIPTION
It seems like there is a mistaken comparison expression where an assignment statement should be used instead. See the commit for the single line which I am referring to.