### PR TITLE
Add missing dependencies to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,17 +45,18 @@ $ waybar
 gtkmm3
 jsoncpp
 libinput
-
 libsigc++
 fmt
 wayland
 wlroots
+chrono-date
+spdlog
 libgtk-3-dev [gtk-layer-shell]
 gobject-introspection [gtk-layer-shell]
 libgirepository1.0-dev [gtk-layer-shell]
 libpulse [Pulseaudio module]
 libnl [Network module]
-sway [Sway modules]
+libappindicator-gtk3 [Tray module]
 libdbusmenu-gtk3 [Tray module]
 libmpdclient [MPD module]
 ```

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ libinput
 libsigc++
 fmt
 wayland
+wayland-protocols
 wlroots
 chrono-date
 spdlog

--- a/README.md
+++ b/README.md
@@ -48,8 +48,6 @@ libinput
 libsigc++
 fmt
 wayland
-wayland-protocols
-wlroots
 chrono-date
 spdlog
 libgtk-3-dev [gtk-layer-shell]
@@ -60,6 +58,15 @@ libnl [Network module]
 libappindicator-gtk3 [Tray module]
 libdbusmenu-gtk3 [Tray module]
 libmpdclient [MPD module]
+```
+
+**Build dependencies**
+
+```
+cmake
+meson
+scdoc
+wayland-protocols
 ```
 
 On Ubuntu 19.10 you can install all the relevant dependencies using this command:


### PR DESCRIPTION
Let's cleanup dependencies list 🙂 

- I removed an empty line, not sure if that separation meant something?
- `chrono-date` and `spdlog` are required, I think in AUR package you should add them instead of letting meson download them
- `sway` is not really a dependency (especially since https://github.com/Alexays/Waybar/commit/6522a7acb4a87ecfa0f8e85a190b9743ba52a6f9) in a sense that sway package provides no shared libraries needed for the modules to work, it feels like adding a dependency on "linux"
- `wlroots` also seems to be not really a dependency, `ldd /usr/bin/waybar | grep wlroots` finds nothing
- `libappindicator-gtk3` should be a required dependency based on [this log message](https://github.com/Alexays/Waybar/blob/9817955fef845444a95092653ea202f75ba7c3e4/src/modules/sni/tray.cpp#L13), I think you should add it to meson.build as well to be honest
- I saw [PR adding pugixml](https://github.com/Alexays/Waybar/pull/661) as dependency, but I dont see it anywhere in the codebase being needed? UPDATE: I see now, will be needed after #659
- `wayland-protocols` is needed during the build as make dependency, for the xml definitions of protocols


----

For your AUR package:

- Move libmpdclient to `depends` (if you compile with mpd support, the shared libraries become required)
- Here's the current list of dependencies as I see it:

```
depends=(
    'gtkmm3'
    'libjsoncpp.so'
    'libinput'
    'libsigc++'
    'fmt'
    'wayland'
    'chrono-date'
    'libspdlog.so'
    'gtk-layer-shell'
    'libpulse'
    'libnl'
    'libappindicator-gtk3'
    'libdbusmenu-gtk3'
    'libmpdclient'
)
makedepends=(
    'git'
    'cmake'
    'meson'
    'scdoc' # For generating manpages
    'wayland-protocols'
)
optdepends=(
    'otf-font-awesome: Icons in the default configuration'
)
```