### PR TITLE
Add a way to exclude specific output

### DIFF
--- a/man/waybar.5.scd
+++ b/man/waybar.5.scd
@@ -28,7 +28,7 @@ Also a minimal example configuration can be found on the at the bottom of this m
 
 *output* ++
 	typeof: string|array ++
-	Specifies on which screen this bar will be displayed.
+	Specifies on which screen this bar will be displayed. Exclamation mark(*!*) can be used to exclude specific output.
 
 *position* ++
 	typeof: string ++

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,28 +64,22 @@ void waybar::Client::handleOutput(struct waybar_output &output) {
 }
 
 bool waybar::Client::isValidOutput(const Json::Value &config, struct waybar_output &output) {
+  if (config["output"].isArray()) {
+    for (auto const &output_conf : config["output"]) {
+      if (output_conf.isString() && output_conf.asString() == output.name) {
+        return true;
+      }
+    }
+  }
 
-  auto check_output = [](std::string_view config_output_name, struct waybar_output &output) {
+  if (config["output"].isString()) {
+    auto config_output_name = config["output"].asString();
     if (!config_output_name.empty()) {
       if (config_output_name.substr(0, 1) == "!") {
           return config_output_name.substr(1) != output.name;
       }
       return config_output_name == output.name;
     }
-    return false;
-  };
-
-  if (config["output"].isArray()) {
-    for (auto const &output_conf : config["output"]) {
-      if (output_conf.isString() && check_output(output_conf.asString(), output)) {
-        if(check_output(output_conf.asString(), output)) {
-          return true;
-        }
-      }
-    }
-  }
-  if (config["output"].isString()) {
-    return check_output(config["output"].asString(), output);
   }
 
   return false;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -77,7 +77,7 @@ bool waybar::Client::isValidOutput(const Json::Value &config, struct waybar_outp
 
   if (config["output"].isArray()) {
     for (auto const &output_conf : config["output"]) {
-      if (output_conf.isString()) {
+      if (output_conf.isString() && check_output(output_conf.asString(), output)) {
         if(check_output(output_conf.asString(), output)) {
           return true;
         }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -82,7 +82,7 @@ bool waybar::Client::isValidOutput(const Json::Value &config, struct waybar_outp
     }
   }
 
-  return false;
+  return true;
 }
 
 struct waybar::waybar_output &waybar::Client::getOutput(void *addr) {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -70,9 +70,8 @@ bool waybar::Client::isValidOutput(const Json::Value &config, struct waybar_outp
         return true;
       }
     }
-  }
-
-  if (config["output"].isString()) {
+    return false;
+  } else if (config["output"].isString()) {
     auto config_output_name = config["output"].asString();
     if (!config_output_name.empty()) {
       if (config_output_name.substr(0, 1) == "!") {


### PR DESCRIPTION
This adds ability to exclude specific output for a bar with `!` character, for example:
```
[
  {
    "layer": "bottom",
    "output": "eDP-1",
    # config for main display
  },
  {
    "layer": "bottom",
    "output": "!eDP-1",
    # config for extra displays
  }
]
```