### PR TITLE
Add state to disk module

### DIFF
--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -31,6 +31,10 @@ Addressed by *disk*
 	typeof: integer ++
 	Positive value to rotate the text label.
 
+*states*: ++
+	typeof: array ++
+	A number of disk utilization states which get activated on certain percentage thresholds (percentage_used). See *waybar-states(5)*.
+
 *max-length*: ++
 	typeof: integer ++
 	The maximum length in character the module should display.

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -47,13 +47,14 @@ auto waybar::modules::Disk::update() -> void {
   auto free = pow_format(stats.f_bavail * stats.f_frsize, "B", true);
   auto used = pow_format((stats.f_blocks - stats.f_bavail) * stats.f_frsize, "B", true);
   auto total = pow_format(stats.f_blocks * stats.f_frsize, "B", true);
+  auto percentage_used = (stats.f_blocks - stats.f_bavail) * 100 / stats.f_blocks;
 
   label_.set_markup(fmt::format(format_
       , stats.f_bavail * 100 / stats.f_blocks
       , fmt::arg("free", free)
       , fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks)
       , fmt::arg("used", used)
-      , fmt::arg("percentage_used", (stats.f_blocks - stats.f_bavail) * 100 / stats.f_blocks)
+      , fmt::arg("percentage_used", percentage_used)
       , fmt::arg("total", total)
       , fmt::arg("path", path_)
       ));
@@ -67,12 +68,13 @@ auto waybar::modules::Disk::update() -> void {
       , fmt::arg("free", free)
       , fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks)
       , fmt::arg("used", used)
-      , fmt::arg("percentage_used", (stats.f_blocks - stats.f_bavail) * 100 / stats.f_blocks)
+      , fmt::arg("percentage_used", percentage_used)
       , fmt::arg("total", total)
       , fmt::arg("path", path_)
       ));
   }
   event_box_.show();
+  getState(percentage_used);
   // Call parent update
   ALabel::update();
 }


### PR DESCRIPTION
I prefer to hide my disk information until only a certain percentage is left. This would implement that functionality in a way like the CPU/memory modules use `state`.