### PR TITLE
fix(sway): resolve destruction dependency between Ipc and SleeperThread

### DIFF
--- a/include/modules/sway/ipc/client.hpp
+++ b/include/modules/sway/ipc/client.hpp
@@ -8,6 +8,7 @@
 #include <memory>
 #include <mutex>
 #include "ipc.hpp"
+#include "util/sleeper_thread.hpp"
 
 namespace waybar::modules::sway {
 
@@ -28,6 +29,7 @@ class Ipc {
   void sendCmd(uint32_t type, const std::string &payload = "");
   void subscribe(const std::string &payload);
   void handleEvent();
+  void setWorker(std::function<void()> &&func);
 
  protected:
   static inline const std::string ipc_magic_ = "i3-ipc";
@@ -38,9 +40,10 @@ class Ipc {
   struct ipc_response send(int fd, uint32_t type, const std::string &payload = "");
   struct ipc_response recv(int fd);
 
-  int        fd_;
-  int        fd_event_;
-  std::mutex mutex_;
+  int                 fd_;
+  int                 fd_event_;
+  std::mutex          mutex_;
+  util::SleeperThread thread_;
 };
 
 }  // namespace waybar::modules::sway

--- a/include/modules/sway/mode.hpp
+++ b/include/modules/sway/mode.hpp
@@ -6,7 +6,6 @@
 #include "client.hpp"
 #include "modules/sway/ipc/client.hpp"
 #include "util/json.hpp"
-#include "util/sleeper_thread.hpp"
 
 namespace waybar::modules::sway {
 
@@ -18,14 +17,11 @@ class Mode : public ALabel, public sigc::trackable {
 
  private:
   void onEvent(const struct Ipc::ipc_response&);
-  void worker();
 
   std::string      mode_;
   util::JsonParser parser_;
   std::mutex       mutex_;
-
-  util::SleeperThread thread_;
-  Ipc                 ipc_;
+  Ipc              ipc_;
 };
 
 }  // namespace waybar::modules::sway

--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -7,7 +7,6 @@
 #include "client.hpp"
 #include "modules/sway/ipc/client.hpp"
 #include "util/json.hpp"
-#include "util/sleeper_thread.hpp"
 
 namespace waybar::modules::sway {
 
@@ -20,7 +19,6 @@ class Window : public ALabel, public sigc::trackable {
  private:
   void                                                   onEvent(const struct Ipc::ipc_response&);
   void                                                   onCmd(const struct Ipc::ipc_response&);
-  void                                                   worker();
   std::tuple<std::size_t, int, std::string, std::string> getFocusedNode(const Json::Value& nodes,
                                                                         std::string&       output);
   void                                                   getTree();
@@ -33,9 +31,7 @@ class Window : public ALabel, public sigc::trackable {
   std::size_t      app_nb_;
   util::JsonParser parser_;
   std::mutex       mutex_;
-
-  util::SleeperThread thread_;
-  Ipc                 ipc_;
+  Ipc              ipc_;
 };
 
 }  // namespace waybar::modules::sway

--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -8,7 +8,6 @@
 #include "client.hpp"
 #include "modules/sway/ipc/client.hpp"
 #include "util/json.hpp"
-#include "util/sleeper_thread.hpp"
 
 namespace waybar::modules::sway {
 
@@ -21,7 +20,6 @@ class Workspaces : public AModule, public sigc::trackable {
  private:
   void              onCmd(const struct Ipc::ipc_response&);
   void              onEvent(const struct Ipc::ipc_response&);
-  void              worker();
   bool              filterButtons();
   Gtk::Button&      addButton(const Json::Value&);
   void              onButtonReady(const Json::Value&, Gtk::Button&);
@@ -38,9 +36,7 @@ class Workspaces : public AModule, public sigc::trackable {
   util::JsonParser                             parser_;
   std::unordered_map<std::string, Gtk::Button> buttons_;
   std::mutex                                   mutex_;
-
-  util::SleeperThread thread_;
-  Ipc                 ipc_;
+  Ipc                                          ipc_;
 };
 
 }  // namespace waybar::modules::sway

--- a/src/modules/sway/ipc/client.cpp
+++ b/src/modules/sway/ipc/client.cpp
@@ -10,18 +10,22 @@ Ipc::Ipc() {
 }
 
 Ipc::~Ipc() {
-  // To fail the IPC header
-  write(fd_, "close-sway-ipc", 14);
-  write(fd_event_, "close-sway-ipc", 14);
+  thread_.stop();
+
   if (fd_ > 0) {
+    // To fail the IPC header
+    write(fd_, "close-sway-ipc", 14);
     close(fd_);
     fd_ = -1;
   }
   if (fd_event_ > 0) {
+    write(fd_event_, "close-sway-ipc", 14);
     close(fd_event_);
     fd_event_ = -1;
   }
 }
+
+void Ipc::setWorker(std::function<void()>&& func) { thread_ = func; }
 
 const std::string Ipc::getSocketPath() const {
   const char* env = getenv("SWAYSOCK");

--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -8,7 +8,13 @@ Mode::Mode(const std::string& id, const Json::Value& config)
   ipc_.subscribe(R"(["mode"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &Mode::onEvent));
   // Launch worker
-  worker();
+  ipc_.setWorker([this] {
+    try {
+      ipc_.handleEvent();
+    } catch (const std::exception& e) {
+      spdlog::error("Mode: {}", e.what());
+    }
+  });
   dp.emit();
 }
 
@@ -29,16 +35,6 @@ void Mode::onEvent(const struct Ipc::ipc_response& res) {
   } catch (const std::exception& e) {
     spdlog::error("Mode: {}", e.what());
   }
-}
-
-void Mode::worker() {
-  thread_ = [this] {
-    try {
-      ipc_.handleEvent();
-    } catch (const std::exception& e) {
-      spdlog::error("Mode: {}", e.what());
-    }
-  };
 }
 
 auto Mode::update() -> void {

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -11,7 +11,13 @@ Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
   // Get Initial focused window
   getTree();
   // Launch worker
-  worker();
+  ipc_.setWorker([this] {
+    try {
+      ipc_.handleEvent();
+    } catch (const std::exception& e) {
+      spdlog::error("Window: {}", e.what());
+    }
+  });
 }
 
 void Window::onEvent(const struct Ipc::ipc_response& res) { getTree(); }
@@ -26,16 +32,6 @@ void Window::onCmd(const struct Ipc::ipc_response& res) {
   } catch (const std::exception& e) {
     spdlog::error("Window: {}", e.what());
   }
-}
-
-void Window::worker() {
-  thread_ = [this] {
-    try {
-      ipc_.handleEvent();
-    } catch (const std::exception& e) {
-      spdlog::error("Window: {}", e.what());
-    }
-  };
 }
 
 auto Window::update() -> void {

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -22,7 +22,13 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
     window.signal_scroll_event().connect(sigc::mem_fun(*this, &Workspaces::handleScroll));
   }
   // Launch worker
-  worker();
+  ipc_.setWorker([this] {
+    try {
+      ipc_.handleEvent();
+    } catch (const std::exception &e) {
+      spdlog::error("Workspaces: {}", e.what());
+    }
+  });
 }
 
 void Workspaces::onEvent(const struct Ipc::ipc_response &res) {
@@ -100,16 +106,6 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
       spdlog::error("Workspaces: {}", e.what());
     }
   }
