### PR TITLE
CI: unbreak FreeBSD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ jobs:
       compiler: clang
       env:
       before_install:
-        - sudo sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
         - sudo pkg install -y gtk-layer-shell gtkmm30 jsoncpp libdbusmenu
                libfmt libmpdclient libudev-devd meson pulseaudio scdoc spdlog
       script:


### PR DESCRIPTION
`/quarterly` package set was recently updated to **2020Q3**, so let's use it instead of bumpy `/latest`.