### PR TITLE
Added waybar_output.identifier support. #602

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -17,6 +17,7 @@ class Factory;
 struct waybar_output {
   Glib::RefPtr<Gdk::Monitor> monitor;
   std::string                name;
+  std::string                identifier;
 
   std::unique_ptr<struct zxdg_output_v1, decltype(&zxdg_output_v1_destroy)> xdg_output = {
       nullptr, &zxdg_output_v1_destroy};

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -45,6 +45,8 @@ class Client {
   static void handleGlobal(void *data, struct wl_registry *registry, uint32_t name,
                            const char *interface, uint32_t version);
   static void handleGlobalRemove(void *data, struct wl_registry *registry, uint32_t name);
+  static void handleOutputDone(void *, struct zxdg_output_v1 *);
+  static void handleOutputName(void *, struct zxdg_output_v1 *, const char *);
   static void handleOutputDescription(void *, struct zxdg_output_v1 *, const char *);
   void        handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor);
   void        handleMonitorRemoved(Glib::RefPtr<Gdk::Monitor> monitor);

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -6,6 +6,7 @@
 #include <unistd.h>
 #include <wayland-client.h>
 #include <wordexp.h>
+
 #include "bar.hpp"
 
 struct zwlr_layer_shell_v1;
@@ -33,18 +34,18 @@ class Client {
   std::tuple<const std::string, const std::string> getConfigs(const std::string &config,
                                                               const std::string &style) const;
   void                                             bindInterfaces();
-  const std::string getValidPath(const std::vector<std::string> &paths) const;
-  void              handleOutput(struct waybar_output &output);
-  bool isValidOutput(const Json::Value &config, struct waybar_output &output);
-  auto setupConfig(const std::string &config_file) -> void;
-  auto setupCss(const std::string &css_file) -> void;
-  struct waybar_output &getOutput(void *);
+  const std::string        getValidPath(const std::vector<std::string> &paths) const;
+  void                     handleOutput(struct waybar_output &output);
+  bool                     isValidOutput(const Json::Value &config, struct waybar_output &output);
+  auto                     setupConfig(const std::string &config_file) -> void;
+  auto                     setupCss(const std::string &css_file) -> void;
+  struct waybar_output &   getOutput(void *);
   std::vector<Json::Value> getOutputConfigs(struct waybar_output &output);
 
   static void handleGlobal(void *data, struct wl_registry *registry, uint32_t name,
                            const char *interface, uint32_t version);
   static void handleGlobalRemove(void *data, struct wl_registry *registry, uint32_t name);
-  static void handleOutputName(void *, struct zxdg_output_v1 *, const char *);
+  static void handleOutputDescription(void *, struct zxdg_output_v1 *, const char *);
   void        handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor);
   void        handleMonitorRemoved(Glib::RefPtr<Gdk::Monitor> monitor);
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -144,10 +144,6 @@ void waybar::Client::handleOutputName(void *      data, struct zxdg_output_v1 * 
   auto client = waybar::Client::inst();
   try {
     auto &output = client->getOutput(data);
-    spdlog::debug("Output detected with name: {} ({} {})",
-                  name,
-                  output.monitor->get_manufacturer(),
-                  output.monitor->get_model());
     output.name = name;
   } catch (const std::exception &e) {
     std::cerr << e.what() << std::endl;


### PR DESCRIPTION
This resolves #602 allowing you to specify the output identifier exactly like Sway allows you to do.

It does this by getting the identifier from the description that is reported. This is how swaybar does it as well: https://github.com/swaywm/sway/pull/3415/files#diff-f1816f4a24dbbcf1a1dc419a0daeee3ac8bfcb410a44bd9d9e75900d1210bbbcR264-R279

