### PR TITLE
Move bar to background when toggled off

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -368,7 +368,7 @@ auto waybar::Bar::toggle() -> void {
 #endif
   }
   setExclusiveZone(width_, height_);
-  //wl_surface_commit(surface);
+  wl_surface_commit(surface);
 }
 
 void waybar::Bar::getModules(const Factory& factory, const std::string& pos) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,14 +1,16 @@
-#include <csignal>
 #include <spdlog/spdlog.h>
+#include <csignal>
 #include "client.hpp"
 
 int main(int argc, char* argv[]) {
   try {
     auto client = waybar::Client::inst();
     std::signal(SIGUSR1, [](int /*signal*/) {
-      for (auto& bar : waybar::Client::inst()->bars) {
-        bar->toggle();
-      }
+      Glib::signal_idle().connect_once([] {
+        for (auto& bar : waybar::Client::inst()->bars) {
+          bar->toggle();
+        }
+      });
     });
 
     for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {


### PR DESCRIPTION
This means the bar doesn't have a clickable area that covers other windows when hidden and layer is `top`. Only works with `gtk-layer-shell` so far.