### PR TITLE
Fix 'date' dependency in meson

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -98,7 +98,7 @@ gtk_layer_shell = dependency('gtk-layer-shell-0',
         required: get_option('gtk-layer-shell'),
         fallback : ['gtk-layer-shell', 'gtk_layer_shell_dep'])
 systemd = dependency('systemd', required: get_option('systemd'))
-tz_dep = dependency('date', default_options : [ 'use_system_tzdb=true' ], fallback: [ 'date', 'tz_dep' ])
+tz_dep = dependency('date', default_options : [ 'use_system_tzdb=true' ], modules : [ 'date::date', 'date::date-tz' ], fallback: [ 'date', 'tz_dep' ])
 
 prefix = get_option('prefix')
 sysconfdir = get_option('sysconfdir')


### PR DESCRIPTION
The 'date' library dependency was incompletly imported with meson.
Only the target 'date::date' seemed to be caught by meson, but
'date::date-tz' not, which lead to build errors in gentoos sandbox
environment.

See this question, too:
https://stackoverflow.com/questions/62951569/meson-doesnt-link-library

Adding the modules in meson imports them all and the library builds
nice.
Note, that this did not happen with a standard checkout and local build
on my system, but only when creating an ebuild for the package.