### PR TITLE
Handle SIGCHLD for exec/forkExec

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,30 +1,70 @@
 #include <csignal>
 #include <list>
+#include <mutex>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <spdlog/spdlog.h>
 #include "client.hpp"
 
-sig_atomic_t is_inserting_pid = false;
+std::mutex reap_mtx;
 std::list<pid_t> reap;
 
-static void handler(int sig) {
-  int saved_errno = errno;
-  if (!is_inserting_pid) {
-    for (auto it = reap.begin(); it != reap.end(); ++it) {
-      if (waitpid(*it, nullptr, WNOHANG) == *it) {
-        it = reap.erase(it);
-      }
+void* signalThread(void* args) {
+  int err, signum;
+  sigset_t mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGCHLD);
+
+  while (true) {
+    err = sigwait(&mask, &signum);
+    if (err != 0) {
+      spdlog::error("sigwait failed: {}", strerror(errno));
+      continue;
+    }
+
+    switch (signum) {
+      case SIGCHLD:
+        spdlog::debug("Received SIGCHLD in signalThread");
+        if (!reap.empty()) {
+          reap_mtx.lock();
+          for (auto it = reap.begin(); it != reap.end(); ++it) {
+            if (waitpid(*it, nullptr, WNOHANG) == *it) {
+              spdlog::debug("Reaped child with PID: {}", *it);
+              it = reap.erase(it);
+            }
+          }
+          reap_mtx.unlock();
+        }
+        break;
+      default:
+        spdlog::debug("Received signal with number {}, but not handling",
+                      signum);
+        break;
     }
   }
-  errno = saved_errno;
 }
 
-inline void installSigChldHandler(void) {
-  struct sigaction sa;
-  sigemptyset(&sa.sa_mask);
-  sa.sa_handler = handler;
-  sigaction(SIGCHLD, &sa, nullptr);
+void startSignalThread(void) {
+  int err;
+  sigset_t mask;
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGCHLD);
+
+  // Block SIGCHLD so it can be handled by the signal thread
+  // Any threads created by this one (the main thread) should not
+  // modify their signal mask to unblock SIGCHLD
+  err = pthread_sigmask(SIG_BLOCK, &mask, nullptr);
+  if (err != 0) {
+    spdlog::error("pthread_sigmask failed in startSignalThread: {}", strerror(err));
+    exit(1);
+  }
+
+  pthread_t thread_id;
+  err = pthread_create(&thread_id, nullptr, signalThread, nullptr);
+  if (err != 0) {
+    spdlog::error("pthread_create failed in startSignalThread: {}", strerror(err));
+    exit(1);
+  }
 }
 
 int main(int argc, char* argv[]) {
@@ -43,7 +83,7 @@ int main(int argc, char* argv[]) {
         }
       });
     }
-    installSigChldHandler();
+    startSignalThread();
 
     auto ret = client->main(argc, argv);
     delete client;


### PR DESCRIPTION
When forkExec is called it begins to ignore all SIGCHLD signals for the rest of the progam's execution so that they are automatically reaped. However, this means that subsequent waitpid calls in the exec function will always fail. So instead handle SIGCHLD by reaping any processes created by forkExec and ignoring all others so that they can be handled directly by the exec function.

I had a custom module disappearing on scroll-up which is fixed by this and I'm 99% sure this is what causes #739 while still fixing #369. I didn't know where to put the signal handler function, so I just put it in main.cpp. It adds a couple of ugly global variables, but I couldn't think of any other way to do it. If waybar was relying on signal(SIGCHLD, SIG_IGN) to reap other child processes not created by forkExec then this won't work, but I couldn't find any other instances of fork(), so I think it's ok.