### PR TITLE
Fix for group module selectors when bar is vertical

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -370,9 +370,6 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   window.get_style_context()->add_class(output->name);
   window.get_style_context()->add_class(config["name"].asString());
   window.get_style_context()->add_class(config["position"].asString());
-  left_.get_style_context()->add_class("modules-left");
-  center_.get_style_context()->add_class("modules-center");
-  right_.get_style_context()->add_class("modules-right");
 
   if (config["layer"] == "top") {
     layer_ = bar_layer::TOP;
@@ -387,11 +384,12 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     center_ = Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0);
     right_ = Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0);
     box_ = Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0);
-    left_.get_style_context()->add_class("modules-left");
-    center_.get_style_context()->add_class("modules-center");
-    right_.get_style_context()->add_class("modules-right");
     vertical = true;
   }
+  
+  left_.get_style_context()->add_class("modules-left");
+  center_.get_style_context()->add_class("modules-center");
+  right_.get_style_context()->add_class("modules-right");
 
   uint32_t height = config["height"].isUInt() ? config["height"].asUInt() : 0;
   uint32_t width = config["width"].isUInt() ? config["width"].asUInt() : 0;

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -387,6 +387,9 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     center_ = Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0);
     right_ = Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0);
     box_ = Gtk::Box(Gtk::ORIENTATION_VERTICAL, 0);
+    left_.get_style_context()->add_class("modules-left");
+    center_.get_style_context()->add_class("modules-center");
+    right_.get_style_context()->add_class("modules-right");
     vertical = true;
   }
 


### PR DESCRIPTION
I noticed that #880 didn't seem to work when the bar was in vertical mode, and it looks like that was because the boxes were being re-assigned after adding the selectors, so I moved the selectors to just after the re-assignment, so now they should work in either mode :)