### PR TITLE
Add format-icons for workspace's name entry in sway/workspaces module

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -283,6 +283,8 @@ std::string Workspaces::getIcon(const std::string &name, const Json::Value &node
       return config_["format-icons"]["persistent"].asString();
     } else if (config_["format-icons"][key].isString()) {
       return config_["format-icons"][key].asString();
+    } else if (config_["format-icons"][trimWorkspaceName(key)].isString()) {
+      return config_["format-icons"][trimWorkspaceName(key)].asString();
     }
   }
   return name;


### PR DESCRIPTION
Hello,
Little hack to have workspace name like `2:Firefox` (to get the default sway workspace bindsym working) with an associated icon without the need to repeat 10 times the line in the configuration file for each case.
~~thanks for the bar~~