### PR TITLE
pulseaudio: adapt icon names to form factors

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -176,11 +176,11 @@ void waybar::modules::Pulseaudio::serverInfoCb(pa_context *context, const pa_ser
 }
 
 static const std::array<std::string, 9> ports = {
-    "headphones",
+    "headphone",
     "speaker",
     "hdmi",
     "headset",
-    "handsfree",
+    "hands-free",
     "portable",
     "car",
     "hifi",


### PR DESCRIPTION
Now that the icon is determined based on the form factor (see 8fb3211594ced057025d2b8a9acc1b63a27cb388), it makes sense to adapt the icon names to the string representation of the form factors.

The [form factor strings are copied from pulseaudio](https://github.com/pulseaudio/pulseaudio/blob/2afadb7119f4d84e39212fc12102c49513f9f1a3/src/modules/bluetooth/module-bluez5-device.c#L203-L225):

```c
static const char *form_factor_to_string(pa_bluetooth_form_factor_t ff) {
    switch (ff) {
        case PA_BLUETOOTH_FORM_FACTOR_UNKNOWN:
            return "unknown";
        case PA_BLUETOOTH_FORM_FACTOR_HEADSET:
            return "headset";
        case PA_BLUETOOTH_FORM_FACTOR_HANDSFREE:
            return "hands-free";
        case PA_BLUETOOTH_FORM_FACTOR_MICROPHONE:
            return "microphone";
        case PA_BLUETOOTH_FORM_FACTOR_SPEAKER:
            return "speaker";
        case PA_BLUETOOTH_FORM_FACTOR_HEADPHONE:
            return "headphone";
        case PA_BLUETOOTH_FORM_FACTOR_PORTABLE:
            return "portable";
        case PA_BLUETOOTH_FORM_FACTOR_CAR:
            return "car";
        case PA_BLUETOOTH_FORM_FACTOR_HIFI:
            return "hifi";
        case PA_BLUETOOTH_FORM_FACTOR_PHONE:
            return "phone";
    }
```