### PR TITLE
Replace lowercase "k" with uppercase "K" to make it look more consistent

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -42,7 +42,7 @@ namespace fmt {
 
       template<class FormatContext>
         auto format(const pow_format& s, FormatContext &ctx) -> decltype (ctx.out()) {
-          const char* units[] = { "", "k",  "M",  "G",  "T",  "P",  nullptr};
+          const char* units[] = { "", "K",  "M",  "G",  "T",  "P",  nullptr};
 
           auto base = s.binary_ ? 1024ull : 1000ll;
           auto fraction = (double) s.val_;


### PR DESCRIPTION
Other units are all uppercased, so using an uppercased "K" makes it look more consistent (especially when `{bandwidthUpBits}` or something like that is used).