### PR TITLE
feat(modules): call user on-update if configured

### DIFF
--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -10,29 +10,29 @@ The *backlight* module displays the current backlight level.
 
 # CONFIGURATION
 
-*interval* ++
+*interval*: ++
 	typeof: integer ++
 	default: 2 ++
 	The interval in which information gets polled.
 
-*format* ++
+*format*: ++
 	typeof: string ++
 	default: {percent}% ++
 	The format, how information should be displayed. On {} data gets inserted.
 
-*max-length* ++
+*max-length*: ++
 	typeof: integer ++
 	The maximum length in characters the module should display.
 
-*rotate* ++
+*rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.
 
-*states* ++
+*states*: ++
 	typeof: array ++
 	A number of backlight states which get activated on certain brightness levels.
 
-*on-click* ++
+*on-click*: ++
 	typeof: string ++
 	Command to execute when the module is clicked.
 
@@ -48,15 +48,15 @@ The *backlight* module displays the current backlight level.
 	typeof: string ++
 	Command to execute when the module is updated.
 
-*on-scroll-up* ++
+*on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when performing a scroll up on the module.
 
-*on-scroll-down* ++
+*on-scroll-down*: ++
 	typeof: string
 	Command to execute when performing a scroll down on the module.
 
-*smooth-scrolling-threshold* ++
+*smooth-scrolling-threshold*: ++
 	typeof: double
 	Threshold to be used when scrolling.
 

--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -40,9 +40,13 @@ The *backlight* module displays the current backlight level.
 	typeof: string ++
 	Command to execute when middle-clicked on the module using mousewheel.
 
-*on-click-right* ++
+*on-click-right*: ++
 	typeof: string ++
 	Command to execute when the module is right clicked.
+
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
 
 *on-scroll-up* ++
 	typeof: string ++

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -62,9 +62,13 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	typeof: string ++
 	Command to execute when middle-clicked on the module using mousewheel.
 
-*on-click-right* ++
+*on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.
+
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
 
 *on-scroll-up*: ++
 	typeof: string ++

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -10,33 +10,33 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 
 # CONFIGURATION
 
-*bat* ++
+*bat*: ++
 	typeof: string ++
 	The battery to monitor, as in /sys/class/power_supply/ instead of auto detect.
 
-*adapter* ++
+*adapter*: ++
 	typeof: string ++
 	The adapter to monitor, as in /sys/class/power_supply/ instead of auto detect.
 
-*full-at* ++
+*full-at*: ++
 	typeof: integer ++
 	Define the max percentage of the battery, usefull for an old battery, e.g. 96
 
-*interval* ++
+*interval*: ++
 	typeof: integer ++
 	default: 60 ++
 	The interval in which the information gets polled.
 
-*states* ++
+*states*: ++
 	typeof: array ++
 	A number of battery states which get activated on certain capacity levels. See *waybar-states(5)*.
 
-*format* ++
+*format*: ++
 	typeof: string ++
 	default: {capacity}% ++
 	The format, how the time should be displayed.
 
-*format-time* ++
+*format-time*: ++
 	typeof: string ++
 	default: {H} h {M} min ++
 	The format, how the time should be displayed.
@@ -78,11 +78,11 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	typeof: string ++
 	Command to execute when scrolling down on the module.
 
-*smooth-scrolling-threshold* ++
+*smooth-scrolling-threshold*: ++
 	typeof: double ++
 	Threshold to be used when scrolling.
 
-*tooltip* ++
+*tooltip*: ++
 	typeof: bool ++
 	default: true ++
 	Option to disable tooltip on hover.

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -51,6 +51,10 @@ The *clock* module displays the current date and time.
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -44,6 +44,10 @@ The *cpu* module displays the current cpu utilization.
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -73,6 +73,10 @@ Addressed by *custom/<name>*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -47,6 +47,10 @@ Addressed by *disk*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-idle-inhibitor.5.scd
+++ b/man/waybar-idle-inhibitor.5.scd
@@ -39,6 +39,10 @@ screensaving, also known as "presentation mode".
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -46,6 +46,10 @@ Addressed by *memory*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -89,6 +89,10 @@ Addressed by *mpd*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -72,6 +72,10 @@ Addressed by *network*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -67,6 +67,10 @@ Additionally you can control the volume by scrolling *up* or *down* while the cu
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module. This replaces the default behaviour of volume control.

