### PR TITLE
Only real batteries are counted as batteries

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -53,8 +53,13 @@ void waybar::modules::Battery::getBatteries() {
       auto bat_defined = config_["bat"].isString();
       if (((bat_defined && dir_name == config_["bat"].asString()) || !bat_defined) &&
           fs::exists(node.path() / "capacity") && fs::exists(node.path() / "uevent") &&
-          fs::exists(node.path() / "status")) {
-        batteries_.push_back(node.path());
+          fs::exists(node.path() / "status") && fs::exists(node.path() / "type")) {
+            std::string type;
+            std::ifstream(node.path() / "type") >> type;
+
+            if (!type.compare("Battery")){
+              batteries_.push_back(node.path());
+            }
       }
       auto adap_defined = config_["adapter"].isString();
       if (((adap_defined && dir_name == config_["adapter"].asString()) || !adap_defined) &&


### PR DESCRIPTION
I have a Wacom pen which is loaded via my laptop. Currently its battery has been added to the laptop battery, which has doubled the total capacity, so I have never been able to charge my laptop over 50% according to the display. But pens are from the type USB, so it is not recognized anymore by my fix.