### PR TITLE
sway/mode: enable pango markup on supported modes

### DIFF
--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -17,7 +17,11 @@ void Mode::onEvent(const struct Ipc::ipc_response& res) {
     std::lock_guard<std::mutex> lock(mutex_);
     auto                        payload = parser_.parse(res.payload);
     if (payload["change"] != "default") {
-      mode_ = Glib::Markup::escape_text(payload["change"].asString());
+      if (payload["pango_markup"].asBool()) {
+        mode_ = payload["change"].asString();
+      } else {
+        mode_ = Glib::Markup::escape_text(payload["change"].asString());
+      }
     } else {
       mode_.clear();
     }


### PR DESCRIPTION
Closes #435.

IPC reports `{"mode": "mode_string", "pango_markup": bool}` on mode change.
Use this to conditionally enable pango markup.