### PR TITLE
Fix non-standard usage of <sys/poll.h>

### DIFF
--- a/src/util/rfkill.cpp
+++ b/src/util/rfkill.cpp
@@ -20,8 +20,8 @@
 
 #include <fcntl.h>
 #include <linux/rfkill.h>
+#include <poll.h>
 #include <stdlib.h>
-#include <sys/poll.h>
 #include <unistd.h>
 
 #include <cerrno>


### PR DESCRIPTION
Fixes the following build warning with musl libc:
```
In file included from ../src/util/rfkill.cpp:24:
/usr/include/sys/poll.h:1:2: warning: #warning redirecting incorrect #include <sys/poll.h> to <poll.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/poll.h> to <poll.h>
      |  ^~~~~~~
```