### PR TITLE
Fix some issues with exclusive zone and margins

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -56,6 +56,7 @@ class Bar {
   void onRealize();
   void onMap(GdkEventAny *ev);
   void setExclusiveZone(uint32_t width, uint32_t height);
+  void setSurfaceSize(uint32_t width, uint32_t height);
   auto setupWidgets() -> void;
   void getModules(const Factory &, const std::string &);
   void setupAltFormatKeyForModule(const std::string &module_name);

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -55,7 +55,7 @@ class Bar {
   void onConfigure(GdkEventConfigure *ev);
   void onRealize();
   void onMap(GdkEventAny *ev);
-  void setMarginsAndZone(uint32_t height, uint32_t width);
+  void setExclusiveZone(uint32_t width, uint32_t height);
   auto setupWidgets() -> void;
   void getModules(const Factory &, const std::string &);
   void setupAltFormatKeyForModule(const std::string &module_name);


### PR DESCRIPTION
Fix some issues with exclusive zones and margins:
- exclusive zone did not include margins after toggling bar
- exclusive zone included incorrect margin when bar is anchored at bottom or right edge
- margins were incorrectly applied over anchored axis (see comment in setSurfaceSize)

There are some remaining issues with specifying size for anchored axis that may require decoupling window size from layer surface size. For now let's just pretend that this works as expected :see_no_evil: 