### PR TITLE
Add option to rewrite sway/window title

### DIFF
--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -22,6 +22,7 @@ class Window : public ALabel, public sigc::trackable {
   std::tuple<std::size_t, int, std::string, std::string> getFocusedNode(const Json::Value& nodes,
                                                                         std::string&       output);
   void                                                   getTree();
+  std::string                                            rewriteTitle(const std::string& title);
 
   const Bar&       bar_;
   std::string      window_;

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -66,12 +66,32 @@ Addressed by *sway/window*
 	default: true ++
 	Option to disable tooltip on hover.
 
+*rewrite*: ++
+	typeof: object ++
+	Rules to rewrite window title. See *rewrite rules*.
+
+# REWRITE RULES
+
+*rewrite* is an object where keys are regular expressions and values are
+rewrite rules if the expression matches. Rules may contain references to
+captures of the expression.
+
+Regular expression and replacement follow ECMA-script rules.
+
+If no expression matches, the title is left unchanged.
+
+Invalid expressions (e.g., mismatched parentheses) are skipped.
+
 # EXAMPLES
 
 ```
 "sway/window": {
     "format": "{}",
-    "max-length": 50
+    "max-length": 50,
+    "rewrite": {
+      "(.*) - Mozilla Firefox": "🌎 $1",
+      "(.*) - zsh": "> [$1]"
+    }
 }
 ```
 

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -141,9 +141,15 @@ std::string Window::rewriteTitle(const std::string& title)
 
   for (auto it = rules.begin(); it != rules.end(); ++it) {
     if (it.key().isString() && it->isString()) {
-      const std::regex rule{it.key().asString()};
-      if (std::regex_match(title, rule)) {
-        return std::regex_replace(title, rule, it->asString());
+      try {
+        // malformated regexes will cause an exception.
+        // in this case, log error and try the next rule.
+        const std::regex rule{it.key().asString()};
+        if (std::regex_match(title, rule)) {
+          return std::regex_replace(title, rule, it->asString());
+        }
+      } catch (const std::regex_error& e) {
+        spdlog::error("Invalid rule {}: {}", it.key().asString(), e.what());
       }
     }
   }


### PR DESCRIPTION
Rewrites window title according to config option "rewrite".

"rewrite" is an object where keys are regular expressions and values are rewrite rules if the expression matches. Rules may contain references to captures of the expression. Regex and replacement follow ECMA-script rules. If no regex matches, the title is left unchanged.

Useful to add icons depending on the window title, e.g.:
```json
"sway/window": {
  "rewrite": {
    "(.*) - Mozilla Firefox": " $1",
    "(.*) - zsh": " [$1]",
  }
}
```

Examples:
- Firefox:
  -  before ![before patch](https://i.imgur.com/LmBSMUy.png)
  -  patched ![after patch](https://i.imgur.com/mhSCDGr.png)
- Terminal / zsh: 
  - before ![before patch](https://i.imgur.com/0RSj65m.png)
  - patched ![after patch](https://i.imgur.com/Ev0v2U9.png)