### PR TITLE
Detect timezone changes

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -1,4 +1,5 @@
 #include "modules/clock.hpp"
+#include <time.h>
 
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     : ALabel(config, "clock", id, "{:%H:%M}", 60) {
@@ -12,6 +13,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 }
 
 auto waybar::modules::Clock::update() -> void {
+  tzset(); // Update timezone information
   auto now = std::chrono::system_clock::now();
   auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
   auto text = fmt::format(format_, localtime);


### PR DESCRIPTION
Fixes #479, because upstream does not intend to.

It may be less expensive to do that only once in a while, or to inotify-watch on /etc/timezone, but this is good enough.