### PR TITLE
[wlr/taskbar] Fix unhandled exception crash when icon name is a path.

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -81,8 +81,6 @@ static Glib::RefPtr<Gdk::Pixbuf> load_icon_from_file(std::string icon_path, int 
     try {
         auto pb = Gdk::Pixbuf::create_from_file(icon_path, size, size);
         return pb;
-    } catch(Glib::Error&) {
-        return {};
     } catch(...) {
         return {};
     }

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -1,5 +1,7 @@
 #include "modules/wlr/taskbar.hpp"
 
+#include "glibmm/error.h"
+#include "glibmm/fileutils.h"
 #include "glibmm/refptr.h"
 #include "util/format.hpp"
 
@@ -72,6 +74,18 @@ static std::vector<std::string> search_prefix()
         spdlog::debug("Using 'desktop' search path prefix: {}", p);
 
     return prefixes;
+}
+
+Glib::RefPtr<Gdk::Pixbuf> load_icon_from_file(std::string icon_path, int size)
+{
+    try {
+        auto pb = Gdk::Pixbuf::create_from_file(icon_path, size, size);
+        return pb;
+    } catch(Glib::Error&) {
+        return {};
+    } catch(...) {
+        return {};
+    }
 }
 
 /* Method 1 - get the correct icon name from the desktop file */
@@ -172,7 +186,17 @@ static bool image_load_icon(Gtk::Image& image, const Glib::RefPtr<Gtk::IconTheme
         if (icon_name.empty())
             icon_name = "unknown";
 
-        auto pixbuf = icon_theme->load_icon(icon_name, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
+        Glib::RefPtr<Gdk::Pixbuf> pixbuf;
+
+        try {
+            pixbuf = icon_theme->load_icon(icon_name, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
+        } catch(...) {
+            if (Glib::file_test(icon_name, Glib::FILE_TEST_EXISTS))
+                pixbuf = load_icon_from_file(icon_name, size);
+            else
+                pixbuf = {};
+        }
+
         if (pixbuf) {
             image.set(pixbuf);
             found = true;

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -76,7 +76,7 @@ static std::vector<std::string> search_prefix()
     return prefixes;
 }
 
-Glib::RefPtr<Gdk::Pixbuf> load_icon_from_file(std::string icon_path, int size)
+static Glib::RefPtr<Gdk::Pixbuf> load_icon_from_file(std::string icon_path, int size)
 {
     try {
         auto pb = Gdk::Pixbuf::create_from_file(icon_path, size, size);


### PR DESCRIPTION
Fixes a crash and handles the edge case where the application.desktop 'Icon' property points to the absolute path of the icon file instead of an icon name, for example:

```
[Desktop Entry]
Name=Cendric
Comment=RPG and Platformer
Exec=/usr/bin/Cendric
Terminal=false
Icon=/usr/share/Cendric/res/icon.ico
Type=Application
Categories=Game;
```