### PR TITLE
fix(memory): provide better free memory approximation on old kernels

### DIFF
--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -17,8 +17,7 @@ class Memory : public ALabel {
   static inline const std::string data_dir_ = "/proc/meminfo";
   void                            parseMeminfo();
 
-  unsigned long memtotal_;
-  unsigned long memfree_;
+  std::unordered_map<std::string, unsigned long> meminfo_;
 
   util::SleeperThread thread_;
 };


### PR DESCRIPTION
The approximation should include `SReclaimable`, and subtract `Shmem`. To prevent the parsing code from ballooning in size, this commit also refactors the parsing into a map.