### PR TITLE
Add simpleclock as fallback when hhdate is not available

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <json/json.h>
+#ifdef HAVE_LIBDATE
 #include "modules/clock.hpp"
+#else
+#include "modules/simpleclock.hpp"
+#endif
 #ifdef HAVE_SWAY
 #include "modules/sway/mode.hpp"
 #include "modules/sway/window.hpp"

--- a/include/modules/simpleclock.hpp
+++ b/include/modules/simpleclock.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <fmt/format.h>
+#if FMT_VERSION < 60000
+#include <fmt/time.h>
+#else
+#include <fmt/chrono.h>
+#endif
+#include "ALabel.hpp"
+#include "util/sleeper_thread.hpp"
+
+namespace waybar::modules {
+
+class Clock : public ALabel {
+ public:
+  Clock(const std::string&, const Json::Value&);
+  ~Clock() = default;
+  auto update() -> void;
+
+ private:
+  util::SleeperThread thread_;
+};
+
+}  // namespace waybar::modules

--- a/meson.build
+++ b/meson.build
@@ -113,7 +113,11 @@ gtk_layer_shell = dependency('gtk-layer-shell-0',
         required: get_option('gtk-layer-shell'),
         fallback : ['gtk-layer-shell', 'gtk_layer_shell_dep'])
 systemd = dependency('systemd', required: get_option('systemd'))
-tz_dep = dependency('date', default_options : [ 'use_system_tzdb=true' ], modules : [ 'date::date', 'date::date-tz' ], fallback: [ 'date', 'tz_dep' ])
+tz_dep = dependency('date',
+    required: false,
+    default_options : [ 'use_system_tzdb=true' ],
+    modules : [ 'date::date', 'date::date-tz' ],
+    fallback: [ 'date', 'tz_dep' ])
 
 prefix = get_option('prefix')
 sysconfdir = get_option('sysconfdir')
@@ -137,7 +141,6 @@ src_files = files(
     'src/factory.cpp',
     'src/AModule.cpp',
     'src/ALabel.cpp',
-    'src/modules/clock.cpp',
     'src/modules/custom.cpp',
     'src/modules/disk.cpp',
     'src/modules/idle_inhibitor.cpp',
@@ -235,6 +238,13 @@ if get_option('rfkill').enabled()
             'src/util/rfkill.cpp'
         )
     endif
+endif
+
+if tz_dep.found()
+    add_project_arguments('-DHAVE_LIBDATE', language: 'cpp')
+    src_files += 'src/modules/clock.cpp'
+else
+    src_files += 'src/modules/simpleclock.cpp'
 endif
 
 subdir('protocol')

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -1,0 +1,33 @@
+#include "modules/simpleclock.hpp"
+#include <time.h>
+
+waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
+    : ALabel(config, "clock", id, "{:%H:%M}", 60) {
+  thread_ = [this] {
+    dp.emit();
+    auto now = std::chrono::system_clock::now();
+    auto timeout = std::chrono::floor<std::chrono::seconds>(now + interval_);
+    auto diff = std::chrono::seconds(timeout.time_since_epoch().count() % interval_.count());
+    thread_.sleep_until(timeout - diff);
+  };
+}
+
+auto waybar::modules::Clock::update() -> void {
+  tzset(); // Update timezone information
+  auto now = std::chrono::system_clock::now();
+  auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
+  auto text = fmt::format(format_, localtime);
+  label_.set_markup(text);
+
+  if (tooltipEnabled()) {
+    if (config_["tooltip-format"].isString()) {
+      auto tooltip_format = config_["tooltip-format"].asString();
+      auto tooltip_text = fmt::format(tooltip_format, localtime);
+      label_.set_tooltip_text(tooltip_text);
+    } else {
+      label_.set_tooltip_text(text);
+    }
+  }
+  // Call parent update
+  ALabel::update();
+}


### PR DESCRIPTION
ref https://github.com/Alexays/Waybar/issues/668

This will allow to have the clock module (before hhdate was introduce) when its not available (Debian disable subprojects download)

wdyt?