### PR TITLE
add length limits for MPD module tags

### DIFF
--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -73,6 +73,22 @@ Addressed by *mpd*
 	default: "MPD (disconnected)" ++
 	Tooltip information displayed when the MPD server can't be reached.
 
+*artist-len*: ++
+    typeof: integer ++
+    Maximum length of the Artist tag.
+
+*album-len*: ++
+    typeof: integer ++
+    Maximum length of the Album tag.
+
+*album-artist-len*: ++
+    typeof: integer ++
+    Maximum length of the Album Artist tag.
+
+*title-len*: ++
+    typeof: integer ++
+    Maximum length of the Title tag.
+
 *rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -2,7 +2,7 @@
 
 #include <fmt/chrono.h>
 #include <spdlog/spdlog.h>
-
+#include <glibmm/ustring.h>
 #include "modules/mpd/state.hpp"
 #if defined(MPD_NOINLINE)
 namespace waybar::modules {
@@ -98,8 +98,8 @@ void waybar::modules::MPD::setLabel() {
   }
 
   auto format = format_;
-
-  std::string          artist, album_artist, album, title, date;
+  Glib::ustring        artist, album_artist, album, title;
+  std::string          date;
   int                  song_pos = 0, queue_length = 0;
   std::chrono::seconds elapsedTime, totalTime;
 
@@ -144,13 +144,25 @@ void waybar::modules::MPD::setLabel() {
   bool        singleActivated = mpd_status_get_single(status_.get());
   std::string singleIcon = getOptionIcon("single", singleActivated);
 
+  auto artistLen = config_["artist-len"].isInt() ?
+                        config_["artist-len"].asInt() : artist.size();
+
+  auto albumArtistLen = config_["album-artist-len"].isInt() ?
+                             config_["album-artist-len"].asInt() : album_artist.size();
+
+  auto albumLen = config_["album-len"].isInt() ?
+                        config_["album-len"].asInt() : album.size();
+
+  auto titleLen = config_["title-len"].isInt() ?
+                        config_["title-len"].asInt() : title.size();
+
   try {
     label_.set_markup(
         fmt::format(format,
-                    fmt::arg("artist", Glib::Markup::escape_text(artist).raw()),
-                    fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist).raw()),
-                    fmt::arg("album", Glib::Markup::escape_text(album).raw()),
-                    fmt::arg("title", Glib::Markup::escape_text(title).raw()),
+                    fmt::arg("artist", Glib::Markup::escape_text(artist.substr(0, artistLen)).raw()),
+                    fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist.substr(0, albumArtistLen)).raw()),
+                    fmt::arg("album", Glib::Markup::escape_text(album.substr(0, albumLen)).raw()),
+                    fmt::arg("title", Glib::Markup::escape_text(title.substr(0, titleLen)).raw()),
                     fmt::arg("date", Glib::Markup::escape_text(date).raw()),
                     fmt::arg("elapsedTime", elapsedTime),
                     fmt::arg("totalTime", totalTime),
@@ -171,10 +183,10 @@ void waybar::modules::MPD::setLabel() {
                                                           : "MPD (connected)";
     try {
       auto tooltip_text = fmt::format(tooltip_format,
-                                      fmt::arg("artist", artist),
-                                      fmt::arg("albumArtist", album_artist),
-                                      fmt::arg("album", album),
-                                      fmt::arg("title", title),
+                                      fmt::arg("artist", artist.substr(0, artistLen).raw()),
+                                      fmt::arg("albumArtist", album_artist.substr(0, albumArtistLen).raw()),
+                                      fmt::arg("album", album.substr(0, albumLen).raw()),
+                                      fmt::arg("title", title.substr(0, titleLen).raw()),
                                       fmt::arg("date", date),
                                       fmt::arg("elapsedTime", elapsedTime),
                                       fmt::arg("totalTime", totalTime),

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -143,26 +143,18 @@ void waybar::modules::MPD::setLabel() {
   std::string repeatIcon = getOptionIcon("repeat", repeatActivated);
   bool        singleActivated = mpd_status_get_single(status_.get());
   std::string singleIcon = getOptionIcon("single", singleActivated);
-
-  auto artistLen = config_["artist-len"].isInt() ?
-                        config_["artist-len"].asInt() : artist.size();
-
-  auto albumArtistLen = config_["album-artist-len"].isInt() ?
-                             config_["album-artist-len"].asInt() : album_artist.size();
-
-  auto albumLen = config_["album-len"].isInt() ?
-                        config_["album-len"].asInt() : album.size();
-
-  auto titleLen = config_["title-len"].isInt() ?
-                        config_["title-len"].asInt() : title.size();
+  if (config_["artist-len"].isInt()) artist = artist.substr(0, config_["artist-len"].asInt());
+  if (config_["album-artist-len"].isInt()) album_artist = album_artist.substr(0, config_["album-artist-len"].asInt());
+  if (config_["album-len"].isInt()) album = album.substr(0, config_["album-len"].asInt());
+  if (config_["title-len"].isInt()) title = title.substr(0,config_["title-len"].asInt());
 
   try {
     label_.set_markup(
         fmt::format(format,
-                    fmt::arg("artist", Glib::Markup::escape_text(artist.substr(0, artistLen)).raw()),
-                    fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist.substr(0, albumArtistLen)).raw()),
-                    fmt::arg("album", Glib::Markup::escape_text(album.substr(0, albumLen)).raw()),
-                    fmt::arg("title", Glib::Markup::escape_text(title.substr(0, titleLen)).raw()),
+                    fmt::arg("artist", Glib::Markup::escape_text(artist).raw()),
+                    fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist).raw()),
+                    fmt::arg("album", Glib::Markup::escape_text(album).raw()),
+                    fmt::arg("title", Glib::Markup::escape_text(title).raw()),
                     fmt::arg("date", Glib::Markup::escape_text(date).raw()),
                     fmt::arg("elapsedTime", elapsedTime),
                     fmt::arg("totalTime", totalTime),
@@ -183,10 +175,10 @@ void waybar::modules::MPD::setLabel() {
                                                           : "MPD (connected)";
     try {
       auto tooltip_text = fmt::format(tooltip_format,
-                                      fmt::arg("artist", artist.substr(0, artistLen).raw()),
-                                      fmt::arg("albumArtist", album_artist.substr(0, albumArtistLen).raw()),
-                                      fmt::arg("album", album.substr(0, albumLen).raw()),
-                                      fmt::arg("title", title.substr(0, titleLen).raw()),
+                                      fmt::arg("artist", artist.raw()),
+                                      fmt::arg("albumArtist", album_artist.raw()),
+                                      fmt::arg("album", album.raw()),
+                                      fmt::arg("title", title.raw()),
                                       fmt::arg("date", date),
                                       fmt::arg("elapsedTime", elapsedTime),
                                       fmt::arg("totalTime", totalTime),


### PR DESCRIPTION
adds the following configuration options to the MPD module:

 - artist-len
 - album-len
 - album-artist-len
 - title-len

to control the maximum length of the tags when they are displayed on the bar.