### PR TITLE
[Module CPU] fix crash due to empty frequencies.

### DIFF
--- a/src/modules/cpu/linux.cpp
+++ b/src/modules/cpu/linux.cpp
@@ -1,3 +1,4 @@
+#include <filesystem>
 #include "modules/cpu.hpp"
 
 std::vector<std::tuple<size_t, size_t>> waybar::modules::Cpu::parseCpuinfo() {
@@ -46,5 +47,31 @@ std::vector<float> waybar::modules::Cpu::parseCpuFrequencies() {
     frequencies.push_back(frequency);
   }
   info.close();
+
+  if (frequencies.size() <= 0) {
+    std::string cpufreq_dir = "/sys/devices/system/cpu/cpufreq";
+    if (std::filesystem::exists(cpufreq_dir)) {
+      std::vector<std::string> frequency_files = {
+        "/cpuinfo_min_freq",
+        "/cpuinfo_max_freq"
+      };
+      for (auto& p: std::filesystem::directory_iterator(cpufreq_dir)) {
+        for (auto freq_file: frequency_files) {
+          std::string freq_file_path = p.path().string() + freq_file;
+          if (std::filesystem::exists(freq_file_path)) {
+            std::string freq_value;
+            std::ifstream freq(freq_file_path);
+            if (freq.is_open()) {
+              getline(freq, freq_value);
+              float frequency = std::strtol(freq_value.c_str(), nullptr, 10);
+              frequencies.push_back(frequency / 1000);
+              freq.close();
+            }
+          }
+        }
+      }
+    }
+  }
+
   return frequencies;
 }


### PR DESCRIPTION
On some systems (eg: ARM) the supported frequencies of the CPU are not properly reported by /proc/cpuinfo so use lscpu instead which is more reliable.