### PR TITLE
Allow enabing pango markup in the taskbar string

### DIFF
--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -32,6 +32,11 @@ Addressed by *wlr/taskbar*
 	default: 16 ++
 	The size of the icon.
 
+*markup*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, pango markup will be accepted in format and tooltip-format.
+
 *tooltip*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -306,7 +306,7 @@ std::string Task::state_string(bool shortened) const
 
 void Task::handle_title(const char *title)
 {
-    title_ = Glib::Markup::escape_text(title);
+    title_ = title;
 }
 
 void Task::handle_app_id(const char *app_id)
@@ -460,38 +460,51 @@ bool Task::operator!=(const Task &o) const
 
 void Task::update()
 {
+    bool markup = config_["markup"].isBool() ? config_["markup"].asBool() : false;
+    std::string title = title_;
+    std::string app_id = app_id_;
+    if (markup) {
+        title = Glib::Markup::escape_text(title);
+        app_id = Glib::Markup::escape_text(app_id);
+    }
     if (!format_before_.empty()) {
-        text_before_.set_label(
-                fmt::format(format_before_,
-                    fmt::arg("title", title_),
-                    fmt::arg("app_id", app_id_),
+        auto txt = fmt::format(format_before_,
+                    fmt::arg("title", title),
+                    fmt::arg("app_id", app_id),
                     fmt::arg("state", state_string()),
                     fmt::arg("short_state", state_string(true))
-                )
-        );
+                );
+        if (markup) 
+            text_before_.set_markup(txt);
+        else
+            text_before_.set_label(txt);
         text_before_.show();
     }
     if (!format_after_.empty()) {
-        text_after_.set_label(
-                fmt::format(format_after_,
-                    fmt::arg("title", title_),
-                    fmt::arg("app_id", app_id_),
+        auto txt = fmt::format(format_after_,
+                    fmt::arg("title", title),
+                    fmt::arg("app_id", app_id),
                     fmt::arg("state", state_string()),
                     fmt::arg("short_state", state_string(true))
-                )
-        );
+                );
+        if (markup) 
+            text_after_.set_markup(txt);
+        else
+            text_after_.set_label(txt);
         text_after_.show();
     }
 
     if (!format_tooltip_.empty()) {
-        button_.set_tooltip_markup(
-                fmt::format(format_tooltip_,
-                    fmt::arg("title", title_),
-                    fmt::arg("app_id", app_id_),
+        auto txt = fmt::format(format_tooltip_,
+                    fmt::arg("title", title),
+                    fmt::arg("app_id", app_id),
                     fmt::arg("state", state_string()),
                     fmt::arg("short_state", state_string(true))
-                )
-        );
+                );
+        if (markup) 
+            button_.set_tooltip_markup(txt);
+        else
+            button_.set_tooltip_text(txt);
     }
 }
 


### PR DESCRIPTION
The fix for taskbar tooltips in 6a2d214b55 was incomplete: it causes the label
to contain escaped titles.  Allow choosing whether to enable markup or not.