--- a/man/waybar-sway-mode.5.scd
+++ b/man/waybar-sway-mode.5.scd
@@ -37,6 +37,10 @@ Addressed by *sway/mode*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -37,6 +37,10 @@ Addressed by *sway/window*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -60,6 +60,10 @@ Addressed by *sway/workspaces*
     default: empty ++
     Lists workspaces that should always be shown, even when non existent
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 # FORMAT REPLACEMENTS
 
 *{value}*: Name of the workspace, as defined by sway.

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -70,6 +70,10 @@ Addressed by *temperature*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -20,6 +20,10 @@ Addressed by *tray*
     typeof: integer ++
     Defines the spacing between the tray icons.
 
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
 # EXAMPLES
 
 ```

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -31,7 +31,7 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
 }
 
 auto ALabel::update() -> void {
-  // Nothing here
+  AModule::update();
 }
 
 std::string ALabel::getIcon(uint16_t percentage, const std::string& alt, uint16_t max) {

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -29,7 +29,10 @@ AModule::~AModule() {
 }
 
 auto AModule::update() -> void {
-  pid_.push_back(util::command::forkExec(config_["on-update"].asString()));
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    pid_.push_back(util::command::forkExec(config_["on-update"].asString()));
+  }
 }
 
 bool AModule::handleToggle(GdkEventButton* const& e) {

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -29,7 +29,7 @@ AModule::~AModule() {
 }
 
 auto AModule::update() -> void {
-  // Nothing here
+  pid_.push_back(util::command::forkExec(config_["on-update"].asString()));
 }
 
 bool AModule::handleToggle(GdkEventButton* const& e) {

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -175,6 +175,11 @@ auto waybar::modules::Backlight::update() -> void {
       return;
     }
 
+    // Run user-provided update handler if configured
+    if (config_["on-update"].isString()) {
+      AModule::update();
+    }
+
     const auto percent = best->get_max() == 0 ? 100 : best->get_actual() * 100 / best->get_max();
     label_.set_markup(fmt::format(
         format_, fmt::arg("percent", std::to_string(percent)), fmt::arg("icon", getIcon(percent))));

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -192,6 +192,8 @@ auto waybar::modules::Backlight::update() -> void {
   }
   previous_best_ = best == nullptr ? std::nullopt : std::optional{*best};
   previous_format_ = format_;
+  // Call parent update
+  ALabel::update();
 }
 
 template <class ForwardIt>

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -175,11 +175,6 @@ auto waybar::modules::Backlight::update() -> void {
       return;
     }
 
-    // Run user-provided update handler if configured
-    if (config_["on-update"].isString()) {
-      AModule::update();
-    }
-
     const auto percent = best->get_max() == 0 ? 100 : best->get_actual() * 100 / best->get_max();
     label_.set_markup(fmt::format(
         format_, fmt::arg("percent", std::to_string(percent)), fmt::arg("icon", getIcon(percent))));

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -149,11 +149,6 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
 }
 
 auto waybar::modules::Battery::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   auto [capacity, time_remaining, status] = getInfos();
   if (status == "Unknown") {
     status = getAdapterStatus(capacity);
@@ -192,4 +187,6 @@ auto waybar::modules::Battery::update() -> void {
                                   fmt::arg("icon", getIcon(capacity, state)),
                                   fmt::arg("time", formatTimeRemaining(time_remaining))));
   }
+  // Call parent update
+  ALabel::update();
 }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -149,6 +149,11 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
 }
 
 auto waybar::modules::Battery::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   auto [capacity, time_remaining, status] = getInfos();
   if (status == "Unknown") {
     status = getAdapterStatus(capacity);

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -13,6 +13,11 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::Clock::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   tzset(); // Update timezone information
   auto now = std::chrono::system_clock::now();
   auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -13,11 +13,6 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::Clock::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   tzset(); // Update timezone information
   auto now = std::chrono::system_clock::now();
   auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
@@ -33,4 +28,6 @@ auto waybar::modules::Clock::update() -> void {
       label_.set_tooltip_text(text);
     }
   }
+  // Call parent update
+  ALabel::update();
 }

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -10,6 +10,11 @@ waybar::modules::Cpu::Cpu(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::Cpu::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   // TODO: as creating dynamic fmt::arg arrays is buggy we have to calc both
   auto cpu_load = getCpuLoad();
   auto [cpu_usage, tooltip] = getCpuUsage();

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -10,11 +10,6 @@ waybar::modules::Cpu::Cpu(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::Cpu::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   // TODO: as creating dynamic fmt::arg arrays is buggy we have to calc both
   auto cpu_load = getCpuLoad();
   auto [cpu_usage, tooltip] = getCpuUsage();
@@ -23,6 +18,8 @@ auto waybar::modules::Cpu::update() -> void {
   }
   label_.set_markup(fmt::format(format_, fmt::arg("load", cpu_load), fmt::arg("usage", cpu_usage)));
   getState(cpu_usage);
+  // Call parent update
+  ALabel::update();
 }
 
 uint16_t waybar::modules::Cpu::getCpuLoad() {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -93,11 +93,6 @@ bool waybar::modules::Custom::handleToggle(GdkEventButton* const& e) {
 }
 
 auto waybar::modules::Custom::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   // Hide label if output is empty
   if (config_["exec"].isString() && (output_.out.empty() || output_.exit_code != 0)) {
     event_box_.hide();
@@ -133,6 +128,8 @@ auto waybar::modules::Custom::update() -> void {
       event_box_.show();
     }
   }
+  // Call parent update
+  ALabel::update();
 }
 
 void waybar::modules::Custom::parseOutputRaw() {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -93,6 +93,11 @@ bool waybar::modules::Custom::handleToggle(GdkEventButton* const& e) {
 }
 
 auto waybar::modules::Custom::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   // Hide label if output is empty
   if (config_["exec"].isString() && (output_.out.empty() || output_.exit_code != 0)) {
     event_box_.hide();

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -73,4 +73,6 @@ auto waybar::modules::Disk::update() -> void {
       ));
   }
   event_box_.show();
+  // Call parent update
+  ALabel::update();
 }

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -26,6 +26,11 @@ waybar::modules::IdleInhibitor::~IdleInhibitor() {
 }
 
 auto waybar::modules::IdleInhibitor::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   label_.set_markup(
       fmt::format(format_, fmt::arg("status", status_), fmt::arg("icon", getIcon(0, status_))));
   label_.get_style_context()->add_class(status_);

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -26,17 +26,14 @@ waybar::modules::IdleInhibitor::~IdleInhibitor() {
 }
 
 auto waybar::modules::IdleInhibitor::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   label_.set_markup(
       fmt::format(format_, fmt::arg("status", status_), fmt::arg("icon", getIcon(0, status_))));
   label_.get_style_context()->add_class(status_);
   if (tooltipEnabled()) {
     label_.set_tooltip_text(status_);
   }
+  // Call parent update
+  ALabel::update();
 }
 
 bool waybar::modules::IdleInhibitor::handleToggle(GdkEventButton* const& e) {

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -9,6 +9,11 @@ waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config
 }
 
 auto waybar::modules::Memory::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   parseMeminfo();
   if (memtotal_ > 0 && memfree_ >= 0) {
     auto total_ram_gigabytes = memtotal_ / std::pow(1024, 2);

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -9,11 +9,6 @@ waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config
 }
 
 auto waybar::modules::Memory::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   parseMeminfo();
   if (memtotal_ > 0 && memfree_ >= 0) {
     auto total_ram_gigabytes = memtotal_ / std::pow(1024, 2);
@@ -35,6 +30,8 @@ auto waybar::modules::Memory::update() -> void {
   } else {
     event_box_.hide();
   }
+  // Call parent update
+  ALabel::update();
 }
 
 void waybar::modules::Memory::parseMeminfo() {

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -35,6 +35,11 @@ waybar::modules::MPD::MPD(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::MPD::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   std::lock_guard guard(connection_lock_);
   tryConnect();
 

--- a/src/modules/mpd.cpp
+++ b/src/modules/mpd.cpp
@@ -35,11 +35,6 @@ waybar::modules::MPD::MPD(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::MPD::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   std::lock_guard guard(connection_lock_);
   tryConnect();
 
@@ -61,6 +56,9 @@ auto waybar::modules::MPD::update() -> void {
   }
 
   setLabel();
+
+  // Call parent update
+  ALabel::update();
 }
 
 std::thread waybar::modules::MPD::event_listener() {

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -228,11 +228,6 @@ const std::string waybar::modules::Network::getNetworkState() const {
 }
 
 auto waybar::modules::Network::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   std::lock_guard<std::mutex> lock(mutex_);
   std::string                 tooltip_format;
   auto down_octets = read_netstat(BANDWIDTH_CATEGORY, BANDWIDTH_DOWN_TOTAL_KEY);
@@ -314,6 +309,9 @@ auto waybar::modules::Network::update() -> void {
       label_.set_tooltip_text(text);
     }
   }
+
+  // Call parent update
+  ALabel::update();
 }
 
 // Based on https://gist.github.com/Yawning/c70d804d4b8ae78cc698

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -228,6 +228,11 @@ const std::string waybar::modules::Network::getNetworkState() const {
 }
 
 auto waybar::modules::Network::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   std::lock_guard<std::mutex> lock(mutex_);
   std::string                 tooltip_format;
   auto down_octets = read_netstat(BANDWIDTH_CATEGORY, BANDWIDTH_DOWN_TOTAL_KEY);

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -196,11 +196,6 @@ const std::string waybar::modules::Pulseaudio::getPortIcon() const {
 }
 
 auto waybar::modules::Pulseaudio::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   auto format = format_;
   std::string format_name = "format";
   if (monitor_.find("a2dp_sink") != std::string::npos) {
@@ -215,7 +210,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
   } else {
     label_.get_style_context()->remove_class("muted");
   }
-  format = 
+  format =
     config_[format_name].isString() ? config_[format_name].asString() : format;
   // TODO: find a better way to split source/sink
   std::string format_source = "{volume}%";
@@ -234,4 +229,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
   if (tooltipEnabled()) {
     label_.set_tooltip_text(desc_);
   }
+
+  // Call parent update
+  ALabel::update();
 }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -196,6 +196,11 @@ const std::string waybar::modules::Pulseaudio::getPortIcon() const {
 }
 
 auto waybar::modules::Pulseaudio::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   auto format = format_;
   std::string format_name = "format";
   if (monitor_.find("a2dp_sink") != std::string::npos) {

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -40,6 +40,8 @@ auto Tray::update() -> void {
   } else {
     box_.show_all();
   }
+  // Call parent update
+  AModule::update();
 }
 
 }  // namespace waybar::modules::SNI

--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -51,6 +51,8 @@ auto Mode::update() -> void {
     }
     event_box_.show();
   }
+  // Call parent update
+  ALabel::update();
 }
 
 }  // namespace waybar::modules::sway

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -64,6 +64,8 @@ auto Window::update() -> void {
   if (tooltipEnabled()) {
     label_.set_tooltip_text(window_);
   }
+  // Call parent update
+  ALabel::update();
 }
 
 std::tuple<std::size_t, int, std::string, std::string> Window::getFocusedNode(

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -176,6 +176,8 @@ auto Workspaces::update() -> void {
     }
     onButtonReady(*it, button);
   }
+  // Call parent update
+  AModule::update();
 }
 
 Gtk::Button &Workspaces::addButton(const Json::Value &node) {

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -19,6 +19,11 @@ waybar::modules::Temperature::Temperature(const std::string& id, const Json::Val
 }
 
 auto waybar::modules::Temperature::update() -> void {
+  // Run user-provided update handler if configured
+  if (config_["on-update"].isString()) {
+    AModule::update();
+  }
+
   auto [temperature_c, temperature_f] = getTemperature();
   auto critical = isCritical(temperature_c);
   auto format = format_;

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -19,11 +19,6 @@ waybar::modules::Temperature::Temperature(const std::string& id, const Json::Val
 }
 
 auto waybar::modules::Temperature::update() -> void {
-  // Run user-provided update handler if configured
-  if (config_["on-update"].isString()) {
-    AModule::update();
-  }
-
   auto [temperature_c, temperature_f] = getTemperature();
   auto critical = isCritical(temperature_c);
   auto format = format_;
@@ -38,6 +33,8 @@ auto waybar::modules::Temperature::update() -> void {
                                 fmt::arg("temperatureC", temperature_c),
                                 fmt::arg("temperatureF", temperature_f),
                                 fmt::arg("icon", getIcon(temperature_c, "", max_temp))));
+  // Call parent update
+  ALabel::update();
 }
 
 std::tuple<uint16_t, uint16_t> waybar::modules::Temperature::getTemperature() {


### PR DESCRIPTION
Adds an "on-update" configuration option to every module that, if configured, is run at the beginning of each call to update(). This can be used to e.g. call a custom bash script that creates a notification every time the volume changes.