### PR TITLE
Fix more issues with duplicated bars

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -120,16 +120,26 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
   auto client = waybar::Client::inst();
   try {
     auto &output = client->getOutput(data);
-    spdlog::debug("Output detection done: {} ({})", output.name, output.identifier);
+    /**
+     * Multiple .done events may arrive in batch. In this case libwayland would queue
+     * xdg_output.destroy and dispatch all pending events, triggering this callback several times
+     * for the same output. .done events can also arrive after that for a scale or position changes.
+     * We wouldn't want to draw a duplicate bar for each such event either.
+     *
+     * All the properties we care about are immutable so it's safe to delete the xdg_output object
+     * on the first event and use the ptr value to check that the callback was already invoked.
+     */
+    if (output.xdg_output) {
+      output.xdg_output.reset();
+      spdlog::debug("Output detection done: {} ({})", output.name, output.identifier);
 
-    auto configs = client->getOutputConfigs(output);
-    if (!configs.empty()) {
-      for (const auto &config : configs) {
-        client->bars.emplace_back(std::make_unique<Bar>(&output, config));
+      auto configs = client->getOutputConfigs(output);
+      if (!configs.empty()) {
+        for (const auto &config : configs) {
+          client->bars.emplace_back(std::make_unique<Bar>(&output, config));
+        }
       }
     }
-    // unsubscribe
-    output.xdg_output.reset();
   } catch (const std::exception &e) {
     std::cerr << e.what() << std::endl;
   }

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -124,7 +124,6 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
 
     auto configs = client->getOutputConfigs(output);
     if (!configs.empty()) {
-      wl_display_roundtrip(client->wl_display);
       for (const auto &config : configs) {
         client->bars.emplace_back(std::make_unique<Bar>(&output, config));
       }


### PR DESCRIPTION
In #992 I missed a certain case: If `kanshi` or something similar automatically aplies configuration when monitors are plugged, resulting xdg_output events could be received and dispatched in a single batch: initial configuration, done, configuration modified by kanshi, done [, ...repeat for each output configured by kanshi].

Also, as #1019 shows outputs may unexpectedly disappear from under our code due to async callback dispatch magic. I addressed a couple of obvious crashes, but there are more, much more... :scream:

Fixes #990 (again), makes #1019 slightly less likely.