### PR TITLE
readme: ubuntu dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,24 @@ libmpdclient [MPD module]
 On Ubuntu 19.10 you can install all the relevant dependencies using this command:
 
 ```
-sudo apt install libgtkmm-3.0-dev libjsoncpp-dev libinput-dev libsigc++-2.0-dev libpulse-dev libnl-3-dev libdbusmenu-gtk3-dev libnl-genl-3-dev libfmt-dev clang-tidy libmpdclient-dev libwayland-dev libgtk-3-dev gobject-introspection libgirepository1.0-dev scdoc
+sudo apt install \
+  clang-tidy \
+  gobject-introspection \
+  libdbusmenu-gtk3-dev \
+  libfmt-dev \
+  libgirepository1.0-dev \
+  libgtk-3-dev \
+  libgtkmm-3.0-dev \
+  libinput-dev \
+  libjsoncpp-dev \
+  libmpdclient-dev \
+  libnl-3-dev \
+  libnl-genl-3-dev \
+  libpulse-dev \
+  libsigc++-2.0-dev \
+  libspdlog-dev \
+  libwayland-dev \
+  scdoc
 ```
 
 


### PR DESCRIPTION
* adding libspdlog-dev to list of ubuntu dependencies
* making list easier to read and copy from
* sorting (ocd)

This morning my build failed on [master](https://github.com/Alexays/Waybar/commit/6c27af35e94e4645a39b58b57bd6b91d782a9838). I noticed a bunch of these errors:
```
../subprojects/spdlog-1.3.1/include/spdlog/details/pattern_formatter.h:99:9: error: ‘assert’ was not declared in this scope
```
Also `meson --reconfigure build` was saying:
```
Run-time dependency spdlog found: NO (tried pkgconfig and cmake)
Looking for a fallback subproject for the dependency spdlog
```

Installing libspdlog-dev seemed to fix it.