### PR TITLE
Add an "exec-on-event" config for the custom module

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -22,6 +22,7 @@ class Custom : public ALabel {
   void continuousWorker();
   void parseOutputRaw();
   void parseOutputJson();
+  void handleEvent();
   bool handleScroll(GdkEventScroll* e);
   bool handleToggle(GdkEventButton* const& e);
 

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -22,6 +22,12 @@ Addressed by *custom/<name>*
 	The path to a script, which determines if the script in *exec* should be executed.
 	*exec* will be executed if the exit code of *exec-if* equals 0.
 
+*exec-on-event*: ++
+	typeof: bool ++
+	default: true ++
+	If an event command is set (e.g. *on-click* or *on-scroll-up*) then re-execute the script after
+	executing the event command.
+
 *return-type*: ++
 	typeof: string ++
 	See *return-type*

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -91,15 +91,21 @@ void waybar::modules::Custom::refresh(int sig) {
   }
 }
 
+void waybar::modules::Custom::handleEvent() {
+  if (!config_["exec-on-event"].isBool() || config_["exec-on-event"].asBool()) {
+    thread_.wake_up();
+  }
+}
+
 bool waybar::modules::Custom::handleScroll(GdkEventScroll* e) {
   auto ret = ALabel::handleScroll(e);
-  thread_.wake_up();
+  handleEvent();
   return ret;
 }
 
 bool waybar::modules::Custom::handleToggle(GdkEventButton* const& e) {
   auto ret = ALabel::handleToggle(e);
-  thread_.wake_up();
+  handleEvent();
   return ret;
 }
 


### PR DESCRIPTION
This pull request adds a new config for the custom module: `exec-on-event`.
This config allows disabling the default behavior of re-executing the script whenever an event that has a command set is triggered.

Fixes #841