### PR TITLE
Tooltips no longer completely break if a custom module updates too frequently

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -131,9 +131,13 @@ auto waybar::modules::Custom::update() -> void {
       label_.set_markup(str);
       if (tooltipEnabled()) {
         if (text_ == tooltip_) {
-          label_.set_tooltip_markup(str);
+          if (label_.get_tooltip_markup() != str) {
+            label_.set_tooltip_markup(str);
+          }
         } else {
-          label_.set_tooltip_markup(tooltip_);
+          if (label_.get_tooltip_markup() != tooltip_) {
+            label_.set_tooltip_markup(tooltip_);
+          }
         }
       }
       auto classes = label_.get_style_context()->list_classes();


### PR DESCRIPTION
This is a fix for https://github.com/Alexays/Waybar/issues/890

The issue was caused by ```label_.set_tooltip_markup``` being called too frequently (more than once every 0.6s), which somehow prevents any tooltips from appearing at all. Now, ```label_.set_tooltip_markup``` is only called if the tooltip markup has changed. This means modules can now output text updates more frequently without breaking tooltips.

It would be good if it was possible to also update tooltip markup frequently without breaking tooltips, but that seems to be a GTK problem, and this is a good start.