### PR TITLE
Support for multiple icon themes and XDG_DATA_DIRS

### DIFF
--- a/include/modules/wlr/taskbar.hpp
+++ b/include/modules/wlr/taskbar.hpp
@@ -131,7 +131,7 @@ class Taskbar : public waybar::AModule
     Gtk::Box box_;
     std::vector<TaskPtr> tasks_;
 
-    Glib::RefPtr<Gtk::IconTheme> icon_theme_;
+    std::vector<Glib::RefPtr<Gtk::IconTheme>> icon_themes_;
 
     struct zwlr_foreign_toplevel_manager_v1 *manager_;
     struct wl_seat *seat_;
@@ -154,7 +154,7 @@ class Taskbar : public waybar::AModule
     bool show_output(struct wl_output *) const;
     bool all_outputs() const;
 
-    Glib::RefPtr<Gtk::IconTheme> icon_theme() const;
+    std::vector<Glib::RefPtr<Gtk::IconTheme>> icon_themes() const;
 };
 
 } /* namespace waybar::modules::wlr */

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -24,7 +24,7 @@ Addressed by *wlr/taskbar*
 	The format, how information should be displayed.
 
 *icon-theme*: ++
-	typeof: string ++
+	typeof: array|string ++
 	The names of the icon-themes that should be used to find an icon. The list will be traversed from left to right. If omitted, the system default will be used.
 
 *icon-size*: ++

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -25,7 +25,7 @@ Addressed by *wlr/taskbar*
 
 *icon-theme*: ++
 	typeof: string ++
-	The name of the icon-theme that should be used. If omitted, the system default will be used.
+	The names of the icon-themes that should be used to find an icon. The list will be traversed from left to right. If omitted, the system default will be used.
 
 *icon-size*: ++
 	typeof: integer ++

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -20,6 +20,27 @@
 
 namespace waybar::modules::wlr {
 
+/* String manipulation methods */
+const std::string WHITESPACE = " \n\r\t\f\v";
+
+static std::string ltrim(const std::string& s)
+{
+	size_t start = s.find_first_not_of(WHITESPACE);
+	return (start == std::string::npos) ? "" : s.substr(start);
+}
+
+static std::string rtrim(const std::string& s)
+{
+	size_t end = s.find_last_not_of(WHITESPACE);
+	return (end == std::string::npos) ? "" : s.substr(0, end + 1);
+}
+
+static std::string trim(const std::string& s)
+{
+	return rtrim(ltrim(s));
+}
+
+
 /* Icon loading functions */
 
 /* Method 1 - get the correct icon name from the desktop file */
@@ -196,13 +217,13 @@ Task::Task(const waybar::Bar &bar, const Json::Value &config, Taskbar *tbar,
         auto icon_pos = format.find("{icon}");
         if (icon_pos == 0) {
             with_icon_ = true;
-            format_after_ = format.substr(6);
+            format_after_ = trim(format.substr(6));
         } else if (icon_pos == std::string::npos) {
             format_before_ = format;
         } else {
             with_icon_ = true;
-            format_before_ = format.substr(0, icon_pos);
-            format_after_ = format.substr(icon_pos + 6);
+            format_before_ = trim(format.substr(0, icon_pos));
+            format_after_ = trim(format.substr(icon_pos + 6));
         }
     } else {
         /* The default is to only show the icon */
@@ -210,11 +231,6 @@ Task::Task(const waybar::Bar &bar, const Json::Value &config, Taskbar *tbar,
     }
 
     /* Strip spaces at the beginning and end of the format strings */
-    if (!format_before_.empty() && format_before_.back() == ' ')
-        format_before_.pop_back();
-    if (!format_after_.empty() && format_after_.front() == ' ')
-        format_after_.erase(std::cbegin(format_after_));
-
     format_tooltip_.clear();
     if (!config_["tooltip"].isBool() || config_["tooltip"].asBool()) {
         if (config_["tooltip-format"].isString())

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -579,22 +579,24 @@ Taskbar::Taskbar(const std::string &id, const waybar::Bar &bar, const Json::Valu
     }
 
     /* Get the configured icon theme if specified */
-    if (config_["icon-theme"].isString()) {
-        auto icon_theme_config = config_["icon-theme"].asString();
-        size_t start = 0, end = 0;
-
-        do {
-            end = icon_theme_config.find(',', start);
-            auto it_name = trim(icon_theme_config.substr(start, end-start));
+    if (config_["icon-theme"].isArray()) {
+        for (auto& c : config_["icon-theme"]) {
+            auto it_name = c.asString();
 
             auto it = Gtk::IconTheme::create();
             it->set_custom_theme(it_name);
             spdlog::debug("Use custom icon theme: {}", it_name);
 
             icon_themes_.push_back(it);
+        }
+    } else if (config_["icon-theme"].isString()) {
+        auto it_name = config_["icon-theme"].asString();
 
-            start = end == std::string::npos ? end : end + 1;
-        } while(end != std::string::npos);
+        auto it = Gtk::IconTheme::create();
+        it->set_custom_theme(it_name);
+        spdlog::debug("Use custom icon theme: {}", it_name);
+
+        icon_themes_.push_back(it);
     }
     icon_themes_.push_back(Gtk::IconTheme::get_default());
 }


### PR DESCRIPTION
Add support for defining multiple icon themes in the config which are used in the given order to lookup icons. With this approach it is possible to define one (or multiple) fallback icon themes if the app cannot be found in the current main icon theme. In addition the module will always lookup icons in the system default icon theme (for GTK this is hicolor).

Also respect XDG_DATA_DIRS now if set to get correct lookup paths for desktop files in the system. Especially for flatpack this is of importance. See #754

In addition I also refactored a little bit the lower_app_id changes done in PR #761