### PR TITLE
Increase specificity of media stylings

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -136,11 +136,11 @@ label:focus {
     min-width: 100px;
 }
 
-.custom-spotify {
+#custom-media.custom-spotify {
     background-color: #66cc99;
 }
 
-.custom-vlc {
+#custom-media.custom-vlc {
     background-color: #ffa000;
 }
 


### PR DESCRIPTION
Because of CSS specificity rules, the `#custom-media` style will always override the `custom-spotify` and `custom-vlc` styles, so the background of the media element is always green rather than sometimes orange when VLC is running. I added `#custom-media` in front of each of the class selectors to increase their specificity so they take precedence.