### PR TITLE
Fix duplicate bars on xdg_output property changes

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -129,9 +129,6 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
       wl_display_roundtrip(client->wl_display);
       for (const auto &config : configs) {
         client->bars.emplace_back(std::make_unique<Bar>(&output, config));
-        Glib::RefPtr<Gdk::Screen> screen = client->bars.back()->window.get_screen();
-        client->style_context_->add_provider_for_screen(
-            screen, client->css_provider_, GTK_STYLE_PROVIDER_PRIORITY_USER);
       }
     }
   } catch (const std::exception &e) {
@@ -232,6 +229,9 @@ auto waybar::Client::setupCss(const std::string &css_file) -> void {
   if (!css_provider_->load_from_path(css_file)) {
     throw std::runtime_error("Can't open style file");
   }
+  // there's always only one screen
+  style_context_->add_provider_for_screen(
+      Gdk::Screen::get_default(), css_provider_, GTK_STYLE_PROVIDER_PRIORITY_USER);
 }
 
 void waybar::Client::bindInterfaces() {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -123,14 +123,14 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
     spdlog::debug("Output detection done: {} ({})", output.name, output.identifier);
 
     auto configs = client->getOutputConfigs(output);
-    if (configs.empty()) {
-      output.xdg_output.reset();
-    } else {
+    if (!configs.empty()) {
       wl_display_roundtrip(client->wl_display);
       for (const auto &config : configs) {
         client->bars.emplace_back(std::make_unique<Bar>(&output, config));
       }
     }
+    // unsubscribe
+    output.xdg_output.reset();
   } catch (const std::exception &e) {
     std::cerr << e.what() << std::endl;
   }


### PR DESCRIPTION
Since both `name` and `description` are not mutable in the protocol version we bind to, it's fine to drop the xdg_output object after receiving an initial set of properties.

Also cleanup the code for attaching styles. There's always only one screen in Gdk so there's no reason to do that for every window.

Fixes #990