### PR TITLE
[Corrected] Add info on "on-click-middle" option to custom module man page

### DIFF
--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -36,6 +36,10 @@ The *backlight* module displays the current backlight level.
 	typeof: string ++
 	Command to execute when the module is clicked.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right* ++
 	typeof: string ++
 	Command to execute when the module is right clicked.

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -54,7 +54,11 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	typeof: string ++
 	Command to execute when clicked on the module.
 
-*on-click-right*: ++
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
+*on-click-right* ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -32,6 +32,10 @@ The *clock* module displays the current date and time.
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -36,6 +36,10 @@ The *cpu* module displays the current cpu utilization.
 	typeof: string  ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -59,6 +59,10 @@ Addressed by *custom/<name>*
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -39,6 +39,10 @@ Addressed by *disk*
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-idle-inhibitor.5.scd
+++ b/man/waybar-idle-inhibitor.5.scd
@@ -31,6 +31,10 @@ screensaving, also known as "presentation mode".
 	typeof: string ++
 	Command to execute when clicked on the module. A click also toggles the state
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -38,6 +38,10 @@ Addressed by *memory*
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -13,110 +13,114 @@ The *mpd* module displays information about a running "Music Player Daemon" inst
 Addressed by *mpd*
 
 *server*: ++
-    typeof: string ++
-    The network address or Unix socket path of the MPD server. If empty, connect to the default host.
+	typeof: string ++
+	The network address or Unix socket path of the MPD server. If empty, connect to the default host.
 
 *port*: ++
-    typeof: integer ++
-    The port MPD listens to. If empty, use the default port.
+	typeof: integer ++
+	The port MPD listens to. If empty, use the default port.
 
 *interval*: ++
-    typeof: integer++
-    default: 5 ++
-    The interval in which the connection to the MPD server is retried
+	typeof: integer++
+	default: 5 ++
+	The interval in which the connection to the MPD server is retried
 
 *timeout*: ++
-    typeof: integer++
-    default: 30 ++
-    The timeout for the connection. Change this if your MPD server has a low `connection_timeout` setting
+	typeof: integer++
+	default: 30 ++
+	The timeout for the connection. Change this if your MPD server has a low `connection_timeout` setting
 
 *unknown-tag*: ++
-    typeof: string ++
-    default: "N/A" ++
-    The text to display when a tag is not present in the current song, but used in `format`
+	typeof: string ++
+	default: "N/A" ++
+	The text to display when a tag is not present in the current song, but used in `format`
 
 *format*: ++
-    typeof: string ++
-    default: "{album} - {artist} - {title}" ++
-    Information displayed when a song is playing or paused
+	typeof: string ++
+	default: "{album} - {artist} - {title}" ++
+	Information displayed when a song is playing or paused
 
 *format-stopped*: ++
-    typeof: string ++
-    default: "stopped" ++
-    Information displayed when the player is stopped.
+	typeof: string ++
+	default: "stopped" ++
+	Information displayed when the player is stopped.
 
 *format-disconnected*: ++
-    typeof: string ++
-    default: "disconnected" ++
-    Information displayed when the MPD server can't be reached.
+	typeof: string ++
+	default: "disconnected" ++
+	Information displayed when the MPD server can't be reached.
 
 *tooltip*: ++
-    typeof: bool ++
-    default: true ++
-    Option to disable tooltip on hover.
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
 
 *tooltip-format*: ++
-    typeof: string ++
-    default: "MPD (connected)" ++
-    Tooltip information displayed when connected to MPD.
+	typeof: string ++
+	default: "MPD (connected)" ++
+	Tooltip information displayed when connected to MPD.
 
 *tooltip-format-disconnected*: ++
-    typeof: string ++
-    default: "MPD (disconnected)" ++
-    Tooltip information displayed when the MPD server can't be reached.
+	typeof: string ++
+	default: "MPD (disconnected)" ++
+	Tooltip information displayed when the MPD server can't be reached.
 
 *rotate*: ++
-    typeof: integer ++
-    Positive value to rotate the text label.
+	typeof: integer ++
+	Positive value to rotate the text label.
 
 *max-length*: ++
-    typeof: integer ++
-    The maximum length in character the module should display.
+	typeof: integer ++
+	The maximum length in character the module should display.
 
 *on-click*: ++
-    typeof: string ++
-    Command to execute when clicked on the module.
+	typeof: string ++
+	Command to execute when clicked on the module.
+
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
 
 *on-click-right*: ++
-    typeof: string ++
-    Command to execute when you right clicked on the module.
+	typeof: string ++
+	Command to execute when you right clicked on the module.
 
 *on-scroll-up*: ++
-    typeof: string ++
-    Command to execute when scrolling up on the module.
+	typeof: string ++
+	Command to execute when scrolling up on the module.
 
 *on-scroll-down*: ++
-    typeof: string ++
-    Command to execute when scrolling down on the module.
+	typeof: string ++
+	Command to execute when scrolling down on the module.
 
 *smooth-scrolling-threshold*: ++
-    typeof: double ++
-    Threshold to be used when scrolling.
+	typeof: double ++
+	Threshold to be used when scrolling.
 
 *state-icons*: ++
-    typeof: object ++
-    default: {} ++
-    Icon to show depending on the play/pause state of the player (*{ "playing": "...", "paused": "..." }*)
+	typeof: object ++
+	default: {} ++
+	Icon to show depending on the play/pause state of the player (*{ "playing": "...", "paused": "..." }*)
 
 *consume-icons*: ++
