### PR TITLE
Add filetype hint for vim.

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -145,3 +145,5 @@
         // "exec": "$HOME/.config/waybar/mediaplayer.py --player spotify 2> /dev/null" // Filter player based on name
     }
 }
+
+// vim:ft=json

--- a/resources/config
+++ b/resources/config
@@ -146,4 +146,4 @@
     }
 }
 
-// vim:ft=json
+// vim:ft=javascript


### PR DESCRIPTION
This will enable syntax highlighting in vim / nvim without the
need of setting it manually via :set syntax=json by providing a vim
filetype hint.