### PR TITLE
sway/workspaces added current_output CSS class to buttons.

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -128,3 +128,4 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
 - *#workspaces button.focused*
 - *#workspaces button.urgent*
 - *#workspaces button.persistent*
+- *#workspaces button.current_output*

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -154,6 +154,15 @@ auto Workspaces::update() -> void {
     } else {
       button.get_style_context()->remove_class("persistent");
     }
+    if ((*it)["output"].isString()) {
+      if (((*it)["output"].asString()) == bar_.output->name) {
+        button.get_style_context()->add_class("current_output");
+      } else {
+        button.get_style_context()->remove_class("current_output");
+      }
+    } else {
+      button.get_style_context()->remove_class("current_output");
+    }
     if (needReorder) {
       box_.reorder_child(button, it - workspaces_.begin());
     }


### PR DESCRIPTION
All workspace buttons that are visible on the same output as the current waybar can be styled with the `current_output` css class.

This is really only useful in combination with the `"all-outputs":
true`. Then the workspaces that are on the current output can be styled
differently than the workspace on other outputs, while all workspaces are visible in every waybar.
