### PR TITLE
Add cpu min/max/avg frequencies

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -22,7 +22,9 @@ class Cpu : public ALabel {
  private:
   uint16_t                                getCpuLoad();
   std::tuple<uint16_t, std::string>       getCpuUsage();
+  std::tuple<float, float, float>         getCpuFrequency();
   std::vector<std::tuple<size_t, size_t>> parseCpuinfo();
+  std::vector<float>                      parseCpuFrequencies();
 
   std::vector<std::tuple<size_t, size_t>> prev_times_;
 

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -79,6 +79,12 @@ The *cpu* module displays the current cpu utilization.
 
 *{usage}*: Current cpu usage.
 
+*{avg_frequency}*: Current cpu average frequency (based on all cores) in GHz.
+
+*{max_frequency}*: Current cpu max frequency (based on the core with the highest frequency) in GHz.
+
+*{min_frequency}*: Current cpu min frequency (based on the core with the lowest frequency) in GHz.
+
 # EXAMPLE
 
 ```

--- a/src/modules/cpu/bsd.cpp
+++ b/src/modules/cpu/bsd.cpp
@@ -2,8 +2,10 @@
 
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#include <spdlog/spdlog.h>
 #include <cstdlib>            // malloc
 #include <unistd.h>           // sysconf
+#include <cmath>              // NAN
 
 #if defined(__NetBSD__) || defined(__OpenBSD__)
 #  include <sys/sched.h>
@@ -97,5 +99,10 @@ std::vector<std::tuple<size_t, size_t>> waybar::modules::Cpu::parseCpuinfo() {
 }
 
 std::vector<float> waybar::modules::Cpu::parseCpuFrequencies() {
-  throw std::runtime_error("Cpu frequency is not implemented on BSD.");
+  static std::vector<float> frequencies;
+  if (frequencies.empty()) {
+    spdlog::warn("cpu/bsd: parseCpuFrequencies is not implemented, expect garbage in {*_frequency}");
+    frequencies.push_back(NAN);
+  }
+  return frequencies;
 }

--- a/src/modules/cpu/bsd.cpp
+++ b/src/modules/cpu/bsd.cpp
@@ -95,3 +95,7 @@ std::vector<std::tuple<size_t, size_t>> waybar::modules::Cpu::parseCpuinfo() {
   free(cp_time);
   return cpuinfo;
 }
+
+std::vector<float> waybar::modules::Cpu::parseCpuFrequencies() {
+  throw std::runtime_error("Cpu frequency is not implemented on BSD.");
+}

--- a/src/modules/cpu/linux.cpp
+++ b/src/modules/cpu/linux.cpp
@@ -27,3 +27,24 @@ std::vector<std::tuple<size_t, size_t>> waybar::modules::Cpu::parseCpuinfo() {
   }
   return cpuinfo;
 }
+
+std::vector<float> waybar::modules::Cpu::parseCpuFrequencies() {
+  const std::string file_path_ = "/proc/cpuinfo";
+  std::ifstream info(file_path_);
+  if (!info.is_open()) {
+    throw std::runtime_error("Can't open " + file_path_);
+  }
+  std::vector<float> frequencies;
+  std::string line;
+  while (getline(info, line)) {
+    if (line.substr(0, 7).compare("cpu MHz") != 0) {
+      continue;
+    }
+
+    std::string frequency_str = line.substr(line.find(":") + 2);
+    float frequency = std::strtol(frequency_str.c_str(), nullptr, 10);
+    frequencies.push_back(frequency);
+  }
+  info.close();
+  return frequencies;
+}


### PR DESCRIPTION
Adds format replacements for the CPU module to get the current min, max and average frequencies.

The implementation for *BSD platforms has been stubbed out for the time being, until someone on these platforms implements it.

Here's a quick example of the output it produces :
![image](https://user-images.githubusercontent.com/2933420/108606072-3678df80-73b8-11eb-8d08-c8a90ade76ea.png)

Closes #764 