### PR TITLE
Add recursive config includes

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -38,7 +38,7 @@ class Client {
   const std::string        getValidPath(const std::vector<std::string> &paths) const;
   void                     handleOutput(struct waybar_output &output);
   bool                     isValidOutput(const Json::Value &config, struct waybar_output &output);
-  auto                     setupConfig(const std::string &config_file) -> void;
+  auto                     setupConfig(const std::string &config_file, int depth) -> void;
   auto                     mergeConfig(Json::Value &a_config_, Json::Value &b_config_) -> void;
   auto                     setupCss(const std::string &css_file) -> void;
   struct waybar_output &   getOutput(void *);

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -39,6 +39,7 @@ class Client {
   void                     handleOutput(struct waybar_output &output);
   bool                     isValidOutput(const Json::Value &config, struct waybar_output &output);
   auto                     setupConfig(const std::string &config_file) -> void;
+  auto                     mergeConfig(Json::Value &a_config_, Json::Value &b_config_) -> void;
   auto                     setupCss(const std::string &css_file) -> void;
   struct waybar_output &   getOutput(void *);
   std::vector<Json::Value> getOutputConfigs(struct waybar_output &output);

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -85,6 +85,10 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	Option to disable the use of gtk-layer-shell for popups.
 	Only functional if compiled with gtk-layer-shell support.
 
+*include* ++
+	typeof: array ++
+	Paths to additional configuration files. In case of duplicate options, the including file's value takes precedence. Make sure to avoid circular imports.
+
 # MODULE FORMAT
 
 You can use PangoMarkupFormat (See https://developer.gnome.org/pango/stable/PangoMarkupFormat.html#PangoMarkupFormat).

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -241,9 +241,9 @@ auto waybar::Client::setupConfig(const std::string &config_file) -> void {
   }
   std::string      str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   util::JsonParser parser;
-  Json::Value tmp_config_ = parser.parse(str);
+  Json::Value      tmp_config_ = parser.parse(str);
   if (tmp_config_["include"].isArray()) {
-    for (const auto& include : tmp_config_["include"]) {
+    for (const auto &include : tmp_config_["include"]) {
       spdlog::info("Including resource file: {}", include.asString());
       setupConfig(getValidPath({include.asString()}));
     }
@@ -252,7 +252,7 @@ auto waybar::Client::setupConfig(const std::string &config_file) -> void {
 }
 
 auto waybar::Client::mergeConfig(Json::Value &a_config_, Json::Value &b_config_) -> void {
-  for (const auto& key : b_config_.getMemberNames()) {
+  for (const auto &key : b_config_.getMemberNames()) {
     if (a_config_[key].type() == Json::objectValue && b_config_[key].type() == Json::objectValue) {
       mergeConfig(a_config_[key], b_config_[key]);
     } else {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -241,7 +241,24 @@ auto waybar::Client::setupConfig(const std::string &config_file) -> void {
   }
   std::string      str((std::istreambuf_iterator<char>(file)), std::istreambuf_iterator<char>());
   util::JsonParser parser;
-  config_ = parser.parse(str);
+  Json::Value tmp_config_ = parser.parse(str);
+  if (tmp_config_["include"].isArray()) {
+    for (const auto& include : tmp_config_["include"]) {
+      spdlog::info("Including resource file: {}", include.asString());
+      setupConfig(getValidPath({include.asString()}));
+    }
+  }
+  mergeConfig(config_, tmp_config_);
+}
+
+auto waybar::Client::mergeConfig(Json::Value &a_config_, Json::Value &b_config_) -> void {
+  for (const auto& key : b_config_.getMemberNames()) {
+    if (a_config_[key].type() == Json::objectValue && b_config_[key].type() == Json::objectValue) {
+      mergeConfig(a_config_[key], b_config_[key]);
+    } else {
+      a_config_[key] = b_config_[key];
+    }
+  }
 }
 
 auto waybar::Client::setupCss(const std::string &css_file) -> void {


### PR DESCRIPTION
Hey,
so I've tried my hand at implementing recursive configuration imports with an "include" array:
```
"include": [
	"$HOME/.config/waybar/included_file"
]
```

**Disclaimer:** I have next to no experience in C++ so I very possibly could've built an error into this. I would welcome it very much if you would be able to have a close look at it.

Some things:
- It does not break existing configs, at least not in my tests.
- It simply tries to recursively merge configuration files specified in an "include" array with the main file.
- Duplicate keys are overwritten. Since it's a bottom-up recursion, the main file overrides included files.
- It is a tiny bit slower for standard configurations since it recursively copies instead of directly assigning the config.
- Cyclic imports completely break it.

If you have comments or would like changes I'd be happy to work on it some more. In that case I would highly appreciate if you could point me into the right direction since I'll probably need to learn about C++ behaviour.
Thanks!