### PR TITLE
Fix workspace scroll wrapping off the end of the list

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -223,7 +223,7 @@ const std::string Workspaces::getCycleWorkspace(std::vector<Json::Value>::iterat
   else if (!prev && it != workspaces_.end())
     ++it;
   if (!prev && it == workspaces_.end()) {
-    return (*(++workspaces_.begin()))["name"].asString();
+    return (*(workspaces_.begin()))["name"].asString();
   }
   return (*it)["name"].asString();
 }


### PR DESCRIPTION
Scrolling off the rear end of the list should advance to the first element, not the second in the list.