### PR TITLE
fix(systemd): restart when service fails

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -6,6 +6,7 @@ After=graphical-session.target
 
 [Service]
 ExecStart=@prefix@/bin/waybar
+Restart=on-failure
 
 [Install]
 WantedBy=graphical-session.target


### PR DESCRIPTION
The current service doesn't play too nice with Sway when it is started
from [sway service](https://github.com/xdbob/sway-services).

Waybar is started before the system has a display.

```
Nov 30 22:11:23 ansan waybar[1352]: Unable to init server: Could not
connect: Connection refused
Nov 30 22:11:23 ansan waybar[1352]: cannot open display:
Nov 30 22:11:23 ansan systemd[1306]: waybar.service: Main process
exited, code=exited, status=1/FAILURE
Nov 30 22:11:23 ansan systemd[1306]: waybar.service: Failed with result
'exit-code'.
```

Restarting the service after the system has been initialized works nicely,
so this restart rule should do the trick without tinkering with the
target.