### PR TITLE
Allow formatting memory with used and available memory

### DIFF
--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -16,9 +16,14 @@ auto waybar::modules::Memory::update() -> void {
   parseMeminfo();
   if (memtotal_ > 0 && memfree_ >= 0) {
     int used_ram_percentage = 100 * (memtotal_ - memfree_) / memtotal_;
-    getState(used_ram_percentage);
-    label_.set_markup(fmt::format(format_, used_ram_percentage));
     auto used_ram_gigabytes = (memtotal_ - memfree_) / std::pow(1024, 2);
+    auto available_ram_gigabytes = memfree_ / std::pow(1024, 2);
+
+    getState(used_ram_percentage);
+    label_.set_markup(fmt::format(format_, used_ram_percentage,
+                                  fmt::arg("percentage", used_ram_percentage),
+                                  fmt::arg("used", used_ram_gigabytes),
+                                  fmt::arg("avail", available_ram_gigabytes)));
     if (tooltipEnabled()) {
       label_.set_tooltip_text(fmt::format("{:.{}f}Gb used", used_ram_gigabytes, 1));
     }


### PR DESCRIPTION
This adds named format parameters while keeping existing formats using `{}` working.