### PR TITLE
Allow CSS to select specific waybars when multiple are in use

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -18,6 +18,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   window.set_name("waybar");
   window.set_decorated(false);
   window.get_style_context()->add_class(output->name);
+  window.get_style_context()->add_class(config["position"].asString());
 
   if (config["position"] == "right" || config["position"] == "left") {
     height_ = 0;

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -18,6 +18,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   window.set_name("waybar");
   window.set_decorated(false);
   window.get_style_context()->add_class(output->name);
+  window.get_style_context()->add_class(config["name"].asString());
   window.get_style_context()->add_class(config["position"].asString());
 
   if (config["position"] == "right" || config["position"] == "left") {


### PR DESCRIPTION
## What

- Adds `name` property for each bar and uses this as a CSS class
- Adds CSS class for the position property

## Why

When using multiple waybars from the same configuration file (https://github.com/Alexays/Waybar/issues/267) it can be preferable to style them individually.

E.g For a bar at the bottom of the screen the `border-bottom` might be better at the top, or a specific named bar might want to have a different background colour.