### PR TITLE
improve module sizing options

### DIFF
--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -24,6 +24,14 @@ The *backlight* module displays the current backlight level.
 	typeof: integer ++
 	The maximum length in characters the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -55,6 +55,14 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	typeof: integer++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *rotate*: ++
 	typeof: integer++
 	Positive value to rotate the text label.

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -35,6 +35,14 @@ Addressed by *bluetooth*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -45,6 +45,14 @@ The *clock* module displays the current date and time.
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -24,6 +24,14 @@ The *cpu* module displays the current cpu utilization.
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -67,6 +67,14 @@ Addressed by *custom/<name>*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -39,6 +39,14 @@ Addressed by *disk*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-idle-inhibitor.5.scd
+++ b/man/waybar-idle-inhibitor.5.scd
@@ -27,6 +27,14 @@ screensaving, also known as "presentation mode".
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module. A click also toggles the state

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -34,6 +34,14 @@ Addressed by *memory*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -81,6 +81,14 @@ Addressed by *mpd*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -64,6 +64,14 @@ Addressed by *network*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -50,6 +50,14 @@ Additionally you can control the volume by scrolling *up* or *down* while the cu
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *scroll-step*: ++
 	typeof: float ++
 	default: 1.0 ++

--- a/man/waybar-sndio.5.scd
+++ b/man/waybar-sndio.5.scd
@@ -26,6 +26,14 @@ cursor is over the module, and clicking on the module toggles mute.
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *scroll-step*: ++
 	typeof: int ++
 	default: 5 ++

--- a/man/waybar-sway-language.5.scd
+++ b/man/waybar-sway-language.5.scd
@@ -25,6 +25,14 @@ Addressed by *sway/language*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-sway-mode.5.scd
+++ b/man/waybar-sway-mode.5.scd
@@ -25,6 +25,14 @@ Addressed by *sway/mode*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -25,6 +25,14 @@ Addressed by *sway/window*
 	typeof: integer ++
 	The maximum length in character the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when clicked on the module.

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -63,6 +63,14 @@ Addressed by *temperature*
 	typeof: integer ++
 	The maximum length in characters the module should display.
 
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
 *on-click*: ++
 	typeof: string ++
 	Command to execute when you clicked on the module.

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -20,7 +20,7 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
   }
   event_box_.add(label_);
   if (config_["max-length"].isUInt()) {
-    label_.set_max_width_chars(config_["max-length"].asUInt());
+    label_.set_max_width_chars(config_["max-length"].asInt());
     label_.set_ellipsize(Pango::EllipsizeMode::ELLIPSIZE_END);
     label_.set_single_line_mode(true);
   } else if (ellipsize && label_.get_max_width_chars() == -1) {
@@ -28,8 +28,8 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
     label_.set_single_line_mode(true);
   }
 
-  if (config_["fixed-length"].isUInt()) {
-    label_.set_width_chars(config_["fixed-length"].asUInt());
+  if (config_["min-length"].isUInt()) {
+    label_.set_width_chars(config_["min-length"].asUInt());
   }
 
   if (config_["align"].isDouble()) {

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -32,14 +32,24 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
     label_.set_width_chars(config_["min-length"].asUInt());
   }
 
-  if (config_["align"].isDouble()) {
-    auto align = config_["align"].asFloat();
-    label_.set_xalign(align);
-  }
+  uint rotate = 0;
 
   if (config_["rotate"].isUInt()) {
-    label_.set_angle(config["rotate"].asUInt());
+    rotate = config["rotate"].asUInt();
+    label_.set_angle(rotate);
   }
+
+  if (config_["align"].isDouble()) {
+    auto align = config_["align"].asFloat();
+    if (rotate == 90 || rotate == 270) {
+      label_.set_yalign(align);
+    } else {
+      label_.set_xalign(align);
+    }
+
+  }
+
+
 }
 
 auto ALabel::update() -> void {

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -28,6 +28,15 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
     label_.set_single_line_mode(true);
   }
 
+  if (config_["fixed-length"].isUInt()) {
+    label_.set_width_chars(config_["fixed-length"].asUInt());
+  }
+
+  if (config_["align"].isDouble()) {
+    auto align = config_["align"].asFloat();
+    label_.set_xalign(align);
+  }
+
   if (config_["rotate"].isUInt()) {
     label_.set_angle(config["rotate"].asUInt());
   }


### PR DESCRIPTION
Add `min-length` config property, can be used in combination with `max-length` to fix the length of a module to a specific size
Also add `align` property to align text in a label

this should help with #883