### PR TITLE
Remove trim usage in format

### DIFF
--- a/include/modules/wlr/taskbar.hpp
+++ b/include/modules/wlr/taskbar.hpp
@@ -70,7 +70,7 @@ class Task
 
     std::string title_;
     std::string app_id_;
-    uint32_t state_;
+    uint32_t state_ = 0;
 
    private:
     std::string repr() const;


### PR DESCRIPTION
Remove trim usage in format because it glues icon with test and takes away control on spaces.
Also some clang-tidy fixes