### PR TITLE
fix: schedule output destruction on idle callback

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -51,6 +51,7 @@ class Client {
   static void handleOutputDescription(void *, struct zxdg_output_v1 *, const char *);
   void        handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor);
   void        handleMonitorRemoved(Glib::RefPtr<Gdk::Monitor> monitor);
+  void        handleDeferredMonitorRemoval(Glib::RefPtr<Gdk::Monitor> monitor);
 
   Json::Value                     config_;
   Glib::RefPtr<Gtk::StyleContext> style_context_;


### PR DESCRIPTION
Defer destruction of bars for the output to the next iteration of the event loop to avoid deleting objects referenced by currently executed code.
Should fix some of the crashes on output disconnect. Could potentially cause a different kind of race conditions, but I haven't found anything that may happen in practice.

Testing: I've been running this patch for a week and attempting to reproduce the crash. Seems good so far.
@baloo, can you please try the patch and test if it fixes the issues in your setup?

Fixes #1019
