### PR TITLE
Clang format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,27 @@
 language: cpp
 
 services:
-    - docker
+  - docker
 
 git:
-    submodules: false
+  submodules: false
 
 env:
-    - distro: debian
-    - distro: archlinux
-    - distro: fedora
-    - distro: alpine
-    - distro: opensuse
+  - distro: debian
+  - distro: archlinux
+  - distro: fedora
+  - distro: alpine
+  - distro: opensuse
 
 before_install:
-    - docker pull alexays/waybar:${distro}
-    - find . -type f \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -r0 clang-format -i
+  - docker pull alexays/waybar:${distro}
+  - find . -type f \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -r0 clang-format -i
 
 script:
-    - echo FROM alexays/waybar:${distro} > Dockerfile
-    - echo ADD . /root >> Dockerfile
-    - docker build -t waybar .
-    - docker run waybar /bin/sh -c "cd /root && meson build -Dman-pages=enabled && ninja -C build"
+  - echo FROM alexays/waybar:${distro} > Dockerfile
+  - echo ADD . /root >> Dockerfile
+  - docker build -t waybar .
+  - docker run waybar /bin/sh -c "cd /root && meson build -Dman-pages=enabled && ninja -C build"
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ env:
 
 before_install:
   - docker pull alexays/waybar:${distro}
-  - find . -type f \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -r0 clang-format -i
 
 script:
   - echo FROM alexays/waybar:${distro} > Dockerfile
@@ -34,3 +33,8 @@ jobs:
       script:
         - meson build -Dman-pages=enabled
         - ninja -C build
+    - env:
+      before_install:
+      script:
+        - find . -type f \( -name '*.cpp' -o -name '*.hpp' \) -print0
+          | xargs -r0 clang-format --dry-run --Werror


### PR DESCRIPTION
Added a formatting job that fails if code is not formatted with clang-format. This will fail now since the code currently is not.

Edit: Never mind, it's actually formatted, my bad. Using the default Travis environment provides clang-format 3.8 which is from 2016. Optionally, one could fetch the latest stable version of clang-format or use Travis's Ubuntu 18.04 environment which should provide clang-format 6.0.0. This would probably require a reformatting of the code in order for that job to be green.

Edit2: In order to do as I've done clang-format version 10.0.0 is needed due that's when `--dry-run` and `--Werror` was introduced. Using an older version of clang-format will require some more scripting.