### PR TITLE
Add a way to configure auto_back_and_forth on Sway workspaces

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -20,7 +20,7 @@ class Workspaces : public AModule, public sigc::trackable {
   auto update() -> void;
 
  private:
-  static inline const std::string workspace_switch_cmd_ = "workspace --no-auto-back-and-forth \"{}\"";
+  static inline const std::string workspace_switch_cmd_ = "workspace {} \"{}\"";
 
   static int convertWorkspaceNameToNum(std::string name);
 

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -66,12 +66,16 @@ Addressed by *sway/workspaces*
     Lists workspaces that should always be shown, even when non existent
 
 *on-update*: ++
-	typeof: string ++
-	Command to execute when the module is updated.
+    typeof: string ++
+    Command to execute when the module is updated.
 
 *numeric-first*: ++
-	typeof: bool ++
-	Whether to put workspaces starting with numbers before workspaces that do not start with a number.
+    typeof: bool ++
+    Whether to put workspaces starting with numbers before workspaces that do not start with a number.
+
+*disable-auto-back-and-forth*: ++
+    typeof: bool ++
+    Whether to disable *workspace_auto_back_and_forth* when clicking on workspaces. If this is set to *true*, clicking on a workspace you are already on won't do anything, even if *workspace_auto_back_and_forth* is enabled in the Sway configuration.
 
 # FORMAT REPLACEMENTS
 

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -257,11 +257,19 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
           ipc_.sendCmd(
               IPC_COMMAND,
               fmt::format(workspace_switch_cmd_ + "; move workspace to output \"{}\"; " + workspace_switch_cmd_,
+                          "--no-auto-back-and-forth",
                           node["name"].asString(),
                           node["target_output"].asString(),
+                          "--no-auto-back-and-forth",
                           node["name"].asString()));
         } else {
-          ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, node["name"].asString()));
+          ipc_.sendCmd(
+              IPC_COMMAND,
+              fmt::format("workspace {} \"{}\"",
+                          config_["disable-auto-back-and-forth"].asBool()
+                            ? "--no-auto-back-and-forth"
+                            : "",
+                          node["name"].asString()));
         }
       } catch (const std::exception &e) {
         spdlog::error("Workspaces: {}", e.what());
@@ -322,7 +330,9 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
     }
   }
   try {
-    ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, name));
+    ipc_.sendCmd(
+        IPC_COMMAND,
+        fmt::format(workspace_switch_cmd_, "--no-auto-back-and-forth", name));
   } catch (const std::exception &e) {
     spdlog::error("Workspaces: {}", e.what());
   }


### PR DESCRIPTION
#736 introduced a behavior that some may like, but some may not ; I'm part of the latter.

This PR adds a configuration entry to Sway workspaces module in order to enable or disable this behavior.
By default, the behavior is to follow what's configured in the Sway config file (seems more logical that way IMO), and you're able to explicitely tell Waybar not to follow what's configured in the Sway config file.
However, the `--no-auto-back-and-forth` flag is conserved when moving workspaces to other outputs or when changing workspaces by scrolling on the bar, since these behaviors were rightfully fixed by #736 and that's fine by me.

The config entry is named `disable-auto-back-and-forth` and is a boolean.

Closes #985 