### PR TITLE
Fix Sway #waybar.solo CSS rule applying on split

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -118,6 +118,7 @@ std::tuple<std::size_t, int, std::string, std::string> gfnWithWorkspace(
 
 std::tuple<std::size_t, int, std::string, std::string> Window::getFocusedNode(
     const Json::Value& nodes, std::string& output) {
+  Json::Value placeholder = 0;
   return gfnWithWorkspace(nodes, output, config_, bar_, placeholder);
 }
 


### PR DESCRIPTION
This error occurs because of an incorrect assumption that the size of the list of nodes that contains the focused window is the number of windows in a workspace.

The windows in a workspace are stored as a tree by Sway, rather than a list, so the number of windows has to be found by counting the leaves of a workspace tree.
