### PR TITLE
fix: No need to format string with unused 'arg' named argument (#484)

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -26,7 +26,6 @@ class AModule : public IModule {
 
   const Json::Value &config_;
   Gtk::EventBox      event_box_;
-  std::string        click_param_;
 
   virtual bool handleToggle(GdkEventButton *const &ev);
   virtual bool handleScroll(GdkEventScroll *);

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -46,7 +46,7 @@ bool AModule::handleToggle(GdkEventButton* const& e) {
     format = config_["on-click-forward"].asString();
   }
   if (!format.empty()) {
-    pid_.push_back(util::command::forkExec(fmt::format(format, fmt::arg("arg", click_param_))));
+    pid_.push_back(util::command::forkExec(format));
   }
   dp.emit();
   return true;


### PR DESCRIPTION
The `fmt::format()` function looks for the `{arg}` named argument in the given "format" string which does not exist. It will fail if the string contains any `{...}` curled-brace substring.

Consequently, any `on-click*` option's command line containing for instance substring like `${var}` or `awk '{...}'` will crash the program.