### PR TITLE
Download patch files from Github instead of wrapdb

### DIFF
--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -5,6 +5,6 @@ source_url = https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz
 source_filename = fmt-5.3.0.tar.gz
 source_hash = defa24a9af4c622a7134076602070b45721a43c51598c8456ec6f2c4dbb51c89
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/fmt/5.3.0/1/get_zip
+patch_url = https://github.com/mesonbuild/fmt/releases/download/5.3.0-1/fmt.zip
 patch_filename = fmt-5.3.0-1-wrap.zip
 patch_hash = 18f21a3b8833949c35d4ac88a7059577d5fa24b98786e4b1b2d3d81bb811440f

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -5,6 +5,6 @@ source_url = https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz
 source_filename = v1.3.1.tar.gz
 source_hash = 160845266e94db1d4922ef755637f6901266731c4cb3b30b45bf41efa0e6ab70
 
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/spdlog/1.3.1/1/get_zip
+patch_url = https://github.com/mesonbuild/spdlog/releases/download/1.3.1-1/spdlog.zip
 patch_filename = spdlog-1.3.1-1-wrap.zip
 patch_hash = 715a0229781019b853d409cc0bf891ee4b9d3a17bec0cf87f4ad30b28bbecc87


### PR DESCRIPTION
Currently wrapdb.mesonbuild.com is offline and its not clear when it
will be up again. Github seems to be the more reliable source for these
files.