### PR TITLE
Fix waybar-pulseaudio with pipewire-pulse

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -178,8 +178,8 @@ void waybar::modules::Pulseaudio::serverInfoCb(pa_context *context, const pa_ser
   pa->default_sink_name_ = i->default_sink_name;
   pa->default_source_name_ = i->default_source_name;
 
-  pa_context_get_sink_info_by_name(context, i->default_sink_name, sinkInfoCb, data);
-  pa_context_get_source_info_by_name(context, i->default_source_name, sourceInfoCb, data);
+  pa_context_get_sink_info_by_name(context, "@DEFAULT_SINK@", sinkInfoCb, data);
+  pa_context_get_source_info_by_name(context, "@DEFAULT_SOURCE@", sourceInfoCb, data);
 }
 
 static const std::array<std::string, 9> ports = {


### PR DESCRIPTION
Yesterday I opened #933, but actually this change was enough to make `waybar-pulseaudio` work with `pipewire-pulse`. What's your opinion about this change?