### PR TITLE
[wlr/taskbar] Check StartupWMClass

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -141,8 +141,10 @@ static std::string get_from_desktop_app_info_search(const std::string &app_id)
                 auto tmp_info = Gio::DesktopAppInfo::create(desktop_list[0][i]);
                 auto startup_class = tmp_info->get_startup_wm_class();
 
-                if (startup_class == app_id)
+                if (startup_class == app_id) {
                     desktop_file = desktop_list[0][i];
+                    break;
+                }
             }
         }
         g_strfreev(desktop_list[0]);

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -135,7 +135,7 @@ static std::string get_from_desktop_app_info_search(const std::string &app_id)
     gchar*** desktop_list = g_desktop_app_info_search(app_id.c_str());
     if (desktop_list != nullptr && desktop_list[0] != nullptr) {
         for (size_t i=0; desktop_list[0][i]; i++) {
-            if(desktop_file == "") {
+            if (desktop_file == "") {
                 desktop_file = desktop_list[0][i];
             } else {
                 auto tmp_info = Gio::DesktopAppInfo::create(desktop_list[0][i]);

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -137,8 +137,13 @@ static std::string get_from_desktop_app_info_search(const std::string &app_id)
         for (size_t i=0; desktop_list[0][i]; i++) {
             if(desktop_file == "") {
                 desktop_file = desktop_list[0][i];
+            } else {
+                auto tmp_info = Gio::DesktopAppInfo::create(desktop_list[0][i]);
+                auto startup_class = tmp_info->get_startup_wm_class();
+
+                if (startup_class == app_id)
+                    desktop_file = desktop_list[0][i];
             }
-            break;
         }
         g_strfreev(desktop_list[0]);
     }


### PR DESCRIPTION
Checks the StartupWMClass property of all .desktop files returned by g_desktop_app_info_search() in order to select the correct .desktop file. 

This fixes issues when applications with similar names are installed, eg: codeblocks, codelite, visual studio code, in this scenario visual studio code which appid is Code and .desktop file is visual-studio-code.desktop, without the check for StartupWMClass would end with either codeblocks or codelite icon. 