### PR TITLE
meson.build: add missing waybar-sway-language manpage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -315,6 +315,7 @@ if scdoc.found()
         'waybar-network.5.scd',
         'waybar-pulseaudio.5.scd',
         'waybar-river-tags.5.scd',
+        'waybar-sway-language.5.scd',
         'waybar-sway-mode.5.scd',
         'waybar-sway-window.5.scd',
         'waybar-sway-workspaces.5.scd',


### PR DESCRIPTION
There's *.scd file for sway/language module's manpage, but it's not mentioned in meson.build.
