### PR TITLE
Add debug log message to print each bar's widget tree

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,7 @@ is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
 fmt = dependency('fmt', version : ['>=5.3.0'], fallback : ['fmt', 'fmt_dep'])
-spdlog = dependency('spdlog', version : ['>=1.3.1'], fallback : ['spdlog', 'spdlog_dep'])
+spdlog = dependency('spdlog', version : ['>=1.3.1'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_protos = dependency('wayland-protocols')

--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,7 @@ is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
 fmt = dependency('fmt', version : ['>=5.3.0'], fallback : ['fmt', 'fmt_dep'])
-spdlog = dependency('spdlog', version : ['>=1.3.1'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
+spdlog = dependency('spdlog', version : ['>=1.8.0'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_protos = dependency('wayland-protocols')

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -460,6 +460,16 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
 
   setupWidgets();
   window.show_all();
+
+  if (spdlog::should_log(spdlog::level::debug)) {
+    // Unfortunately, this function isn't in the C++ bindings, so we have to call the C version.
+    char* gtk_tree = gtk_style_context_to_string(
+        window.get_style_context()->gobj(),
+        (GtkStyleContextPrintFlags)(GTK_STYLE_CONTEXT_PRINT_RECURSE |
+                                    GTK_STYLE_CONTEXT_PRINT_SHOW_STYLE));
+    spdlog::debug("GTK widget tree:\n{}", gtk_tree);
+    g_free(gtk_tree);
+  }
 }
 
 void waybar::Bar::onMap(GdkEventAny*) {

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,10 +1,13 @@
 [wrap-file]
-directory = spdlog-1.3.1
+directory = spdlog-1.8.1
 
-source_url = https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz
-source_filename = v1.3.1.tar.gz
-source_hash = 160845266e94db1d4922ef755637f6901266731c4cb3b30b45bf41efa0e6ab70
+source_url = https://github.com/gabime/spdlog/archive/v1.8.1.tar.gz
+source_filename = v1.8.1.tar.gz
+source_hash = 5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb
 
-patch_url = https://github.com/mesonbuild/spdlog/releases/download/1.3.1-1/spdlog.zip
-patch_filename = spdlog-1.3.1-1-wrap.zip
-patch_hash = 715a0229781019b853d409cc0bf891ee4b9d3a17bec0cf87f4ad30b28bbecc87
+patch_url = https://github.com/mesonbuild/spdlog/releases/download/1.8.1-1/spdlog.zip
+patch_filename = spdlog-1.8.1-1-wrap.zip
+patch_hash = 76844292a8e912aec78450618271a311841b33b17000988f215ddd6c64dd71b3
+
+[provide]
+spdlog = spdlog_dep


### PR DESCRIPTION
This is very useful when writing CSS that affects more than just a single widget. Pass `-l debug` to enable debug logging and show this information.

Example output:

    [2020-11-30 12:38:51.141] [debug] GTK widget tree:
    window#waybar.background.bottom.eDP-1.:dir(ltr)
      decoration:dir(ltr)
      box.horizontal:dir(ltr)
        box.horizontal.modules-left:dir(ltr)
          widget:dir(ltr)
            box#workspaces.horizontal:dir(ltr)
          widget:dir(ltr)
            label#mode:dir(ltr)
          widget:dir(ltr)
            label#window:dir(ltr)
        box.horizontal.modules-center:dir(ltr)
        box.horizontal.modules-right:dir(ltr)
          widget:dir(ltr)
            box#tray.horizontal:dir(ltr)
          widget:dir(ltr)
            label#idle_inhibitor:dir(ltr)
          widget:dir(ltr)
            label#pulseaudio:dir(ltr)
          widget:dir(ltr)
            label#network:dir(ltr)
          widget:dir(ltr)
            label#cpu:dir(ltr)
          widget:dir(ltr)
            label#memory:dir(ltr)
          widget:dir(ltr)
            label#temperature:dir(ltr)
          widget:dir(ltr)
            label#backlight:dir(ltr)
          widget:dir(ltr)
            label#battery:dir(ltr)
          widget:dir(ltr)
            label#clock:dir(ltr)