### PR TITLE
Fixing logic in getIcon

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -60,14 +60,14 @@ std::string ALabel::getIcon(uint16_t percentage, const std::string& alt, uint16_
 std::string ALabel::getIcon(uint16_t percentage, std::vector<std::string>& alts, uint16_t max) {
   auto format_icons = config_["format-icons"];
   if (format_icons.isObject()) {
+    std::string _alt = "default";
     for (const auto& alt : alts) {
       if (!alt.empty() && (format_icons[alt].isString() || format_icons[alt].isArray())) {
-        format_icons = format_icons[alt];
+        _alt = alt;
         break;
-      } else {
-        format_icons = format_icons["default"];
       }
     }
+    format_icons = format_icons[_alt];
   }
   if (format_icons.isArray()) {
     auto size = format_icons.size();


### PR DESCRIPTION
fixes #896

This fixes a logical error in the loop checking several alts to get the right icon. The old logic assigned "default" on each failure to find the right one. This made the loop fail on the next iteration unless default also was an object that contained the other alts looked for.

My fix changes the logic to use a default value for the name that should be used and assigns to that name if it finds the value. Finally it assigns to `format_icons` once it either found the one we're looking for or nothing was found.