### PR TITLE
Add config options for exclusive zone and input event passthrough

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -65,6 +65,7 @@ class Bar {
   struct waybar_output *output;
   Json::Value           config;
   struct wl_surface *   surface;
+  bool                  exclusive = true;
   bool                  visible = true;
   bool                  vertical = false;
   Gtk::Window           window;

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -44,6 +44,7 @@ class BarSurface {
   virtual void setExclusiveZone(bool enable) = 0;
   virtual void setLayer(bar_layer layer) = 0;
   virtual void setMargins(const struct bar_margins &margins) = 0;
+  virtual void setPassThrough(bool enable) = 0;
   virtual void setPosition(const std::string_view &position) = 0;
   virtual void setSize(uint32_t width, uint32_t height) = 0;
   virtual void commit(){};

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -68,6 +68,17 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	typeof: string ++
 	Optional name added as a CSS class, for styling multiple waybars.
 
+*exclusive* ++
+	typeof: bool ++
+	default: *true* unless the layer is set to *overlay* ++
+	Option to request an exclusive zone from the compositor. Disable this to allow drawing application windows underneath or on top of the bar.
+
+*passthrough* ++
+	typeof: bool ++
+	default: *false* unless the layer is set to *overlay* ++
+	Option to pass any pointer events to the window under the bar.
+	Intended to be used with either *top* or *overlay* layers and without exclusive zone.
+
 *gtk-layer-shell* ++
 	typeof: bool ++
 	default: true ++

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -409,6 +409,13 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     layer_ = bar_layer::OVERLAY;
   }
 
+  if (config["exclusive"].isBool()) {
+    exclusive = config["exclusive"].asBool();
+  } else if (layer_ == bar_layer::OVERLAY) {
+    // swaybar defaults: overlay mode does not reserve an exclusive zone
+    exclusive = false;
+  }
+
   bool passthrough = false;
   if (config["passthrough"].isBool()) {
     passthrough = config["passthrough"].asBool();
@@ -492,7 +499,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   }
 
   surface_impl_->setLayer(layer_);
-  surface_impl_->setExclusiveZone(true);
+  surface_impl_->setExclusiveZone(exclusive);
   surface_impl_->setMargins(margins_);
   surface_impl_->setPassThrough(passthrough);
   surface_impl_->setPosition(position);
@@ -533,7 +540,7 @@ void waybar::Bar::setVisible(bool value) {
     window.set_opacity(1);
     surface_impl_->setLayer(layer_);
   }
-  surface_impl_->setExclusiveZone(visible);
+  surface_impl_->setExclusiveZone(exclusive && visible);
   surface_impl_->commit();
 }
 


### PR DESCRIPTION
So I sneakily added the `overlay` layer value in one of the previous PRs, but it wasn't behaving as a real `overlay` mode of `swaybar`. Here's the two missing bits: input passthrough flag that makes the bar ignore any pointer events and allows the window underneath to handle those, and a flag to disable the exclusive zone.

Possible uses:
 - A bar on the `bottom` layer with `"exclusive": false` which is only visible on an empty workspace.
 - A transparent bar on the `overlay` or `top` layer which shows some data over the application window, but cannot be interacted with.
 - If you look closely at the swaybar `hide` mode (the one where you only see a bar when the binding is pressed), it actually does not set exclusive zone but still accepts input.
   Now we can get _almost_ similar behavior with creative use of `bindsym --no-repeat`, `bindsym --no-repeat --release` and `SIGUSR1`. With possibility of races, bar states out of sync between different screens and other wonderful bugs.

Fixes #1091
 
