### PR TITLE
Add style for battery state "plugged"

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -107,7 +107,7 @@ window#waybar.chromium {
     color: #000000;
 }
 
-#battery.charging {
+#battery.charging, #battery.plugged {
     color: #ffffff;
     background-color: #26A65B;
 }


### PR DESCRIPTION
Hi Alex,

the default style does not apply the green background to the battery module if the status is reported as "plugged" (eg. when the charge limiter is active). I think re-using the style currently used for "charging" is a better default.

Cheers,
Martin
