### PR TITLE
WIP : Layout dockerfiles

### DIFF
--- a/Dockerfiles/alpine
+++ b/Dockerfiles/alpine
@@ -2,4 +2,4 @@
 
 FROM alpine:latest
 
-RUN apk add --no-cache git meson alpine-sdk libinput-dev wayland-dev wayland-protocols mesa-dev libxkbcommon-dev eudev-dev pixman-dev gtkmm3-dev jsoncpp-dev pugixml libnl3-dev pulseaudio-dev libmpdclient-dev scdoc
+RUN apk add --no-cache git meson alpine-sdk libinput-dev wayland-dev wayland-protocols mesa-dev libxkbcommon-dev eudev-dev pixman-dev gtkmm3-dev jsoncpp-dev pugixml-dev libnl3-dev pulseaudio-dev libmpdclient-dev scdoc

--- a/Dockerfiles/opensuse
+++ b/Dockerfiles/opensuse
@@ -4,4 +4,4 @@ FROM opensuse/tumbleweed:latest
 
 RUN zypper -n up && \
     zypper -n install -t pattern devel_C_C++ && \
-    zypper -n install git meson clang libinput10 libinput-devel libpugixml1 libwayland-client0 libwayland-cursor0 wayland-protocols-devel wayland-devel Mesa-libEGL-devel Mesa-libGLESv2-devel libgbm-devel libxkbcommon-devel libudev-devel libpixman-1-0-devel gtkmm3-devel jsoncpp-devel scdoc
+    zypper -n install git meson clang libinput10 libinput-devel pugixml-devel libwayland-client0 libwayland-cursor0 wayland-protocols-devel wayland-devel Mesa-libEGL-devel Mesa-libGLESv2-devel libgbm-devel libxkbcommon-devel libudev-devel libpixman-1-0-devel gtkmm3-devel jsoncpp-devel scdoc


### PR DESCRIPTION
This PR fixed alpine and opensuse Dockerfiles for building #659 .
This time I was able to test on my own computer, so I am more confident about the validity of this.

I have a problem with fedora : [pugixml-devel (fedora)](https://apps.fedoraproject.org/packages/pugixml-devel) is a terrible package. It doesn't include `/usr/lib/pkgconfig/pugixml.pc` so pkg-config is confused about this :
```
Run-time dependency pugixml found: NO (tried pkgconfig)

meson.build:78:0: ERROR: Dependency "pugixml" not found, tried pkgconfig
```
I don't know what is the expected way to fix this : should I manually download the file during the Dockerfile build, add a fedora specifig meson.build.patch, or add a wrapfile ?
ping @Alexays