### PR TITLE
refactor(client): use std::list<waybar_output> to store outputs

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -30,12 +30,12 @@ class Client {
                                                               const std::string &style) const;
   void                                             bindInterfaces();
   const std::string getValidPath(const std::vector<std::string> &paths) const;
-  void              handleOutput(std::unique_ptr<struct waybar_output> &output);
-  bool isValidOutput(const Json::Value &config, std::unique_ptr<struct waybar_output> &output);
+  void              handleOutput(struct waybar_output &output);
+  bool isValidOutput(const Json::Value &config, struct waybar_output &output);
   auto setupConfig(const std::string &config_file) -> void;
   auto setupCss(const std::string &css_file) -> void;
-  std::unique_ptr<struct waybar_output> &getOutput(void *);
-  std::vector<Json::Value> getOutputConfigs(std::unique_ptr<struct waybar_output> &output);
+  struct waybar_output &getOutput(void *);
+  std::vector<Json::Value> getOutputConfigs(struct waybar_output &output);
 
   static void handleGlobal(void *data, struct wl_registry *registry, uint32_t name,
                            const char *interface, uint32_t version);
@@ -44,10 +44,10 @@ class Client {
   void        handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor);
   void        handleMonitorRemoved(Glib::RefPtr<Gdk::Monitor> monitor);
 
-  Json::Value                                        config_;
-  Glib::RefPtr<Gtk::StyleContext>                    style_context_;
-  Glib::RefPtr<Gtk::CssProvider>                     css_provider_;
-  std::vector<std::unique_ptr<struct waybar_output>> outputs_;
+  Json::Value                     config_;
+  Glib::RefPtr<Gtk::StyleContext> style_context_;
+  Glib::RefPtr<Gtk::CssProvider>  css_provider_;
+  std::list<struct waybar_output> outputs_;
 };
 
 }  // namespace waybar


### PR DESCRIPTION
std::unique_ptr is not required here as the only benefit it gives is stability of address on vector resize and it's easy to invalidate it accidentally. std::list provides the same guarantee of stable addresses
of the elements and correct destruction while avoiding smart pointer overhead.

Also fixes #554, caused by my inability to read the manual for std::remove_if :smile:

To be honest, fixing remove_if would be enough, but I already did the refactoring part and decided to proceed with that.