### PR TITLE
network: make missing nl80211 non-fatal

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -158,7 +158,7 @@ void waybar::modules::Network::createInfoSocket() {
   }
   nl80211_id_ = genl_ctrl_resolve(sock_, "nl80211");
   if (nl80211_id_ < 0) {
-    throw std::runtime_error("Can't resolve nl80211 interface");
+    spdlog::warn("Can't resolve nl80211 interface");
   }
 }
 


### PR DESCRIPTION
This will enable the networking module to be used for ethernet
interfaces on kernels without nl80211 support.

It should be reasonable to allow desktop systems without
wireless interfaces to run custom kenrel configs
without nl80211 compiled in.