### PR TITLE
Fix clock is always a second off

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -14,11 +14,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     auto sub_m =
         std::chrono::duration_cast<std::chrono::seconds>(time_s.time_since_epoch()).count() %
         interval_.count();
-    if (sub_m > 0) {
-      thread_.sleep_until(timeout - std::chrono::seconds(sub_m - 1));
-    } else {
-      thread_.sleep_until(timeout - std::chrono::seconds(sub_m));
-    }
+    thread_.sleep_until(timeout - std::chrono::seconds(sub_m));
   };
 }
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -23,7 +23,8 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::Clock::update() -> void {
-  auto localtime = fmt::localtime(std::time(nullptr));
+  auto now = std::chrono::system_clock::now();
+  auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
   auto text = fmt::format(format_, localtime);
   label_.set_markup(text);
 


### PR DESCRIPTION
I don't understand why these two clocks disagree, but they do, and this way always seems to update the second exactly on time.