### PR TITLE
Add default styling for disk module

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -69,6 +69,7 @@ window#waybar.chromium {
 #battery,
 #cpu,
 #memory,
+#disk,
 #temperature,
 #backlight,
 #network,
@@ -140,6 +141,10 @@ label:focus {
 
 #memory {
     background-color: #9b59b6;
+}
+
+#disk {
+    background-color: #964B00;
 }
 
 #backlight {


### PR DESCRIPTION
This patch adds some default styling for the disk module, which previously did not have any styling specified. It uses a brown background since brown isn't used by any other modules.