### PR TITLE
sway/workspaces: make clicking on workspaces idempotent

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -20,6 +20,8 @@ class Workspaces : public AModule, public sigc::trackable {
   auto update() -> void;
 
  private:
+  static inline const std::string workspace_switch_cmd_ = "workspace --no-auto-back-and-forth \"{}\"";
+
   void              onCmd(const struct Ipc::ipc_response&);
   void              onEvent(const struct Ipc::ipc_response&);
   bool              filterButtons();

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -219,12 +219,12 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
       if (node["target_output"].isString()) {
         ipc_.sendCmd(
             IPC_COMMAND,
-            fmt::format("workspace \"{}\"; move workspace to output \"{}\"; workspace \"{}\"",
+            fmt::format(workspace_switch_cmd_ + "; move workspace to output \"{}\"; " + workspace_switch_cmd_,
                         node["name"].asString(),
                         node["target_output"].asString(),
                         node["name"].asString()));
       } else {
-        ipc_.sendCmd(IPC_COMMAND, fmt::format("workspace \"{}\"", node["name"].asString()));
+        ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, node["name"].asString()));
       }
     } catch (const std::exception &e) {
       spdlog::error("Workspaces: {}", e.what());
@@ -276,7 +276,7 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
     }
   }
   try {
-    ipc_.sendCmd(IPC_COMMAND, fmt::format("workspace \"{}\"", name));
+    ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, name));
   } catch (const std::exception &e) {
     spdlog::error("Workspaces: {}", e.what());
   }


### PR DESCRIPTION
Previously, clicking on the same workspace you were on would throw you
to another workspace if `workspace_auto_back_and_forth yes` was
specified in your sway config. This also fixes workspace output moving
misbehaving and doing the same.