### PR TITLE
[modules/pulseaudio] fix bluetooth class for PipeWire

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -210,7 +210,8 @@ auto waybar::modules::Pulseaudio::update() -> void {
   std::string                 tooltip_format;
   if (!alt_) {
     std::string format_name = "format";
-    if (monitor_.find("a2dp_sink") != std::string::npos) {
+    if (monitor_.find("a2dp_sink") != std::string::npos || // PulseAudio
+        monitor_.find("a2dp-sink") != std::string::npos) { // PipeWire
       format_name = format_name + "-bluetooth";
       label_.get_style_context()->add_class("bluetooth");
     } else {


### PR DESCRIPTION
Apparently, pipewire-pulse slightly changed the naming of the sink.

To me it looks like this name parsing is in general quite prone to this kind of bugs but I don't know pulseaudio/pipewire and what additional ways it might provide for this kind of information so for now I just sticked to the way it was already handled anyway.