### PR TITLE
Revert "Fix waybar-pulseaudio with pipewire-pulse"

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -178,8 +178,8 @@ void waybar::modules::Pulseaudio::serverInfoCb(pa_context *context, const pa_ser
   pa->default_sink_name_ = i->default_sink_name;
   pa->default_source_name_ = i->default_source_name;
 
-  pa_context_get_sink_info_by_name(context, "@DEFAULT_SINK@", sinkInfoCb, data);
-  pa_context_get_source_info_by_name(context, "@DEFAULT_SOURCE@", sourceInfoCb, data);
+  pa_context_get_sink_info_by_name(context, i->default_sink_name, sinkInfoCb, data);
+  pa_context_get_source_info_by_name(context, i->default_source_name, sourceInfoCb, data);
 }
 
 static const std::array<std::string, 9> ports = {


### PR DESCRIPTION
This reverts commit 0d03c1d4da50ef248b197c29301e7cd879f98336.

As pointed out in [#933](https://github.com/Alexays/Waybar/issues/933#issuecomment-748444973), #937 wasn't fixing anything at all... waybar works with pipewire after its restart, thus a different patch is needed.