### PR TITLE
Fix resizing of the bar with gtk-layer-shell

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -53,13 +53,18 @@ class Bar {
   static void layerSurfaceHandleClosed(void *, struct zwlr_layer_surface_v1 *);
 
 #ifdef HAVE_GTK_LAYER_SHELL
+  /* gtk-layer-shell code */
   void initGtkLayerShell();
+  void onConfigureGLS(GdkEventConfigure *ev);
+  void onMapGLS(GdkEventAny *ev);
 #endif
+  /* fallback layer-surface code */
   void onConfigure(GdkEventConfigure *ev);
   void onRealize();
   void onMap(GdkEventAny *ev);
-  void setExclusiveZone(uint32_t width, uint32_t height);
   void setSurfaceSize(uint32_t width, uint32_t height);
+  /* common code */
+  void setExclusiveZone(uint32_t width, uint32_t height);
   auto setupWidgets() -> void;
   void getModules(const Factory &, const std::string &);
   void setupAltFormatKeyForModule(const std::string &module_name);

--- a/subprojects/gtk-layer-shell.wrap
+++ b/subprojects/gtk-layer-shell.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-directory = gtk-layer-shell-0.2.0
-source_filename = gtk-layer-shell-0.2.0.tar.gz
-source_hash = 6934376b5296d079fca2c1ba6b222ec91db6bf3667142340ee2bdebfb4b69116
-source_url = https://github.com/wmww/gtk-layer-shell/archive/v0.2.0/gtk-layer-shell-0.2.0.tar.gz
+directory = gtk-layer-shell-0.3.0
+source_filename = gtk-layer-shell-0.3.0.tar.gz
+source_hash = edd5e31279d494df66da9e9190c219fa295da547f5538207685e98468dbc134d
+source_url = https://github.com/wmww/gtk-layer-shell/archive/v0.3.0/gtk-layer-shell-0.3.0.tar.gz


### PR DESCRIPTION
In the hindsight, it wasn't a good idea to have one set of GTK event handlers for both code paths. Took me a while to remember which code is needed for gtk-layer-shell and which one is for bare layer-surface. Apparently `Bar::onConfigure` wasn't passing the right values to `setExclusiveZone` because it was written with assumption that `layerSurfaceHandleConfigure` already done everything required.
***
At some point GTK stopped listening to `resize`/`set_size_request` if the requested size is insufficient. This is now causing occasional bar size changes and warnings in the log for both code paths.
This would also cause an interesting behavior if `gtk-layer-shell` is disabled and the bar height is a fixed value from the config file; the bar would expand according to a content size, but the exclusive zone size would stay as configured.

Fixes: #799 (only for gtk-layer-shell).
Also fixes xdg_wm_base.version mismatch warning via gtk-layer-shell 0.3.0 update.