### PR TITLE
Add configurable time display for battery module

### DIFF
--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -32,6 +32,11 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	default: {capacity}% ++
 	The format, how the time should be displayed.
 
+*format-time* ++
+	typeof: string ++
+	default: {H} h {M} min ++
+	The format, how the time should be displayed.
+
 *format-icons*
 	typeof: array/object
 	Based on the current capacity, the corresponding icon gets selected. ++
@@ -77,6 +82,14 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 *{icon}*: Icon, as defined in *format-icons*.
 
 *{time}*: Estimate of time until full or empty. Note that this is based on the power draw at the last refresh time, not an average.
+
+# TIME FORMAT
+
+The *battery* module allows you to define how time should be formatted via *format-time*.
+
+The two arguments are:
+*{H}*: Hours
+*{M}*: Minutes
 
 # CUSTOM FORMATS
 

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -141,7 +141,11 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
   hoursRemaining = std::fabs(hoursRemaining);
   uint16_t full_hours = static_cast<uint16_t>(hoursRemaining);
   uint16_t minutes = static_cast<uint16_t>(60 * (hoursRemaining - full_hours));
-  return std::to_string(full_hours) + " h " + std::to_string(minutes) + " min";
+  auto format = std::string("{H} h {M} min");
+  if (config_["format-time"].isString()) {
+    format = config_["format-time"].asString();
+  }
+  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes));
 }
 
 auto waybar::modules::Battery::update() -> void {


### PR DESCRIPTION
Adds a `format-time` configuration for the battery module so that users
can configure how they want their remaining time to be displayed.

The default format remains the same as before, i.e. `{H} h {M} min`,
but users can choose something like `{H}:{M:02d}` to give an output
like `4:29` if wanted.