### PR TITLE
fix(network): add missing include

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -2,6 +2,7 @@
 #include <spdlog/spdlog.h>
 #include <sys/eventfd.h>
 #include <fstream>
+#include <cassert>
 #include "util/format.hpp"
 
 


### PR DESCRIPTION
Fixes:
```
../src/modules/network.cpp:68:3: error: 'assert' was not declared in this scope
   68 |   assert(starts_with(read, category));
      |   ^~~~~~
../src/modules/network.cpp:6:1: note: 'assert' is defined in header '<cassert>'; did you forget to '#include <cassert>'?
    5 | #include "util/format.hpp"
  +++ |+#include <cassert>
    6 |
```