### PR TITLE
Add more locking in mpd module

### DIFF
--- a/include/modules/mpd.hpp
+++ b/include/modules/mpd.hpp
@@ -65,6 +65,9 @@ class MPD : public ALabel {
   unique_status status_;
   mpd_state     state_;
   unique_song   song_;
+
+  // To make sure the previous periodic_updater stops before creating a new one
+  std::mutex periodic_lock_;
 };
 
 }  // namespace waybar::modules


### PR DESCRIPTION
This PR aims to solve issue #281 by taking the `connection_lock_` in `waitForEvent()`.

Additionally, I observed that multiple `periodic_updater`s could be running.
This happens when mpd is playing and no events happen.
This causes the mpd connection to drop when `mpd_recv_idle` times out.
If the current `periodic_updater` is sleeping at this moment, `update` will run and start a new one,
while the current one will also continue running (there is a new connection to mpd at this moment, so it sees no reason to stop). Adding a mutex to make sure `update` only continues when the current `periodic_updater` has stopped, fixes this.

It would be nice if more people could try out this code, since I'm not sure #281 is solved by  this, maybe it just happens more infrequently.