### PR TITLE
mpd: support password protected MPD

### DIFF
--- a/include/modules/mpd/mpd.hpp
+++ b/include/modules/mpd/mpd.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <mpd/client.h>
 #include <fmt/format.h>
+#include <mpd/client.h>
 #include <spdlog/spdlog.h>
 
 #include <condition_variable>
@@ -22,8 +22,9 @@ class MPD : public ALabel {
 
   // Not using unique_ptr since we don't manage the pointer
   // (It's either nullptr, or from the config)
-  const char*    server_;
-  const unsigned port_;
+  const char*       server_;
+  const unsigned    port_;
+  const std::string password_;
 
   unsigned timeout_;
 

--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -20,6 +20,10 @@ Addressed by *mpd*
 	typeof: integer ++
 	The port MPD listens to. If empty, use the default port.
 
+*password*: ++
+	typeof: string ++
+	The password required to connect to the MPD server. If empty, no password is sent to MPD.
+
 *interval*: ++
 	typeof: integer++
 	default: 5 ++


### PR DESCRIPTION
I saw an unfinished draft pull-request which added MPD password support; so, I went ahead and completed it. It works locally, with and without a password (but not without password when MPD requires one.)

- Add MPD module option `password`, and document it.
- Add logic to send the password, directly after connecting to
  MPD.

Fixes: #576
Signed-off-by: Joseph Benden <joe@benden.us>