### PR TITLE
Fix "restart-interval" in the custom module

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -50,7 +50,6 @@ void waybar::modules::Custom::continuousWorker() {
   thread_ = [this, cmd] {
     char*  buff = nullptr;
     size_t len = 0;
-    bool   restart = false;
     if (getline(&buff, &len, fp_) == -1) {
       int exit_code = 1;
       if (fp_) {
@@ -63,8 +62,8 @@ void waybar::modules::Custom::continuousWorker() {
         spdlog::error("{} stopped unexpectedly, is it endless?", name_);
       }
       if (config_["restart-interval"].isUInt()) {
-        restart = true;
         pid_ = -1;
+        thread_.sleep_for(std::chrono::seconds(config_["restart-interval"].asUInt()));
         fp_ = util::command::open(cmd, pid_);
         if (!fp_) {
           throw std::runtime_error("Unable to open " + cmd);
@@ -82,9 +81,6 @@ void waybar::modules::Custom::continuousWorker() {
       }
       output_ = {0, output};
       dp.emit();
-    }
-    if (restart) {
-      thread_.sleep_for(std::chrono::seconds(config_["restart-interval"].asUInt()));
     }
   };
 }


### PR DESCRIPTION
This pull request fixes the issue where the process would restart immediately and the thread would sleep after the process has restarted, and not before.

Fixes #621