### PR TITLE
rewriteTitle: allow multiple sequential rewrites

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -132,12 +132,13 @@ void Window::getTree() {
   }
 }
 
-std::string Window::rewriteTitle(const std::string& title)
-{
+std::string Window::rewriteTitle(const std::string& title) {
   const auto& rules = config_["rewrite"];
   if (!rules.isObject()) {
     return title;
   }
+
+  std::string res = title;
 
   for (auto it = rules.begin(); it != rules.end(); ++it) {
     if (it.key().isString() && it->isString()) {
@@ -146,7 +147,7 @@ std::string Window::rewriteTitle(const std::string& title)
         // in this case, log error and try the next rule.
         const std::regex rule{it.key().asString()};
         if (std::regex_match(title, rule)) {
-          return std::regex_replace(title, rule, it->asString());
+          res = std::regex_replace(res, rule, it->asString());
         }
       } catch (const std::regex_error& e) {
         spdlog::error("Invalid rule {}: {}", it.key().asString(), e.what());
@@ -154,7 +155,7 @@ std::string Window::rewriteTitle(const std::string& title)
     }
   }
 
-  return title;
+  return res;
 }
 
 }  // namespace waybar::modules::sway


### PR DESCRIPTION
For example, before if I had

```json
"rewrite": {
  "a": "x",
  "b": "y"
}
```

and my window title was `ab` it would get rewritten to `xb`, with this PR it's `xy` (for a specific use-case, I use it to rewrite my home dir to ~ and add icons without having really weird regex logic)

Open question: do we want to have this match in the middle of titles? You can easily opt out of that behaviour with `^$` but it's a lot harder to opt in (you'd need something like `(.*)pattern(.*) => $1...$n`)