### PR TITLE
Switch default Makefile rule from run to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build build-debug run clean default install
 
-default: run
+default: build
 
 build:
 	meson build


### PR DESCRIPTION
This commit makes it so that running `make` without arguments builds rather than builds and runs, which is unconventional and surprising behaviour.
