### PR TITLE
Add rfkill status to network module and new bluetooth module

### DIFF
--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -18,6 +18,7 @@ class Bluetooth : public ALabel {
  private:
   std::string           status_;
   util::SleeperThread 	thread_;
+  util::SleeperThread 	intervall_thread_;
 
   util::Rfkill rfkill_;
 };

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -5,6 +5,7 @@
 
 #include <fmt/chrono.h>
 #include "util/sleeper_thread.hpp"
+#include "util/rfkill.hpp"
 
 namespace waybar::modules {
 
@@ -15,8 +16,10 @@ class Bluetooth : public ALabel {
   auto update() -> void;
 
  private:
-  std::string                   status_;
-  util::SleeperThread thread_;
+  std::string           status_;
+  util::SleeperThread 	thread_;
+
+  util::Rfkill rfkill_;
 };
 
 }  // namespace waybar::modules

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -11,6 +11,7 @@
 #include <sys/epoll.h>
 #include "ALabel.hpp"
 #include "util/sleeper_thread.hpp"
+#include "util/rfkill.hpp"
 
 namespace waybar::modules {
 
@@ -71,6 +72,8 @@ class Network : public ALabel {
 
   util::SleeperThread thread_;
   util::SleeperThread thread_timer_;
+
+  util::Rfkill rfkill_;
 };
 
 }  // namespace waybar::modules

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -72,6 +72,7 @@ class Network : public ALabel {
 
   util::SleeperThread thread_;
   util::SleeperThread thread_timer_;
+  util::SleeperThread thread_rfkill_;
 
   util::Rfkill rfkill_;
 };

--- a/include/util/rfkill.hpp
+++ b/include/util/rfkill.hpp
@@ -9,12 +9,11 @@ class Rfkill {
   Rfkill(enum rfkill_type rfkill_type);
   ~Rfkill() = default;
   void waitForEvent();
-  int getState() const;
+  bool getState() const;
 
  private:
   enum rfkill_type rfkill_type_;
   int state_ = 0;
-  int prev_state_ = 0;
 };
 
 }  // namespace waybar::util

