### PR TITLE
Update fmt subproject to 7.1.3

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,7 @@ is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
 fmt = dependency('fmt', version : ['>=5.3.0'], fallback : ['fmt', 'fmt_dep'])
-spdlog = dependency('spdlog', version : ['>=1.3.1'], fallback : ['spdlog', 'spdlog_dep'])
+spdlog = dependency('spdlog', version : ['>=1.3.1'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_protos = dependency('wayland-protocols')

--- a/meson.build
+++ b/meson.build
@@ -80,7 +80,7 @@ is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
 fmt = dependency('fmt', version : ['>=5.3.0'], fallback : ['fmt', 'fmt_dep'])
-spdlog = dependency('spdlog', version : ['>=1.3.1'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
+spdlog = dependency('spdlog', version : ['>=1.8.0'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_protos = dependency('wayland-protocols')

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,10 +1,13 @@
 [wrap-file]
-directory = fmt-5.3.0
+directory = fmt-7.1.3
 
-source_url = https://github.com/fmtlib/fmt/archive/5.3.0.tar.gz
-source_filename = fmt-5.3.0.tar.gz
-source_hash = defa24a9af4c622a7134076602070b45721a43c51598c8456ec6f2c4dbb51c89
+source_url = https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz
+source_filename = fmt-7.1.3.tar.gz
+source_hash = 5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc
 
-patch_url = https://github.com/mesonbuild/fmt/releases/download/5.3.0-1/fmt.zip
-patch_filename = fmt-5.3.0-1-wrap.zip
-patch_hash = 18f21a3b8833949c35d4ac88a7059577d5fa24b98786e4b1b2d3d81bb811440f
+patch_url = https://github.com/mesonbuild/fmt/releases/download/7.1.3-1/fmt.zip
+patch_filename = fmt-7.1.3-1-wrap.zip
+patch_hash = 6eb951a51806fd6ffd596064825c39b844c1fe1799840ef507b61a53dba08213
+
+[provide]
+fmt = fmt_dep

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,10 +1,13 @@
 [wrap-file]
-directory = spdlog-1.3.1
+directory = spdlog-1.8.1
 
-source_url = https://github.com/gabime/spdlog/archive/v1.3.1.tar.gz
-source_filename = v1.3.1.tar.gz
-source_hash = 160845266e94db1d4922ef755637f6901266731c4cb3b30b45bf41efa0e6ab70
+source_url = https://github.com/gabime/spdlog/archive/v1.8.1.tar.gz
+source_filename = v1.8.1.tar.gz
+source_hash = 5197b3147cfcfaa67dd564db7b878e4a4b3d9f3443801722b3915cdeced656cb
 
-patch_url = https://github.com/mesonbuild/spdlog/releases/download/1.3.1-1/spdlog.zip
-patch_filename = spdlog-1.3.1-1-wrap.zip
-patch_hash = 715a0229781019b853d409cc0bf891ee4b9d3a17bec0cf87f4ad30b28bbecc87
+patch_url = https://github.com/mesonbuild/spdlog/releases/download/1.8.1-1/spdlog.zip
+patch_filename = spdlog-1.8.1-1-wrap.zip
+patch_hash = 76844292a8e912aec78450618271a311841b33b17000988f215ddd6c64dd71b3
+
+[provide]
+spdlog = spdlog_dep


### PR DESCRIPTION
There is no particular change in this update that we require. However, our previous version, 5.3.0, is nearly two years old, so it seems prudent to pull in all the upstream fixes that have been made since then.

New wrap file taken from https://wrapdb.mesonbuild.com/fmt and modified to download from GitHub as per commit 99dde1aff8db ("Download patch files from Github instead of wrapdb").