### PR TITLE
Update waybar-bluetooth.5.scd

### DIFF
--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -85,7 +85,7 @@ Addressed by *bluetooth*
 		"enabled": "",
 		"disabled": ""
 	},
-	"tooltip-format": "{status}"
+	"tooltip-format": "{}"
 }
 ```
 


### PR DESCRIPTION
Remove the `status` from the `tooltip-format` example since it will
throw error. Related to #685