### PR TITLE
Simplify and improve battery state calculations

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -31,16 +31,16 @@ class Battery : public ALabel {
  private:
   static inline const fs::path data_dir_ = "/sys/class/power_supply/";
 
-  void                                          getBatteries();
+  void                                          refreshBatteries();
   void                                          worker();
   const std::string                             getAdapterStatus(uint8_t capacity) const;
   const std::tuple<uint8_t, float, std::string> getInfos() const;
   const std::string                             formatTimeRemaining(float hoursRemaining);
 
-  std::vector<fs::path> batteries_;
+  int                   global_watch;
+  std::map<fs::path,int> batteries_;
   fs::path              adapter_;
   int                   fd_;
-  std::vector<int>      wds_;
   std::string           old_status_;
 
   util::SleeperThread   thread_;

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -20,7 +20,7 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 
 *full-at*: ++
 	typeof: integer ++
-	Define the max percentage of the battery, useful for an old battery, e.g. 96
+	Define the max percentage of the battery, for when you've set the battery to stop charging at a lower level to save it. For example, if you've set the battery to stop at 80% that will become the new 100%.
 
 *interval*: ++
 	typeof: integer ++

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -80,18 +80,15 @@ void waybar::modules::Battery::getBatteries() {
 
 const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos() const {
   try {
-    uint16_t    total = 0;
     uint32_t    total_power = 0;   // μW
     uint32_t    total_energy = 0;  // μWh
     uint32_t    total_energy_full = 0;
     std::string status = "Unknown";
     for (auto const& bat : batteries_) {
-      uint16_t    capacity;
       uint32_t    power_now;
       uint32_t    energy_full;
       uint32_t    energy_now;
       std::string _status;
-      std::ifstream(bat / "capacity") >> capacity;
       std::ifstream(bat / "status") >> _status;
       auto rate_path = fs::exists(bat / "current_now") ? "current_now" : "power_now";
       std::ifstream(bat / rate_path) >> power_now;
@@ -102,7 +99,6 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
       if (_status != "Unknown") {
         status = _status;
       }
-      total += capacity;
       total_power += power_now;
       total_energy += energy_now;
       total_energy_full += energy_full;
@@ -120,7 +116,7 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
     } else if (status == "Charging" && total_power != 0) {
       time_remaining = -(float)(total_energy_full - total_energy) / total_power;
     }
-    uint16_t capacity = total / batteries_.size();
+    float capacity = ((float)total_energy * 100.0f / (float) total_energy_full);
     // Handle full-at
     if (config_["full-at"].isUInt()) {
       auto full_at = config_["full-at"].asUInt();

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -200,10 +200,14 @@ const std::string waybar::modules::Battery::getAdapterStatus(uint8_t capacity) c
 }
 
 const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemaining) {
-  hoursRemaining = std::fabs(hoursRemaining);
+  hoursRemaining = std::fabs(hoursRemaining); 
   uint16_t full_hours = static_cast<uint16_t>(hoursRemaining);
   uint16_t minutes = static_cast<uint16_t>(60 * (hoursRemaining - full_hours));
   auto     format = std::string("{H} h {M} min");
+  if (full_hours == 0 && minutes == 0) {
+    // Migh as well not show "0h 0min"
+    return "";
+  }
   if (config_["format-time"].isString()) {
     format = config_["format-time"].asString();
   }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -138,7 +138,7 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
       capacity = 100.f;
       status = "Full";
     }
-    return {capacity, time_remaining, status};
+    return {round(capacity), time_remaining, status};
   } catch (const std::exception& e) {
     spdlog::error("Battery: {}", e.what());
     return {0, 0, "Unknown"};

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -115,6 +115,11 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
       time_remaining = (float)total_energy / total_power;
     } else if (status == "Charging" && total_power != 0) {
       time_remaining = -(float)(total_energy_full - total_energy) / total_power;
+      if (time_remaining > 0.0f) {
+        // If we've turned positive it means the battery is past 100% and so
+        // just report that as no time remaining
+        time_remaining = 0.0f;
+      }
     }
     float capacity = ((float)total_energy * 100.0f / (float) total_energy_full);
     // Handle full-at
@@ -126,6 +131,12 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
           capacity = full_at;
         }
       }
+    }
+    if (capacity > 100.f) {
+      // This can happen when the battery is calibrating and goes above 100%
+      // Handle it gracefully by clamping at 100% and presenting it as full
+      capacity = 100.f;
+      status = "Full";
     }
     return {capacity, time_remaining, status};
   } catch (const std::exception& e) {

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -134,11 +134,17 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
     }
     if (capacity > 100.f) {
       // This can happen when the battery is calibrating and goes above 100%
-      // Handle it gracefully by clamping at 100% and presenting it as full
+      // Handle it gracefully by clamping at 100%
       capacity = 100.f;
+    }
+    uint8_t cap = round(capacity);
+    if (cap == 100) {
+      // If we've reached 100% just mark as full as some batteries can stay
+      // stuck reporting they're still charging but not yet done
       status = "Full";
     }
-    return {round(capacity), time_remaining, status};
+
+    return {cap, time_remaining, status};
   } catch (const std::exception& e) {
     spdlog::error("Battery: {}", e.what());
     return {0, 0, "Unknown"};

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -127,9 +127,6 @@ const std::tuple<uint8_t, float, std::string> waybar::modules::Battery::getInfos
       auto full_at = config_["full-at"].asUInt();
       if (full_at < 100) {
         capacity = 100.f * capacity / full_at;
-        if (capacity > full_at) {
-          capacity = full_at;
-        }
       }
     }
     if (capacity > 100.f) {


### PR DESCRIPTION
I've come across a few inconsistencies in the battery state calculations so I had a go at the code to try and make it simpler and fix some of the issues. This PR includes:

- Calculating the battery state from just the energy values. Using other values for the total capacity was resulting in broken results in other cases. Since the energy information is already enough and was already present this simplifies the code and avoids the inconsistency.
- Clamp battery states above 100%. This can happen when the battery recalibrates and charges more than the capacity it thinks it has. Just show 100% in those cases.
- Round the battery state so that 99.9% shows as 100%. This avoids some cases where the last bit of battery doesn't charge but the battery is effectively full already.
- Whenever the capacity has been calculated as 100% show the state as full, so that the formatting rules are applied accordingly

I don't have a way to check as I don't have a removable second battery but this may help with #490. To fully fix that it's probably best to enumerate all the batteries on update instead of generating the list of batteries on startup.