### PR TITLE
add padding for mpd module in default style

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -75,7 +75,8 @@ window#waybar.chromium {
 #custom-media,
 #tray,
 #mode,
-#idle_inhibitor {
+#idle_inhibitor,
+#mpd {
     padding: 0 10px;
     margin: 0 4px;
     color: #ffffff;


### PR DESCRIPTION
In the default style.css many modules (clock, battery, cpu, ...) get horizontal padding, but mpd module does not. This commit adds mpd to the list of modules that get the padding.

Before:
![image](https://user-images.githubusercontent.com/2893599/65066792-6206c780-d985-11e9-9f6b-5cea95cda20a.png)

After:
![image](https://user-images.githubusercontent.com/2893599/65066838-76e35b00-d985-11e9-9e04-cf65503e4049.png)

