### PR TITLE
[sway/window] Add app_id to usable fields in title

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -56,7 +56,8 @@ auto Window::update() -> void {
     bar_.window.get_style_context()->remove_class("solo");
     bar_.window.get_style_context()->remove_class("empty");
   }
-  label_.set_markup(fmt::format(format_, window_));
+  label_.set_markup(fmt::format(format_, fmt::arg("title", window_),
+                                fmt::arg("app_id", app_id_)));
   if (tooltipEnabled()) {
     label_.set_tooltip_text(window_);
   }


### PR DESCRIPTION
I know it's a pretty naive implementation but I hope:

1. It will work
2. It will be retro-compatible with existing configuration file

I have to confess I'm not a C++ developer (far from it).

Closes #1000 