### PR TITLE
adds the wl output name as a css class

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -17,6 +17,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   window.set_title("waybar");
   window.set_name("waybar");
   window.set_decorated(false);
+  window.get_style_context()->add_class(output->name);
 
   if (config["position"] == "right" || config["position"] == "left") {
     height_ = 0;


### PR DESCRIPTION
now you can have a custom styling for each bar. this wasn't possible before, since every bar defined the same set of ids and classes.

also question:

the height/width parameters are useless inside of the css file. i noticed the width and height were being set via a different api. is there any way we can set this to "auto" so the css can take precedence over the width/height of the bar?