### PR TITLE
style: add 4px margins to window and workspaces modules

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -83,6 +83,21 @@ window#waybar.chromium {
     color: #ffffff;
 }
 
+#window,
+#workspaces {
+    margin: 0 4px;
+}
+
+/* If workspaces is the leftmost module, omit left margin */
+.modules-left > widget:first-child > #workspaces {
+    margin-left: 0;
+}
+
+/* If workspaces is the rightmost module, omit right margin */
+.modules-right > widget:last-child > #workspaces {
+    margin-right: 0;
+}
+
 #clock {
     background-color: #64727D;
 }


### PR DESCRIPTION
These modules, unlike others, have no horizontal margins by default. This means that they'll appear uncomfortably close together in any config that puts them side-by-side. In general, the default style should make configs with any module ordering look good. Add the same 4px horizontal margins that other module have to these.

This affects rendering of the default config by moving the workspace buttons 4px to the right.

Before:
![Before](https://user-images.githubusercontent.com/1082640/91652698-b0628880-ea67-11ea-8b23-d0f3c76b3b2e.png)

After:
![After](https://user-images.githubusercontent.com/1082640/91652702-b6586980-ea67-11ea-997d-14d3c4be9f46.png)