### PR TITLE
switch workspace on mouse-down to match swaybar

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -249,7 +249,7 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
   auto &&button = pair.first->second;
   box_.pack_start(button, false, false, 0);
   button.set_relief(Gtk::RELIEF_NONE);
-  button.signal_clicked().connect([this, node] {
+  button.signal_pressed().connect([this, node] {
     try {
       if (node["target_output"].isString()) {
         ipc_.sendCmd(


### PR DESCRIPTION
closes #686

Previously, the workspace only switched when you release the mouse, which feels slow and clunky compared to i3bar and swaybar.