### PR TITLE
fix(sway/workspaces): ignore emulated scroll events

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -291,6 +291,12 @@ std::string Workspaces::getIcon(const std::string &name, const Json::Value &node
 }
 
 bool Workspaces::handleScroll(GdkEventScroll *e) {
+  if (gdk_event_get_pointer_emulated((GdkEvent *)e)) {
+    /**
+     * Ignore emulated scroll events on window
+     */
+    return false;
+  }
   auto dir = AModule::getScrollDir(e);
   if (dir == SCROLL_DIR::NONE) {
     return true;


### PR DESCRIPTION
GDK Wayland backend can emit two events for mouse scroll: one is a
GDK_SCROLL_SMOOTH and the other one is an emulated scroll event with
direction. We only receive emulated events on a window, thus it is not
possible to handle these in a module and stop propagation.

Ignoring emulated events should be safe since those are duplicates of
smooth scroll events anyways.

Fixes #386
CC @emmanueltouzery, @somini: please, confirm if that works and fixes the issue for you.