### PR TITLE
systemd service: fix start up ordering

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -2,6 +2,7 @@
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki/
 PartOf=wayland-session.target
+After=wayland-session.target
 
 [Service]
 Type=dbus


### PR DESCRIPTION
the service needs to have After=wayland-session.target otherwise it'll
be started in parallel to the compositor which might not be fully
configured.

ps. sorry I overlooked this setting when I was sending the previous pull request.