### PR TITLE
clock: initialize cached date

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -29,7 +29,7 @@ class Clock : public ALabel {
   const date::time_zone* time_zone_;
   bool fixed_time_zone_;
   int time_zone_idx_;
-  date::year_month_day cached_calendar_ymd_;
+  date::year_month_day cached_calendar_ymd_ = date::January/1/0;
   std::string cached_calendar_text_;
 
   bool handleScroll(GdkEventScroll* e);


### PR DESCRIPTION
We are currently using this value once before it's initialized, since we check it before we set it in `Clock::calendar_text()`. This was caught by Valgrind, producing the following error:

    ==8962== Conditional jump or move depends on uninitialised value(s)
    ==8962==    at 0x138285: date::operator==(date::year_month_day const&, date::year_month_day const&) (date.h:2793)
    ==8962==    by 0x135F11: waybar::modules::Clock::calendar_text[abi:cxx11](waybar::modules::waybar_time const&) (clock.cpp:111)
    ==8962==    by 0x13587C: waybar::modules::Clock::update() (clock.cpp:62)
    ==8962==    by 0x156EFA: waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1}::operator()() const (bar.cpp:577)
    ==8962==    by 0x157F39: sigc::adaptor_functor<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1}>::operator()() const (adaptor_trait.h:256)
    ==8962==    by 0x157D94: sigc::internal::slot_call0<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)::{lambda()#1}, void>::call_it(sigc::internal::slot_rep*) (slot.h:136)
    ==8962==    by 0x5177B21: Glib::DispatchNotifier::pipe_io_handler(Glib::IOCondition) (in /usr/lib/libglibmm-2.4.so.1.3.0)
    ==8962==    by 0x517DB5B: Glib::IOSource::dispatch(sigc::slot_base*) (in /usr/lib/libglibmm-2.4.so.1.3.0)
    ==8962==    by 0x5188B96: Glib::Source::dispatch_vfunc(_GSource*, int (*)(void*), void*) (in /usr/lib/libglibmm-2.4.so.1.3.0)
    ==8962==    by 0x5CBC913: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.6600.2)
    ==8962==    by 0x5D107D0: ??? (in /usr/lib/libglib-2.0.so.0.6600.2)
    ==8962==    by 0x5CBB120: g_main_context_iteration (in /usr/lib/libglib-2.0.so.0.6600.2)

Initialize the value to prevent the error.