### PR TITLE
man: adding and clarification of configuration options

### DIFF
--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -37,32 +37,32 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	default: {H} h {M} min ++
 	The format, how the time should be displayed.
 
-*format-icons*
-	typeof: array/object
+*format-icons*: ++
+	typeof: array/object ++
 	Based on the current capacity, the corresponding icon gets selected. ++
 	The order is *low* to *high*. Or by the state if it is an object.
 
-*max-length* ++
+*max-length*: ++
 	typeof: integer++
 	The maximum length in character the module should display.
 
-*rotate* ++
+*rotate*: ++
 	typeof: integer++
 	Positive value to rotate the text label.
 
-*on-click* ++
+*on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.
 
-*on-click-right* ++
+*on-click-right*: ++
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
-*on-scroll-up* ++
+*on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.
 
-*on-scroll-down* ++
+*on-scroll-down*: ++
 	typeof: string ++
 	Command to execute when scrolling down on the module.
 

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -21,6 +21,11 @@ Addressed by *network*
 	default: 60 ++
 	The interval in which the network information gets polled (e.g. signal strength).
 
+*family*: ++
+	typeof: string ++
+	default: *ipv4* ++
+	The address family that is used for the format replacement {ipaddr} and to determine if a network connection is present.
+
 *format*: ++
 	typeof: string  ++
 	default: *{ifname}* ++

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -47,6 +47,11 @@ Addressed by *network*
 	typeof: string ++
 	This format is used when the displayed interface is disconnected.
 
+*format-icons*: ++
+	typeof: array/object ++
+	Based on the current signal strength, the corresponding icon gets selected. ++
+	The order is *low* to *high*. Or by the state if it is an object.
+
 *rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.
@@ -121,6 +126,8 @@ Addressed by *network*
 *{bandwidthUpOctets}*: Instant up speed in octets/seconds.
 
 *{bandwidthDownOctets}*: Instant down speed in octets/seconds.
+
+*{icon}*: Icon, as defined in *format-icons*.
 
 # EXAMPLES
 

--- a/man/waybar.5.scd
+++ b/man/waybar.5.scd
@@ -23,7 +23,8 @@ Also a minimal example configuration can be found on the at the bottom of this m
 *layer* ++
 	typeof: string ++
 	default: bottom ++
-	Decide if the bar is displayed in front of the windows or behind them.
+	Decide if the bar is displayed in front (*top*) of the windows or behind (*bottom*)
+	them.
 
 *output* ++
 	typeof: string|array ++

--- a/man/waybar.5.scd
+++ b/man/waybar.5.scd
@@ -66,6 +66,12 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	typeof: string ++
 	Optional name added as a CSS class, for styling multiple waybars.
 
+*gtk-layer-shell* ++
+	typeof: bool ++
+	default: true ++
+	Option to disable the use of gtk-layer-shell for popups.
+	Only functional if compiled with gtk-layer-shell support.
+
 # MODULE FORMAT
 
 You can use PangoMarkupFormat (See https://developer.gnome.org/pango/stable/PangoMarkupFormat.html#PangoMarkupFormat).


### PR DESCRIPTION
This pull request adds documentation for the configuration options:
* gtk-layer-shell
* network->family
* network->format-icon

Further, it clarifies the available options for the layer configuration and fixes the layout of the waybar-battery man page.

I will also try to update the Github wiki.