### PR TITLE
[calendar] CJK locale formatting

### DIFF
--- a/include/util/ustring_clen.hpp
+++ b/include/util/ustring_clen.hpp
@@ -1,0 +1,5 @@
+#pragma once
+#include <glibmm/ustring.h>
+
+// calculate column width of ustring
+int ustring_clen(const Glib::ustring &str);

--- a/meson.build
+++ b/meson.build
@@ -147,6 +147,7 @@ src_files = files(
     'src/main.cpp',
     'src/bar.cpp',
     'src/client.cpp',
+    'src/util/ustring_clen.cpp'
 )
 
 if is_linux

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -5,6 +5,7 @@
 
 #include <sstream>
 #include <type_traits>
+#include "util/ustring_clen.hpp"
 #ifdef HAVE_LANGINFO_1STDAY
 #include <langinfo.h>
 #include <locale.h>
@@ -154,12 +155,16 @@ auto waybar::modules::Clock::weekdays_header(const date::weekday& first_dow, std
   do {
     if (wd != first_dow) os << ' ';
     Glib::ustring wd_ustring(date::format(locale_, "%a", wd));
-    auto          wd_len = wd_ustring.length();
-    if (wd_len > 2) {
-      wd_ustring = wd_ustring.substr(0, 2);
-      wd_len = 2;
+    auto clen = ustring_clen(wd_ustring);
+    auto wd_len = wd_ustring.length();
+    fmt::print("{} {}\n", clen, wd_len);
+    while (clen > 2) {
+      wd_ustring = wd_ustring.substr(0, wd_len-1);
+      wd_len--;
+      clen = ustring_clen(wd_ustring);
     }
-    const std::string pad(2 - wd_len, ' ');
+    fmt::print("{} {}", clen, wd_len);
+    const std::string pad(2 - clen, ' ');
     os << pad << wd_ustring;
   } while (++wd != first_dow);
   os << "\n";

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -157,13 +157,11 @@ auto waybar::modules::Clock::weekdays_header(const date::weekday& first_dow, std
     Glib::ustring wd_ustring(date::format(locale_, "%a", wd));
     auto clen = ustring_clen(wd_ustring);
     auto wd_len = wd_ustring.length();
-    fmt::print("{} {}\n", clen, wd_len);
     while (clen > 2) {
       wd_ustring = wd_ustring.substr(0, wd_len-1);
       wd_len--;
       clen = ustring_clen(wd_ustring);
     }
-    fmt::print("{} {}", clen, wd_len);
     const std::string pad(2 - clen, ' ');
     os << pad << wd_ustring;
   } while (++wd != first_dow);

--- a/src/util/ustring_clen.cpp
+++ b/src/util/ustring_clen.cpp
@@ -1,0 +1,9 @@
+#include "util/ustring_clen.hpp"
+
+int ustring_clen(const Glib::ustring &str){
+  int total = 0;
+  for (auto i = str.begin(); i != str.end(); ++i) {
+    total += g_unichar_iswide(*i) + 1;
+  }
+  return total;
+}


### PR DESCRIPTION
fix for #976

uses g_unichar_iswide to calculate the column width of a string; this is used to properly format the calendar under CJK locales