### PR TITLE
Use PA_PROP_DEVICE_FORM_FACTOR for device icon.

### DIFF
--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -34,6 +34,7 @@ class Pulseaudio : public ALabel {
   pa_cvolume  pa_volume_;
   bool        muted_;
   std::string port_name_;
+  std::string form_factor_;
   std::string desc_;
   std::string monitor_;
   // SOURCE

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -158,6 +158,9 @@ void waybar::modules::Pulseaudio::sinkInfoCb(pa_context * /*context*/, const pa_
     pa->desc_ = i->description;
     pa->monitor_ = i->monitor_source_name;
     pa->port_name_ = i->active_port != nullptr ? i->active_port->name : "Unknown";
+    if (auto ff = pa_proplist_gets(i->proplist, PA_PROP_DEVICE_FORM_FACTOR)) {
+      pa->form_factor_ = ff;
+    }
     pa->dp.emit();
   }
 }
@@ -185,7 +188,7 @@ static const std::array<std::string, 9> ports = {
 };
 
 const std::string waybar::modules::Pulseaudio::getPortIcon() const {
-  std::string nameLC = port_name_;
+  std::string nameLC = port_name_ + form_factor_;
   std::transform(nameLC.begin(), nameLC.end(), nameLC.begin(), ::tolower);
   for (auto const &port : ports) {
     if (nameLC.find(port) != std::string::npos) {


### PR DESCRIPTION
It makes finding the icon a little more reliable. [PA_PROP_DEVICE_FORM_FACTOR](https://freedesktop.org/software/pulseaudio/doxygen/proplist_8h.html#a77c49f81eb8426259c13fc53619b9670)

Though this should probably get refactored to use [PA_PROP_DEVICE_ICON_NAME](https://freedesktop.org/software/pulseaudio/doxygen/proplist_8h.html#ad2eee8a3a9bbad4ed65eb7eb094a7518) in the future.

This is how Pulseaudio finds the icon: [sink.c](https://github.com/pulseaudio/pulseaudio/blob/f5d3606fe76302c7dbdb0f6a80400df829a5f846/src/pulsecore/sink.c#L3443)
