### PR TITLE
Fix various mpd bugs

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -144,42 +144,51 @@ void waybar::modules::MPD::setLabel() {
   bool        singleActivated = mpd_status_get_single(status_.get());
   std::string singleIcon = getOptionIcon("single", singleActivated);
 
-  // TODO: format can fail
-  label_.set_markup(
-      fmt::format(format,
-                  fmt::arg("artist", Glib::Markup::escape_text(artist).raw()),
-                  fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist).raw()),
-                  fmt::arg("album", Glib::Markup::escape_text(album).raw()),
-                  fmt::arg("title", Glib::Markup::escape_text(title).raw()),
-                  fmt::arg("date", Glib::Markup::escape_text(date).raw()),
-                  fmt::arg("elapsedTime", elapsedTime),
-                  fmt::arg("totalTime", totalTime),
-                  fmt::arg("songPosition", song_pos),
-                  fmt::arg("queueLength", queue_length),
-                  fmt::arg("stateIcon", stateIcon),
-                  fmt::arg("consumeIcon", consumeIcon),
-                  fmt::arg("randomIcon", randomIcon),
-                  fmt::arg("repeatIcon", repeatIcon),
-                  fmt::arg("singleIcon", singleIcon)));
+  try {
+    label_.set_markup(
+        fmt::format(format,
+                    fmt::arg("artist", Glib::Markup::escape_text(artist).raw()),
+                    fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist).raw()),
+                    fmt::arg("album", Glib::Markup::escape_text(album).raw()),
+                    fmt::arg("title", Glib::Markup::escape_text(title).raw()),
+                    fmt::arg("date", Glib::Markup::escape_text(date).raw()),
+                    fmt::arg("elapsedTime", elapsedTime),
+                    fmt::arg("totalTime", totalTime),
+                    fmt::arg("songPosition", song_pos),
+                    fmt::arg("queueLength", queue_length),
+                    fmt::arg("stateIcon", stateIcon),
+                    fmt::arg("consumeIcon", consumeIcon),
+                    fmt::arg("randomIcon", randomIcon),
+                    fmt::arg("repeatIcon", repeatIcon),
+                    fmt::arg("singleIcon", singleIcon)));
+  } catch (fmt::format_error const& e) {
+    spdlog::warn("mpd: format error: {}", e.what());
+  }
 
   if (tooltipEnabled()) {
     std::string tooltip_format;
     tooltip_format = config_["tooltip-format"].isString() ? config_["tooltip-format"].asString()
                                                           : "MPD (connected)";
-    auto tooltip_text = fmt::format(tooltip_format,
-                                    fmt::arg("artist", artist),
-                                    fmt::arg("albumArtist", album_artist),
-                                    fmt::arg("album", album),
-                                    fmt::arg("title", title),
-                                    fmt::arg("date", date),
-                                    fmt::arg("songPosition", song_pos),
-                                    fmt::arg("queueLength", queue_length),
-                                    fmt::arg("stateIcon", stateIcon),
-                                    fmt::arg("consumeIcon", consumeIcon),
-                                    fmt::arg("randomIcon", randomIcon),
-                                    fmt::arg("repeatIcon", repeatIcon),
-                                    fmt::arg("singleIcon", singleIcon));
-    label_.set_tooltip_text(tooltip_text);
+    try {
+      auto tooltip_text = fmt::format(tooltip_format,
+                                      fmt::arg("artist", artist),
+                                      fmt::arg("albumArtist", album_artist),
+                                      fmt::arg("album", album),
+                                      fmt::arg("title", title),
+                                      fmt::arg("date", date),
+                                      fmt::arg("elapsedTime", elapsedTime),
+                                      fmt::arg("totalTime", totalTime),
+                                      fmt::arg("songPosition", song_pos),
+                                      fmt::arg("queueLength", queue_length),
+                                      fmt::arg("stateIcon", stateIcon),
+                                      fmt::arg("consumeIcon", consumeIcon),
+                                      fmt::arg("randomIcon", randomIcon),
+                                      fmt::arg("repeatIcon", repeatIcon),
+                                      fmt::arg("singleIcon", singleIcon));
+      label_.set_tooltip_text(tooltip_text);
+    } catch (fmt::format_error const& e) {
+      spdlog::warn("mpd: format error (tooltip): {}", e.what());
+    }
   }
 }
 
@@ -269,8 +278,9 @@ void waybar::modules::MPD::checkErrors(mpd_connection* conn) {
     default:
       if (conn) {
         auto error_message = mpd_connection_get_error_message(conn);
+        std::string error(error_message);
         mpd_connection_clear_error(conn);
-        throw std::runtime_error(std::string(error_message));
+        throw std::runtime_error(error);
       }
       throw std::runtime_error("Invalid connection");
   }

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -341,6 +341,7 @@ void Disconnected::disarm_timer() noexcept {
 }
 
 void Disconnected::entry() noexcept {
+  ctx_->emit();
   arm_timer(1'000);
 }
 


### PR DESCRIPTION
- Add elapsedTime and totalTime to tooltip format arguments
- Catch format exceptions and print error
- Copy mpd connection error message before it gets freed
- Update display after connection to mpd was lost