### PR TITLE
Use 5 Moon emoji icons for the backlight module

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -86,7 +86,7 @@
     "backlight": {
         // "device": "acpi_video1",
         "format": "{percent}% {icon}",
-        "format-icons": ["", ""]
+        "format-icons": ["🌕", "🌔", "🌓", "🌒", "🌑"]
     },
     "battery": {
         "states": {


### PR DESCRIPTION
This is a simple commit which adds the backlight icons that [polybar uses](https://github.com/polybar/polybar/wiki/Module:-backlight#additional-formatting) to the default config. These emojis have a scale from 0-4 (4 being full), so it provides greater accuracy than the simple 0-1 scale that was there before.