### PR TITLE
Adding bandwidth support for network module

### DIFF
--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -56,6 +56,9 @@ class Network : public ALabel {
   int                         nl80211_id_;
   std::mutex                  mutex_;
 
+  unsigned long long bandwidth_down_total_;
+  unsigned long long bandwidth_up_total_;
+
   std::string essid_;
   std::string ifname_;
   std::string ipaddr_;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -302,10 +302,10 @@ auto waybar::modules::Network::update() -> void {
                           fmt::arg("cidr", cidr_),
                           fmt::arg("frequency", frequency_),
                           fmt::arg("icon", getIcon(signal_strength_, connectiontype)),
-                          fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull, "b")),
-                          fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull, "b")),
-                          fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down, "o")),
-                          fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up, "o")));
+                          fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / interval_.count(), "b/s")),
+                          fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / interval_.count(), "b/s")),
+                          fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / interval_.count(), "o/s")),
+                          fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / interval_.count(), "o/s")));
   label_.set_markup(text);
   if (tooltipEnabled()) {
     if (!tooltip_format.empty()) {
@@ -319,10 +319,10 @@ auto waybar::modules::Network::update() -> void {
                                       fmt::arg("cidr", cidr_),
                                       fmt::arg("frequency", frequency_),
                                       fmt::arg("icon", getIcon(signal_strength_, connectiontype)),
-                                      fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull, "b")),
-                                      fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull, "b")),
-                                      fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down, "o")),
-                                      fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up, "o")));
+                                      fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / interval_.count(), "b/s")),
+                                      fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / interval_.count(), "b/s")),
+                                      fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / interval_.count(), "o/s")),
+                                      fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / interval_.count(), "o/s")));
       label_.set_tooltip_text(tooltip_text);
     } else {
       label_.set_tooltip_text(text);

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -330,7 +330,7 @@ auto waybar::modules::Network::update() -> void {
       if (label_.get_tooltip_text() != text) {
         label_.set_tooltip_text(tooltip_text);
       }
-    } else {
+    } else if (label_.get_tooltip_text() != text) {
       label_.set_tooltip_text(text);
     }
   }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -1,6 +1,7 @@
 #include "modules/network.hpp"
 #include <sys/eventfd.h>
 #include <fstream>
+#include <iostream>
 
 namespace {
 
@@ -12,6 +13,7 @@ namespace {
   std::ifstream netstat(NETSTAT_FILE);
   std::optional<unsigned long long> read_netstat(std::string_view category, std::string_view key) {
     if (!netstat) {
+      std::cerr << "Failed to open netstat file " << NETSTAT_FILE << '\n' << std::flush;
       return {};
     }
     netstat.seekg(std::ios_base::beg);
@@ -26,6 +28,7 @@ namespace {
     std::string read;
     while (std::getline(netstat, read) && !starts_with(read, category));
     if (!starts_with(read, category)) {
+      std::cerr << "Category '" << category << "' not found in netstat file " << NETSTAT_FILE << '\n' << std::flush;
       return {};
     }
 
@@ -49,6 +52,7 @@ namespace {
     }
 
     if (r_it == read.end() && k_it != key.end()) {
+      std::cerr << "Key '" << key << "' not found in category '" << category << "' of netstat file " << NETSTAT_FILE << '\n' << std::flush;
       return {};
     }
 


### PR DESCRIPTION
This PR adds support for 4 new tags for the network modules:
* `{bandwidthDownBits}` and `{bandwidthUpBits}`
* `{bandwidthDownOctets}` and `{bandwidthUpOctets}`

Those tags, in combination with the `{interval}` tag, allows users to monitor ongoing network traffic

As of current state, this PR implements those only for linux, but I tried to make it easy to add support for FreeBSD
As I am not running under FreeBSD, I'd rather have some FreeBSD dude add this part. FreeBSD implementation can apparently be done using the [/proc/net/dev](https://www.freebsd.org/cgi/man.cgi?query=proc&apropos=0&sektion=5&manpath=CentOS+7.1&arch=default&format=html) file

If no one is willing to implement this, then I'll go ahead and try to implement it, though I won't be able to test it and would as such like to avoid it