### PR TITLE
systemd: use standard targets, update service type

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -1,13 +1,11 @@
 [Unit]
 Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
 Documentation=https://github.com/Alexays/Waybar/wiki/
-PartOf=wayland-session.target
-After=wayland-session.target
+PartOf=graphical-session.target
+After=graphical-session.target
 
 [Service]
-Type=dbus
-BusName=fr.arouillard.waybar
 ExecStart=@prefix@/bin/waybar
 
 [Install]
-WantedBy=wayland-session.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
`wayland-session.target` is a non-standard target, and [systemd will not include it](https://github.com/systemd/systemd/pull/15180). The effect is that this service is useless unless people manually create this `wayland-session.target`. We should be using `graphical-session.target` instead, which is a standard target meant to mean "any graphical session".

Even for people who use both X11 and Wayland, I don't think it will be terrible, the service would supposedly just silently fail when attempted to start under X11, and next time they logout and login in Wayland it will start again (this time successfully).

If that is a problem, there are alternatives, e.g. users could manually start the service when launching Wayland session instead of enabling the service for auto-start. If even that is a problem, we could even add some startup conditions, but this is really hacky, and many apps aren't doing it anyway (especially those that were written for X11).

I also changed the service type, because I don't think Waybar can be started by DBUS, it may use DBUS for its modules, but it should be started manually after WM such as sway starts. Please tell me if I completely misunderstood this part 🙂 