### PR TITLE
Add tooltip formatting to custom module

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -112,10 +112,16 @@ auto waybar::modules::Custom::update() -> void {
     } else {
       label_.set_markup(str);
       if (tooltipEnabled()) {
-        if (text_ == tooltip_) {
-          label_.set_tooltip_text(str);
+        if (config_["tooltip-format"].isString()) {
+          auto tooltip_format = config_["tooltip-format"].asString();
+          auto tooltip_text = fmt::format(tooltip_format,
+                              text_,
+                              fmt::arg("alt", alt_),
+                              fmt::arg("icon", getIcon(percentage_, alt_)),
+                              fmt::arg("percentage", percentage_));
+          label_.set_tooltip_text(tooltip_text);
         } else {
-          label_.set_tooltip_text(tooltip_);
+          label_.set_tooltip_text(str);
         }
       }
       auto classes = label_.get_style_context()->list_classes();


### PR DESCRIPTION
This respects the tooltip-format option, and if tooltip is enabled and this option is a string formats the custom tooltip exactly like it formats the normal text, but using the tooltip_format.

Disclaimer:
I am not a cpp developer and mostly copied the code from the clock module, so it is very likely I did something wrong. I also do not quite understand the code that I replaced. But this seems to work for me quite well.