### PR TITLE
Wifi signal strength, potential fix?

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -752,8 +752,9 @@ void waybar::modules::Network::parseSignal(struct nlattr **bss) {
     // WiFi-hardware usually operates in the range -90 to -20dBm.
     const int hardwareMax = -20;
     const int hardwareMin = -90;
-    const int strength =
-      ((signal_strength_dbm_ - hardwareMin) / double{hardwareMax - hardwareMin}) * 100;
+    /* const int strength = */
+    /*   ((signal_strength_dbm_ - hardwareMin) / double{hardwareMax - hardwareMin}) * 100; */
+    const int strength = (signal_strength_dbm_ > hardwareMin) ? signal_strength_dbm_ + 100 - hardwareMax : 0;
     signal_strength_ = std::clamp(strength, 0, 100);
   }
   if (bss[NL80211_BSS_SIGNAL_UNSPEC] != nullptr) {


### PR DESCRIPTION
Potential fix for #641 

I tried to see if I could find a more accurate way of calculating wifi signal strength that would line up with `nmcli` better. I found a couple sources about how `nmcli` calculates its signal strength values ([the most thorough being here](https://web.archive.org/web/20141222024740/http://www.ces.clemson.edu/linux/nm-ipw2200.shtml)), but after a lot of testing on my machine as well as a friend's, for dBm values between ~-70 and ~-20, the best fit was just `signal_strength_dbm_ + 120`.

I'm honestly not very convinced that this is accurate, but it's lining up really consistently for me and the other person I was testing with. I even tried histogramming its residuals against those from the method from the link above, and they're pretty close, but just adding 120 still comes out pretty solidly on top.

Very open to criticism or just being shut down on this one, just thought I'd try to at least get the ball rolling :slightly_smiling_face: 

<details><summary>Click for histograms</summary>
(there are some outliers from sudden changes before nmcli had a chance to catch up)

```python
====== Quadratic Fit ======

 56|           o                  
 53|           o                  
 50|           o                  
 47|           o                  
 44|           o                  
 41|           o                  
 38|           o                  
 35|           o                  
 32|           o                  
 30|           o                  
 27|           o                  
 24|          oo                  
 21|          oo                  
 18|          oo                  
 15|          oo                  
 12|          oo   o              
  9|          oo   o o            
  6|          oooooo oo o       o 
  3| o      o ooooooooooo       o 
  1| oo     oooooooooooooooooo  oo
    -----------------------------
    - - - - - 1 3 5 7 9 1 1 1 1 1 
    9 7 5 3 1           1 3 5 7 9
----------------------------------
|            Summary             |
----------------------------------
|       observations: 173        |
|      min value: -9.000000      |
|        mean : 3.485549         |
|      max value: 19.000000      |
----------------------------------

====== Adding ======

 78|              o                  
 74|              o                  
 70|              o                  
 66|              o                  
 62|              o                  
 58|              o                  
 54|              o                  
 50|              o                  
 46|              o                  
 42|              o                  
 37|              o                  
 33|              o                  
 29|              o                  
 25|              o                  
 21|              o                  
 17|              oo                 
 13|             ooo                 
  9|             ooo                 
  5|           o ooooo    o        o 
  1| o o    oo oooooooooooooooooo  oo
    --------------------------------
    - - - - - - - 1 3 5 7 9 1 1 1 1 
    1 1 9 7 5 3 1           1 3 5 7 
    3 1                             
-----------------------------------
|             Summary             |
-----------------------------------
|        observations: 173        |
|      min value: -13.000000      |
|         mean : 1.595376         |
|       max value: 18.000000      |
-----------------------------------
```
</details>