### PR TITLE
fix(client): suppress intempestive error message

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -249,7 +249,7 @@ int waybar::Client::main(int argc, char *argv[]) {
   if (!log_level.empty()) {
     spdlog::set_level(spdlog::level::from_str(log_level));
   }
-  gtk_app = Gtk::Application::create(argc, argv, "fr.arouillard.waybar");
+  gtk_app = Gtk::Application::create("fr.arouillard.waybar");
   gdk_display = Gdk::Display::get_default();
   if (!gdk_display) {
     throw std::runtime_error("Can't find display");


### PR DESCRIPTION
Before this commit, launching waybar with any option would produce the
the following message on stderr: "Unknown option <option>".

Fixes #646