### PR TITLE
restore SIGCHLD settings to SIG_DFL. #600

### DIFF
--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -88,6 +88,7 @@ inline int32_t forkExec(std::string cmd) {
   // Child executes the command
   if (!pid) {
     setpgid(pid, pid);
+    signal(SIGCHLD, SIG_DFL);
     execl("/bin/sh", "sh", "-c", cmd.c_str(), (char*)0);
     exit(0);
   } else {


### PR DESCRIPTION
I startup "Terminator", a terminal emulator, from Waybar button.

Waybar forks on button click, and the child process executes Terminator,
and the Waybar process itself setups SIGCHLD to SIG_IGN to discard defunct child processes.
But the SIGCHLD setting is inherited to a new child process on fork when I click the button next time.

That is why Terminator startups with SIGCHLD setting of SIG_IGN on the second click.

Terminator forks, executes `uname -p`, and waits finishing of the `uname -p` process.
But because Terminator's SIGCHLD setting is SIG_IGN, `uname -p` process disappears just after it exits,
and Terminator can't wait it, raise an exeception, and exits.

The solution is to restore SIGCHLD setting of child processes to SIG_DFL after forks.
Then, Terminator's SIGCHLD setting becomes SIG_DFL, and `uname -p` process doesn't disappears until
Terminator waits.
