### PR TITLE
[wlr/taskbar] More icon search improvements.

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -15,6 +15,7 @@
 #include <gtkmm/icontheme.h>
 
 #include <giomm/desktopappinfo.h>
+#include <gio/gdesktopappinfo.h>
 
 #include <spdlog/spdlog.h>
 
@@ -64,6 +65,9 @@ static std::vector<std::string> search_prefix()
         } while(end != std::string::npos);
     }
 
+    std::string home_dir = std::getenv("HOME");
+    prefixes.push_back(home_dir + "/.local/share/");
+
     for (auto& p : prefixes)
         spdlog::debug("Using 'desktop' search path prefix: {}", p);
 
@@ -111,6 +115,26 @@ static std::string get_from_icon_theme(const Glib::RefPtr<Gtk::IconTheme>& icon_
     return "";
 }
 
+/* Method 3 - as last resort perform a search for most appropriate desktop info file */
+static std::string get_from_desktop_app_info_search(const std::string &app_id)
+{
+    std::string desktop_file = "";
+
+    gchar*** desktop_list = g_desktop_app_info_search(app_id.c_str());
+    if (desktop_list != nullptr && desktop_list[0] != nullptr) {
+        for (size_t i=0; desktop_list[0][i]; i++) {
+            if(desktop_file == "") {
+                desktop_file = desktop_list[0][i];
+            }
+            break;
+        }
+        g_strfreev(desktop_list[0]);
+    }
+    g_free(desktop_list);
+
+    return get_from_desktop_app_info(desktop_file);
+}
+
 static bool image_load_icon(Gtk::Image& image, const Glib::RefPtr<Gtk::IconTheme>& icon_theme,
         const std::string &app_id_list, int size)
 {
@@ -142,9 +166,11 @@ static bool image_load_icon(Gtk::Image& image, const Glib::RefPtr<Gtk::IconTheme
             icon_name = get_from_desktop_app_info(lower_app_id);
         if (icon_name.empty())
             icon_name = get_from_desktop_app_info(app_name);
+        if (icon_name.empty())
+            icon_name = get_from_desktop_app_info_search(app_id);
 
         if (icon_name.empty())
-            continue;
+            icon_name = "unknown";
 
         auto pixbuf = icon_theme->load_icon(icon_name, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
         if (pixbuf) {


### PR DESCRIPTION
While using waybar noticed that other apps where also missing icon and added these extra changes:

* Added ~/.local/share prefix to search in current user defined apps.
* Add support for apps that don't properly set an id like pamac-manager which desktop info file is org.manjaro.pamac.manager.desktop but wayfire reports its id as pamac-manager.
* Lastly, If no icon is found use "unknown" as default icon instead of displaying an empty square button.

For icon issues like with pamac-manager I had to use g_desktop_app_info_search directly since I didn't see any bind to it on the giomm c++ binding.