### PR TITLE
fix(meson): Support libc++ >=9.0.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ project(
     ],
 )
 
+compiler = meson.get_compiler('cpp')
+
 cpp_args = []
 cpp_link_args = []
 
@@ -16,12 +18,13 @@ if get_option('libcxx')
     cpp_args += ['-stdlib=libc++']
     cpp_link_args += ['-stdlib=libc++', '-lc++abi']
 
-    cpp_link_args += ['-lc++fs']
+    if compiler.has_link_argument('-lc++fs')
+        cpp_link_args += ['-lc++fs']
+    endif
 else
     cpp_link_args += ['-lstdc++fs']
 endif
 
-compiler = meson.get_compiler('cpp')
 git = find_program('git', required: false)
 
 if not git.found()


### PR DESCRIPTION
From LLVM libc++ documentation:
"Prior to LLVM 9.0, libc++ provides the implementation of the
filesystem library in a separate static library."

Now the filesystem library (not the experimental one) is shipped
inside the libc++.so library.

Check if '-lc++fs' link flag is needed and supported before adding
it.