### PR TITLE
Add options to use a .json extension for the config filename

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -207,9 +207,13 @@ std::tuple<const std::string, const std::string> waybar::Client::getConfigs(
     const std::string &config, const std::string &style) const {
   auto config_file = config.empty() ? getValidPath({
                                           "$XDG_CONFIG_HOME/waybar/config",
+                                          "$XDG_CONFIG_HOME/waybar/config.json",
                                           "$HOME/.config/waybar/config",
+                                          "$HOME/.config/waybar/config.json",
                                           "$HOME/waybar/config",
+                                          "$HOME/waybar/config.json",
                                           "/etc/xdg/waybar/config",
+                                          "/etc/xdg/waybar/config.json",
                                           SYSCONFDIR "/xdg/waybar/config",
                                           "./resources/config",
                                       })

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -207,13 +207,13 @@ std::tuple<const std::string, const std::string> waybar::Client::getConfigs(
     const std::string &config, const std::string &style) const {
   auto config_file = config.empty() ? getValidPath({
                                           "$XDG_CONFIG_HOME/waybar/config",
-                                          "$XDG_CONFIG_HOME/waybar/config.json",
+                                          "$XDG_CONFIG_HOME/waybar/config.jsonc",
                                           "$HOME/.config/waybar/config",
-                                          "$HOME/.config/waybar/config.json",
+                                          "$HOME/.config/waybar/config.jsonc",
                                           "$HOME/waybar/config",
-                                          "$HOME/waybar/config.json",
+                                          "$HOME/waybar/config.jsonc",
                                           "/etc/xdg/waybar/config",
-                                          "/etc/xdg/waybar/config.json",
+                                          "/etc/xdg/waybar/config.jsonc",
                                           SYSCONFDIR "/xdg/waybar/config",
                                           "./resources/config",
                                       })


### PR DESCRIPTION
This is to allow text editors such as Visual Studio Code to recognize that the file is a JSON file and add syntax highlighting accordingly