### PR TITLE
Allow downstream to disable manpages even if scdoc is found

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -153,7 +153,7 @@ install_data(
     install_dir: join_paths(get_option('out'), 'etc/xdg/waybar')
 )
 
-scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: false)
+scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))
 
 if scdoc.found()
     scdoc_prog = find_program(scdoc.get_pkgconfig_variable('scdoc'), native: true)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -3,5 +3,6 @@ option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl suppo
 option('libudev', type: 'feature', value: 'auto', description: 'Enable libudev support for udev related features')
 option('pulseaudio', type: 'feature', value: 'auto', description: 'Enable support for pulseaudio')
 option('dbusmenu-gtk', type: 'feature', value: 'auto', description: 'Enable support for tray')
+option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('mpd', type: 'feature', value: 'auto', description: 'Enable support for the Music Player Daemon')
 option('out', type: 'string', value : '/', description: 'output prefix directory')


### PR DESCRIPTION
Like sway e.g.,
```
$ pkg-config --modversion scdoc
1.9.6

$ meson -Dman-pages=disabled _build
[...]
Dependency scdoc skipped: feature man-pages disabled
[...]
```
