### PR TITLE
Fix: CPU load values

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <unistd.h>
 #include <cstdint>
 #include <fstream>
 #include <numeric>
@@ -20,7 +19,7 @@ class Cpu : public ALabel {
   auto update() -> void;
 
  private:
-  uint16_t                                getCpuLoad();
+  double                                  getCpuLoad();
   std::tuple<uint16_t, std::string>       getCpuUsage();
   std::vector<std::tuple<size_t, size_t>> parseCpuinfo();
 

--- a/src/modules/cpu/common.cpp
+++ b/src/modules/cpu/common.cpp
@@ -32,10 +32,10 @@ auto waybar::modules::Cpu::update() -> void {
   ALabel::update();
 }
 
-uint16_t waybar::modules::Cpu::getCpuLoad() {
+double waybar::modules::Cpu::getCpuLoad() {
   double load[1];
   if (getloadavg(load, 1) != -1) {
-    return load[0] * 100 / sysconf(_SC_NPROCESSORS_ONLN);
+    return load[0];
   }
   throw std::runtime_error("Can't get Cpu load");
 }


### PR DESCRIPTION
Remove the division of the load by the number of online (or available) processors.

The current displayed value is quite counter-intuitive and hard to get a grasp on as it is different from the values of `uptime` and `top`; moreover there already is the other `{usage}` format, as argued in #769 by @gvccandido.
Furthermore, this (very small) fix would lead Waybar CPU load output to be the same as the one displayed by `i3status`.
Another possibility would be to keep the current format and add a new format for this "more standard" load.

This would fix #769 .
Thank you for Waybar, it is a very useful software I use daily.