### PR TITLE
install a systemd user service unit

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -62,6 +62,13 @@ libnlgen = dependency('libnl-genl-3.0', required: get_option('libnl'))
 libpulse = dependency('libpulse', required: get_option('pulseaudio'))
 libudev = dependency('libudev', required: get_option('libudev'))
 libmpdclient = dependency('libmpdclient', required: get_option('mpd'))
+systemd = dependency('systemd', required: get_option('systemd'))
+
+if systemd.found()
+  user_units_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
+  install_data('./resources/waybar.service',
+    install_dir: user_units_dir)
+endif
 
 src_files = files(
     'src/factory.cpp',

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,6 +2,7 @@ option('libcxx', type : 'boolean', value : false, description : 'Build with Clan
 option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl support for network related features')
 option('libudev', type: 'feature', value: 'auto', description: 'Enable libudev support for udev related features')
 option('pulseaudio', type: 'feature', value: 'auto', description: 'Enable support for pulseaudio')
+option('systemd', type: 'feature', value: 'auto', description: 'Install systemd user service unit')
 option('dbusmenu-gtk', type: 'feature', value: 'auto', description: 'Enable support for tray')
 option('man-pages', type: 'feature', value: 'auto', description: 'Generate and install man pages')
 option('mpd', type: 'feature', value: 'auto', description: 'Enable support for the Music Player Daemon')

--- a/resources/waybar.service
+++ b/resources/waybar.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
+Documentation=https://github.com/Alexays/Waybar/wiki/
+PartOf=wayland-session.target
+
+[Service]
+Type=dbus
+BusName=fr.arouillard.waybar
+ExecStart=/usr/bin/waybar
+
+[Install]
+WantedBy=wayland-session.target


### PR DESCRIPTION
add a systemd --user unit/service file, so that one can run waybar as a
--user systemd service.

this feature is automatically enabled if systemd is found, but can be disabled
with -Dsystemd=disabled