### PR TITLE
Add module "sway/hide" for swaybar integration

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -30,12 +30,12 @@ class Bar {
   ~Bar() = default;
 
   auto toggle() -> void;
+  auto setVisible(bool) -> void;
   void handleSignal(int);
 
   struct waybar_output *output;
   Json::Value           config;
   struct wl_surface *   surface;
-  struct zwlr_layer_surface_v1 *layer_surface_;
   bool                  visible = true;
   bool                  vertical = false;
   Gtk::Window           window;
@@ -77,6 +77,7 @@ class Bar {
     int bottom = 0;
     int left = 0;
   } margins_;
+  struct zwlr_layer_surface_v1 *layer_surface_;
   // use gtk-layer-shell instead of handling layer surfaces directly
   bool                                          use_gls_ = false;
   uint32_t                                      width_ = 0;

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -35,6 +35,7 @@ class Bar {
   struct waybar_output *output;
   Json::Value           config;
   struct wl_surface *   surface;
+  struct zwlr_layer_surface_v1 *layer_surface_;
   bool                  visible = true;
   bool                  vertical = false;
   Gtk::Window           window;
@@ -76,7 +77,6 @@ class Bar {
     int bottom = 0;
     int left = 0;
   } margins_;
-  struct zwlr_layer_surface_v1 *layer_surface_;
   // use gtk-layer-shell instead of handling layer surfaces directly
   bool                                          use_gls_ = false;
   uint32_t                                      width_ = 0;

--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -6,6 +6,7 @@
 #include "modules/sway/mode.hpp"
 #include "modules/sway/window.hpp"
 #include "modules/sway/workspaces.hpp"
+#include "modules/sway/hide.hpp"
 #endif
 #ifdef HAVE_WLR
 #include "modules/wlr/taskbar.hpp"

--- a/include/modules/sway/hide.hpp
+++ b/include/modules/sway/hide.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <fmt/format.h>
+#include <tuple>
+#include "ALabel.hpp"
+#include "bar.hpp"
+#include "client.hpp"
+#include "modules/sway/ipc/client.hpp"
+#include "util/json.hpp"
+#include "util/sleeper_thread.hpp"
+
+namespace waybar::modules::sway {
+
+class Hide : public ALabel, public sigc::trackable {
+ public:
+  Hide(const std::string&, const waybar::Bar&, const Json::Value&);
+  ~Hide() = default;
+  auto update() -> void;
+
+ private:
+  void onEvent(const struct Ipc::ipc_response&);
+  void worker();
+
+  const Bar&       bar_;
+  std::string      window_;
+  int              windowId_;
+  util::JsonParser parser_;
+
+  util::SleeperThread thread_;
+  Ipc                 ipc_;
+};
+
+}  // namespace waybar::modules::sway

--- a/include/modules/sway/hide.hpp
+++ b/include/modules/sway/hide.hpp
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 #include <tuple>
+#include <mutex>
 #include "ALabel.hpp"
 #include "bar.hpp"
 #include "client.hpp"
@@ -29,6 +30,7 @@ class Hide : public ALabel, public sigc::trackable {
   util::JsonParser parser_;
 
   util::SleeperThread thread_;
+  std::mutex          mutex_;
   Ipc                 ipc_;
 };
 

--- a/include/modules/sway/hide.hpp
+++ b/include/modules/sway/hide.hpp
@@ -21,8 +21,8 @@ class Hide : public ALabel, public sigc::trackable {
   void onEvent(const struct Ipc::ipc_response&);
   void worker();
 
-  std::string      current_mode;
-  bool             visible_on_modifier;
+  std::string      current_mode_;
+  bool             visible_by_modifier_;
   const Bar&       bar_;
   std::string      window_;
   int              windowId_;

--- a/include/modules/sway/hide.hpp
+++ b/include/modules/sway/hide.hpp
@@ -21,6 +21,8 @@ class Hide : public ALabel, public sigc::trackable {
   void onEvent(const struct Ipc::ipc_response&);
   void worker();
 
+  std::string      current_mode;
+  bool             visible_on_modifier;
   const Bar&       bar_;
   std::string      window_;
   int              windowId_;

--- a/meson.build
+++ b/meson.build
@@ -158,7 +158,8 @@ src_files += [
     'src/modules/sway/ipc/client.cpp',
     'src/modules/sway/mode.cpp',
     'src/modules/sway/window.cpp',
-    'src/modules/sway/workspaces.cpp'
+    'src/modules/sway/workspaces.cpp',
+    'src/modules/sway/hide.cpp',
 ]
 
 if true

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -260,7 +260,7 @@ void waybar::Bar::onMap(GdkEventAny* ev) {
 
 void waybar::Bar::setExclusiveZone(uint32_t width, uint32_t height) {
   auto zone = 0;
-  if (visible && config["layer"] != "overlay") {
+  if (visible) {
     // exclusive zone already includes margin for anchored edge,
     // only opposite margin should be added
     if (vertical) {

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -389,8 +389,8 @@ void waybar::Bar::layerSurfaceHandleClosed(void* data, struct zwlr_layer_surface
   o->modules_right_.clear();
 }
 
-auto waybar::Bar::toggle() -> void {
-  visible = !visible;
+auto waybar::Bar::setVisible(bool nvis) -> void {
+  visible = nvis;
   if (!visible) {
     window.get_style_context()->add_class("hidden");
     window.set_opacity(0);
@@ -402,6 +402,10 @@ auto waybar::Bar::toggle() -> void {
   if (!use_gls_) {
     wl_surface_commit(surface);
   }
+}
+
+auto waybar::Bar::toggle() -> void {
+  return setVisible(!visible);
 }
 
 void waybar::Bar::getModules(const Factory& factory, const std::string& pos) {

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -260,7 +260,7 @@ void waybar::Bar::onMap(GdkEventAny* ev) {
 
 void waybar::Bar::setExclusiveZone(uint32_t width, uint32_t height) {
   auto zone = 0;
-  if (visible) {
+  if (visible && config["layer"] != "overlay") {
     // exclusive zone already includes margin for anchored edge,
     // only opposite margin should be added
     if (vertical) {

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -22,6 +22,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "sway/window") {
       return new waybar::modules::sway::Window(id, bar_, config_[name]);
     }
+    if (ref == "sway/hide") {
+      return new waybar::modules::sway::Hide(id, bar_, config_[name]);
+    }
 #endif
 #ifdef HAVE_WLR
     if (ref == "wlr/taskbar") {

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -1,4 +1,3 @@
-#include <iostream>
 #include "modules/sway/hide.hpp"
 #include <spdlog/spdlog.h>
 #include "client.hpp"
@@ -30,7 +29,7 @@ void Hide::onEvent(const struct Ipc::ipc_response& res) {
   } else if (payload.isMember("visible_by_modifier")) {
     // bar_state_update: get visible_by_modifier
     visible_by_modifier_ = payload["visible_by_modifier"].asBool();
-    std::cerr << "WayBar Shown: " << payload["visible_by_modifier"] << std::endl;
+    spdlog::info("WayBar Shown: {}", visible_by_modifier_);
     for (auto& bar : waybar::Client::inst()->bars) {
       bar->setVisible(visible_by_modifier_);
     }

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -20,7 +20,13 @@ void Hide::onEvent(const struct Ipc::ipc_response& res) {
   std::lock_guard<std::mutex> lock(mutex_);
   if (payload.isMember("mode")) {
     // barconfig_update: get mode
-    current_mode_ = payload["mode"].asString();
+    auto mode = payload["mode"].asString();
+    if (mode == "hide") {
+      // Hide the bars when configuring the "hide" bar
+      for (auto& bar : waybar::Client::inst()->bars) {
+        bar->setVisible(false);
+      }
+    }
   } else if (payload.isMember("visible_by_modifier")) {
     // bar_state_update: get visible_by_modifier
     visible_by_modifier_ = payload["visible_by_modifier"].asBool();

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -5,9 +5,6 @@
 
 namespace waybar::modules::sway {
 
-std::string current_mode = "hide";
-bool visible_by_modifier = true;
-
 Hide::Hide(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "hide", id, "{}", 0, true), bar_(bar), windowId_(-1) {
   ipc_.subscribe(R"(["bar_state_update","barconfig_update"])");
@@ -23,13 +20,13 @@ void Hide::onEvent(const struct Ipc::ipc_response& res) {
   auto payload = parser_.parse(res.payload);
   if (payload.isMember("mode")) {
     // barconfig_update: get mode
-    current_mode = payload["mode"];
+    current_mode_ = payload["mode"].asString();
   } else if (payload.isMember("visible_by_modifier")) {
     // bar_state_update: get visible_by_modifier
-    visible_by_modifier = payload["visible_by_modifier"].asBool();
+    visible_by_modifier_ = payload["visible_by_modifier"].asBool();
   }
-  if (current_mode == "invisible"
-      || (current_mode == "hide" && ! visible_by_modifier)) {
+  if (current_mode_ == "invisible"
+      || (current_mode_ == "hide" && ! visible_by_modifier_)) {
     bar_.window.get_style_context()->add_class("hidden");
     zwlr_layer_surface_v1_set_layer(bar_.layer_surface,
                                     ZWLR_LAYER_SHELL_V1_LAYER_BOTTOM);

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -17,6 +17,7 @@ Hide::Hide(const std::string& id, const Bar& bar, const Json::Value& config)
 
 void Hide::onEvent(const struct Ipc::ipc_response& res) {
   auto payload = parser_.parse(res.payload);
+  std::lock_guard<std::mutex> lock(mutex_);
   if (payload.isMember("mode")) {
     // barconfig_update: get mode
     current_mode_ = payload["mode"].asString();

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -9,7 +9,6 @@ Hide::Hide(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "hide", id, "{}", 0, true), bar_(bar), windowId_(-1) {
   ipc_.subscribe(R"(["bar_state_update","barconfig_update"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &Hide::onEvent));
-  bar_.window.get_style_context()->add_class("hidden");
   // Launch worker
   worker();
 }

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -24,7 +24,7 @@ void Hide::onEvent(const struct Ipc::ipc_response& res) {
   } else if (payload.isMember("visible_by_modifier")) {
     // bar_state_update: get visible_by_modifier
     visible_by_modifier_ = payload["visible_by_modifier"].asBool();
-    std::cerr << "WayBar Hide: " << payload["visible_by_modifier"] << std::endl;
+    std::cerr << "WayBar Shown: " << payload["visible_by_modifier"] << std::endl;
     for (auto& bar : waybar::Client::inst()->bars) {
       bar->setVisible(visible_by_modifier_);
     }

--- a/src/modules/sway/hide.cpp
+++ b/src/modules/sway/hide.cpp
@@ -1,0 +1,38 @@
+#include "modules/sway/hide.hpp"
+#include <spdlog/spdlog.h>
+
+namespace waybar::modules::sway {
+
+Hide::Hide(const std::string& id, const Bar& bar, const Json::Value& config)
+    : ALabel(config, "hide", id, "{}", 0, true), bar_(bar), windowId_(-1) {
+  ipc_.subscribe(R"(["bar_state_update"])");
+  ipc_.signal_event.connect(sigc::mem_fun(*this, &Hide::onEvent));
+  bar_.window.get_style_context()->add_class("hidden");
+  // Launch worker
+  worker();
+}
+
+void Hide::onEvent(const struct Ipc::ipc_response& res) {
+
+  auto payload = parser_.parse(res.payload);
+  if (payload.isMember("visible_by_modifier")) {
+    if (payload["visible_by_modifier"].asBool())
+      bar_.window.get_style_context()->remove_class("hidden");
+    else
+      bar_.window.get_style_context()->add_class("hidden");
+  }
+}
+
+void Hide::worker() {
+  thread_ = [this] {
+    try {
+      ipc_.handleEvent();
+    } catch (const std::exception& e) {
+      spdlog::error("Hide: {}", e.what());
+    }
+  };
+}
+
+auto Hide::update() -> void {
+}
+}  // namespace waybar::modules::sway


### PR DESCRIPTION
Rebases and continues work by @xPMo in https://github.com/xPMo/Waybar/tree/sway-hide

This allows auto-showing the bar when the modifier is pressed
    
Closes #255
    
Setup instructions:
- Set the `mode` of the bar to "hide" in sway configuration file
 - Add "sway/hide" into `modules-left` in Waybar configuration file