### PR TITLE
chore: update subprojects for date, gtk-layer-shell

### DIFF
--- a/protocol/wlr-layer-shell-unstable-v1.xml
+++ b/protocol/wlr-layer-shell-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_layer_shell_v1" version="1">
+  <interface name="zwlr_layer_shell_v1" version="3">
     <description summary="create surfaces that are layers of the desktop">
       Clients can use this interface to assign the surface_layer role to
       wl_surfaces. Such surfaces are assigned to a "layer" of the output and
@@ -82,17 +82,27 @@
       <entry name="top" value="2"/>
       <entry name="overlay" value="3"/>
     </enum>
+
+    <!-- Version 3 additions -->
+
+    <request name="destroy" type="destructor" since="3">
+      <description summary="destroy the layer_shell object">
+        This request indicates that the client will not use the layer_shell
+        object any more. Objects that have been created through this instance
+        are not affected.
+      </description>
+    </request>
   </interface>
 
-  <interface name="zwlr_layer_surface_v1" version="1">
+  <interface name="zwlr_layer_surface_v1" version="3">
     <description summary="layer metadata interface">
       An interface that may be implemented by a wl_surface, for surfaces that
       are designed to be rendered as a layer of a stacked desktop-like
       environment.
 
-      Layer surface state (size, anchor, exclusive zone, margin, interactivity)
-      is double-buffered, and will be applied at the time wl_surface.commit of
-      the corresponding wl_surface is called.
+      Layer surface state (layer, size, anchor, exclusive zone,
+      margin, interactivity) is double-buffered, and will be applied at the
+      time wl_surface.commit of the corresponding wl_surface is called.
     </description>
 
     <request name="set_size">
@@ -115,7 +125,7 @@
     <request name="set_anchor">
       <description summary="configures the anchor point of the surface">
         Requests that the compositor anchor the surface to the specified edges
-        and corners. If two orthoginal edges are specified (e.g. 'top' and
+        and corners. If two orthogonal edges are specified (e.g. 'top' and
         'left'), then the anchor point will be the intersection of the edges
         (e.g. the top left corner of the output); otherwise the anchor point
         will be centered on that edge, or in the center if none is specified.
@@ -127,20 +137,25 @@
 
     <request name="set_exclusive_zone">
       <description summary="configures the exclusive geometry of this surface">
-        Requests that the compositor avoids occluding an area of the surface
-        with other surfaces. The compositor's use of this information is
+        Requests that the compositor avoids occluding an area with other
+        surfaces. The compositor's use of this information is
         implementation-dependent - do not assume that this region will not
         actually be occluded.
 
-        A positive value is only meaningful if the surface is anchored to an
-        edge, rather than a corner. The zone is the number of surface-local
-        coordinates from the edge that are considered exclusive.
+        A positive value is only meaningful if the surface is anchored to one
+        edge or an edge and both perpendicular edges. If the surface is not
+        anchored, anchored to only two perpendicular edges (a corner), anchored
+        to only two parallel edges or anchored to all edges, a positive value
+        will be treated the same as zero.
+
+        A positive zone is the distance from the edge in surface-local
+        coordinates to consider exclusive.
 
         Surfaces that do not wish to have an exclusive zone may instead specify
         how they should interact with surfaces that do. If set to zero, the
         surface indicates that it would like to be moved to avoid occluding
-        surfaces with a positive excluzive zone. If set to -1, the surface
-        indicates that it would not like to be moved to accomodate for other
+        surfaces with a positive exclusive zone. If set to -1, the surface
+        indicates that it would not like to be moved to accommodate for other
         surfaces, and the compositor should extend it all the way to the edges
         it is anchored to.
 
@@ -281,5 +296,16 @@
       <entry name="left" value="4" summary="the left edge of the anchor rectangle"/>
       <entry name="right" value="8" summary="the right edge of the anchor rectangle"/>
     </enum>
+
+    <!-- Version 2 additions -->
+
+    <request name="set_layer" since="2">
+      <description summary="change the layer of the surface">
+        Change the layer that the surface is rendered on.
+
+        Layer is double-buffered, see wl_surface.commit.
+      </description>
+      <arg name="layer" type="uint" enum="zwlr_layer_shell_v1.layer" summary="layer to move this surface to"/>
+    </request>
   </interface>
 </protocol>

--- a/subprojects/date.wrap
+++ b/subprojects/date.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-source_url=https://github.com/HowardHinnant/date/archive/v2.4.1.tar.gz
-source_filename=date-2.4.1.tar.gz
-source_hash=98907d243397483bd7ad889bf6c66746db0d7d2a39cc9aacc041834c40b65b98
-directory=date-2.4.1
+source_url=https://github.com/HowardHinnant/date/archive/v3.0.0.tar.gz
+source_filename=date-3.0.0.tar.gz
+source_hash=87bba2eaf0ebc7ec539e5e62fc317cb80671a337c1fb1b84cb9e4d42c6dbebe3
+directory=date-3.0.0
 
-patch_url = https://github.com/mesonbuild/hinnant-date/releases/download/2.4.1-1/hinnant-date.zip
-patch_filename = hinnant-date-2.4.1-1-wrap.zip
-patch_hash = 2061673a6f8e6d63c3a40df4da58fa2b3de2835fd9b3e74649e8279599f3a8f6
+patch_url = https://github.com/mesonbuild/hinnant-date/releases/download/3.0.0-1/hinnant-date.zip
+patch_filename = hinnant-date-3.0.0-1-wrap.zip
+patch_hash = 6ccaf70732d8bdbd1b6d5fdf3e1b935c23bf269bda12fdfd0e561276f63432fe

--- a/subprojects/gtk-layer-shell.wrap
+++ b/subprojects/gtk-layer-shell.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-directory = gtk-layer-shell-0.1.0
-source_filename = gtk-layer-shell-0.1.0.tar.gz
-source_hash = f7569e27ae30b1a94c3ad6c955cf56240d6bc272b760d9d266ce2ccdb94a5cf0
-source_url = https://github.com/wmww/gtk-layer-shell/archive/v0.1.0/gtk-layer-shell-0.1.0.tar.gz
+directory = gtk-layer-shell-0.2.0
+source_filename = gtk-layer-shell-0.2.0.tar.gz
+source_hash = 6934376b5296d079fca2c1ba6b222ec91db6bf3667142340ee2bdebfb4b69116
+source_url = https://github.com/wmww/gtk-layer-shell/archive/v0.2.0/gtk-layer-shell-0.2.0.tar.gz


### PR DESCRIPTION
Fixes: #776, fixes #780 (via date 3.0.0)
Fixes: #530, fixes #750 (via gtk-layer-shell 0.2.0)
***
gtk-layer-shell will now print a harmless warning about xdg-wm-base version mismatch. This is caused by gtk-layer-shell bundling xdg-shell protocol of older version, which I'll try to fix upstream before upcoming 0.2.1 release.

CI is not using gtk-layer-shell subproject:
```
|subprojects/gtk-layer-shell-0.2.0/src/meson.build:24:0: Exception: Static libraries can only be introspected with GObject-Introspection >=1.58.1
...
    gtk-layer-shell: NO Static libraries can only be introspected with GObject-Introspection >=1.58.1
```
Sounds like missing dependency in docker files.

