### PR TITLE
Adding sway/workspaces:persistant_workspaces

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -35,6 +35,7 @@ class Workspaces : public IModule, public sigc::trackable {
   const Bar&                                   bar_;
   const Json::Value&                           config_;
   std::vector<Json::Value>                     workspaces_;
+  std::vector<std::string>                     workspaces_order_;
   waybar::util::SleeperThread                  thread_;
   std::mutex                                   mutex_;
   Gtk::Box                                     box_;

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -16,7 +16,7 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
   ipc_.signal_cmd.connect(sigc::mem_fun(*this, &Workspaces::onCmd));
   ipc_.sendCmd(IPC_GET_WORKSPACES);
   if (!config["disable-bar-scroll"].asBool()) {
-    auto &window = const_cast<Bar&>(bar_).window;
+    auto &window = const_cast<Bar &>(bar_).window;
     window.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     window.signal_scroll_event().connect(sigc::mem_fun(*this, &Workspaces::handleScroll));
   }
@@ -49,11 +49,11 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
                      });
 
         // adding persistant workspaces (as per the config file)
-        const Json::Value &p_workspaces = config_["persistant_workspaces"];
+        const Json::Value &            p_workspaces = config_["persistant_workspaces"];
         const std::vector<std::string> p_workspaces_names = p_workspaces.getMemberNames();
         for (const std::string &p_w_name : p_workspaces_names) {
           const Json::Value &p_w = p_workspaces[p_w_name];
-          auto it =
+          auto               it =
               std::find_if(payload.begin(), payload.end(), [&p_w_name](const Json::Value &node) {
                 return node["name"].asString() == p_w_name;
               });
@@ -68,6 +68,7 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
               if (output.asString() == bar_.output->name) {
                 Json::Value v;
                 v["name"] = p_w_name;
+                v["target_output"] = bar_.output->name;
                 workspaces_.emplace_back(std::move(v));
                 break;
               }
@@ -99,7 +100,7 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
             if (it != ws_end) {
               sorted_workspaces.emplace_back(*it);
               --ws_end;
-              if (ws_end == workspaces_.begin()) { // we've extracted everything
+              if (ws_end == workspaces_.begin()) {  // we've extracted everything
                 break;
               }
               ws_end->swap(*it);
@@ -202,9 +203,18 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
   auto &button = pair.first->second;
   box_.pack_start(button, false, false, 0);
   button.set_relief(Gtk::RELIEF_NONE);
-  button.signal_clicked().connect([this, pair] {
+  button.signal_clicked().connect([this, node] {
     try {
-      ipc_.sendCmd(IPC_COMMAND, fmt::format("workspace \"{}\"", pair.first->first));
+      if (node["target_output"].isString()) {
+        ipc_.sendCmd(
+            IPC_COMMAND,
+            fmt::format("workspace \"{}\"; move workspace to output \"{}\"; workspace \"{}\"",
+                        node["name"].asString(),
+                        node["target_output"].asString(),
+                        node["name"].asString()));
+      } else {
+        ipc_.sendCmd(IPC_COMMAND, fmt::format("workspace \"{}\""));
+      }
     } catch (const std::exception &e) {
       std::cerr << e.what() << std::endl;
     }

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -83,8 +83,8 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
 
         if (workspaces_order_.empty()) {
           // Saving starting order
-          workspaces_order_.reserve(workspaces_.size());
-          for (const Json::Value &workspace : workspaces_) {
+          workspaces_order_.reserve(payload.size());
+          for (const Json::Value &workspace : payload) {
             workspaces_order_.emplace_back(workspace["name"].asString());
           }
         } else {

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -99,6 +99,9 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
             if (it != ws_end) {
               sorted_workspaces.emplace_back(*it);
               --ws_end;
+              if (ws_end == workspaces_.begin()) { // we've extracted everything
+                break;
+              }
               ws_end->swap(*it);
             }
           }

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -106,7 +106,7 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
             }
           }
 
-          // Adding new workspaces to the output (those where never showed in this output before)
+          // Adding new workspaces to the output (those were never showed in this output before)
           for (int i = 0; workspaces_.size() > sorted_workspaces.size(); ++i) {
             workspaces_order_.emplace_back(workspaces_[i]["name"].asString());
             sorted_workspaces.emplace_back(workspaces_[i]);


### PR DESCRIPTION
Implements https://github.com/Alexays/Waybar/issues/210

Adds the `persistant_workspaces` option to the module `sway/workspaces`.
Within `persistant_workspaces`, you can list workspaces that should always be showed, even when non existant as per sway. It is possible to indicate which outputs they should be displayed on ; if no output was indicated, it will display on all outputs.

example:
```
"sway/workspaces": {
    "persistant_workspaces": {
        "3": [], // Always show a workspace with name '3', on all outputs if it does not exists
        "4": ["eDP-1"], // Always show a workspace with name '4', on output 'eDP-1' if it does not exists
        "5": ["eDP-1", "DP-2"] // Always show a workspace with name '5', on outputs 'eDP-1' and 'DP-2' if it does not exists
    }
}
```

Known issue: upon clicking on a non-existing workspace, the new workspace will be created and opened on the output that is currently focused, instead of on the one where the click occured (except if there are further restriction on sway's config)