### PR TITLE
Fix: WindowId recieves 'u'

### DIFF
--- a/protocol/dbus-status-notifier-item.xml
+++ b/protocol/dbus-status-notifier-item.xml
@@ -31,7 +31,9 @@
     <property name='Id' type='s' access='read'/>
     <property name='Title' type='s' access='read'/>
     <property name='Status' type='s' access='read'/>
+    <!-- See discussion on pull #536
     <property name='WindowId' type='u' access='read'/>
+    -->
     <property name='IconThemePath' type='s' access='read'/>
     <property name='IconName' type='s' access='read'/>
     <property name='IconPixmap' type='a(iiay)' access='read'/>


### PR DESCRIPTION
I noticed a lot of errors of the sort:
```
(waybar:165190): "GLib-GIO-WARNING **: 16:39:02.710: Received property WindowId with type i does not match expected type u in the expected interface"
```