### PR TITLE
pulseaudio: track only the default sink and source

### DIFF
--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -37,12 +37,14 @@ class Pulseaudio : public ALabel {
   std::string form_factor_;
   std::string desc_;
   std::string monitor_;
+  std::string default_sink_name_;
   // SOURCE
   uint32_t    source_idx_{0};
   uint16_t    source_volume_;
   bool        source_muted_;
   std::string source_port_name_;
   std::string source_desc_;
+  std::string default_source_name_;
 };
 
 }  // namespace waybar::modules


### PR DESCRIPTION
When you have multiple sinks (resp. sources), the module used to display
the state of the most recently changed one. This changes remembers the
default sink name, and only records changes to that one.