### PR TITLE
service file: allow for waybar installed in different prefix

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -66,8 +66,13 @@ systemd = dependency('systemd', required: get_option('systemd'))
 
 if systemd.found()
   user_units_dir = systemd.get_pkgconfig_variable('systemduserunitdir')
-  install_data('./resources/waybar.service',
-    install_dir: user_units_dir)
+
+  configure_file(
+    configuration: config,
+    input: './resources/waybar.service.in',
+    output: '@BASENAME@',
+    install_dir: user_units_dir
+  )
 endif
 
 src_files = files(

--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -6,7 +6,7 @@ PartOf=wayland-session.target
 [Service]
 Type=dbus
 BusName=fr.arouillard.waybar
-ExecStart=/usr/bin/waybar
+ExecStart=@prefix@/bin/waybar
 
 [Install]
 WantedBy=wayland-session.target


### PR DESCRIPTION
ie. don't assume waybar is always gonna be installed in `/usr/bin/waybar`