### PR TITLE
Simplify .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,34 @@
+language: cpp
+
+services:
+    - docker
+
 git:
     submodules: false
 
-_linux_shared: &linux_shared
-    os: linux
-    sudo: false
-    services:
-        - docker
-    before_install:
-        - docker pull alexays/waybar:${distro}
-        - find . -type f \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -r0 clang-format -i
-    script:
-        - echo FROM alexays/waybar:${distro} > Dockerfile
-        - echo ADD . /root >> Dockerfile
-        - docker build -t waybar .
-        - docker run waybar /bin/sh -c "cd /root && meson build -Dman-pages=enabled && ninja -C build"
+env:
+    - distro: debian
+    - distro: archlinux
+    - distro: fedora
+    - distro: alpine
+    - distro: opensuse
+
+before_install:
+    - docker pull alexays/waybar:${distro}
+    - find . -type f \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -r0 clang-format -i
+
+script:
+    - echo FROM alexays/waybar:${distro} > Dockerfile
+    - echo ADD . /root >> Dockerfile
+    - docker build -t waybar .
+    - docker run waybar /bin/sh -c "cd /root && meson build -Dman-pages=enabled && ninja -C build"
 
 jobs:
   include:
-    - <<: *linux_shared
-      env: distro=debian
-    - <<: *linux_shared
-      env: distro=archlinux
-    - <<: *linux_shared
-      env: distro=fedora
-    - <<: *linux_shared
-      env: distro=alpine
-    - <<: *linux_shared
-      env: distro=opensuse
     - os: freebsd
-      language: cpp
       compiler: clang
-      sudo: required
-      install:
+      env:
+      before_install:
         - sudo sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
         - sudo pkg install -y date gtk-layer-shell gtkmm30 jsoncpp libdbusmenu
                libfmt libmpdclient libudev-devd meson pulseaudio scdoc spdlog


### PR DESCRIPTION
I'm still new to TravisCI thus have misunderstood how `jobs.include` work. It seems topmost phases are not appended but overwritten. So, let's go back to the previous matrix for (implicit) `os: linux`.

While here
- Drop `sudo` because it has [no effect](https://config.travis-ci.com/ref/sudo)
- Move `language` to the top, so `os: linux` builds aren't tagged as Ruby