-}
-
-void Workspaces::worker() {
-  thread_ = [this] {
-    try {
-      ipc_.handleEvent();
-    } catch (const std::exception &e) {
-      spdlog::error("Workspaces: {}", e.what());
-    }
-  };
 }
 
 bool Workspaces::filterButtons() {


### PR DESCRIPTION
Could fix some rare crashes when disconnecting monitors. I'm still not satisfied with the change but it works and I don't think I'll have a better fix anytime soon.

Differences from the first attempt: `Ipc` now owns the `SleeperThread`

AddressSanitizer backtrace:
```
=================================================================
==78099==ERROR: AddressSanitizer: heap-use-after-free on address 0x6030001b2ce8 at pc 0x000000ac9815 bp 0x7f4c7d1ea570 sp 0x7f4c7d1ea568
READ of size 8 at 0x6030001b2ce8 thread T7
    #0 0xac9814 in std::__cxx11::list<sigc::slot_base, std::allocator<sigc::slot_base> >::empty() const /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/bits/stl_list.h:1052:38
    #1 0xac8f60 in sigc::internal::signal_emit1<void, waybar::modules::sway::Ipc::ipc_response const&, sigc::nil>::emit(sigc::internal::signal_impl*, waybar::modules::sway::Ipc::ipc_response const&) /usr/include/sigc++-2.0/sigc++/signal.h:1033:33
    #2 0xac8ba2 in sigc::signal1<void, waybar::modules::sway::Ipc::ipc_response const&, sigc::nil>::emit(waybar::modules::sway::Ipc::ipc_response const&) const /usr/include/sigc++-2.0/sigc++/signal.h:2951:14
    #3 0xac8737 in waybar::modules::sway::Ipc::handleEvent() /home/alebastr/sources/waybar/build-asan/../src/modules/sway/ipc/client.cpp:142:16
    #4 0xae1de7 in waybar::modules::sway::Window::worker()::$_0::operator()() const /home/alebastr/sources/waybar/build-asan/../src/modules/sway/window.cpp:34:12
    #5 0xae16c7 in std::_Function_handler<void (), waybar::modules::sway::Window::worker()::$_0>::_M_invoke(std::_Any_data const&) /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/bits/std_function.h:300:2
    #6 0x7958a9 in std::function<void ()>::operator()() const /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/bits/std_function.h:690:14
    #7 0x7956c6 in waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()::operator()() const /home/alebastr/sources/waybar/build-asan/../include/util/sleeper_thread.hpp:27:9
    #8 0x795537 in void std::__invoke_impl<void, waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()>(std::__invoke_other, waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()&&) /usr/bin/../lib/gcc/x86_64-redha
t-linux/9/../../../../include/c++/9/bits/invoke.h:60:14
    #9 0x795317 in std::__invoke_result<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()>::type std::__invoke<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()>(waybar::util::SleeperThread::operator=(std::
function<void ()>)::'lambda'()&&) /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/bits/invoke.h:95:14
    #10 0x795260 in void std::thread::_Invoker<std::tuple<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()> >::_M_invoke<0ul>(std::_Index_tuple<0ul>) /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/thread:244:1
3
    #11 0x795137 in std::thread::_Invoker<std::tuple<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()> >::operator()() /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/thread:251:11
    #12 0x79396a in std::thread::_State_impl<std::thread::_Invoker<std::tuple<waybar::util::SleeperThread::operator=(std::function<void ()>)::'lambda'()> > >::_M_run() /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/thread:195:13
    #13 0x7f4c96e496f3  (/lib64/libstdc++.so.6+0xd76f3)
    #14 0x7f4c96c134e1 in start_thread (/lib64/libpthread.so.0+0x94e1)
    #15 0x7f4c96b146d2 in clone (/lib64/libc.so.6+0x1016d2)

0x6030001b2ce8 is located 8 bytes inside of 32-byte region [0x6030001b2ce0,0x6030001b2d00)
freed by thread T0 here:
    #0 0x6c3c37 in operator delete(void*, unsigned long) (/home/alebastr/sources/waybar/build-asan/waybar+0x6c3c37)
    #1 0x7f4c984d7e26 in sigc::signal_base::~signal_base() (/lib64/libsigc-2.0.so.0+0x3e26)

previously allocated by thread T0 here:
    #0 0x6c2db7 in operator new(unsigned long) (/home/alebastr/sources/waybar/build-asan/waybar+0x6c2db7)
    #1 0x7f4c984d7a2c in sigc::signal_base::impl() const (/lib64/libsigc-2.0.so.0+0x3a2c)

Thread T7 created by T0 here:
    #0 0x60ba06 in pthread_create (/home/alebastr/sources/waybar/build-asan/waybar+0x60ba06)
    #1 0x7f4c96e499b8 in std::thread::_M_start_thread(std::unique_ptr<std::thread::_State, std::default_delete<std::thread::_State> >, void (*)()) (/lib64/libstdc++.so.6+0xd79b8)
    #2 0x7901c4 in waybar::util::SleeperThread::operator=(std::function<void ()>) /home/alebastr/sources/waybar/build-asan/../include/util/sleeper_thread.hpp:24:15
    #3 0xad9e66 in waybar::modules::sway::Window::worker() /home/alebastr/sources/waybar/build-asan/../src/modules/sway/window.cpp:32:11
    #4 0xad81a0 in waybar::modules::sway::Window::Window(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, waybar::Bar const&, Json::Value const&) /home/alebastr/sources/waybar/build-asan/../src/modules/sway/window.cpp
:14:3
    #5 0x6c6acd in waybar::Factory::makeModule(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) const /home/alebastr/sources/waybar/build-asan/../src/factory.cpp:23:18
    #6 0x98671d in waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&) /home/alebastr/sources/waybar/build-asan/../src/bar.cpp:367:31
    #7 0x97e02a in waybar::Bar::setupWidgets() /home/alebastr/sources/waybar/build-asan/../src/bar.cpp:404:3
    #8 0x979da0 in waybar::Bar::Bar(waybar::waybar_output*, Json::Value const&) /home/alebastr/sources/waybar/build-asan/../src/bar.cpp:111:3
    #9 0x9c224e in std::_MakeUniq<waybar::Bar>::__single_object std::make_unique<waybar::Bar, waybar::waybar_output*, Json::Value const&>(waybar::waybar_output*&&, Json::Value const&) /usr/bin/../lib/gcc/x86_64-redhat-linux/9/../../../../include/c++/9/bits
/unique_ptr.h:849:34
    #10 0x9b0464 in waybar::Client::handleOutputName(void*, zxdg_output_v1*, char const*) /home/alebastr/sources/waybar/build-asan/../src/client.cpp:123:35
    #11 0x7f4c96a0eaa7 in ffi_call_unix64 (/lib64/libffi.so.6+0x6aa7)
```