### PR TITLE
Update to the latest version of the foreign toplevel manager protocol

### DIFF
--- a/protocol/wlr-foreign-toplevel-management-unstable-v1.xml
+++ b/protocol/wlr-foreign-toplevel-management-unstable-v1.xml
@@ -25,7 +25,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zwlr_foreign_toplevel_manager_v1" version="2">
+  <interface name="zwlr_foreign_toplevel_manager_v1" version="3">
     <description summary="list and control opened apps">
       The purpose of this protocol is to enable the creation of taskbars
       and docks by providing them with a list of opened applications and
@@ -68,7 +68,7 @@
     </event>
   </interface>
 
-  <interface name="zwlr_foreign_toplevel_handle_v1" version="2">
+  <interface name="zwlr_foreign_toplevel_handle_v1" version="3">
     <description summary="an opened toplevel">
       A zwlr_foreign_toplevel_handle_v1 object represents an opened toplevel
       window. Each app may have multiple opened toplevels.
@@ -255,5 +255,16 @@
         actually changes, this will be indicated by the state event.
       </description>
     </request>
+
+    <!-- Version 3 additions -->
+
+    <event name="parent" since="3">
+      <description summary="parent change">
+        This event is emitted whenever the parent of the toplevel changes.
+
+        No event is emitted when the parent handle is destroyed by the client.
+      </description>
+      <arg name="parent" type="object" interface="zwlr_foreign_toplevel_handle_v1" allow-null="true"/>
+    </event>
   </interface>
 </protocol>

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -187,6 +187,12 @@ static void tl_handle_done(void *data, struct zwlr_foreign_toplevel_handle_v1 *h
     return static_cast<Task*>(data)->handle_done();
 }
 
+static void tl_handle_parent(void *data, struct zwlr_foreign_toplevel_handle_v1 *handle,
+        struct zwlr_foreign_toplevel_handle_v1 *parent)
+{
+    /* This is explicitly left blank */
+}
+
 static void tl_handle_closed(void *data, struct zwlr_foreign_toplevel_handle_v1 *handle)
 {
     return static_cast<Task*>(data)->handle_closed();
@@ -200,6 +206,7 @@ static const struct zwlr_foreign_toplevel_handle_v1_listener toplevel_handle_imp
     .state = tl_handle_state,
     .done = tl_handle_done,
     .closed = tl_handle_closed,
+    .parent = tl_handle_parent,
 };
 
 Task::Task(const waybar::Bar &bar, const Json::Value &config, Taskbar *tbar,
@@ -661,9 +668,11 @@ void Taskbar::register_manager(struct wl_registry *registry, uint32_t name, uint
         spdlog::warn("Register foreign toplevel manager again although already existing!");
         return;
     }
-    if (version < ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_STATE_FULLSCREEN_SINCE_VERSION) {
-        spdlog::warn("Using different foreign toplevel manager protocol version: {}", version);
+    if (version < ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_SET_FULLSCREEN_SINCE_VERSION) {
+        spdlog::warn("Foreign toplevel manager server does not have the appropriate version."
+                " To be able to use all features, you need at least version 2, but server is version {}", version);
     }
+
     // limit version to a highest supported by the client protocol file
     version = std::min<uint32_t>(version, zwlr_foreign_toplevel_manager_v1_interface.version);
 

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -546,6 +546,11 @@ void Task::activate()
 
 void Task::fullscreen(bool set)
 {
+    if (zwlr_foreign_toplevel_handle_v1_get_version(handle_) < ZWLR_FOREIGN_TOPLEVEL_HANDLE_V1_SET_FULLSCREEN_SINCE_VERSION) {
+        spdlog::warn("Foreign toplevel manager server does not support for set/unset fullscreen.");
+        return;
+    }
+
     if (set)
         zwlr_foreign_toplevel_handle_v1_set_fullscreen(handle_, nullptr);
     else


### PR DESCRIPTION
There was an update the of the toplevel manager protocol. Unfortunately,
there are no new interesting updates with regard to the taskbar
implementation. Nonetheless, update the protocol xml files to the latest
version so that the implementation is up-to-date.

While being there, also change the debug warning that is shown when
there is a version mismatch between the server and client version of the
protocol.