### PR TITLE
add dependencies of gtk-layer-shell to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ libsigc++
 fmt
 wayland
 wlroots
+libgtk-3-dev [gtk-layer-shell]
+gobject-introspection [gtk-layer-shell]
+libgirepository1.0-dev [gtk-layer-shell]
 libpulse [Pulseaudio module]
 libnl [Network module]
 sway [Sway modules]
@@ -59,7 +62,7 @@ libmpdclient [MPD module]
 On Ubuntu 19.10 you can install all the relevant dependencies using this command:
 
 ```
-sudo apt install libgtkmm-3.0-dev libjsoncpp-dev libinput-dev libsigc++-2.0-dev libpulse-dev libnl-3-dev libdbusmenu-gtk3-dev libnl-genl-3-dev libfmt-dev clang-tidy scdoc libmpdclient-dev
+sudo apt install libgtkmm-3.0-dev libjsoncpp-dev libinput-dev libsigc++-2.0-dev libpulse-dev libnl-3-dev libdbusmenu-gtk3-dev libnl-genl-3-dev libfmt-dev clang-tidy libmpdclient-dev libwayland-dev libgtk-3-dev gobject-introspection libgirepository1.0-dev scdoc
 ```
 
 


### PR DESCRIPTION
Add missing dependencies of the new gtk-layer-shell to the README.

I have tested the apt install only on Debian testing, not on Ubuntu 19.10