### PR TITLE
Fix twitchy scrolling on touchpads

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -36,6 +36,7 @@ class ALabel : public IModule {
 
  private:
   std::vector<int> pid_;
+  gdouble distance_scrolled_;
 };
 
 }  // namespace waybar

--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -41,6 +41,7 @@ class Workspaces : public IModule, public sigc::trackable {
   util::JsonParser                             parser_;
   bool                                         scrolling_;
   std::unordered_map<std::string, Gtk::Button> buttons_;
+  gdouble                                      distance_scrolled_;
 
   util::SleeperThread thread_;
   Ipc                 ipc_;

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -97,11 +97,23 @@ bool waybar::ALabel::handleScroll(GdkEventScroll* e) {
   }
   if (e->direction == GDK_SCROLL_SMOOTH) {
     gdouble delta_x, delta_y;
-    gdk_event_get_scroll_deltas(reinterpret_cast<const GdkEvent*>(e), &delta_x, &delta_y);
-    if (delta_y < 0) {
+    gdk_event_get_scroll_deltas(reinterpret_cast<const GdkEvent *>(e), &delta_x, &delta_y);
+    distance_scrolled_ += delta_y;
+    gdouble threshold = 0;
+    if (config_["smooth-scrolling-threshold"].isNumeric()) {
+      threshold = config_["smooth-scrolling-threshold"].asDouble();
+    }
+
+    if (distance_scrolled_ < -threshold) {
       direction_up = true;
-    } else if (delta_y > 0) {
+    } else if (distance_scrolled_ > threshold) {
       direction_up = false;
+    }
+    if(abs(distance_scrolled_) > threshold) {
+      distance_scrolled_ = 0;
+    } else {
+      // Don't execute the action if we haven't met the threshold!
+      return false;
     }
   }
   if (direction_up && config_["on-scroll-up"].isString()) {

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -234,24 +234,37 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
     }
     switch (e->direction) {
       case GDK_SCROLL_DOWN:
-      case GDK_SCROLL_RIGHT:
+      case GDK_SCROLL_RIGHT: {
         name = getCycleWorkspace(it, false);
         break;
+      }
       case GDK_SCROLL_UP:
-      case GDK_SCROLL_LEFT:
+      case GDK_SCROLL_LEFT: {
         name = getCycleWorkspace(it, true);
         break;
-      case GDK_SCROLL_SMOOTH:
+      }
+      case GDK_SCROLL_SMOOTH: {
         gdouble delta_x, delta_y;
         gdk_event_get_scroll_deltas(reinterpret_cast<const GdkEvent *>(e), &delta_x, &delta_y);
-        if (delta_y < 0) {
+        distance_scrolled_ += delta_y;
+        gdouble threshold = 0;
+        if (config_["smooth-scrolling-threshold"].isNumeric()) {
+          threshold = config_["smooth-scrolling-threshold"].asDouble();
+        }
+
+        if (distance_scrolled_ < -threshold) {
           name = getCycleWorkspace(it, true);
-        } else if (delta_y > 0) {
+        } else if (distance_scrolled_ > threshold) {
           name = getCycleWorkspace(it, false);
         }
+        if(abs(distance_scrolled_) > threshold) {
+          distance_scrolled_ = 0;
+        }
         break;
-      default:
+      }
+      default: {
         break;
+      }
     }
     if (name.empty() || name == (*it)["name"].asString()) {
       scrolling_ = false;

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -246,7 +246,12 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
       case GDK_SCROLL_SMOOTH: {
         gdouble delta_x, delta_y;
         gdk_event_get_scroll_deltas(reinterpret_cast<const GdkEvent *>(e), &delta_x, &delta_y);
-        distance_scrolled_ += delta_y;
+
+        if (abs(delta_x) > abs(delta_y)) {
+          distance_scrolled_ += delta_x;
+        } else {
+          distance_scrolled_ += delta_y;
+        }
         gdouble threshold = 0;
         if (config_["smooth-scrolling-threshold"].isNumeric()) {
           threshold = config_["smooth-scrolling-threshold"].asDouble();


### PR DESCRIPTION
Previously, any and all scroll events were interpreted as reason to switch
workspaces. This resulted in twitchy behaviour, where the scrolling was
practically unusable.

Now, we pool all scroll values, and only scroll if the value is larger than the
new config option "smooth-scrolling-threshold". If this option is not set, the
behaviour is unchanged.