### PR TITLE
Add option for no workspace switch on click

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -31,6 +31,11 @@ Addressed by *sway/workspaces*
     default: false ++
     If set to false, you can scroll to cycle through workspaces. If set to true this behaviour is disabled.
 
+*disable-click*: ++
+    typeof: bool ++
+    default: false ++
+    If set to false, you can click to change workspace. If set to true this behaviour is disabled.
+
 *smooth-scrolling-threshold*: ++
     typeof: double ++
     Threshold to be used when scrolling.

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -249,22 +249,24 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
   auto &&button = pair.first->second;
   box_.pack_start(button, false, false, 0);
   button.set_relief(Gtk::RELIEF_NONE);
-  button.signal_pressed().connect([this, node] {
-    try {
-      if (node["target_output"].isString()) {
-        ipc_.sendCmd(
-            IPC_COMMAND,
-            fmt::format(workspace_switch_cmd_ + "; move workspace to output \"{}\"; " + workspace_switch_cmd_,
-                        node["name"].asString(),
-                        node["target_output"].asString(),
-                        node["name"].asString()));
-      } else {
-        ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, node["name"].asString()));
+  if (!config_["disable-click"].asBool()) {
+    button.signal_pressed().connect([this, node] {
+      try {
+        if (node["target_output"].isString()) {
+          ipc_.sendCmd(
+              IPC_COMMAND,
+              fmt::format(workspace_switch_cmd_ + "; move workspace to output \"{}\"; " + workspace_switch_cmd_,
+                          node["name"].asString(),
+                          node["target_output"].asString(),
+                          node["name"].asString()));
+        } else {
+          ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, node["name"].asString()));
+        }
+      } catch (const std::exception &e) {
+        spdlog::error("Workspaces: {}", e.what());
       }
-    } catch (const std::exception &e) {
-      spdlog::error("Workspaces: {}", e.what());
-    }
-  });
+    });
+  }
   return button;
 }
 


### PR DESCRIPTION
In sway/workspaces, just like `disable-scroll` turns on/off the ability to change workspaces by scrolling the mouse add `disable-click` that turns on/off the ability to change workspaces by clicking.