### PR TITLE
Don't update battery list on every update

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -34,16 +34,19 @@ class Battery : public ALabel {
   void                                          refreshBatteries();
   void                                          worker();
   const std::string                             getAdapterStatus(uint8_t capacity) const;
-  const std::tuple<uint8_t, float, std::string> getInfos() const;
+  const std::tuple<uint8_t, float, std::string> getInfos();
   const std::string                             formatTimeRemaining(float hoursRemaining);
 
   int                   global_watch;
   std::map<fs::path,int> batteries_;
   fs::path              adapter_;
-  int                   fd_;
+  int                   battery_watch_fd_;
+  int                   global_watch_fd_;
+  std::mutex            battery_list_mutex_;
   std::string           old_status_;
 
   util::SleeperThread   thread_;
+  util::SleeperThread   thread_battery_update_;
   util::SleeperThread   thread_timer_;
 };
 


### PR DESCRIPTION
Speedup battery state update by only updating the battery list when we get a CREATE/DELETE event in the directory or whenever we do a full refresh on the interval.

This doesn't seem to make much difference in CPU performance either way that I've been able to measure. But the code doesn't look too bad, although it does need a mutex. It's a judgment call weather to do this or to just get rid of the TODO and live with the refresh on every update. There may be situations where the battery state is updating very fast where this is a relevant gain.