### PR TITLE
 fix(custom): ignore selected_player if not defined. Fixes #419 

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -140,5 +140,6 @@
         },
         "escape": true,
         "exec": "$HOME/.config/waybar/mediaplayer.py 2> /dev/null" // Script in resources folder
+        // "exec": "$HOME/.config/waybar/mediaplayer.py --player spotify 2> /dev/null" // Filter player based on name
     }
 }

--- a/resources/custom_modules/mediaplayer.py
+++ b/resources/custom_modules/mediaplayer.py
@@ -45,7 +45,7 @@ def on_metadata(player, metadata, manager):
 
 
 def on_player_appeared(manager, player, selected_player=None):
-    if player is not None and player.name == selected_player:
+    if player is not None and (selected_player is None or player.name == selected_player):
         init_player(manager, player)
     else:
         logger.debug("New player appeared, but it's not the selected player, skipping")


### PR DESCRIPTION
When the command line argument `--player <name>` is not defined, custom module is not picking up new players.
Also added example usage of argument to config.
