### PR TITLE
Fixes for wlr/taskbar

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -214,7 +214,7 @@ Task::Task(const waybar::Bar &bar, const Json::Value &config, Taskbar *tbar,
 
     /* Handle click events if configured */
     if (config_["on-click"].isString() || config_["on-click-middle"].isString()
-            || config_["on-click-left"].isString()) {
+            || config_["on-click-right"].isString()) {
         button_.add_events(Gdk::BUTTON_PRESS_MASK);
         button_.signal_button_press_event().connect(
                 sigc::mem_fun(*this, &Task::handle_clicked), false);

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -187,7 +187,7 @@ Task::Task(const waybar::Bar &bar, const Json::Value &config, Taskbar *tbar,
             with_icon_ = true;
             format_after_ = format.substr(6);
         } else if (icon_pos == std::string::npos) {
-            format_after_ = format;
+            format_before_ = format;
         } else {
             with_icon_ = true;
             format_before_ = format.substr(0, icon_pos);
@@ -421,7 +421,7 @@ void Task::update()
     }
     if (!format_after_.empty()) {
         text_after_.set_label(
-                fmt::format(format_before_,
+                fmt::format(format_after_,
                     fmt::arg("title", title_),
                     fmt::arg("app_id", app_id_),
                     fmt::arg("state", state_string()),


### PR DESCRIPTION
These two commits fix the problems with the 'on-click-right' click events and the 'format' option.

Resolves #728, Resolves #735 