### PR TITLE
New clock features

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -10,7 +10,7 @@ namespace waybar {
 class ALabel : public AModule {
  public:
   ALabel(const Json::Value &, const std::string &, const std::string &, const std::string &format,
-         uint16_t interval = 0, bool ellipsize = false);
+         uint16_t interval = 0, bool ellipsize = false, bool enable_click = false, bool enable_scroll = false);
   virtual ~ALabel() = default;
   virtual auto        update() -> void;
   virtual std::string getIcon(uint16_t, const std::string &alt = "", uint16_t max = 0);

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -28,8 +28,11 @@ class Clock : public ALabel {
   std::locale locale_;
   const date::time_zone* time_zone_;
   bool fixed_time_zone_;
+  int time_zone_idx_;
   date::year_month_day cached_calendar_ymd_;
   std::string cached_calendar_text_;
+
+  bool handleScroll(GdkEventScroll* e);
 
   auto calendar_text(const waybar_time& wtime) -> std::string;
   auto weekdays_header(const date::weekday& first_dow, std::ostream& os) -> void;

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -31,6 +31,11 @@ The *clock* module displays the current date and time.
 	default: inferred from current locale ++
 	A locale to be used to display the time. Intended to render times in custom timezones with the proper language and format.
 
+*today-format*: ++
+	typeof: string ++
+	default: <b><u>{}</u></b> ++
+	The format of today's date in the calendar.
+
 *max-length*: ++
 	typeof: integer ++
 	The maximum length in character the module should display.

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -26,6 +26,11 @@ The *clock* module displays the current date and time.
 	default: inferred local timezone ++
 	The timezone to display the time in, e.g. America/New_York.
 
+*timezones*: ++
+	typeof: list of strings ++
+	A list of timezones to use for time display, changed using the scroll wheel. ++
+	Use "" to represent the system's local timezone.  Using %Z in the format or tooltip format is useful to track which time zone is currently displayed.
+
 *locale*: ++
 	typeof: string ++
 	default: inferred from current locale ++

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -5,8 +5,9 @@
 namespace waybar {
 
 ALabel::ALabel(const Json::Value& config, const std::string& name, const std::string& id,
-               const std::string& format, uint16_t interval, bool ellipsize)
-    : AModule(config, name, id, config["format-alt"].isString()),
+               const std::string& format, uint16_t interval, bool ellipsize, bool enable_click,
+               bool enable_scroll)
+    : AModule(config, name, id, config["format-alt"].isString() || enable_click, enable_scroll),
       format_(config_["format"].isString() ? config_["format"].asString() : format),
       interval_(config_["interval"] == "once"
                     ? std::chrono::seconds(100000000)

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -99,7 +99,12 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
       os << '\n';
     }
     if (d == curr_day) {
-      os << "<b><u>" << date::format("%e", d) << "</u></b>";
+      if (config_["today-format"].isString()) {
+        auto today_format = config_["today-format"].asString();
+        os << fmt::format(today_format, date::format("%e", d));
+      } else {
+        os << "<b><u>" << date::format("%e", d) << "</u></b>";
+      }
     } else {
       os << date::format("%e", d);
     }

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -13,7 +13,7 @@
 using waybar::modules::waybar_time;
 
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
-    : ALabel(config, "clock", id, "{:%H:%M}", 60), fixed_time_zone_(false) {
+    : ALabel(config, "clock", id, "{:%H:%M}", 60, false, false, true), fixed_time_zone_(false) {
   if (config_["timezone"].isString()) {
     spdlog::warn("As using a timezone, some format args may be missing as the date library havn't got a release since 2018.");
     time_zone_ = date::locate_zone(config_["timezone"].asString());
@@ -69,6 +69,40 @@ auto waybar::modules::Clock::update() -> void {
   }
   // Call parent update
   ALabel::update();
+}
+
+bool waybar::modules::Clock::handleScroll(GdkEventScroll *e) {
+  // defer to user commands if set
+  if (config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString()) {
+    return AModule::handleScroll(e);
+  }
+
+  auto dir = AModule::getScrollDir(e);
+  if (dir != SCROLL_DIR::UP && dir != SCROLL_DIR::DOWN) {
+    return true;
+  }
+  if (!config_["timezones"].isArray() || config_["timezones"].empty()) {
+    return true;
+  }
+  auto nr_zones = config_["timezones"].size();
+  int new_idx = time_zone_idx_ + ((dir == SCROLL_DIR::UP) ? 1 : -1);
+  if (new_idx < 0) {
+    time_zone_idx_ = nr_zones - 1;
+  } else if (new_idx >= nr_zones) {
+    time_zone_idx_ = 0;
+  } else {
+    time_zone_idx_ = new_idx;
+  }
+  auto zone_name = config_["timezones"][time_zone_idx_];
+  if (!zone_name.isString() || zone_name.empty()) {
+    fixed_time_zone_ = false;
+  } else {
+    time_zone_ = date::locate_zone(zone_name.asString());
+    fixed_time_zone_ = true;
+  }
+
+  update();
+  return true;
 }
 
 auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::string {


### PR DESCRIPTION
Timezone switching inspired by KDE's clock module; calendar formatting fix because the bold/underline is easy to miss on my font/monitor (I use "<b><span color='green'>{}</span></b>").