### PR TITLE
Don't escape sway/window tooltip text

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -56,7 +56,8 @@ auto Window::update() -> void {
     bar_.window.get_style_context()->remove_class("solo");
     bar_.window.get_style_context()->remove_class("empty");
   }
-  label_.set_markup(fmt::format(format_, window_));
+  std::string escaped_window = Glib::Markup::escape_text(window_);
+  label_.set_markup(fmt::format(format_, escaped_window));
   if (tooltipEnabled()) {
     label_.set_tooltip_text(window_);
   }
@@ -77,7 +78,7 @@ std::tuple<std::size_t, int, std::string, std::string> Window::getFocusedNode(
                                                 : node["window_properties"]["instance"].asString();
         return {nodes.size(),
                 node["id"].asInt(),
-                Glib::Markup::escape_text(node["name"].asString()),
+                node["name"].asString(),
                 app_id};
       }
     }


### PR DESCRIPTION
Tooltip text doesn't accept markup so don't escape the text for that and end up with `&apos;` and other HTML escape codes literally in the tooltip.

Fixes #833