### PR TITLE
Use the same StatusNotifierWatcher for all trays

### DIFF
--- a/include/modules/sni/tray.hpp
+++ b/include/modules/sni/tray.hpp
@@ -21,7 +21,7 @@ class Tray : public AModule {
 
   static inline std::size_t nb_hosts_ = 0;
   Gtk::Box                  box_;
-  SNI::Watcher              watcher_;
+  SNI::Watcher::singleton   watcher_;
   SNI::Host                 host_;
 };
 

--- a/include/modules/sni/watcher.hpp
+++ b/include/modules/sni/watcher.hpp
@@ -7,9 +7,23 @@
 namespace waybar::modules::SNI {
 
 class Watcher {
+ private:
+  Watcher();
+
  public:
-  Watcher(std::size_t id);
   ~Watcher();
+
+  using singleton = std::shared_ptr<Watcher>;
+  static singleton getInstance() {
+    static std::weak_ptr<Watcher> weak;
+
+    std::shared_ptr<Watcher> strong = weak.lock();
+    if (!strong) {
+      strong = std::shared_ptr<Watcher>(new Watcher());
+      weak = strong;
+    }
+    return strong;
+  }
 
  private:
   typedef enum { GF_WATCH_TYPE_HOST, GF_WATCH_TYPE_ITEM } GfWatchType;
@@ -34,7 +48,6 @@ class Watcher {
   void updateRegisteredItems(SnWatcher *obj);
 
   uint32_t   bus_name_id_;
-  uint32_t   watcher_id_;
   GSList *   hosts_ = nullptr;
   GSList *   items_ = nullptr;
   SnWatcher *watcher_ = nullptr;

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -6,7 +6,7 @@ namespace waybar::modules::SNI {
 Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
     : AModule(config, "tray", id),
       box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0),
-      watcher_(nb_hosts_),
+      watcher_(SNI::Watcher::getInstance()),
       host_(nb_hosts_, config, std::bind(&Tray::onAdd, this, std::placeholders::_1),
             std::bind(&Tray::onRemove, this, std::placeholders::_1)) {
   spdlog::warn(


### PR DESCRIPTION
Fixes #359

This uses a singleton so we only ever use one StatusNotifierWatcher for
all of our bars (and all of their trays).

Before we had one per tray module. The first one to get the DBus name
would prevent the others from getting it. When that tray disappears (due
to dpms toggles for example), the other watchers do not react to it
correctly. Plus, I am not even sure that it is correct for the same
process to try to acquire the same name multiple times.

This does not solve the fact that we should be able to lose the
name and get it back on the bus, but at least we are not deceiving
ourselves :).