### PR TITLE
Fix a few compiler warnings

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -85,13 +85,11 @@ bool waybar::modules::Clock::handleScroll(GdkEventScroll *e) {
     return true;
   }
   auto nr_zones = config_["timezones"].size();
-  int new_idx = time_zone_idx_ + ((dir == SCROLL_DIR::UP) ? 1 : -1);
-  if (new_idx < 0) {
-    time_zone_idx_ = nr_zones - 1;
-  } else if (new_idx >= nr_zones) {
-    time_zone_idx_ = 0;
+  if (dir == SCROLL_DIR::UP) {
+    size_t new_idx = time_zone_idx_ + 1;
+    time_zone_idx_ = new_idx == nr_zones ? 0 : new_idx;
   } else {
-    time_zone_idx_ = new_idx;
+    time_zone_idx_ = time_zone_idx_ == 0 ? nr_zones - 1 : time_zone_idx_ - 1;
   }
   auto zone_name = config_["timezones"][time_zone_idx_];
   if (!zone_name.isString() || zone_name.empty()) {

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -100,7 +100,7 @@ void waybar::modules::MPD::setLabel() {
   auto format = format_;
 
   std::string          artist, album_artist, album, title, date;
-  int                  song_pos, queue_length;
+  int                  song_pos = 0, queue_length = 0;
   std::chrono::seconds elapsedTime, totalTime;
 
   std::string stateIcon = "";


### PR DESCRIPTION
There was one uninitialized value warning and two mismatched-sign compare warnings. They both appear valid, the first occurring when MPD's `format-stopped` contains `{songPosition}` or `{queueLength}` and the second occurring when the clock's `timezones` array is more than 2 billion items long (not likely, I admit). Fix both issues.