--- a/include/util/rfkill.hpp
+++ b/include/util/rfkill.hpp
@@ -5,12 +5,11 @@
 namespace waybar::util {
 
 class Rfkill {
- public:
+ public:;
   Rfkill(enum rfkill_type rfkill_type);
   ~Rfkill() = default;
-  bool isDisabled() const;
   void waitForEvent();
-  int getState();
+  int getState() const;
 
  private:
   enum rfkill_type rfkill_type_;

--- a/include/util/rfkill.hpp
+++ b/include/util/rfkill.hpp
@@ -2,8 +2,20 @@
 
 #include <linux/rfkill.h>
 
-namespace waybar::util::rfkill {
+namespace waybar::util {
 
-bool isDisabled(enum rfkill_type rfkill_type);
+class Rfkill {
+ public:
+  Rfkill(enum rfkill_type rfkill_type);
+  ~Rfkill() = default;
+  bool isDisabled() const;
+  void waitForEvent();
+  int getState();
+
+ private:
+  enum rfkill_type rfkill_type_;
+  int state_ = 0;
+  int prev_state_ = 0;
+};
 
 }  // namespace waybar::util

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -1,0 +1,94 @@
+waybar-bluetooth(5)
+
+# NAME
+
+waybar - bluetooth module
+
+# DESCRIPTION
+
+The *bluetooth* module displays information about the status of the device's bluetooth device.
+
+# CONFIGURATION
+
+Addressed by *bluetooth*
+
+*interval*: ++
+	typeof: integer ++
+	default: 60 ++
+	The interval in which the network information gets polled (e.g. signal strength).
+
+*format*: ++
+	typeof: string  ++
+	default: *{icon}* ++
+	The format, how information should be displayed. This format is used when other formats aren't specified.
+
+*format-icons*: ++
+	typeof: array/object ++
+	Based on the device status, the corresponding icon gets selected. ++
+	The order is *low* to *high*. Or by the state if it is an object.
+
+*rotate*: ++
+	typeof: integer ++
+	Positive value to rotate the text label.
+
+*max-length*: ++
+	typeof: integer ++
+	The maximum length in character the module should display.
+
+*on-click*: ++
+	typeof: string ++
+	Command to execute when clicked on the module.
+
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
+*on-click-right*: ++
+	typeof: string ++
+	Command to execute when you right clicked on the module.
+
+*on-scroll-up*: ++
+	typeof: string ++
+	Command to execute when scrolling up on the module.
+
+*on-scroll-down*: ++
+	typeof: string ++
+	Command to execute when scrolling down on the module.
+
+*smooth-scrolling-threshold*: ++
+	typeof: double ++
+	Threshold to be used when scrolling.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: *true* ++
+	Option to disable tooltip on hover.
+
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. This format is used when other formats aren't specified.
+
+# FORMAT REPLACEMENTS
+
+*{status}*: Status of the bluetooth device.
+
+*{icon}*: Icon, as defined in *format-icons*.
+
+# EXAMPLES
+
+```
+"bluetooth": {
+	"format": "{icon}",
+	"format-alt": "bluetooth: {status}",
+	"interval": 30,
+	"format-icons": {
+		"enabled": "",
+		"disabled": ""
+	}
+	"tooltip-format": "{status}"
+}
+```
+
+# STYLE
+
+- *#bluetooth*

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -15,7 +15,7 @@ Addressed by *bluetooth*
 *interval*: ++
 	typeof: integer ++
 	default: 60 ++
-	The interval in which the network information gets polled (e.g. signal strength).
+	The interval in which the bluetooth state gets updated.
 
 *format*: ++
 	typeof: string  ++

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -47,6 +47,10 @@ Addressed by *network*
 	typeof: string ++
 	This format is used when the displayed interface is disconnected.
 
+*format-disabled*: ++
+	typeof: string ++
+	This format is used when the displayed interface is disabled.
+
 *format-icons*: ++
 	typeof: array/object ++
 	Based on the current signal strength, the corresponding icon gets selected. ++
@@ -105,6 +109,10 @@ Addressed by *network*
 	typeof: string ++
 	This format is used when the displayed interface is disconnected.
 
+*tooltip-format-disabled*: ++
+	typeof: string ++
+	This format is used when the displayed interface is disabled.
+
 # FORMAT REPLACEMENTS
 
 *{ifname}*: Name of the network interface.
@@ -142,6 +150,7 @@ Addressed by *network*
 	"format-wifi": "{essid} ({signalStrength}%) ",
 	"format-ethernet": "{ifname} ",
 	"format-disconnected": "", //An empty format will hide the module.
+	"format-disconnected": "",
 	"tooltip-format": "{ifname}",
 	"tooltip-format-wifi": "{essid} ({signalStrength}%) ",
 	"tooltip-format-ethernet": "{ifname} ",
@@ -154,6 +163,7 @@ Addressed by *network*
 
 - *#network*
 - *#network.disconnected*
+- *#network.disabled*
 - *#network.linked*
 - *#network.ethernet*
 - *#network.wifi*

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project(
     'waybar', 'cpp', 'c',
-    version: '0.8.0',
+    version: '0.9.0',
     license: 'MIT',
     default_options : [
         'cpp_std=c++17',

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -165,9 +165,9 @@ auto waybar::modules::Battery::update() -> void {
   }
   // Transform to lowercase
   std::transform(status.begin(), status.end(), status.begin(), ::tolower);
-  // Replace space with underscore
+  // Replace space with dash
   std::transform(status.begin(), status.end(), status.begin(), [](char ch) {
-    return ch == ' ' ? '_' : ch;
+    return ch == ' ' ? '-' : ch;
   });
   auto format = format_;
   auto state = getState(capacity, true);

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -163,7 +163,12 @@ auto waybar::modules::Battery::update() -> void {
     }
     label_.set_tooltip_text(tooltip_text);
   }
+  // Transform to lowercase
   std::transform(status.begin(), status.end(), status.begin(), ::tolower);
+  // Replace space with underscore
+  std::transform(status.begin(), status.end(), status.begin(), [](char ch) {
+    return ch == ' ' ? '_' : ch;
+  });
   auto format = format_;
   auto state = getState(capacity, true);
   if (!old_status_.empty()) {

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -3,20 +3,24 @@
 #include <linux/rfkill.h>
 #include <time.h>
 
-#include <iostream>
-
 waybar::modules::Bluetooth::Bluetooth(const std::string& id, const Json::Value& config)
-    : ALabel(config, "bluetooth", id, "{status}", 10),
+    : ALabel(config, "bluetooth", id, "{icon}", 10),
       status_("disabled"),
-      rfkill_(*(new waybar::util::Rfkill(RFKILL_TYPE_BLUETOOTH))) {
+      rfkill_{RFKILL_TYPE_BLUETOOTH} {
   thread_ = [this] {
     dp.emit();
     rfkill_.waitForEvent();
   };
+  intervall_thread_ = [this] {
+    auto now = std::chrono::system_clock::now();
+    auto timeout = std::chrono::floor<std::chrono::seconds>(now + interval_);
+    auto diff = std::chrono::seconds(timeout.time_since_epoch().count() % interval_.count());
+    thread_.sleep_until(timeout - diff);
+    dp.emit();
+  };
 }
 
 auto waybar::modules::Bluetooth::update() -> void {
-  status_ = "enabled";
   if (rfkill_.getState()) {
     status_ = "disabled";
   } else {
@@ -24,16 +28,18 @@ auto waybar::modules::Bluetooth::update() -> void {
   }
 
   label_.set_markup(
-      fmt::format(format_, fmt::arg("status", status_), fmt::arg("icon", getIcon(0, status_))));
-  label_.get_style_context()->add_class(status_);
+      fmt::format(
+        format_,
+        fmt::arg("status", status_),
+        fmt::arg("icon", getIcon(0, status_))));
 
-  //if (tooltipEnabled()) {
-    //if (config_["tooltip-format"].isString()) {
-      //auto tooltip_format = config_["tooltip-format"].asString();
-      ////auto tooltip_text = fmt::format(tooltip_format, localtime);
-      //label_.set_tooltip_text(tooltip_text);
-    //} else {
-      //label_.set_tooltip_text(status_);
-    //}
-  //}
+  if (tooltipEnabled()) {
+    if (config_["tooltip-format"].isString()) {
+      auto tooltip_format = config_["tooltip-format"].asString();
+      auto tooltip_text = fmt::format(tooltip_format, status_);
+      label_.set_tooltip_text(tooltip_text);
+    } else {
+      label_.set_tooltip_text(status_);
+    }
+  }
 }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -280,6 +280,11 @@ auto waybar::modules::Network::update() -> void {
       fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / interval_.count(), "o/s")));
   if (text != label_.get_label()) {
     label_.set_markup(text);
+    if (text.empty()) {
+      event_box_.hide();
+    } else {
+      event_box_.show();
+    }
   }
   if (tooltipEnabled()) {
     if (tooltip_format.empty() && config_["tooltip-format"].isString()) {

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -87,7 +87,9 @@ waybar::modules::Network::Network(const std::string &id, const Json::Value &conf
       cidr_(-1),
       signal_strength_dbm_(0),
       signal_strength_(0),
-      frequency_(0) {
+      frequency_(0),
+      rfkill_(*(new waybar::util::Rfkill(RFKILL_TYPE_WLAN))) {
+
   auto down_octets = read_netstat(BANDWIDTH_CATEGORY, BANDWIDTH_DOWN_TOTAL_KEY);
   auto up_octets = read_netstat(BANDWIDTH_CATEGORY, BANDWIDTH_UP_TOTAL_KEY);
   if (down_octets) {
@@ -224,7 +226,7 @@ void waybar::modules::Network::worker() {
 
 const std::string waybar::modules::Network::getNetworkState() const {
   if (ifid_ == -1) {
-    if (waybar::util::rfkill::isDisabled(RFKILL_TYPE_WLAN))
+    if (rfkill_.isDisabled())
       return "disabled";
     return "disconnected";
   }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -3,7 +3,6 @@
 #include <sys/eventfd.h>
 #include <fstream>
 #include <cassert>
-#include <linux/rfkill.h>
 #include "util/format.hpp"
 #include "util/rfkill.hpp"
 

--- a/src/util/rfkill.cpp
+++ b/src/util/rfkill.cpp
@@ -3,9 +3,71 @@
 #include <stdlib.h>
 #include <cstring>
 #include <fcntl.h>
+#include <sys/poll.h>
 #include <cerrno>
+#include <stdio.h>
 
-bool waybar::util::rfkill::isDisabled(enum rfkill_type rfkill_type) {
+waybar::util::Rfkill::Rfkill(const enum rfkill_type rfkill_type)
+  : rfkill_type_(rfkill_type) {
+}
+
+void waybar::util::Rfkill::waitForEvent() {
+  struct rfkill_event event;
+  struct pollfd p;
+  ssize_t len;
+  int fd, n;
+
+  fd = open("/dev/rfkill", O_RDONLY);
+  if (fd < 0) {
+    //perror("Can't open RFKILL control device");
+    return;
+  }
+
+  memset(&p, 0, sizeof(p));
+  p.fd = fd;
+  p.events = POLLIN | POLLHUP;
+
+  while (1) {
+    n = poll(&p, 1, -1);
+    if (n < 0) {
+      //perror("Failed to poll RFKILL control device");
+      break;
+    }
+
+    if (n == 0)
+      continue;
+
+    len = read(fd, &event, sizeof(event));
+    if (len < 0) {
+      //perror("Reading of RFKILL events failed");
+      break;
+    }
+
+    if (len != RFKILL_EVENT_SIZE_V1) {
+      //fprintf(stderr, "Wrong size of RFKILL event\n");
+      continue;
+    }
+
+    if(event.type == rfkill_type_) {
+      state_ = event.soft || event.hard;
+      if (prev_state_ != state_) {
+        prev_state_ = state_;
+        break;
+      }
+      //ret = event.soft || event.hard;
+    }
+  }
+
+  close(fd);
+  return;
+}
+
+
+int waybar::util::Rfkill::getState() {
+  return state_;
+}
+
+bool waybar::util::Rfkill::isDisabled() const {
   struct rfkill_event event;
   ssize_t len;
   int fd;
@@ -38,7 +100,7 @@ bool waybar::util::rfkill::isDisabled(enum rfkill_type rfkill_type) {
       return false;
     }
 
-    if(event.type == rfkill_type) {
+    if(event.type == rfkill_type_) {
       ret = event.soft || event.hard;
       break;
     }

--- a/src/util/rfkill.cpp
+++ b/src/util/rfkill.cpp
@@ -1,3 +1,21 @@
+/* https://git.kernel.org/pub/scm/linux/kernel/git/jberg/rfkill.git/
+ *
+ * Copyright 2009 Johannes Berg <johannes@sipsolutions.net>
+ * Copyright 2009 Marcel Holtmann <marcel@holtmann.org>
+ * Copyright 2009 Tim Gardner <tim.gardner@canonical.com>
+ * 
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. */
+
 #include "util/rfkill.hpp"
 #include <linux/rfkill.h>
 #include <unistd.h>

--- a/src/util/rfkill.cpp
+++ b/src/util/rfkill.cpp
@@ -78,6 +78,6 @@ void waybar::util::Rfkill::waitForEvent() {
 }
 
 
-int waybar::util::Rfkill::getState() const {
+bool waybar::util::Rfkill::getState() const {
   return state_;
 }


### PR DESCRIPTION
I added an interface to the [linux rfkill utility](https://wireless.wiki.kernel.org/en/users/Documentation/rfkill). This allows modules to update based on changes of the rfkill state. I added this to the existing network module and created a new bluetooth module implementing the feature.

### rfkill
The code is adapted from [here](https://git.kernel.org/pub/scm/linux/kernel/git/jberg/rfkill.git/).

### bluetooth
I was never sure if my bluetooth module was deactivated or not connecting to my devices for another reason.
It's possible to update the module via an interval in addition to rfkill events.

### network module
Two main changes were made:
1. Distinction between no wifi connection present and wifi module turned off. (think: airplane mode)
1. Update status on rfkill event in addition to interval based updates.

The second actually gave me some trouble as there seems to be an unrelated bug. The module doesn't seem to reflect a change in status in the bar, even though the corresponding `update()` function was executed both via the interval as well as based on the rfkill event.
I reproduced this on v0.9 from the arch community repos.  Also see my comment in #494.

I am open to any feedback, especially on style. I don't have much experience with c++.