### PR TITLE
Set FontAwesome as first priority to avoid clashes

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -1,7 +1,7 @@
 * {
     border: none;
     border-radius: 0;
-    font-family: Roboto, Helvetica, Arial, sans-serif;
+    font-family: "FontAwesome 5 Free Solid", Roboto, Helvetica, Arial, sans-serif;
     font-size: 13px;
     min-height: 0;
 }


### PR DESCRIPTION
In some cases FontAwesome icons were replaced by letters and symbols from other fonts. Add the font as the first priority in the style sheet to avoid this issue.