### PR TITLE
Add back unprefixed global config directory

### DIFF
--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -14,6 +14,7 @@ Valid locations for this file are:
 - *~/.config/waybar/config*
 - *~/waybar/config*
 - */etc/xdg/waybar/config*
+- *@sysconfdir@/xdg/waybar/config*
 
 A good starting point is the default configuration found at https://github.com/Alexays/Waybar/blob/master/resources/config
 Also a minimal example configuration can be found on the at the bottom of this man page.

--- a/meson.build
+++ b/meson.build
@@ -9,6 +9,8 @@ project(
     ],
 )
 
+fs = import('fs')
+
 compiler = meson.get_compiler('cpp')
 
 cpp_args = []
@@ -256,9 +258,20 @@ scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_opti
 if scdoc.found()
     scdoc_prog = find_program(scdoc.get_pkgconfig_variable('scdoc'), native: true)
     sh = find_program('sh', native: true)
+
+    main_manpage = configure_file(
+        input: 'man/waybar.5.scd.in',
+        output: 'waybar.5.scd',
+        configuration: {
+            'sysconfdir': join_paths(prefix, sysconfdir)
+        }
+    )
+
+    main_manpage_path = join_paths(meson.build_root(), '@0@'.format(main_manpage))
+
     mandir = get_option('mandir')
     man_files = [
-        'waybar.5.scd',
+        main_manpage_path,
         'waybar-backlight.5.scd',
         'waybar-battery.5.scd',
         'waybar-clock.5.scd',
@@ -281,14 +294,18 @@ if scdoc.found()
         'waybar-bluetooth.5.scd',
     ]
 
-    foreach filename : man_files
-        topic = filename.split('.')[-3].split('/')[-1]
-        section = filename.split('.')[-2]
+    foreach file : man_files
+        path = '@0@'.format(file)
+        basename = fs.name(path)
+
+        topic = basename.split('.')[-3].split('/')[-1]
+        section = basename.split('.')[-2]
         output = '@0@.@1@'.format(topic, section)
 
         custom_target(
             output,
-            input: 'man/@0@'.format(filename),
+            # drops the 'man' if `path` is an absolute path
+            input: join_paths('man', path),
             output: output,
             command: [
                 sh, '-c', '@0@ < @INPUT@ > @1@'.format(scdoc_prog.path(), output)

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -162,6 +162,7 @@ std::tuple<const std::string, const std::string> waybar::Client::getConfigs(
                                           "$XDG_CONFIG_HOME/waybar/config",
                                           "$HOME/.config/waybar/config",
                                           "$HOME/waybar/config",
+                                          "/etc/xdg/waybar/config",
                                           SYSCONFDIR "/xdg/waybar/config",
                                           "./resources/config",
                                       })
@@ -170,6 +171,7 @@ std::tuple<const std::string, const std::string> waybar::Client::getConfigs(
                                       "$XDG_CONFIG_HOME/waybar/style.css",
                                       "$HOME/.config/waybar/style.css",
                                       "$HOME/waybar/style.css",
+                                      "/etc/xdg/waybar/style.css",
                                       SYSCONFDIR "/xdg/waybar/style.css",
                                       "./resources/style.css",
                                   })


### PR DESCRIPTION
This still allows loading the installed default config, but also add back the path `/etc/xdg/waybar` unconditionally for the people who were using it as their configuration directory and have a "prefixed" waybar installation. Should fix https://github.com/Alexays/Waybar/issues/714 and https://github.com/NixOS/nixpkgs/issues/99057

Also added the sysconfdir-prefixed path in the man page to prevent some confusion. The meson code is kinda messy, sorry about that. If there's a better way to do this, please do tell.