### PR TITLE
fix(bar): set exclusive zone early for gtk-layer-shell

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -175,6 +175,11 @@ void waybar::Bar::initGtkLayerShell() {
   gtk_layer_set_margin(gtk_window, GTK_LAYER_SHELL_EDGE_RIGHT, margins_.right);
   gtk_layer_set_margin(gtk_window, GTK_LAYER_SHELL_EDGE_TOP, margins_.top);
   gtk_layer_set_margin(gtk_window, GTK_LAYER_SHELL_EDGE_BOTTOM, margins_.bottom);
+
+  if (width_ > 1 && height_ > 1) {
+    /* configure events are not emitted if the bar is using initial size */
+    setExclusiveZone(width_, height_);
+  }
 }
 #endif
 


### PR DESCRIPTION
If the bar is using initial size from the config (i.e both width and height are set and resize is not required), GtkWindow configure event is is not emitted. Initialize exclusive zone earlier for that case.

Fixes #609