### PR TITLE
[modules/battery] allow format-discharging-full

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -216,7 +216,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       capacity = 100.f;
     }
     uint8_t cap = round(capacity);
-    if (cap == 100) {
+    if (cap == 100 && status == "Charging") {
       // If we've reached 100% just mark as full as some batteries can stay
       // stuck reporting they're still charging but not yet done
       status = "Full";


### PR DESCRIPTION
`format-discharging-full` has been impossible since #923 made it impossible to be full and discharging at the same time. This should fix that by only making `format-charging-full` impossible. Whether or not that should be allowed is a good question, but beyond the scope of this change.

Fixes #1031