### PR TITLE
Fix and extend the wlr/taskbar example in the man page

### DIFF
--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -87,10 +87,12 @@ Addressed by *wlr/taskbar*
 
 ```
 "wlr/taskbar": {
-    "format": "{icon}",
+	"format": "{icon}",
+	"icon-size": 14,
+	"icon-theme": "Numix-Circle",
 	"tooltip-format": "{title}",
 	"on-click": "activate",
-	"on-middle-click": "close"
+	"on-click-middle": "close"
 }
 ```
 


### PR DESCRIPTION
The example incorrectly used 'on-middle-click' as option although it
should be 'on-click-middle'. Fix this and also add some other options.