### PR TITLE
Support format-{state} for cpu/disk/memory

### DIFF
--- a/src/modules/cpu/common.cpp
+++ b/src/modules/cpu/common.cpp
@@ -15,8 +15,19 @@ auto waybar::modules::Cpu::update() -> void {
   if (tooltipEnabled()) {
     label_.set_tooltip_text(tooltip);
   }
-  label_.set_markup(fmt::format(format_, fmt::arg("load", cpu_load), fmt::arg("usage", cpu_usage)));
-  getState(cpu_usage);
+  auto format = format_;
+  auto state = getState(cpu_usage);
+  if (!state.empty() && config_["format-" + state].isString()) {
+    format = config_["format-" + state].asString();
+  }
+
+  if (format.empty()) {
+    event_box_.hide();
+  } else {
+    event_box_.show();
+    label_.set_markup(fmt::format(format, fmt::arg("load", cpu_load), fmt::arg("usage", cpu_usage)));
+  }
+
   // Call parent update
   ALabel::update();
 }

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -49,15 +49,27 @@ auto waybar::modules::Disk::update() -> void {
   auto total = pow_format(stats.f_blocks * stats.f_frsize, "B", true);
   auto percentage_used = (stats.f_blocks - stats.f_bavail) * 100 / stats.f_blocks;
 
-  label_.set_markup(fmt::format(format_
-      , stats.f_bavail * 100 / stats.f_blocks
-      , fmt::arg("free", free)
-      , fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks)
-      , fmt::arg("used", used)
-      , fmt::arg("percentage_used", percentage_used)
-      , fmt::arg("total", total)
-      , fmt::arg("path", path_)
-      ));
+  auto format = format_;
+  auto state = getState(percentage_used);
+  if (!state.empty() && config_["format-" + state].isString()) {
+    format = config_["format-" + state].asString();
+  }
+
+  if (format.empty()) {
+    event_box_.hide();
+  } else {
+    event_box_.show();
+    label_.set_markup(fmt::format(format
+        , stats.f_bavail * 100 / stats.f_blocks
+        , fmt::arg("free", free)
+        , fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks)
+        , fmt::arg("used", used)
+        , fmt::arg("percentage_used", percentage_used)
+        , fmt::arg("total", total)
+        , fmt::arg("path", path_)
+        ));
+  }
+
   if (tooltipEnabled()) {
     std::string tooltip_format = "{used} used out of {total} on {path} ({percentage_used}%)";
     if (config_["tooltip-format"].isString()) {
@@ -73,8 +85,6 @@ auto waybar::modules::Disk::update() -> void {
       , fmt::arg("path", path_)
       ));
   }
-  event_box_.show();
-  getState(percentage_used);
   // Call parent update
   ALabel::update();
 }

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -28,13 +28,24 @@ auto waybar::modules::Memory::update() -> void {
     auto used_ram_gigabytes = (memtotal - memfree) / std::pow(1024, 2);
     auto available_ram_gigabytes = memfree / std::pow(1024, 2);
 
-    getState(used_ram_percentage);
-    label_.set_markup(fmt::format(format_,
-                                  used_ram_percentage,
-                                  fmt::arg("total", total_ram_gigabytes),
-                                  fmt::arg("percentage", used_ram_percentage),
-                                  fmt::arg("used", used_ram_gigabytes),
-                                  fmt::arg("avail", available_ram_gigabytes)));
+    auto format = format_;
+    auto state = getState(used_ram_percentage);
+    if (!state.empty() && config_["format-" + state].isString()) {
+      format = config_["format-" + state].asString();
+    }
+
+    if (format.empty()) {
+      event_box_.hide();
+    } else {
+      event_box_.show();
+      label_.set_markup(fmt::format(format,
+                                    used_ram_percentage,
+                                    fmt::arg("total", total_ram_gigabytes),
+                                    fmt::arg("percentage", used_ram_percentage),
+                                    fmt::arg("used", used_ram_gigabytes),
+                                    fmt::arg("avail", available_ram_gigabytes)));
+    }
+
     if (tooltipEnabled()) {
       if (config_["tooltip-format"].isString()) {
         auto tooltip_format = config_["tooltip-format"].asString();
@@ -48,7 +59,6 @@ auto waybar::modules::Memory::update() -> void {
         label_.set_tooltip_text(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
       }
     }
-    event_box_.show();
   } else {
     event_box_.hide();
   }


### PR DESCRIPTION
According to the [wiki page on states](https://github.com/Alexays/Waybar/wiki/States), the following is true:

- Some modules support 'states'
- [E]ach state can have its own `format`. Those can be configured via `format-<name>`.

I sadly found this not to be true when I wanted to hide the CPU, Disk and Memory modules whenever my states are 'good'. The text here seems to have been copied directly from the Battery module wiki page, even though no other modules supported it. I'll update the wiki to reflect these changes if this gets merged.