### PR TITLE
fix(network): stack-use-after-return found by address sanitizer

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -201,8 +201,9 @@ void waybar::modules::Network::worker() {
     }
     thread_timer_.sleep_for(interval_);
   };
-  std::array<struct epoll_event, EPOLL_MAX> events{};
-  thread_ = [this, &events] {
+  thread_ = [this] {
+    std::array<struct epoll_event, EPOLL_MAX> events{};
+
     int ec = epoll_wait(efd_, events.data(), EPOLL_MAX, -1);
     if (ec > 0) {
       for (auto i = 0; i < ec; i++) {

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -130,7 +130,8 @@ std::tuple<std::string, std::string> Host::getBusNameAndObjectPath(const std::st
 }
 
 void Host::addRegisteredItem(std::string service) {
-  auto [bus_name, object_path] = getBusNameAndObjectPath(service);
+  std::string bus_name, object_path;
+  std::tie(bus_name, object_path) = getBusNameAndObjectPath(service);
   auto it = std::find_if(items_.begin(), items_.end(), [&bus_name, &object_path](const auto& item) {
     return bus_name == item->bus_name && object_path == item->object_path;
   });


### PR DESCRIPTION
```
==587==ERROR: AddressSanitizer: stack-use-after-return on address 0x7f22313f0084 at pc 0x000000778010 bp 0x7f22132c27d0 sp 0x7f22132c27c8
READ of size 4 at 0x7f22313f0084 thread T11
    #0 0x77800f in waybar::modules::Network::worker()::$_1::operator()() const /home/alebastr/sources/Waybar/build-asan/../src/modules/network.cpp:117:28
    #1 0x7777ec in std::_Function_handler<void (), waybar::modules::Network::worker()::$_1>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/bits/std_function.h:297:2
    #2 0x5f5a68 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/bits/std_function.h:687:14
    #3 0x5f58aa in waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()::operator()() const /home/alebastr/sources/Waybar/build-asan/../include/util/sleeper_thread.hpp:26:9
    #4 0x5f571c in void std::__invoke_impl<void, waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()>(std::__invoke_other, waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()&&) /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/bits/invoke.h:60:14
    #5 0x5f551c in std::__invoke_result<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()>::type std::__invoke<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()>(waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()&&) /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/bits/invoke.h:95:14
    #6 0x5f546e in decltype(std::__invoke(_S_declval<0ul>())) std::thread::_Invoker<std::tuple<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/thread:244:13
    #7 0x5f5351 in std::thread::_Invoker<std::tuple<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()> >::operator()() /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/thread:253:11
    #8 0x5f3c8c in std::thread::_State_impl<std::thread::_Invoker<std::tuple<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-redhat-linux/8/../../../../include/c++/8/thread:196:13
    #9 0x7f2235a0d9a2  (/lib64/libstdc++.so.6+0xc39a2)
    #10 0x7f22357ac58d in start_thread (/lib64/libpthread.so.0+0x858d)
    #11 0x7f22356ae6a2 in __GI___clone (/lib64/libc.so.6+0xfd6a2)

Address 0x7f22313f0084 is located in stack of thread T0 at offset 132 in frame
    #0 0x7664af in waybar::modules::Network::worker() /home/alebastr/sources/Waybar/build-asan/../src/modules/network.cpp:104
```
Also fixes compilation with clang: <https://stackoverflow.com/a/46115028>

My asan test script:
```bash
#!/bin/bash
env CC=clang CXX=clang++                 \
meson setup build-asan --buildtype debug \
    -Db_lundef=false -Db_sanitize=address,undefined
ninja -C build-asan
# new_delete_type_mismatch=0: see libsigcplusplus/libsigcplusplus#10
env ASAN_OPTIONS=new_delete_type_mismatch=0,detect_stack_use_after_return=1,check_initialization_order=1,strict_string_checks=1 \
    ./build-asan/waybar

```