### PR TITLE
Add IDs to sway workspace buttons for CSS styling

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -139,3 +139,4 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
 - *#workspaces button.urgent*
 - *#workspaces button.persistent*
 - *#workspaces button.current_output*
+- *#workspaces button#sway-workspace-${name}

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -248,6 +248,7 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
   auto   pair = buttons_.emplace(node["name"].asString(), node["name"].asString());
   auto &&button = pair.first->second;
   box_.pack_start(button, false, false, 0);
+  button.set_name("sway-workspace-" + node["name"].asString());
   button.set_relief(Gtk::RELIEF_NONE);
   if (!config_["disable-click"].asBool()) {
     button.signal_pressed().connect([this, node] {


### PR DESCRIPTION
In case you want to style a specific workspace add IDs to the workspace buttons. Styling is done by matching button#sway-workspace-${name}.