### PR TITLE
fix(clock): lower precision of zoned_time to avoid fractional seconds in output

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -14,7 +14,7 @@ namespace waybar::modules {
 
 struct waybar_time {
   std::locale locale;
-  date::zoned_time<std::chrono::system_clock::duration> ztime;
+  date::zoned_seconds ztime;
 };
 
 class Clock : public ALabel {

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -37,8 +37,9 @@ auto waybar::modules::Clock::update() -> void {
     // Time zone can change. Be sure to pick that.
     time_zone_ = date::current_zone();
   }
-  auto now = std::chrono::system_clock::now();
-  waybar_time wtime = {locale_, date::make_zoned(time_zone_, now)};
+  auto        now = std::chrono::system_clock::now();
+  waybar_time wtime = {locale_,
+                       date::make_zoned(time_zone_, date::floor<std::chrono::seconds>(now))};
 
   auto text = fmt::format(format_, wtime);
   label_.set_markup(text);


### PR DESCRIPTION
`date` includes fractional seconds into `%S` format string output (see https://github.com/HowardHinnant/date/issues/543 for details).
This change should address the issue with seconds formatting reported in https://github.com/Alexays/Waybar/issues/565#issuecomment-579382135