### PR TITLE
 Add a criticial threshold for both CPU and Memory usage

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -22,6 +22,7 @@ class Cpu : public ALabel {
  private:
   static inline const std::string         data_dir_ = "/proc/stat";
   uint16_t                                getCpuLoad();
+  bool                                    isCritical(uint16_t);
   std::tuple<uint16_t, std::string>       getCpuUsage();
   std::vector<std::tuple<size_t, size_t>> parseCpuinfo();
 

--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -17,6 +17,7 @@ class Memory : public ALabel {
  private:
   static inline const std::string data_dir_ = "/proc/meminfo";
   void                            parseMeminfo();
+  bool                            isCritical(uint16_t);
 
   std::unordered_map<std::string, unsigned long> meminfo_;
 

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -15,6 +15,10 @@ The *cpu* module displays the current cpu utilization.
 	default: 10 ++
 	The interval in which the information gets polled.
 
+*critical-threshold*: ++
+	typeof: integer ++
+	The threshold before it is considered critical (percentage used).
+
 *format*: ++
 	typeof: string  ++
 	default: {usage}% ++

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -17,6 +17,10 @@ Addressed by *memory*
 	default: 30 ++
 	The interval in which the information gets polled.
 
+*critical-threshold*
+	typeof: integer ++
+	The threshold before it is considered critical (percentage used).
+
 *format*: ++
 	typeof: string ++
 	default: {percentage}% ++

--- a/resources/config
+++ b/resources/config
@@ -69,10 +69,12 @@
         "format-alt": "{:%Y-%m-%d}"
     },
     "cpu": {
+        // "critical-threshold": 80,
         "format": "{usage}% ",
         "tooltip": false
     },
     "memory": {
+        // "critical-threshold": 80,
         "format": "{}% "
     },
     "temperature": {

--- a/resources/style.css
+++ b/resources/style.css
@@ -123,8 +123,16 @@ label:focus {
     color: #000000;
 }
 
+#cpu.critical {
+    background-color: #eb4d4b;
+}
+
 #memory {
     background-color: #9b59b6;
+}
+
+#memory.critical {
+    background-color: #eb4d4b;
 }
 
 #backlight {

--- a/src/modules/memory.cpp
+++ b/src/modules/memory.cpp
@@ -28,6 +28,15 @@ auto waybar::modules::Memory::update() -> void {
     auto used_ram_gigabytes = (memtotal - memfree) / std::pow(1024, 2);
     auto available_ram_gigabytes = memfree / std::pow(1024, 2);
 
+    auto critical = isCritical(used_ram_percentage);
+    auto format = format_;
+    if (critical) {
+      format = config_["format-critical"].isString() ? config_["format-critical"].asString() : format;
+      label_.get_style_context()->add_class("critical");
+    } else {
+      label_.get_style_context()->remove_class("critical");
+    }
+
     getState(used_ram_percentage);
     label_.set_markup(fmt::format(format_,
                                   used_ram_percentage,
@@ -62,4 +71,9 @@ void waybar::modules::Memory::parseMeminfo() {
     int64_t     value = std::stol(line.substr(posDelim + 1));
     meminfo_[name] = value;
   }
+}
+
+bool waybar::modules::Memory::isCritical(uint16_t cpu_load) {
+  return config_["critical-threshold"].isInt() &&
+         cpu_load >= config_["critical-threshold"].asInt();
 }


### PR DESCRIPTION
This will allow users to configure percentage based thresholds where the CSS for a module can be changed once the threshold is reached.

It's pretty much just copied from the way that the temperature module implements it.

(this PR should be good, and not messed up like my previous one)