-    typeof: object ++
-    default: {} ++
-    Icon to show depending on the "consume" option (*{ "on": "...", "off": "..." }*)
+	typeof: object ++
+	default: {} ++
+	Icon to show depending on the "consume" option (*{ "on": "...", "off": "..." }*)
 
 *random-icons*: ++
-    typeof: object ++
-    default: {} ++
-    Icon to show depending on the "random" option (*{ "on": "...", "off": "..." }*)
+	typeof: object ++
+	default: {} ++
+	Icon to show depending on the "random" option (*{ "on": "...", "off": "..." }*)
 
 *repeat-icons*: ++
-    typeof: object ++
-    default: {} ++
-    Icon to show depending on the "repeat" option (*{ "on": "...", "off": "..." }*)
+	typeof: object ++
+	default: {} ++
+	Icon to show depending on the "repeat" option (*{ "on": "...", "off": "..." }*)
 
 *single-icons*: ++
-    typeof: object ++
-    default: {} ++
-    Icon to show depending on the "single" option (*{ "on": "...", "off": "..." }*)
+	typeof: object ++
+	default: {} ++
+	Icon to show depending on the "single" option (*{ "on": "...", "off": "..." }*)
 
 # FORMAT REPLACEMENTS
 

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -64,6 +64,10 @@ Addressed by *network*
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -59,6 +59,10 @@ Additionally you can control the volume by scrolling *up* or *down* while the cu
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-sway-mode.5.scd
+++ b/man/waybar-sway-mode.5.scd
@@ -29,6 +29,10 @@ Addressed by *sway/mode*
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -29,6 +29,10 @@ Addressed by *sway/window*
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
 *on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -13,67 +13,71 @@ The *temperature* module displays the current temperature from a thermal zone.
 Addressed by *temperature*
 
 *thermal-zone*: ++
-    typeof: integer ++
-    The thermal zone, as in */sys/class/thermal/*.
+	typeof: integer ++
+	The thermal zone, as in */sys/class/thermal/*.
 
 *hwmon-path*: ++
-    typeof: string ++
-    The temperature path to use, e.g. */sys/class/hwmon/hwmon2/temp1_input* instead of one in */sys/class/thermal/*.
+	typeof: string ++
+	The temperature path to use, e.g. */sys/class/hwmon/hwmon2/temp1_input* instead of one in */sys/class/thermal/*.
 
 *critical-threshold*: ++
-    typeof: integer ++
-    The threshold before it is considered critical (Celcius).
+	typeof: integer ++
+	The threshold before it is considered critical (Celcius).
 
 *interval*: ++
-    typeof: integer ++
-    default: 10 ++
-    The interval in which the information gets polled.
+	typeof: integer ++
+	default: 10 ++
+	The interval in which the information gets polled.
 
 *format-critical*: ++
-    typeof: string ++
-    The format to use when temperature is considered critical
+	typeof: string ++
+	The format to use when temperature is considered critical
 
 *format*: ++
-    typeof: string  ++
-    default: {temperatureC}°C ++
-    The format (Celcius/Farenheit) in which the temperature should be displayed.
+	typeof: string  ++
+	default: {temperatureC}°C ++
+	The format (Celcius/Farenheit) in which the temperature should be displayed.
 
 *format-icons*: ++
-    typeof: array ++
-    Based on the current temperature (Celcius) and *critical-threshold* if available, the corresponding icon gets selected. The order is *low* to *high*.
+	typeof: array ++
+	Based on the current temperature (Celcius) and *critical-threshold* if available, the corresponding icon gets selected. The order is *low* to *high*.
 
 *rotate*: ++
-    typeof: integer ++
-    Positive value to rotate the text label.
+	typeof: integer ++
+	Positive value to rotate the text label.
 
 *max-length*: ++
-    typeof: integer ++
-    The maximum length in characters the module should display.
+	typeof: integer ++
+	The maximum length in characters the module should display.
 
 *on-click*: ++
-    typeof: string ++
-    Command to execute when you clicked on the module.
+	typeof: string ++
+	Command to execute when you clicked on the module.
+
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
 
 *on-click-right*: ++
-    typeof: string ++
-    Command to execute when you right clicked on the module.
+	typeof: string ++
+	Command to execute when you right clicked on the module.
 
 *on-scroll-up*: ++
-    typeof: string ++
-    Command to execute when scrolling up on the module.
+	typeof: string ++
+	Command to execute when scrolling up on the module.
 
 *on-scroll-down*: ++
-    typeof: string ++
-    Command to execute when scrolling down on the module.
+	typeof: string ++
+	Command to execute when scrolling down on the module.
 
 *smooth-scrolling-threshold*: ++
-    typeof: double ++
-    Threshold to be used when scrolling.
+	typeof: double ++
+	Threshold to be used when scrolling.
 
 *tooltip*: ++
-    typeof: bool ++
-    default: true ++
-    Option to disable tooltip on hover.
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
 
 # FORMAT REPLACEMENTS
 


### PR DESCRIPTION
#505 fix attempt two. #517 had a space on an empty line which caused a build error, this fixes that.

Also changed the spacing in the mpd and temperature modules to use tabs instead of spaces, to be consistent with the other modules.