### PR TITLE
Conditionally execute modules

### DIFF
--- a/include/util/condshow.hpp
+++ b/include/util/condshow.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "util/command.hpp"
+#include "util/json.hpp"
+
+namespace waybar::util::condshow {
+
+/** Extract the `show-if` field from the given config and execute it as a command if possible.
+ * Returns `true` if the return code is 0 or the `show-if` field isn't a string, returns `false`
+ * otherwise.
+ */
+inline bool show_module(const Json::Value& config, const std::string args) {
+  if (config["show-if"].isString()) {
+    std::ostringstream command;
+    command << config["show-if"].asString() << " " << args;
+    auto res = util::command::exec(command.str());
+    return res.exit_code == 0;
+  }
+  return true;
+}
+
+}  // namespace waybar::util::condshow

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -1,8 +1,5 @@
-#include <iostream>
-#include <sstream>
-#include <string>
 #include "modules/backlight.hpp"
-#include "util/command.hpp"
+#include "util/condshow.hpp"
 
 #include <algorithm>
 #include <chrono>
@@ -181,15 +178,7 @@ auto waybar::modules::Backlight::update() -> void {
 
     const auto percent = best->get_max() == 0 ? 100 : best->get_actual() * 100 / best->get_max();
 
-    bool show_module = true;
-    if (config_["exec-if"].isString()) {
-      std::ostringstream command;
-      command << config_["exec-if"].asString() << " " << percent;
-      auto res = util::command::exec(command.str());
-      if (res.exit_code != 0) {
-        show_module = false;
-      }
-    }
+    bool show_module = util::condshow::show_module(config_, std::to_string(percent));
     if (show_module) {
       label_.set_markup(fmt::format(format_,
                                     fmt::arg("percent", std::to_string(percent)),

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <sstream>
 
 #include <libudev.h>
 
@@ -178,8 +179,9 @@ auto waybar::modules::Backlight::update() -> void {
 
     const auto percent = best->get_max() == 0 ? 100 : best->get_actual() * 100 / best->get_max();
 
-    bool show_module = util::condshow::show_module(config_, std::to_string(percent));
-    if (show_module) {
+    std::stringstream args;
+    args << percent;
+    if (util::condshow::show_module(config_, args.str())) {
       label_.set_markup(fmt::format(format_,
                                     fmt::arg("percent", std::to_string(percent)),
                                     fmt::arg("icon", getIcon(percent))));

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -1,5 +1,6 @@
-#include "modules/battery.hpp"
 #include <spdlog/spdlog.h>
+#include "modules/battery.hpp"
+#include "util/condshow.hpp"
 
 waybar::modules::Battery::Battery(const std::string& id, const Json::Value& config)
     : ALabel(config, "battery", id, "{capacity}%", 60) {
@@ -177,10 +178,16 @@ auto waybar::modules::Battery::update() -> void {
   if (format.empty()) {
     event_box_.hide();
   } else {
-    event_box_.show();
-    label_.set_markup(fmt::format(format,
-                                  fmt::arg("capacity", capacity),
-                                  fmt::arg("icon", getIcon(capacity, state)),
-                                  fmt::arg("time", formatTimeRemaining(time_remaining))));
+    std::stringstream args;
+    args << capacity << " " << time_remaining;
+    if (util::condshow::show_module(config_, args.str())) {
+      event_box_.show();
+      label_.set_markup(fmt::format(format,
+                                    fmt::arg("capacity", capacity),
+                                    fmt::arg("icon", getIcon(capacity, state)),
+                                    fmt::arg("time", formatTimeRemaining(time_remaining))));
+    } else {
+      event_box_.hide();
+    }
   }
 }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -1,4 +1,5 @@
 #include <spdlog/spdlog.h>
+#include <sstream>
 #include "modules/battery.hpp"
 #include "util/condshow.hpp"
 

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -1,5 +1,6 @@
-#include "modules/cpu.hpp"
 #include <numeric>
+#include "modules/cpu.hpp"
+#include "util/condshow.hpp"
 
 waybar::modules::Cpu::Cpu(const std::string& id, const Json::Value& config)
     : ALabel(config, "cpu", id, "{usage}%", 10) {
@@ -16,8 +17,16 @@ auto waybar::modules::Cpu::update() -> void {
   if (tooltipEnabled()) {
     label_.set_tooltip_text(tooltip);
   }
-  label_.set_markup(fmt::format(format_, fmt::arg("load", cpu_load), fmt::arg("usage", cpu_usage)));
-  getState(cpu_usage);
+  bool show_module =
+      util::condshow::show_module(config_, std::to_string(cpu_load) + std::to_string(cpu_usage));
+  if (show_module) {
+    label_.set_markup(
+        fmt::format(format_, fmt::arg("load", cpu_load), fmt::arg("usage", cpu_usage)));
+    getState(cpu_usage);
+    event_box_.show();
+  } else {
+    event_box_.hide();
+  }
 }
 
 uint16_t waybar::modules::Cpu::getCpuLoad() {

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -1,4 +1,5 @@
 #include <numeric>
+#include <sstream>
 #include "modules/cpu.hpp"
 #include "util/condshow.hpp"
 
@@ -17,9 +18,9 @@ auto waybar::modules::Cpu::update() -> void {
   if (tooltipEnabled()) {
     label_.set_tooltip_text(tooltip);
   }
-  bool show_module =
-      util::condshow::show_module(config_, std::to_string(cpu_load) + std::to_string(cpu_usage));
-  if (show_module) {
+  std::stringstream args;
+  args << cpu_load << " " << cpu_usage;
+  if (util::condshow::show_module(config_, args.str())) {
     label_.set_markup(
         fmt::format(format_, fmt::arg("load", cpu_load), fmt::arg("usage", cpu_usage)));
     getState(cpu_usage);

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -1,4 +1,6 @@
+#include <sstream>
 #include "modules/memory.hpp"
+#include "util/condshow.hpp"
 
 waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config)
     : ALabel(config, "memory", id, "{}%", 30) {
@@ -16,17 +18,24 @@ auto waybar::modules::Memory::update() -> void {
     auto used_ram_gigabytes = (memtotal_ - memfree_) / std::pow(1024, 2);
     auto available_ram_gigabytes = memfree_ / std::pow(1024, 2);
 
-    getState(used_ram_percentage);
-    label_.set_markup(fmt::format(format_,
-                                  used_ram_percentage,
-                                  fmt::arg("total", total_ram_gigabytes),
-                                  fmt::arg("percentage", used_ram_percentage),
-                                  fmt::arg("used", used_ram_gigabytes),
-                                  fmt::arg("avail", available_ram_gigabytes)));
-    if (tooltipEnabled()) {
-      label_.set_tooltip_text(fmt::format("{:.{}f}Gb used", used_ram_gigabytes, 1));
+    std::stringstream args;
+    args << total_ram_gigabytes << " " << used_ram_percentage << " " << used_ram_gigabytes << " "
+         << available_ram_gigabytes;
+    if (util::condshow::show_module(config_, args.str())) {
+      getState(used_ram_percentage);
+      label_.set_markup(fmt::format(format_,
+                                    used_ram_percentage,
+                                    fmt::arg("total", total_ram_gigabytes),
+                                    fmt::arg("percentage", used_ram_percentage),
+                                    fmt::arg("used", used_ram_gigabytes),
+                                    fmt::arg("avail", available_ram_gigabytes)));
+      if (tooltipEnabled()) {
+        label_.set_tooltip_text(fmt::format("{:.{}f}Gb used", used_ram_gigabytes, 1));
+      }
+      event_box_.show();
+    } else {
+      event_box_.hide();
     }
-    event_box_.show();
   } else {
     event_box_.hide();
   }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -1,4 +1,6 @@
+#include <sstream>
 #include "modules/pulseaudio.hpp"
+#include "util/condshow.hpp"
 
 waybar::modules::Pulseaudio::Pulseaudio(const std::string &id, const Json::Value &config)
     : ALabel(config, "pulseaudio", id, "{volume}%"),
@@ -215,13 +217,20 @@ auto waybar::modules::Pulseaudio::update() -> void {
   } else if (!source_muted_ && config_["format-source"].isString()) {
     format_source = config_["format-source"].asString();
   }
-  format_source = fmt::format(format_source, fmt::arg("volume", source_volume_));
-  label_.set_markup(fmt::format(format,
-                                fmt::arg("volume", volume_),
-                                fmt::arg("format_source", format_source),
-                                fmt::arg("icon", getIcon(volume_, getPortIcon()))));
-  getState(volume_);
-  if (tooltipEnabled()) {
-    label_.set_tooltip_text(desc_);
+  std::stringstream args;
+  args << volume_;
+  if (util::condshow::show_module(config_, args.str())) {
+    format_source = fmt::format(format_source, fmt::arg("volume", source_volume_));
+    label_.set_markup(fmt::format(format,
+                                  fmt::arg("volume", volume_),
+                                  fmt::arg("format_source", format_source),
+                                  fmt::arg("icon", getIcon(volume_, getPortIcon()))));
+    getState(volume_);
+    if (tooltipEnabled()) {
+      label_.set_tooltip_text(desc_);
+    }
+    event_box_.show();
+  } else {
+    event_box_.hide();
   }
 }

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -1,4 +1,6 @@
+#include <sstream>
 #include "modules/temperature.hpp"
+#include "util/condshow.hpp"
 
 waybar::modules::Temperature::Temperature(const std::string& id, const Json::Value& config)
     : ALabel(config, "temperature", id, "{temperatureC}°C", 10) {
@@ -29,10 +31,18 @@ auto waybar::modules::Temperature::update() -> void {
     label_.get_style_context()->remove_class("critical");
   }
   auto max_temp = config_["critical-threshold"].isInt() ? config_["critical-threshold"].asInt() : 0;
-  label_.set_markup(fmt::format(format,
-                                fmt::arg("temperatureC", temperature_c),
-                                fmt::arg("temperatureF", temperature_f),
-                                fmt::arg("icon", getIcon(temperature_c, "", max_temp))));
+
+  std::stringstream args;
+  args << temperature_c << " " << temperature_f;
+  if (util::condshow::show_module(config_, args.str())) {
+    label_.set_markup(fmt::format(format,
+                                  fmt::arg("temperatureC", temperature_c),
+                                  fmt::arg("temperatureF", temperature_f),
+                                  fmt::arg("icon", getIcon(temperature_c, "", max_temp))));
+    event_box_.show();
+  } else {
+    event_box_.hide();
+  }
 }
 
 std::tuple<uint16_t, uint16_t> waybar::modules::Temperature::getTemperature() {


### PR DESCRIPTION
This adds a `show-if` field to the config JSON for some core modules. This allows a user to define a script which is executed to see if the module should be displayed. If this field is not present there should be no change in behaviour.

The scripts are called with relevant arguments. I imagine these would need to be documented somewhere (perhaps the wiki?) with the rest of the details for users.

This is effectively `exec-if` from the custom module but I found `show-if` to be a bit more instructive.

Some things I'm unsure about:
- whether this should be implemented for more or fewer modules
- a good approach to the order of arguments passed to the scripts
-  the choice of arguments passed to the scripts