### PR TITLE
add support for muted bluetooth audio, fix #420

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -116,6 +116,7 @@
         // "scroll-step": 1, // %, can be a float
         "format": "{volume}% {icon} {format_source}",
         "format-bluetooth": "{volume}% {icon} {format_source}",
+        "format-bluetooth-muted": " {icon} {format_source}",
         "format-muted": " {format_source}",
         "format-source": "{volume}% ",
         "format-source-muted": "",

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -197,19 +197,21 @@ const std::string waybar::modules::Pulseaudio::getPortIcon() const {
 
 auto waybar::modules::Pulseaudio::update() -> void {
   auto format = format_;
-  if (muted_) {
-    format = config_["format-muted"].isString() ? config_["format-muted"].asString() : format;
+  std::string format_name = "format";
+  if (monitor_.find("a2dp_sink") != std::string::npos) {
+    format_name = format_name + "-bluetooth";
+    label_.get_style_context()->add_class("bluetooth");
+  } else {
+    label_.get_style_context()->remove_class("bluetooth");
+  }
+  if (muted_ ) {
+    format_name = format_name + "-muted";
     label_.get_style_context()->add_class("muted");
   } else {
     label_.get_style_context()->remove_class("muted");
-    if (monitor_.find("a2dp_sink") != std::string::npos) {
-      format =
-          config_["format-bluetooth"].isString() ? config_["format-bluetooth"].asString() : format;
-      label_.get_style_context()->add_class("bluetooth");
-    } else {
-      label_.get_style_context()->remove_class("bluetooth");
-    }
   }
+  format = 
+    config_[format_name].isString() ? config_[format_name].asString() : format;
   // TODO: find a better way to split source/sink
   std::string format_source = "{volume}%";
   if (source_muted_ && config_["format-source-muted"].isString()) {


### PR DESCRIPTION
This adds the format-bluetooth-muted option to handle muted bluetooth audio as described in #420.
If no format-bluetooth-muted entry is present, the "format" fallback is used like it was before.