### PR TITLE
Use GtkButton instead of GtkLabel for Modules

### DIFF
--- a/include/AButton.hpp
+++ b/include/AButton.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <glibmm/markup.h>
+#include <gtkmm/button.h>
+#include <gtkmm/label.h>
+#include <json/json.h>
+
+#include "AModule.hpp"
+
+namespace waybar {
+
+class AButton : public AModule {
+ public:
+  AButton(const Json::Value &, const std::string &, const std::string &, const std::string &format,
+          uint16_t interval = 0, bool ellipsize = false, bool enable_click = false,
+          bool enable_scroll = false);
+  virtual ~AButton() = default;
+  virtual auto update() -> void;
+  virtual std::string getIcon(uint16_t, const std::string &alt = "", uint16_t max = 0);
+  virtual std::string getIcon(uint16_t, const std::vector<std::string> &alts, uint16_t max = 0);
+
+ protected:
+  Gtk::Button button_ = Gtk::Button(name_);
+  Gtk::Label *label_ = (Gtk::Label *)button_.get_child();
+  std::string format_;
+  const std::chrono::seconds interval_;
+  bool alt_ = false;
+  std::string default_format_;
+
+  virtual bool handleToggle(GdkEventButton *const &e);
+  virtual std::string getState(uint8_t value, bool lesser = false);
+};
+
+}  // namespace waybar

--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -23,8 +23,8 @@
 #endif
 #ifdef HAVE_HYPRLAND
 #include "modules/hyprland/backend.hpp"
-#include "modules/hyprland/window.hpp"
 #include "modules/hyprland/language.hpp"
+#include "modules/hyprland/window.hpp"
 #endif
 #if defined(__linux__) && !defined(NO_FILESYSTEM)
 #include "modules/battery.hpp"

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -5,7 +5,7 @@
 #include <string_view>
 #include <vector>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/json.hpp"
 #include "util/sleeper_thread.hpp"
 
@@ -14,7 +14,7 @@ struct udev_device;
 
 namespace waybar::modules {
 
-class Backlight : public ALabel {
+class Backlight : public AButton {
   class BacklightDev {
    public:
     BacklightDev() = default;

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <vector>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
@@ -24,7 +24,7 @@ namespace fs = std::experimental::filesystem;
 namespace fs = std::filesystem;
 #endif
 
-class Battery : public ALabel {
+class Battery : public AButton {
  public:
   Battery(const std::string&, const Json::Value&);
   ~Battery();

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #ifdef WANT_RFKILL
 #include "util/rfkill.hpp"
 #endif
@@ -12,7 +12,7 @@
 
 namespace waybar::modules {
 
-class Bluetooth : public ALabel {
+class Bluetooth : public AButton {
   struct ControllerInfo {
     std::string path;
     std::string address;

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -2,7 +2,7 @@
 
 #include <date/tz.h>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar {
@@ -14,7 +14,7 @@ namespace modules {
 const std::string kCalendarPlaceholder = "calendar";
 const std::string KTimezonedTimeListPlaceholder = "timezoned_time_list";
 
-class Clock : public ALabel {
+class Clock : public AButton {
  public:
   Clock(const std::string&, const Json::Value&);
   ~Clock() = default;

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -9,12 +9,12 @@
 #include <utility>
 #include <vector>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Cpu : public ALabel {
+class Cpu : public AButton {
  public:
   Cpu(const std::string&, const Json::Value&);
   ~Cpu() = default;

--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -5,14 +5,14 @@
 #include <csignal>
 #include <string>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/command.hpp"
 #include "util/json.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Custom : public ALabel {
+class Custom : public AButton {
  public:
   Custom(const std::string&, const std::string&, const Json::Value&);
   ~Custom();

--- a/include/modules/disk.hpp
+++ b/include/modules/disk.hpp
@@ -5,13 +5,13 @@
 
 #include <fstream>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/format.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Disk : public ALabel {
+class Disk : public AButton {
  public:
   Disk(const std::string&, const Json::Value&);
   ~Disk() = default;

--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -1,30 +1,28 @@
 #pragma once
-#include <string>
-#include <memory>
-#include <mutex>
 #include <deque>
 #include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
 #include <thread>
 
 namespace waybar::modules::hyprland {
 class IPC {
-public:
+ public:
   IPC() { startIPC(); }
 
   void registerForIPC(const std::string&, std::function<void(const std::string&)>);
 
   std::string getSocket1Reply(const std::string& rq);
 
-private:
+ private:
+  void startIPC();
+  void parseIPC(const std::string&);
 
- void startIPC();
- void parseIPC(const std::string&);
-
- std::mutex callbackMutex;
- std::deque<std::pair<std::string, std::function<void(const std::string&)>>> callbacks;
+  std::mutex callbackMutex;
+  std::deque<std::pair<std::string, std::function<void(const std::string&)>>> callbacks;
 };
 
 inline std::unique_ptr<IPC> gIPC;
 inline bool modulesReady = false;
-};
-
+};  // namespace waybar::modules::hyprland

--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -1,20 +1,20 @@
 #include <fmt/format.h>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
 #include "util/json.hpp"
 
 namespace waybar::modules::hyprland {
 
-class Language : public waybar::ALabel {
-public:
+class Language : public waybar::AButton {
+ public:
   Language(const std::string&, const waybar::Bar&, const Json::Value&);
   ~Language() = default;
 
   auto update() -> void;
 
-private:
+ private:
   void onEvent(const std::string&);
 
   void initLanguage();
@@ -26,4 +26,4 @@ private:
   std::string layoutName_;
 };
 
-}
+}  // namespace waybar::modules::hyprland

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -10,13 +10,13 @@
 namespace waybar::modules::hyprland {
 
 class Window : public waybar::ALabel {
-public:
+ public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
   ~Window() = default;
 
   auto update() -> void;
 
-private:
+ private:
   void onEvent(const std::string&);
 
   std::mutex mutex_;
@@ -25,4 +25,4 @@ private:
   std::string lastView;
 };
 
-}
+}  // namespace waybar::modules::hyprland

--- a/include/modules/idle_inhibitor.hpp
+++ b/include/modules/idle_inhibitor.hpp
@@ -2,13 +2,13 @@
 
 #include <fmt/format.h>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "bar.hpp"
 #include "client.hpp"
 
 namespace waybar::modules {
 
-class IdleInhibitor : public ALabel {
+class IdleInhibitor : public AButton {
   sigc::connection timeout_;
 
  public:

--- a/include/modules/inhibitor.hpp
+++ b/include/modules/inhibitor.hpp
@@ -4,12 +4,12 @@
 
 #include <memory>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "bar.hpp"
 
 namespace waybar::modules {
 
-class Inhibitor : public ALabel {
+class Inhibitor : public AButton {
  public:
   Inhibitor(const std::string&, const waybar::Bar&, const Json::Value&);
   ~Inhibitor() override;

--- a/include/modules/jack.hpp
+++ b/include/modules/jack.hpp
@@ -1,9 +1,11 @@
 #pragma once
 
 #include <fmt/format.h>
-#include <fstream>
 #include <jack/jack.h>
 #include <jack/thread.h>
+
+#include <fstream>
+
 #include "ALabel.hpp"
 #include "util/sleeper_thread.hpp"
 
@@ -11,26 +13,26 @@ namespace waybar::modules {
 
 class JACK : public ALabel {
  public:
-  JACK(const std::string&, const Json::Value&);
+  JACK(const std::string &, const Json::Value &);
   ~JACK() = default;
   auto update() -> void;
 
-  int                 bufSize(jack_nframes_t size);
-  int                 sampleRate(jack_nframes_t rate);
-  int                 xrun();
-  void                shutdown();
+  int bufSize(jack_nframes_t size);
+  int sampleRate(jack_nframes_t rate);
+  int xrun();
+  void shutdown();
 
  private:
-  std::string         JACKState();
+  std::string JACKState();
 
-  jack_client_t*      client_;
-  jack_nframes_t      bufsize_;
-  jack_nframes_t      samplerate_;
-  unsigned int        xruns_;
-  float               load_;
-  bool                running_;
-  std::mutex          mutex_;
-  std::string         state_;
+  jack_client_t *client_;
+  jack_nframes_t bufsize_;
+  jack_nframes_t samplerate_;
+  unsigned int xruns_;
+  float load_;
+  bool running_;
+  std::mutex mutex_;
+  std::string state_;
   util::SleeperThread thread_;
 };
 

--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -5,12 +5,12 @@
 #include <fstream>
 #include <unordered_map>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Memory : public ALabel {
+class Memory : public AButton {
  public:
   Memory(const std::string&, const Json::Value&);
   ~Memory() = default;

--- a/include/modules/mpd/mpd.hpp
+++ b/include/modules/mpd/mpd.hpp
@@ -7,12 +7,12 @@
 #include <condition_variable>
 #include <thread>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "modules/mpd/state.hpp"
 
 namespace waybar::modules {
 
-class MPD : public ALabel {
+class MPD : public AButton {
   friend class detail::Context;
 
   // State machine

--- a/include/modules/mpd/state.hpp
+++ b/include/modules/mpd/state.hpp
@@ -7,7 +7,7 @@
 #include <condition_variable>
 #include <thread>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 
 namespace waybar::modules {
 class MPD;

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -10,7 +10,7 @@
 
 #include <optional>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 #ifdef WANT_RFKILL
 #include "util/rfkill.hpp"
@@ -18,7 +18,7 @@
 
 namespace waybar::modules {
 
-class Network : public ALabel {
+class Network : public AButton {
  public:
   Network(const std::string&, const Json::Value&);
   ~Network();

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -7,11 +7,11 @@
 #include <algorithm>
 #include <array>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 
 namespace waybar::modules {
 
-class Pulseaudio : public ALabel {
+class Pulseaudio : public AButton {
  public:
   Pulseaudio(const std::string&, const Json::Value&);
   ~Pulseaudio();

--- a/include/modules/simpleclock.hpp
+++ b/include/modules/simpleclock.hpp
@@ -2,12 +2,12 @@
 
 #include <fmt/chrono.h>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Clock : public ALabel {
+class Clock : public AButton {
  public:
   Clock(const std::string&, const Json::Value&);
   ~Clock() = default;

--- a/include/modules/sndio.hpp
+++ b/include/modules/sndio.hpp
@@ -4,12 +4,12 @@
 
 #include <vector>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Sndio : public ALabel {
+class Sndio : public AButton {
  public:
   Sndio(const std::string &, const Json::Value &);
   ~Sndio();

--- a/include/modules/sway/language.hpp
+++ b/include/modules/sway/language.hpp
@@ -6,7 +6,7 @@
 #include <map>
 #include <string>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "bar.hpp"
 #include "client.hpp"
 #include "modules/sway/ipc/client.hpp"
@@ -14,7 +14,7 @@
 
 namespace waybar::modules::sway {
 
-class Language : public ALabel, public sigc::trackable {
+class Language : public AButton, public sigc::trackable {
  public:
   Language(const std::string& id, const Json::Value& config);
   ~Language() = default;

--- a/include/modules/sway/mode.hpp
+++ b/include/modules/sway/mode.hpp
@@ -2,7 +2,7 @@
 
 #include <fmt/format.h>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "bar.hpp"
 #include "client.hpp"
 #include "modules/sway/ipc/client.hpp"
@@ -10,7 +10,7 @@
 
 namespace waybar::modules::sway {
 
-class Mode : public ALabel, public sigc::trackable {
+class Mode : public AButton, public sigc::trackable {
  public:
   Mode(const std::string&, const Json::Value&);
   ~Mode() = default;

--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -4,12 +4,12 @@
 
 #include <fstream>
 
-#include "ALabel.hpp"
+#include "AButton.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Temperature : public ALabel {
+class Temperature : public AButton {
  public:
   Temperature(const std::string&, const Json::Value&);
   ~Temperature() = default;

--- a/meson.build
+++ b/meson.build
@@ -143,6 +143,7 @@ endif
 src_files = files(
     'src/factory.cpp',
     'src/AModule.cpp',
+    'src/AButton.cpp',
     'src/ALabel.cpp',
     'src/AIconLabel.cpp',
     'src/modules/custom.cpp',

--- a/resources/style.css
+++ b/resources/style.css
@@ -34,6 +34,12 @@ window#waybar.chromium {
     border: none;
 }
 
+/* https://github.com/Alexays/Waybar/wiki/FAQ#the-workspace-buttons-have-a-strange-hover-effect */
+button:hover {
+    background: inherit;
+    box-shadow: inset 0 -3px #ffffff;
+}
+
 #workspaces button {
     padding: 0 5px;
     background-color: transparent;
@@ -45,10 +51,8 @@ window#waybar.chromium {
     border-radius: 0;
 }
 
-/* https://github.com/Alexays/Waybar/wiki/FAQ#the-workspace-buttons-have-a-strange-hover-effect */
 #workspaces button:hover {
     background: rgba(0, 0, 0, 0.2);
-    box-shadow: inset 0 -3px #ffffff;
 }
 
 #workspaces button.focused {

--- a/src/AButton.cpp
+++ b/src/AButton.cpp
@@ -1,0 +1,154 @@
+#include "AButton.hpp"
+
+#include <fmt/format.h>
+
+#include <util/command.hpp>
+
+namespace waybar {
+
+AButton::AButton(const Json::Value& config, const std::string& name, const std::string& id,
+                 const std::string& format, uint16_t interval, bool ellipsize, bool enable_click,
+                 bool enable_scroll)
+    : AModule(config, name, id, config["format-alt"].isString() || enable_click, enable_scroll),
+      format_(config_["format"].isString() ? config_["format"].asString() : format),
+      interval_(config_["interval"] == "once"
+                    ? std::chrono::seconds(100000000)
+                    : std::chrono::seconds(
+                          config_["interval"].isUInt() ? config_["interval"].asUInt() : interval)),
+      default_format_(format_) {
+  button_.set_name(name);
+  button_.set_relief(Gtk::RELIEF_NONE);
+  if (!id.empty()) {
+    button_.get_style_context()->add_class(id);
+  }
+  event_box_.add(button_);
+  if (config_["max-length"].isUInt()) {
+    label_->set_max_width_chars(config_["max-length"].asInt());
+    label_->set_ellipsize(Pango::EllipsizeMode::ELLIPSIZE_END);
+    label_->set_single_line_mode(true);
+  } else if (ellipsize && label_->get_max_width_chars() == -1) {
+    label_->set_ellipsize(Pango::EllipsizeMode::ELLIPSIZE_END);
+    label_->set_single_line_mode(true);
+  }
+
+  if (config_["min-length"].isUInt()) {
+    label_->set_width_chars(config_["min-length"].asUInt());
+  }
+
+  uint rotate = 0;
+
+  if (config_["rotate"].isUInt()) {
+    rotate = config["rotate"].asUInt();
+    label_->set_angle(rotate);
+  }
+
+  if (config_["align"].isDouble()) {
+    auto align = config_["align"].asFloat();
+    if (rotate == 90 || rotate == 270) {
+      label_->set_yalign(align);
+    } else {
+      label_->set_xalign(align);
+    }
+  }
+
+  if (!(config_["on-click"].isString() || config_["on-click-middle"].isString() ||
+        config_["on-click-backward"].isString() || config_["on-click-forward"].isString() ||
+        config_["on-click-right"].isString() || config_["format-alt"].isString() || enable_click)) {
+    button_.set_sensitive(false);
+  } else {
+    button_.signal_pressed().connect([this] {
+      GdkEventButton* e = (GdkEventButton*)gdk_event_new(GDK_BUTTON_PRESS);
+      e->button = 1;
+      handleToggle(e);
+    });
+  }
+}
+
+auto AButton::update() -> void { AModule::update(); }
+
+std::string AButton::getIcon(uint16_t percentage, const std::string& alt, uint16_t max) {
+  auto format_icons = config_["format-icons"];
+  if (format_icons.isObject()) {
+    if (!alt.empty() && (format_icons[alt].isString() || format_icons[alt].isArray())) {
+      format_icons = format_icons[alt];
+    } else {
+      format_icons = format_icons["default"];
+    }
+  }
+  if (format_icons.isArray()) {
+    auto size = format_icons.size();
+    auto idx = std::clamp(percentage / ((max == 0 ? 100 : max) / size), 0U, size - 1);
+    format_icons = format_icons[idx];
+  }
+  if (format_icons.isString()) {
+    return format_icons.asString();
+  }
+  return "";
+}
+
+std::string AButton::getIcon(uint16_t percentage, const std::vector<std::string>& alts,
+                             uint16_t max) {
+  auto format_icons = config_["format-icons"];
+  if (format_icons.isObject()) {
+    std::string _alt = "default";
+    for (const auto& alt : alts) {
+      if (!alt.empty() && (format_icons[alt].isString() || format_icons[alt].isArray())) {
+        _alt = alt;
+        break;
+      }
+    }
+    format_icons = format_icons[_alt];
+  }
+  if (format_icons.isArray()) {
+    auto size = format_icons.size();
+    auto idx = std::clamp(percentage / ((max == 0 ? 100 : max) / size), 0U, size - 1);
+    format_icons = format_icons[idx];
+  }
+  if (format_icons.isString()) {
+    return format_icons.asString();
+  }
+  return "";
+}
+
+bool waybar::AButton::handleToggle(GdkEventButton* const& e) {
+  if (config_["format-alt-click"].isUInt() && e->button == config_["format-alt-click"].asUInt()) {
+    alt_ = !alt_;
+    if (alt_ && config_["format-alt"].isString()) {
+      format_ = config_["format-alt"].asString();
+    } else {
+      format_ = default_format_;
+    }
+  }
+  return AModule::handleToggle(e);
+}
+
+std::string AButton::getState(uint8_t value, bool lesser) {
+  if (!config_["states"].isObject()) {
+    return "";
+  }
+  // Get current state
+  std::vector<std::pair<std::string, uint8_t>> states;
+  if (config_["states"].isObject()) {
+    for (auto it = config_["states"].begin(); it != config_["states"].end(); ++it) {
+      if (it->isUInt() && it.key().isString()) {
+        states.emplace_back(it.key().asString(), it->asUInt());
+      }
+    }
+  }
+  // Sort states
+  std::sort(states.begin(), states.end(), [&lesser](auto& a, auto& b) {
+    return lesser ? a.second < b.second : a.second > b.second;
+  });
+  std::string valid_state;
+  for (auto const& state : states) {
+    if ((lesser ? value <= state.second : value >= state.second) && valid_state.empty()) {
+      label_->get_style_context()->add_class(state.first);
+      valid_state = state.first;
+    } else {
+      label_->get_style_context()->remove_class(state.first);
+    }
+  }
+  return valid_state;
+}
+
+}  // namespace waybar

--- a/src/AButton.cpp
+++ b/src/AButton.cpp
@@ -142,10 +142,10 @@ std::string AButton::getState(uint8_t value, bool lesser) {
   std::string valid_state;
   for (auto const& state : states) {
     if ((lesser ? value <= state.second : value >= state.second) && valid_state.empty()) {
-      label_->get_style_context()->add_class(state.first);
+      button_.get_style_context()->add_class(state.first);
       valid_state = state.first;
     } else {
-      label_->get_style_context()->remove_class(state.first);
+      button_.get_style_context()->remove_class(state.first);
     }
   }
   return valid_state;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -87,7 +87,7 @@ int waybar::modules::Backlight::BacklightDev::get_max() const { return max_; }
 void waybar::modules::Backlight::BacklightDev::set_max(int max) { max_ = max; }
 
 waybar::modules::Backlight::Backlight(const std::string &id, const Json::Value &config)
-    : ALabel(config, "backlight", id, "{percent}%", 2),
+    : AButton(config, "backlight", id, "{percent}%", 2),
       preferred_device_(config["device"].isString() ? config["device"].asString() : "") {
   // Get initial state
   {
@@ -174,19 +174,19 @@ auto waybar::modules::Backlight::update() -> void {
 
     const uint8_t percent =
         best->get_max() == 0 ? 100 : round(best->get_actual() * 100.0f / best->get_max());
-    label_.set_markup(fmt::format(format_, fmt::arg("percent", std::to_string(percent)),
-                                  fmt::arg("icon", getIcon(percent))));
+    label_->set_markup(fmt::format(format_, fmt::arg("percent", std::to_string(percent)),
+                                   fmt::arg("icon", getIcon(percent))));
     getState(percent);
   } else {
     if (!previous_best_.has_value()) {
       return;
     }
-    label_.set_markup("");
+    label_->set_markup("");
   }
   previous_best_ = best == nullptr ? std::nullopt : std::optional{*best};
   previous_format_ = format_;
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 template <class ForwardIt>

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -3,7 +3,7 @@
 #include <spdlog/spdlog.h>
 
 waybar::modules::Battery::Battery(const std::string& id, const Json::Value& config)
-    : ALabel(config, "battery", id, "{capacity}%", 60) {
+    : AButton(config, "battery", id, "{capacity}%", 60) {
   battery_watch_fd_ = inotify_init1(IN_CLOEXEC);
   if (battery_watch_fd_ == -1) {
     throw std::runtime_error("Unable to listen batteries.");
@@ -309,7 +309,8 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
     format = config_["format-time"].asString();
   }
   std::string zero_pad_minutes = fmt::format("{:02d}", minutes);
-  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes), fmt::arg("m", zero_pad_minutes));
+  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes),
+                     fmt::arg("m", zero_pad_minutes));
 }
 
 auto waybar::modules::Battery::update() -> void {
@@ -346,14 +347,14 @@ auto waybar::modules::Battery::update() -> void {
     } else if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_.set_tooltip_text(fmt::format(tooltip_format, fmt::arg("timeTo", tooltip_text_default),
-                                        fmt::arg("capacity", capacity),
-                                        fmt::arg("time", time_remaining_formatted)));
+    label_->set_tooltip_text(fmt::format(tooltip_format, fmt::arg("timeTo", tooltip_text_default),
+                                         fmt::arg("capacity", capacity),
+                                         fmt::arg("time", time_remaining_formatted)));
   }
   if (!old_status_.empty()) {
-    label_.get_style_context()->remove_class(old_status_);
+    label_->get_style_context()->remove_class(old_status_);
   }
-  label_.get_style_context()->add_class(status);
+  label_->get_style_context()->add_class(status);
   old_status_ = status;
   if (!state.empty() && config_["format-" + status + "-" + state].isString()) {
     format = config_["format-" + status + "-" + state].asString();
@@ -367,10 +368,10 @@ auto waybar::modules::Battery::update() -> void {
   } else {
     event_box_.show();
     auto icons = std::vector<std::string>{status + "-" + state, status, state};
-    label_.set_markup(fmt::format(format, fmt::arg("capacity", capacity), fmt::arg("power", power),
-                                  fmt::arg("icon", getIcon(capacity, icons)),
-                                  fmt::arg("time", time_remaining_formatted)));
+    label_->set_markup(fmt::format(format, fmt::arg("capacity", capacity), fmt::arg("power", power),
+                                   fmt::arg("icon", getIcon(capacity, icons)),
+                                   fmt::arg("time", time_remaining_formatted)));
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -352,9 +352,9 @@ auto waybar::modules::Battery::update() -> void {
                                          fmt::arg("time", time_remaining_formatted)));
   }
   if (!old_status_.empty()) {
-    label_->get_style_context()->remove_class(old_status_);
+    button_.get_style_context()->remove_class(old_status_);
   }
-  label_->get_style_context()->add_class(status);
+  button_.get_style_context()->add_class(status);
   old_status_ = status;
   if (!state.empty() && config_["format-" + status + "-" + state].isString()) {
     format = config_["format-" + status + "-" + state].asString();

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -347,7 +347,7 @@ auto waybar::modules::Battery::update() -> void {
     } else if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_->set_tooltip_text(fmt::format(tooltip_format, fmt::arg("timeTo", tooltip_text_default),
+    button_.set_tooltip_text(fmt::format(tooltip_format, fmt::arg("timeTo", tooltip_text_default),
                                          fmt::arg("capacity", capacity),
                                          fmt::arg("time", time_remaining_formatted)));
   }

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -80,7 +80,7 @@ auto getUcharProperty(GDBusProxy* proxy, const char* property_name) -> unsigned 
 }  // namespace
 
 waybar::modules::Bluetooth::Bluetooth(const std::string& id, const Json::Value& config)
-    : ALabel(config, "bluetooth", id, " {status}", 10),
+    : AButton(config, "bluetooth", id, " {status}", 10),
 #ifdef WANT_RFKILL
       rfkill_{RFKILL_TYPE_BLUETOOTH},
 #endif
@@ -189,10 +189,10 @@ auto waybar::modules::Bluetooth::update() -> void {
   format_.empty() ? event_box_.hide() : event_box_.show();
 
   auto update_style_context = [this](const std::string& style_class, bool in_next_state) {
-    if (in_next_state && !label_.get_style_context()->has_class(style_class)) {
-      label_.get_style_context()->add_class(style_class);
-    } else if (!in_next_state && label_.get_style_context()->has_class(style_class)) {
-      label_.get_style_context()->remove_class(style_class);
+    if (in_next_state && !label_->get_style_context()->has_class(style_class)) {
+      label_->get_style_context()->add_class(style_class);
+    } else if (!in_next_state && label_->get_style_context()->has_class(style_class)) {
+      label_->get_style_context()->remove_class(style_class);
     }
   };
   update_style_context("discoverable", cur_controller_.discoverable);
@@ -204,7 +204,7 @@ auto waybar::modules::Bluetooth::update() -> void {
   update_style_context(state, true);
   state_ = state;
 
-  label_.set_markup(fmt::format(
+  label_->set_markup(fmt::format(
       format_, fmt::arg("status", state_), fmt::arg("num_connections", connected_devices_.size()),
       fmt::arg("controller_address", cur_controller_.address),
       fmt::arg("controller_address_type", cur_controller_.address_type),
@@ -245,7 +245,7 @@ auto waybar::modules::Bluetooth::update() -> void {
         device_enumerate_.erase(0, 1);
       }
     }
-    label_.set_tooltip_text(fmt::format(
+    label_->set_tooltip_text(fmt::format(
         tooltip_format, fmt::arg("status", state_),
         fmt::arg("num_connections", connected_devices_.size()),
         fmt::arg("controller_address", cur_controller_.address),
@@ -259,7 +259,7 @@ auto waybar::modules::Bluetooth::update() -> void {
   }
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 // NOTE: only for when the org.bluez.Battery1 interface is added/removed after/before a device is

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -189,10 +189,10 @@ auto waybar::modules::Bluetooth::update() -> void {
   format_.empty() ? event_box_.hide() : event_box_.show();
 
   auto update_style_context = [this](const std::string& style_class, bool in_next_state) {
-    if (in_next_state && !label_->get_style_context()->has_class(style_class)) {
-      label_->get_style_context()->add_class(style_class);
-    } else if (!in_next_state && label_->get_style_context()->has_class(style_class)) {
-      label_->get_style_context()->remove_class(style_class);
+    if (in_next_state && !button_.get_style_context()->has_class(style_class)) {
+      button_.get_style_context()->add_class(style_class);
+    } else if (!in_next_state && button_.get_style_context()->has_class(style_class)) {
+      button_.get_style_context()->remove_class(style_class);
     }
   };
   update_style_context("discoverable", cur_controller_.discoverable);

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -245,7 +245,7 @@ auto waybar::modules::Bluetooth::update() -> void {
         device_enumerate_.erase(0, 1);
       }
     }
-    label_->set_tooltip_text(fmt::format(
+    button_.set_tooltip_text(fmt::format(
         tooltip_format, fmt::arg("status", state_),
         fmt::arg("num_connections", connected_devices_.size()),
         fmt::arg("controller_address", cur_controller_.address),

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -119,7 +119,7 @@ auto waybar::modules::Clock::update() -> void {
       text =
           fmt::format(tooltip_format, wtime, fmt::arg(kCalendarPlaceholder.c_str(), calendar_lines),
                       fmt::arg(KTimezonedTimeListPlaceholder.c_str(), timezoned_time_lines));
-      label_->set_tooltip_markup(text);
+      button_.set_tooltip_markup(text);
     }
   }
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -18,7 +18,7 @@
 using waybar::waybar_time;
 
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
-    : ALabel(config, "clock", id, "{:%H:%M}", 60, false, false, true),
+    : AButton(config, "clock", id, "{:%H:%M}", 60, false, false, true),
       current_time_zone_idx_(0),
       is_calendar_in_tooltip_(false),
       is_timezoned_list_in_tooltip_(false) {
@@ -107,7 +107,7 @@ auto waybar::modules::Clock::update() -> void {
   } else {
     text = fmt::format(format_, wtime);
   }
-  label_.set_markup(text);
+  label_->set_markup(text);
 
   if (tooltipEnabled()) {
     if (config_["tooltip-format"].isString()) {
@@ -119,12 +119,12 @@ auto waybar::modules::Clock::update() -> void {
       text =
           fmt::format(tooltip_format, wtime, fmt::arg(kCalendarPlaceholder.c_str(), calendar_lines),
                       fmt::arg(KTimezonedTimeListPlaceholder.c_str(), timezoned_time_lines));
-      label_.set_tooltip_markup(text);
+      label_->set_tooltip_markup(text);
     }
   }
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 bool waybar::modules::Clock::handleScroll(GdkEventScroll* e) {

--- a/src/modules/cpu/common.cpp
+++ b/src/modules/cpu/common.cpp
@@ -23,7 +23,7 @@ auto waybar::modules::Cpu::update() -> void {
   auto [cpu_usage, tooltip] = getCpuUsage();
   auto [max_frequency, min_frequency, avg_frequency] = getCpuFrequency();
   if (tooltipEnabled()) {
-    label_->set_tooltip_text(tooltip);
+    button_.set_tooltip_text(tooltip);
   }
   auto format = format_;
   auto total_usage = cpu_usage.empty() ? 0 : cpu_usage[0];

--- a/src/modules/cpu/common.cpp
+++ b/src/modules/cpu/common.cpp
@@ -10,7 +10,7 @@
 #endif
 
 waybar::modules::Cpu::Cpu(const std::string& id, const Json::Value& config)
-    : ALabel(config, "cpu", id, "{usage}%", 10) {
+    : AButton(config, "cpu", id, "{usage}%", 10) {
   thread_ = [this] {
     dp.emit();
     thread_.sleep_for(interval_);
@@ -23,7 +23,7 @@ auto waybar::modules::Cpu::update() -> void {
   auto [cpu_usage, tooltip] = getCpuUsage();
   auto [max_frequency, min_frequency, avg_frequency] = getCpuFrequency();
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(tooltip);
+    label_->set_tooltip_text(tooltip);
   }
   auto format = format_;
   auto total_usage = cpu_usage.empty() ? 0 : cpu_usage[0];
@@ -52,11 +52,11 @@ auto waybar::modules::Cpu::update() -> void {
       auto icon_format = fmt::format("icon{}", core_i);
       store.push_back(fmt::arg(icon_format.c_str(), getIcon(cpu_usage[i], icons)));
     }
-    label_.set_markup(fmt::vformat(format, store));
+    label_->set_markup(fmt::vformat(format, store));
   }
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 double waybar::modules::Cpu::getCpuLoad() {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -4,7 +4,7 @@
 
 waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
                                 const Json::Value& config)
-    : ALabel(config, "custom-" + name, id, "{}"),
+    : AButton(config, "custom-" + name, id, "{}"),
       name_(name),
       id_(id),
       percentage_(0),
@@ -103,13 +103,13 @@ void waybar::modules::Custom::handleEvent() {
 }
 
 bool waybar::modules::Custom::handleScroll(GdkEventScroll* e) {
-  auto ret = ALabel::handleScroll(e);
+  auto ret = AButton::handleScroll(e);
   handleEvent();
   return ret;
 }
 
 bool waybar::modules::Custom::handleToggle(GdkEventButton* const& e) {
-  auto ret = ALabel::handleToggle(e);
+  auto ret = AButton::handleToggle(e);
   handleEvent();
   return ret;
 }
@@ -131,31 +131,31 @@ auto waybar::modules::Custom::update() -> void {
     if (str.empty()) {
       event_box_.hide();
     } else {
-      label_.set_markup(str);
+      label_->set_markup(str);
       if (tooltipEnabled()) {
         if (text_ == tooltip_) {
-          if (label_.get_tooltip_markup() != str) {
-            label_.set_tooltip_markup(str);
+          if (label_->get_tooltip_markup() != str) {
+            label_->set_tooltip_markup(str);
           }
         } else {
-          if (label_.get_tooltip_markup() != tooltip_) {
-            label_.set_tooltip_markup(tooltip_);
+          if (label_->get_tooltip_markup() != tooltip_) {
+            label_->set_tooltip_markup(tooltip_);
           }
         }
       }
-      auto classes = label_.get_style_context()->list_classes();
+      auto classes = label_->get_style_context()->list_classes();
       for (auto const& c : classes) {
         if (c == id_) continue;
-        label_.get_style_context()->remove_class(c);
+        label_->get_style_context()->remove_class(c);
       }
       for (auto const& c : class_) {
-        label_.get_style_context()->add_class(c);
+        label_->get_style_context()->add_class(c);
       }
       event_box_.show();
     }
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 void waybar::modules::Custom::parseOutputRaw() {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -143,14 +143,16 @@ auto waybar::modules::Custom::update() -> void {
           }
         }
       }
-      auto classes = label_->get_style_context()->list_classes();
+      auto classes = button_.get_style_context()->list_classes();
       for (auto const& c : classes) {
         if (c == id_) continue;
-        label_->get_style_context()->remove_class(c);
+        button_.get_style_context()->remove_class(c);
       }
       for (auto const& c : class_) {
-        label_->get_style_context()->add_class(c);
+        button_.get_style_context()->add_class(c);
       }
+      button_.get_style_context()->add_class("flat");
+      button_.get_style_context()->add_class("text-button");
       event_box_.show();
     }
   }

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -134,12 +134,12 @@ auto waybar::modules::Custom::update() -> void {
       label_->set_markup(str);
       if (tooltipEnabled()) {
         if (text_ == tooltip_) {
-          if (label_->get_tooltip_markup() != str) {
-            label_->set_tooltip_markup(str);
+          if (button_.get_tooltip_markup() != str) {
+            button_.set_tooltip_markup(str);
           }
         } else {
-          if (label_->get_tooltip_markup() != tooltip_) {
-            label_->set_tooltip_markup(tooltip_);
+          if (button_.get_tooltip_markup() != tooltip_) {
+            button_.set_tooltip_markup(tooltip_);
           }
         }
       }

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -3,7 +3,7 @@
 using namespace waybar::util;
 
 waybar::modules::Disk::Disk(const std::string& id, const Json::Value& config)
-    : ALabel(config, "disk", id, "{}%", 30), path_("/") {
+    : AButton(config, "disk", id, "{}%", 30), path_("/") {
   thread_ = [this] {
     dp.emit();
     thread_.sleep_for(interval_);
@@ -58,7 +58,7 @@ auto waybar::modules::Disk::update() -> void {
     event_box_.hide();
   } else {
     event_box_.show();
-    label_.set_markup(
+    label_->set_markup(
         fmt::format(format, stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
                     fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks),
                     fmt::arg("used", used), fmt::arg("percentage_used", percentage_used),
@@ -70,12 +70,12 @@ auto waybar::modules::Disk::update() -> void {
     if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_.set_tooltip_text(
+    label_->set_tooltip_text(
         fmt::format(tooltip_format, stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
                     fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks),
                     fmt::arg("used", used), fmt::arg("percentage_used", percentage_used),
                     fmt::arg("total", total), fmt::arg("path", path_)));
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -70,7 +70,7 @@ auto waybar::modules::Disk::update() -> void {
     if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_->set_tooltip_text(
+    button_.set_tooltip_text(
         fmt::format(tooltip_format, stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
                     fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks),
                     fmt::arg("used", used), fmt::arg("percentage_used", percentage_used),

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -9,7 +9,7 @@
 namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
-    : ALabel(config, "language", id, "{}", 0, true), bar_(bar) {
+    : AButton(config, "language", id, "{}", 0, true), bar_(bar) {
   modulesReady = true;
 
   if (!gIPC.get()) {
@@ -19,8 +19,8 @@ Language::Language(const std::string& id, const Bar& bar, const Json::Value& con
   // get the active layout when open
   initLanguage();
 
-  label_.hide();
-  ALabel::update();
+  button_.hide();
+  AButton::update();
 
   // register for hyprland ipc
   gIPC->registerForIPC("activelayout", [&](const std::string& ev) { this->onEvent(ev); });
@@ -30,13 +30,13 @@ auto Language::update() -> void {
   std::lock_guard<std::mutex> lg(mutex_);
 
   if (!format_.empty()) {
-    label_.show();
-    label_.set_markup(layoutName_);
+    button_.show();
+    label_->set_markup(layoutName_);
   } else {
-    label_.hide();
+    button_.hide();
   }
 
-  ALabel::update();
+  AButton::update();
 }
 
 void Language::onEvent(const std::string& ev) {

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -44,13 +44,13 @@ waybar::modules::IdleInhibitor::~IdleInhibitor() {
 auto waybar::modules::IdleInhibitor::update() -> void {
   // Check status
   if (status) {
-    label_->get_style_context()->remove_class("deactivated");
+    button_.get_style_context()->remove_class("deactivated");
     if (idle_inhibitor_ == nullptr) {
       idle_inhibitor_ = zwp_idle_inhibit_manager_v1_create_inhibitor(
           waybar::Client::inst()->idle_inhibit_manager, bar_.surface);
     }
   } else {
-    label_->get_style_context()->remove_class("activated");
+    button_.get_style_context()->remove_class("activated");
     if (idle_inhibitor_ != nullptr) {
       zwp_idle_inhibitor_v1_destroy(idle_inhibitor_);
       idle_inhibitor_ = nullptr;
@@ -60,7 +60,7 @@ auto waybar::modules::IdleInhibitor::update() -> void {
   std::string status_text = status ? "activated" : "deactivated";
   label_->set_markup(fmt::format(format_, fmt::arg("status", status_text),
                                  fmt::arg("icon", getIcon(0, status_text))));
-  label_->get_style_context()->add_class(status_text);
+  button_.get_style_context()->add_class(status_text);
   if (tooltipEnabled()) {
     label_->set_tooltip_markup(
         status ? fmt::format(config_["tooltip-format-activated"].isString()

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -8,7 +8,7 @@ bool waybar::modules::IdleInhibitor::status = false;
 
 waybar::modules::IdleInhibitor::IdleInhibitor(const std::string& id, const Bar& bar,
                                               const Json::Value& config)
-    : ALabel(config, "idle_inhibitor", id, "{status}"),
+    : AButton(config, "idle_inhibitor", id, "{status}", 0, false, true),
       bar_(bar),
       idle_inhibitor_(nullptr),
       pid_(-1) {
@@ -44,13 +44,13 @@ waybar::modules::IdleInhibitor::~IdleInhibitor() {
 auto waybar::modules::IdleInhibitor::update() -> void {
   // Check status
   if (status) {
-    label_.get_style_context()->remove_class("deactivated");
+    label_->get_style_context()->remove_class("deactivated");
     if (idle_inhibitor_ == nullptr) {
       idle_inhibitor_ = zwp_idle_inhibit_manager_v1_create_inhibitor(
           waybar::Client::inst()->idle_inhibit_manager, bar_.surface);
     }
   } else {
-    label_.get_style_context()->remove_class("activated");
+    label_->get_style_context()->remove_class("activated");
     if (idle_inhibitor_ != nullptr) {
       zwp_idle_inhibitor_v1_destroy(idle_inhibitor_);
       idle_inhibitor_ = nullptr;
@@ -58,11 +58,11 @@ auto waybar::modules::IdleInhibitor::update() -> void {
   }
 
   std::string status_text = status ? "activated" : "deactivated";
-  label_.set_markup(fmt::format(format_, fmt::arg("status", status_text),
-                                fmt::arg("icon", getIcon(0, status_text))));
-  label_.get_style_context()->add_class(status_text);
+  label_->set_markup(fmt::format(format_, fmt::arg("status", status_text),
+                                 fmt::arg("icon", getIcon(0, status_text))));
+  label_->get_style_context()->add_class(status_text);
   if (tooltipEnabled()) {
-    label_.set_tooltip_markup(
+    label_->set_tooltip_markup(
         status ? fmt::format(config_["tooltip-format-activated"].isString()
                                  ? config_["tooltip-format-activated"].asString()
                                  : "{status}",
@@ -75,7 +75,7 @@ auto waybar::modules::IdleInhibitor::update() -> void {
                              fmt::arg("icon", getIcon(0, status_text))));
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 bool waybar::modules::IdleInhibitor::handleToggle(GdkEventButton* const& e) {
@@ -115,6 +115,6 @@ bool waybar::modules::IdleInhibitor::handleToggle(GdkEventButton* const& e) {
     }
   }
 
-  ALabel::handleToggle(e);
+  AButton::handleToggle(e);
   return true;
 }

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -62,7 +62,7 @@ auto waybar::modules::IdleInhibitor::update() -> void {
                                  fmt::arg("icon", getIcon(0, status_text))));
   button_.get_style_context()->add_class(status_text);
   if (tooltipEnabled()) {
-    label_->set_tooltip_markup(
+    button_.set_tooltip_markup(
         status ? fmt::format(config_["tooltip-format-activated"].isString()
                                  ? config_["tooltip-format-activated"].asString()
                                  : "{status}",

--- a/src/modules/inhibitor.cpp
+++ b/src/modules/inhibitor.cpp
@@ -117,10 +117,10 @@ auto Inhibitor::activated() -> bool { return handle_ != -1; }
 auto Inhibitor::update() -> void {
   std::string status_text = activated() ? "activated" : "deactivated";
 
-  label_->get_style_context()->remove_class(activated() ? "deactivated" : "activated");
+  button_.get_style_context()->remove_class(activated() ? "deactivated" : "activated");
   label_->set_markup(fmt::format(format_, fmt::arg("status", status_text),
                                  fmt::arg("icon", getIcon(0, status_text))));
-  label_->get_style_context()->add_class(status_text);
+  button_.get_style_context()->add_class(status_text);
 
   if (tooltipEnabled()) {
     label_->set_tooltip_text(status_text);

--- a/src/modules/inhibitor.cpp
+++ b/src/modules/inhibitor.cpp
@@ -98,7 +98,7 @@ auto getInhibitors(const Json::Value& config) -> std::string {
 namespace waybar::modules {
 
 Inhibitor::Inhibitor(const std::string& id, const Bar& bar, const Json::Value& config)
-    : ALabel(config, "inhibitor", id, "{status}", true),
+    : AButton(config, "inhibitor", id, "{status}", true),
       dbus_(::dbus()),
       inhibitors_(::getInhibitors(config)) {
   event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
@@ -117,16 +117,16 @@ auto Inhibitor::activated() -> bool { return handle_ != -1; }
 auto Inhibitor::update() -> void {
   std::string status_text = activated() ? "activated" : "deactivated";
 
-  label_.get_style_context()->remove_class(activated() ? "deactivated" : "activated");
-  label_.set_markup(fmt::format(format_, fmt::arg("status", status_text),
-                                fmt::arg("icon", getIcon(0, status_text))));
-  label_.get_style_context()->add_class(status_text);
+  label_->get_style_context()->remove_class(activated() ? "deactivated" : "activated");
+  label_->set_markup(fmt::format(format_, fmt::arg("status", status_text),
+                                 fmt::arg("icon", getIcon(0, status_text))));
+  label_->get_style_context()->add_class(status_text);
 
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(status_text);
+    label_->set_tooltip_text(status_text);
   }
 
-  return ALabel::update();
+  return AButton::update();
 }
 
 auto Inhibitor::handleToggle(GdkEventButton* const& e) -> bool {
@@ -142,7 +142,7 @@ auto Inhibitor::handleToggle(GdkEventButton* const& e) -> bool {
     }
   }
 
-  return ALabel::handleToggle(e);
+  return AButton::handleToggle(e);
 }
 
 }  // namespace waybar::modules

--- a/src/modules/inhibitor.cpp
+++ b/src/modules/inhibitor.cpp
@@ -123,7 +123,7 @@ auto Inhibitor::update() -> void {
   button_.get_style_context()->add_class(status_text);
 
   if (tooltipEnabled()) {
-    label_->set_tooltip_text(status_text);
+    button_.set_tooltip_text(status_text);
   }
 
   return AButton::update();

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -1,7 +1,7 @@
 #include "modules/memory.hpp"
 
 waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config)
-    : ALabel(config, "memory", id, "{}%", 30) {
+    : AButton(config, "memory", id, "{}%", 30) {
   thread_ = [this] {
     dp.emit();
     thread_.sleep_for(interval_);
@@ -54,7 +54,7 @@ auto waybar::modules::Memory::update() -> void {
     } else {
       event_box_.show();
       auto icons = std::vector<std::string>{state};
-      label_.set_markup(fmt::format(
+      label_->set_markup(fmt::format(
           format, used_ram_percentage, fmt::arg("icon", getIcon(used_ram_percentage, icons)),
           fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
           fmt::arg("percentage", used_ram_percentage),
@@ -66,7 +66,7 @@ auto waybar::modules::Memory::update() -> void {
     if (tooltipEnabled()) {
       if (config_["tooltip-format"].isString()) {
         auto tooltip_format = config_["tooltip-format"].asString();
-        label_.set_tooltip_text(fmt::format(
+        label_->set_tooltip_text(fmt::format(
             tooltip_format, used_ram_percentage, fmt::arg("total", total_ram_gigabytes),
             fmt::arg("swapTotal", total_swap_gigabytes),
             fmt::arg("percentage", used_ram_percentage),
@@ -74,12 +74,12 @@ auto waybar::modules::Memory::update() -> void {
             fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
             fmt::arg("swapAvail", available_swap_gigabytes)));
       } else {
-        label_.set_tooltip_text(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
+        label_->set_tooltip_text(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
       }
     }
   } else {
     event_box_.hide();
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -66,7 +66,7 @@ auto waybar::modules::Memory::update() -> void {
     if (tooltipEnabled()) {
       if (config_["tooltip-format"].isString()) {
         auto tooltip_format = config_["tooltip-format"].asString();
-        label_->set_tooltip_text(fmt::format(
+        button_.set_tooltip_text(fmt::format(
             tooltip_format, used_ram_percentage, fmt::arg("total", total_ram_gigabytes),
             fmt::arg("swapTotal", total_swap_gigabytes),
             fmt::arg("percentage", used_ram_percentage),
@@ -74,7 +74,7 @@ auto waybar::modules::Memory::update() -> void {
             fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
             fmt::arg("swapAvail", available_swap_gigabytes)));
       } else {
-        label_->set_tooltip_text(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
+        button_.set_tooltip_text(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
       }
     }
   } else {

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -12,7 +12,7 @@ namespace waybar::modules {
 #endif
 
 waybar::modules::MPD::MPD(const std::string& id, const Json::Value& config)
-    : ALabel(config, "mpd", id, "{album} - {artist} - {title}", 5),
+    : AButton(config, "mpd", id, "{album} - {artist} - {title}", 5, false, true),
       module_name_(id.empty() ? "mpd" : "mpd#" + id),
       server_(nullptr),
       port_(config_["port"].isUInt() ? config["port"].asUInt() : 0),
@@ -44,7 +44,7 @@ auto waybar::modules::MPD::update() -> void {
   context_.update();
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 void waybar::modules::MPD::queryMPD() {
@@ -85,15 +85,15 @@ std::string waybar::modules::MPD::getFilename() const {
 
 void waybar::modules::MPD::setLabel() {
   if (connection_ == nullptr) {
-    label_.get_style_context()->add_class("disconnected");
-    label_.get_style_context()->remove_class("stopped");
-    label_.get_style_context()->remove_class("playing");
-    label_.get_style_context()->remove_class("paused");
+    label_->get_style_context()->add_class("disconnected");
+    label_->get_style_context()->remove_class("stopped");
+    label_->get_style_context()->remove_class("playing");
+    label_->get_style_context()->remove_class("paused");
 
     auto format = config_["format-disconnected"].isString()
                       ? config_["format-disconnected"].asString()
                       : "disconnected";
-    label_.set_markup(format);
+    label_->set_markup(format);
 
     if (tooltipEnabled()) {
       std::string tooltip_format;
@@ -101,11 +101,11 @@ void waybar::modules::MPD::setLabel() {
                            ? config_["tooltip-format-disconnected"].asString()
                            : "MPD (disconnected)";
       // Nothing to format
-      label_.set_tooltip_text(tooltip_format);
+      label_->set_tooltip_text(tooltip_format);
     }
     return;
   } else {
-    label_.get_style_context()->remove_class("disconnected");
+    label_->get_style_context()->remove_class("disconnected");
   }
 
   auto format = format_;
@@ -118,19 +118,19 @@ void waybar::modules::MPD::setLabel() {
   if (stopped()) {
     format =
         config_["format-stopped"].isString() ? config_["format-stopped"].asString() : "stopped";
-    label_.get_style_context()->add_class("stopped");
-    label_.get_style_context()->remove_class("playing");
-    label_.get_style_context()->remove_class("paused");
+    label_->get_style_context()->add_class("stopped");
+    label_->get_style_context()->remove_class("playing");
+    label_->get_style_context()->remove_class("paused");
   } else {
-    label_.get_style_context()->remove_class("stopped");
+    label_->get_style_context()->remove_class("stopped");
     if (playing()) {
-      label_.get_style_context()->add_class("playing");
-      label_.get_style_context()->remove_class("paused");
+      label_->get_style_context()->add_class("playing");
+      label_->get_style_context()->remove_class("paused");
     } else if (paused()) {
       format = config_["format-paused"].isString() ? config_["format-paused"].asString()
                                                    : config_["format"].asString();
-      label_.get_style_context()->add_class("paused");
-      label_.get_style_context()->remove_class("playing");
+      label_->get_style_context()->add_class("paused");
+      label_->get_style_context()->remove_class("playing");
     }
 
     stateIcon = getStateIcon();
@@ -166,7 +166,7 @@ void waybar::modules::MPD::setLabel() {
   if (config_["title-len"].isInt()) title = title.substr(0, config_["title-len"].asInt());
 
   try {
-    label_.set_markup(fmt::format(
+    label_->set_markup(fmt::format(
         format, fmt::arg("artist", Glib::Markup::escape_text(artist).raw()),
         fmt::arg("albumArtist", Glib::Markup::escape_text(album_artist).raw()),
         fmt::arg("album", Glib::Markup::escape_text(album).raw()),
@@ -195,7 +195,7 @@ void waybar::modules::MPD::setLabel() {
                       fmt::arg("queueLength", queue_length), fmt::arg("stateIcon", stateIcon),
                       fmt::arg("consumeIcon", consumeIcon), fmt::arg("randomIcon", randomIcon),
                       fmt::arg("repeatIcon", repeatIcon), fmt::arg("singleIcon", singleIcon));
-      label_.set_tooltip_text(tooltip_text);
+      label_->set_tooltip_text(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpd: format error (tooltip): {}", e.what());
     }

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -85,10 +85,10 @@ std::string waybar::modules::MPD::getFilename() const {
 
 void waybar::modules::MPD::setLabel() {
   if (connection_ == nullptr) {
-    label_->get_style_context()->add_class("disconnected");
-    label_->get_style_context()->remove_class("stopped");
-    label_->get_style_context()->remove_class("playing");
-    label_->get_style_context()->remove_class("paused");
+    button_.get_style_context()->add_class("disconnected");
+    button_.get_style_context()->remove_class("stopped");
+    button_.get_style_context()->remove_class("playing");
+    button_.get_style_context()->remove_class("paused");
 
     auto format = config_["format-disconnected"].isString()
                       ? config_["format-disconnected"].asString()
@@ -105,7 +105,7 @@ void waybar::modules::MPD::setLabel() {
     }
     return;
   } else {
-    label_->get_style_context()->remove_class("disconnected");
+    button_.get_style_context()->remove_class("disconnected");
   }
 
   auto format = format_;
@@ -118,19 +118,19 @@ void waybar::modules::MPD::setLabel() {
   if (stopped()) {
     format =
         config_["format-stopped"].isString() ? config_["format-stopped"].asString() : "stopped";
-    label_->get_style_context()->add_class("stopped");
-    label_->get_style_context()->remove_class("playing");
-    label_->get_style_context()->remove_class("paused");
+    button_.get_style_context()->add_class("stopped");
+    button_.get_style_context()->remove_class("playing");
+    button_.get_style_context()->remove_class("paused");
   } else {
-    label_->get_style_context()->remove_class("stopped");
+    button_.get_style_context()->remove_class("stopped");
     if (playing()) {
-      label_->get_style_context()->add_class("playing");
-      label_->get_style_context()->remove_class("paused");
+      button_.get_style_context()->add_class("playing");
+      button_.get_style_context()->remove_class("paused");
     } else if (paused()) {
       format = config_["format-paused"].isString() ? config_["format-paused"].asString()
                                                    : config_["format"].asString();
-      label_->get_style_context()->add_class("paused");
-      label_->get_style_context()->remove_class("playing");
+      button_.get_style_context()->add_class("paused");
+      button_.get_style_context()->remove_class("playing");
     }
 
     stateIcon = getStateIcon();

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -101,7 +101,7 @@ void waybar::modules::MPD::setLabel() {
                            ? config_["tooltip-format-disconnected"].asString()
                            : "MPD (disconnected)";
       // Nothing to format
-      label_->set_tooltip_text(tooltip_format);
+      button_.set_tooltip_text(tooltip_format);
     }
     return;
   } else {
@@ -195,7 +195,7 @@ void waybar::modules::MPD::setLabel() {
                       fmt::arg("queueLength", queue_length), fmt::arg("stateIcon", stateIcon),
                       fmt::arg("consumeIcon", consumeIcon), fmt::arg("randomIcon", randomIcon),
                       fmt::arg("repeatIcon", repeatIcon), fmt::arg("singleIcon", singleIcon));
-      label_->set_tooltip_text(tooltip_text);
+      button_.set_tooltip_text(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpd: format error (tooltip): {}", e.what());
     }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -309,8 +309,8 @@ auto waybar::modules::Network::update() -> void {
 
   if (!alt_) {
     auto state = getNetworkState();
-    if (!state_.empty() && label_->get_style_context()->has_class(state_)) {
-      label_->get_style_context()->remove_class(state_);
+    if (!state_.empty() && button_.get_style_context()->has_class(state_)) {
+      button_.get_style_context()->remove_class(state_);
     }
     if (config_["format-" + state].isString()) {
       default_format_ = config_["format-" + state].asString();
@@ -322,8 +322,8 @@ auto waybar::modules::Network::update() -> void {
     if (config_["tooltip-format-" + state].isString()) {
       tooltip_format = config_["tooltip-format-" + state].asString();
     }
-    if (!label_->get_style_context()->has_class(state)) {
-      label_->get_style_context()->add_class(state);
+    if (!button_.get_style_context()->has_class(state)) {
+      button_.get_style_context()->add_class(state);
     }
     format_ = default_format_;
     state_ = state;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -382,11 +382,11 @@ auto waybar::modules::Network::update() -> void {
           fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")),
           fmt::arg("bandwidthTotalBytes",
                    pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "B/s")));
-      if (label_->get_tooltip_text() != tooltip_text) {
-        label_->set_tooltip_markup(tooltip_text);
+      if (button_.get_tooltip_text() != tooltip_text) {
+        button_.set_tooltip_markup(tooltip_text);
       }
-    } else if (label_->get_tooltip_text() != text) {
-      label_->set_tooltip_markup(text);
+    } else if (button_.get_tooltip_text() != text) {
+      button_.set_tooltip_markup(text);
     }
   }
 

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -78,7 +78,7 @@ waybar::modules::Network::readBandwidthUsage() {
 }
 
 waybar::modules::Network::Network(const std::string &id, const Json::Value &config)
-    : ALabel(config, "network", id, DEFAULT_FORMAT, 60),
+    : AButton(config, "network", id, DEFAULT_FORMAT, 60),
       ifid_(-1),
       family_(config["family"] == "ipv6" ? AF_INET6 : AF_INET),
       efd_(-1),
@@ -95,11 +95,11 @@ waybar::modules::Network::Network(const std::string &id, const Json::Value &conf
 #endif
       frequency_(0.0) {
 
-  // Start with some "text" in the module's label_, update() will then
+  // Start with some "text" in the module's label_-> update() will then
   // update it. Since the text should be different, update() will be able
   // to show or hide the event_box_. This is to work around the case where
   // the module start with no text, but the the event_box_ is shown.
-  label_.set_markup("<s></s>");
+  label_->set_markup("<s></s>");
 
   auto bandwidth = readBandwidthUsage();
   if (bandwidth.has_value()) {
@@ -309,8 +309,8 @@ auto waybar::modules::Network::update() -> void {
 
   if (!alt_) {
     auto state = getNetworkState();
-    if (!state_.empty() && label_.get_style_context()->has_class(state_)) {
-      label_.get_style_context()->remove_class(state_);
+    if (!state_.empty() && label_->get_style_context()->has_class(state_)) {
+      label_->get_style_context()->remove_class(state_);
     }
     if (config_["format-" + state].isString()) {
       default_format_ = config_["format-" + state].asString();
@@ -322,8 +322,8 @@ auto waybar::modules::Network::update() -> void {
     if (config_["tooltip-format-" + state].isString()) {
       tooltip_format = config_["tooltip-format-" + state].asString();
     }
-    if (!label_.get_style_context()->has_class(state)) {
-      label_.get_style_context()->add_class(state);
+    if (!label_->get_style_context()->has_class(state)) {
+      label_->get_style_context()->add_class(state);
     }
     format_ = default_format_;
     state_ = state;
@@ -349,8 +349,8 @@ auto waybar::modules::Network::update() -> void {
       fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")),
       fmt::arg("bandwidthTotalBytes",
                pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "B/s")));
-  if (text.compare(label_.get_label()) != 0) {
-    label_.set_markup(text);
+  if (text.compare(label_->get_label()) != 0) {
+    label_->set_markup(text);
     if (text.empty()) {
       event_box_.hide();
     } else {
@@ -382,16 +382,16 @@ auto waybar::modules::Network::update() -> void {
           fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")),
           fmt::arg("bandwidthTotalBytes",
                    pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "B/s")));
-      if (label_.get_tooltip_text() != tooltip_text) {
-        label_.set_tooltip_markup(tooltip_text);
+      if (label_->get_tooltip_text() != tooltip_text) {
+        label_->set_tooltip_markup(tooltip_text);
       }
-    } else if (label_.get_tooltip_text() != text) {
-      label_.set_tooltip_markup(text);
+    } else if (label_->get_tooltip_text() != text) {
+      label_->set_tooltip_markup(text);
     }
   }
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 bool waybar::modules::Network::checkInterface(std::string name) {

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -240,9 +240,9 @@ auto waybar::modules::Pulseaudio::update() -> void {
     if (monitor_.find("a2dp_sink") != std::string::npos ||  // PulseAudio
         monitor_.find("a2dp-sink") != std::string::npos) {  // PipeWire
       format_name = format_name + "-bluetooth";
-      label_->get_style_context()->add_class("bluetooth");
+      button_.get_style_context()->add_class("bluetooth");
     } else {
-      label_->get_style_context()->remove_class("bluetooth");
+      button_.get_style_context()->remove_class("bluetooth");
     }
     if (muted_) {
       // Check muted bluetooth format exist, otherwise fallback to default muted format
@@ -250,23 +250,23 @@ auto waybar::modules::Pulseaudio::update() -> void {
         format_name = "format";
       }
       format_name = format_name + "-muted";
-      label_->get_style_context()->add_class("muted");
-      label_->get_style_context()->add_class("sink-muted");
+      button_.get_style_context()->add_class("muted");
+      button_.get_style_context()->add_class("sink-muted");
     } else {
-      label_->get_style_context()->remove_class("muted");
-      label_->get_style_context()->remove_class("sink-muted");
+      button_.get_style_context()->remove_class("muted");
+      button_.get_style_context()->remove_class("sink-muted");
     }
     format = config_[format_name].isString() ? config_[format_name].asString() : format;
   }
   // TODO: find a better way to split source/sink
   std::string format_source = "{volume}%";
   if (source_muted_) {
-    label_->get_style_context()->add_class("source-muted");
+    button_.get_style_context()->add_class("source-muted");
     if (config_["format-source-muted"].isString()) {
       format_source = config_["format-source-muted"].asString();
     }
   } else {
-    label_->get_style_context()->remove_class("source-muted");
+    button_.get_style_context()->remove_class("source-muted");
     if (config_["format-source-muted"].isString()) {
       format_source = config_["format-source"].asString();
     }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -1,7 +1,7 @@
 #include "modules/pulseaudio.hpp"
 
 waybar::modules::Pulseaudio::Pulseaudio(const std::string &id, const Json::Value &config)
-    : ALabel(config, "pulseaudio", id, "{volume}%"),
+    : AButton(config, "pulseaudio", id, "{volume}%"),
       mainloop_(nullptr),
       mainloop_api_(nullptr),
       context_(nullptr),
@@ -240,9 +240,9 @@ auto waybar::modules::Pulseaudio::update() -> void {
     if (monitor_.find("a2dp_sink") != std::string::npos ||  // PulseAudio
         monitor_.find("a2dp-sink") != std::string::npos) {  // PipeWire
       format_name = format_name + "-bluetooth";
-      label_.get_style_context()->add_class("bluetooth");
+      label_->get_style_context()->add_class("bluetooth");
     } else {
-      label_.get_style_context()->remove_class("bluetooth");
+      label_->get_style_context()->remove_class("bluetooth");
     }
     if (muted_) {
       // Check muted bluetooth format exist, otherwise fallback to default muted format
@@ -250,29 +250,29 @@ auto waybar::modules::Pulseaudio::update() -> void {
         format_name = "format";
       }
       format_name = format_name + "-muted";
-      label_.get_style_context()->add_class("muted");
-      label_.get_style_context()->add_class("sink-muted");
+      label_->get_style_context()->add_class("muted");
+      label_->get_style_context()->add_class("sink-muted");
     } else {
-      label_.get_style_context()->remove_class("muted");
-      label_.get_style_context()->remove_class("sink-muted");
+      label_->get_style_context()->remove_class("muted");
+      label_->get_style_context()->remove_class("sink-muted");
     }
     format = config_[format_name].isString() ? config_[format_name].asString() : format;
   }
   // TODO: find a better way to split source/sink
   std::string format_source = "{volume}%";
   if (source_muted_) {
-    label_.get_style_context()->add_class("source-muted");
+    label_->get_style_context()->add_class("source-muted");
     if (config_["format-source-muted"].isString()) {
       format_source = config_["format-source-muted"].asString();
     }
   } else {
-    label_.get_style_context()->remove_class("source-muted");
+    label_->get_style_context()->remove_class("source-muted");
     if (config_["format-source-muted"].isString()) {
       format_source = config_["format-source"].asString();
     }
   }
   format_source = fmt::format(format_source, fmt::arg("volume", source_volume_));
-  label_.set_markup(fmt::format(
+  label_->set_markup(fmt::format(
       format, fmt::arg("desc", desc_), fmt::arg("volume", volume_),
       fmt::arg("format_source", format_source), fmt::arg("source_volume", source_volume_),
       fmt::arg("source_desc", source_desc_), fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
@@ -283,16 +283,16 @@ auto waybar::modules::Pulseaudio::update() -> void {
       tooltip_format = config_["tooltip-format"].asString();
     }
     if (!tooltip_format.empty()) {
-      label_.set_tooltip_text(fmt::format(
+      label_->set_tooltip_text(fmt::format(
           tooltip_format, fmt::arg("desc", desc_), fmt::arg("volume", volume_),
           fmt::arg("format_source", format_source), fmt::arg("source_volume", source_volume_),
           fmt::arg("source_desc", source_desc_),
           fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
     } else {
-      label_.set_tooltip_text(desc_);
+      label_->set_tooltip_text(desc_);
     }
   }
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -283,13 +283,13 @@ auto waybar::modules::Pulseaudio::update() -> void {
       tooltip_format = config_["tooltip-format"].asString();
     }
     if (!tooltip_format.empty()) {
-      label_->set_tooltip_text(fmt::format(
+      button_.set_tooltip_text(fmt::format(
           tooltip_format, fmt::arg("desc", desc_), fmt::arg("volume", volume_),
           fmt::arg("format_source", format_source), fmt::arg("source_volume", source_volume_),
           fmt::arg("source_desc", source_desc_),
           fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
     } else {
-      label_->set_tooltip_text(desc_);
+      button_.set_tooltip_text(desc_);
     }
   }
 

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -3,7 +3,7 @@
 #include <time.h>
 
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
-    : ALabel(config, "clock", id, "{:%H:%M}", 60) {
+    : AButton(config, "clock", id, "{:%H:%M}", 60) {
   thread_ = [this] {
     dp.emit();
     auto now = std::chrono::system_clock::now();
@@ -19,17 +19,17 @@ auto waybar::modules::Clock::update() -> void {
   auto now = std::chrono::system_clock::now();
   auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
   auto text = fmt::format(format_, localtime);
-  label_.set_markup(text);
+  label_->set_markup(text);
 
   if (tooltipEnabled()) {
     if (config_["tooltip-format"].isString()) {
       auto tooltip_format = config_["tooltip-format"].asString();
       auto tooltip_text = fmt::format(tooltip_format, localtime);
-      label_.set_tooltip_text(tooltip_text);
+      label_->set_tooltip_text(tooltip_text);
     } else {
-      label_.set_tooltip_text(text);
+      label_->set_tooltip_text(text);
     }
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -25,9 +25,9 @@ auto waybar::modules::Clock::update() -> void {
     if (config_["tooltip-format"].isString()) {
       auto tooltip_format = config_["tooltip-format"].asString();
       auto tooltip_text = fmt::format(tooltip_format, localtime);
-      label_->set_tooltip_text(tooltip_text);
+      button_.set_tooltip_text(tooltip_text);
     } else {
-      label_->set_tooltip_text(text);
+      button_.set_tooltip_text(text);
     }
   }
   // Call parent update

--- a/src/modules/sndio.cpp
+++ b/src/modules/sndio.cpp
@@ -105,9 +105,9 @@ auto Sndio::update() -> void {
   unsigned int vol = 100. * static_cast<double>(volume_) / static_cast<double>(maxval_);
 
   if (volume_ == 0) {
-    label_->get_style_context()->add_class("muted");
+    button_.get_style_context()->add_class("muted");
   } else {
-    label_->get_style_context()->remove_class("muted");
+    button_.get_style_context()->remove_class("muted");
   }
 
   label_->set_markup(fmt::format(format, fmt::arg("volume", vol), fmt::arg("raw_value", volume_)));

--- a/src/modules/sndio.cpp
+++ b/src/modules/sndio.cpp
@@ -41,7 +41,7 @@ auto Sndio::connect_to_sndio() -> void {
 }
 
 Sndio::Sndio(const std::string &id, const Json::Value &config)
-    : ALabel(config, "sndio", id, "{volume}%", 1),
+    : AButton(config, "sndio", id, "{volume}%", 1, false, true),
       hdl_(nullptr),
       pfds_(0),
       addr_(0),
@@ -105,14 +105,14 @@ auto Sndio::update() -> void {
   unsigned int vol = 100. * static_cast<double>(volume_) / static_cast<double>(maxval_);
 
   if (volume_ == 0) {
-    label_.get_style_context()->add_class("muted");
+    label_->get_style_context()->add_class("muted");
   } else {
-    label_.get_style_context()->remove_class("muted");
+    label_->get_style_context()->remove_class("muted");
   }
 
-  label_.set_markup(fmt::format(format, fmt::arg("volume", vol), fmt::arg("raw_value", volume_)));
+  label_->set_markup(fmt::format(format, fmt::arg("volume", vol), fmt::arg("raw_value", volume_)));
 
-  ALabel::update();
+  AButton::update();
 }
 
 auto Sndio::set_desc(struct sioctl_desc *d, unsigned int val) -> void {

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -18,7 +18,7 @@ const std::string Language::XKB_LAYOUT_NAMES_KEY = "xkb_layout_names";
 const std::string Language::XKB_ACTIVE_LAYOUT_NAME_KEY = "xkb_active_layout_name";
 
 Language::Language(const std::string& id, const Json::Value& config)
-    : ALabel(config, "language", id, "{}", 0, true) {
+    : AButton(config, "language", id, "{}", 0, true) {
   is_variant_displayed = format_.find("{variant}") != std::string::npos;
   if (format_.find("{}") != std::string::npos || format_.find("{short}") != std::string::npos) {
     displayed_short_flag |= static_cast<std::byte>(DispayedShortFlag::ShortName);
@@ -99,7 +99,7 @@ auto Language::update() -> void {
       format_, fmt::arg("short", layout_.short_name),
       fmt::arg("shortDescription", layout_.short_description), fmt::arg("long", layout_.full_name),
       fmt::arg("variant", layout_.variant), fmt::arg("flag", layout_.country_flag())));
-  label_.set_markup(display_layout);
+  label_->set_markup(display_layout);
   if (tooltipEnabled()) {
     if (tooltip_format_ != "") {
       auto tooltip_display_layout = trim(
@@ -107,22 +107,22 @@ auto Language::update() -> void {
                       fmt::arg("shortDescription", layout_.short_description),
                       fmt::arg("long", layout_.full_name), fmt::arg("variant", layout_.variant),
                       fmt::arg("flag", layout_.country_flag())));
-      label_.set_tooltip_markup(tooltip_display_layout);
+      label_->set_tooltip_markup(tooltip_display_layout);
     } else {
-      label_.set_tooltip_markup(display_layout);
+      label_->set_tooltip_markup(display_layout);
     }
   }
 
   event_box_.show();
 
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 auto Language::set_current_layout(std::string current_layout) -> void {
-  label_.get_style_context()->remove_class(layout_.short_name);
+  label_->get_style_context()->remove_class(layout_.short_name);
   layout_ = layouts_map_[current_layout];
-  label_.get_style_context()->add_class(layout_.short_name);
+  label_->get_style_context()->add_class(layout_.short_name);
 }
 
 auto Language::init_layouts_map(const std::vector<std::string>& used_layouts) -> void {

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -107,9 +107,9 @@ auto Language::update() -> void {
                       fmt::arg("shortDescription", layout_.short_description),
                       fmt::arg("long", layout_.full_name), fmt::arg("variant", layout_.variant),
                       fmt::arg("flag", layout_.country_flag())));
-      label_->set_tooltip_markup(tooltip_display_layout);
+      button_.set_tooltip_markup(tooltip_display_layout);
     } else {
-      label_->set_tooltip_markup(display_layout);
+      button_.set_tooltip_markup(display_layout);
     }
   }
 

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -120,9 +120,9 @@ auto Language::update() -> void {
 }
 
 auto Language::set_current_layout(std::string current_layout) -> void {
-  label_->get_style_context()->remove_class(layout_.short_name);
+  button_.get_style_context()->remove_class(layout_.short_name);
   layout_ = layouts_map_[current_layout];
-  label_->get_style_context()->add_class(layout_.short_name);
+  button_.get_style_context()->add_class(layout_.short_name);
 }
 
 auto Language::init_layouts_map(const std::vector<std::string>& used_layouts) -> void {

--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -44,7 +44,7 @@ auto Mode::update() -> void {
   } else {
     label_->set_markup(fmt::format(format_, mode_));
     if (tooltipEnabled()) {
-      label_->set_tooltip_text(mode_);
+      button_.set_tooltip_text(mode_);
     }
     event_box_.show();
   }

--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -5,7 +5,7 @@
 namespace waybar::modules::sway {
 
 Mode::Mode(const std::string& id, const Json::Value& config)
-    : ALabel(config, "mode", id, "{}", 0, true) {
+    : AButton(config, "mode", id, "{}", 0, true) {
   ipc_.subscribe(R"(["mode"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &Mode::onEvent));
   // Launch worker
@@ -42,14 +42,14 @@ auto Mode::update() -> void {
   if (mode_.empty()) {
     event_box_.hide();
   } else {
-    label_.set_markup(fmt::format(format_, mode_));
+    label_->set_markup(fmt::format(format_, mode_));
     if (tooltipEnabled()) {
-      label_.set_tooltip_text(mode_);
+      label_->set_tooltip_text(mode_);
     }
     event_box_.show();
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 }  // namespace waybar::modules::sway

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -67,7 +67,7 @@ auto waybar::modules::Temperature::update() -> void {
     if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_->set_tooltip_text(fmt::format(tooltip_format, fmt::arg("temperatureC", temperature_c),
+    button_.set_tooltip_text(fmt::format(tooltip_format, fmt::arg("temperatureC", temperature_c),
                                          fmt::arg("temperatureF", temperature_f),
                                          fmt::arg("temperatureK", temperature_k)));
   }

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -10,8 +10,7 @@
 #endif
 
 waybar::modules::Temperature::Temperature(const std::string& id, const Json::Value& config)
-    : ALabel(config, "temperature", id, "{temperatureC}°C", 10) {
-
+    : AButton(config, "temperature", id, "{temperatureC}°C", 10) {
 #if defined(__FreeBSD__)
 // try to read sysctl?
 #else
@@ -46,9 +45,9 @@ auto waybar::modules::Temperature::update() -> void {
   auto format = format_;
   if (critical) {
     format = config_["format-critical"].isString() ? config_["format-critical"].asString() : format;
-    label_.get_style_context()->add_class("critical");
+    label_->get_style_context()->add_class("critical");
   } else {
-    label_.get_style_context()->remove_class("critical");
+    label_->get_style_context()->remove_class("critical");
   }
 
   if (format.empty()) {
@@ -59,21 +58,21 @@ auto waybar::modules::Temperature::update() -> void {
   }
 
   auto max_temp = config_["critical-threshold"].isInt() ? config_["critical-threshold"].asInt() : 0;
-  label_.set_markup(fmt::format(format, fmt::arg("temperatureC", temperature_c),
-                                fmt::arg("temperatureF", temperature_f),
-                                fmt::arg("temperatureK", temperature_k),
-                                fmt::arg("icon", getIcon(temperature_c, "", max_temp))));
+  label_->set_markup(fmt::format(format, fmt::arg("temperatureC", temperature_c),
+                                 fmt::arg("temperatureF", temperature_f),
+                                 fmt::arg("temperatureK", temperature_k),
+                                 fmt::arg("icon", getIcon(temperature_c, "", max_temp))));
   if (tooltipEnabled()) {
     std::string tooltip_format = "{temperatureC}°C";
     if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_.set_tooltip_text(fmt::format(tooltip_format, fmt::arg("temperatureC", temperature_c),
-                                        fmt::arg("temperatureF", temperature_f),
-                                        fmt::arg("temperatureK", temperature_k)));
+    label_->set_tooltip_text(fmt::format(tooltip_format, fmt::arg("temperatureC", temperature_c),
+                                         fmt::arg("temperatureF", temperature_f),
+                                         fmt::arg("temperatureK", temperature_k)));
   }
   // Call parent update
-  ALabel::update();
+  AButton::update();
 }
 
 float waybar::modules::Temperature::getTemperature() {
@@ -82,12 +81,13 @@ float waybar::modules::Temperature::getTemperature() {
   size_t size = sizeof temp;
 
   if (sysctlbyname("hw.acpi.thermal.tz0.temperature", &temp, &size, NULL, 0) != 0) {
-    throw std::runtime_error("sysctl hw.acpi.thermal.tz0.temperature or dev.cpu.0.temperature failed");
+    throw std::runtime_error(
+        "sysctl hw.acpi.thermal.tz0.temperature or dev.cpu.0.temperature failed");
   }
-  auto temperature_c = ((float)temp-2732)/10;  
+  auto temperature_c = ((float)temp - 2732) / 10;
   return temperature_c;
 
-#else // Linux
+#else  // Linux
   std::ifstream temp(file_path_);
   if (!temp.is_open()) {
     throw std::runtime_error("Can't open " + file_path_);

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -45,9 +45,9 @@ auto waybar::modules::Temperature::update() -> void {
   auto format = format_;
   if (critical) {
     format = config_["format-critical"].isString() ? config_["format-critical"].asString() : format;
-    label_->get_style_context()->add_class("critical");
+    button_.get_style_context()->add_class("critical");
   } else {
-    label_->get_style_context()->remove_class("critical");
+    button_.get_style_context()->remove_class("critical");
   }
 
   if (format.empty()) {


### PR DESCRIPTION
This PR turns the ```GtkLabel``` into a ```GtkButton```. This has some visual advantages:

+ The ```:hover``` qualifier can be set on modules in ```style.css```
+ There is a nice hover and click animation of the label included
+ If the module is merely informative, the button is deactivated and acts just as before

Checkout my dotfiles (.config/waybar/*) for how I use this PR to distinguish modules spawning a window on click from those just changing format.

**Caveats**: ```GtkButton``` catches all single mouse button click events regardless of the flags set on it. Therefore, I had to connect its ```signal_pressed``` method to the underlying, preceding ```handleToggle``` method.
Another workaround would have been to connect ```handelToggle``` to ```signal_button_release_event``` instead of  ```signal_button_press_event``` in ```AModule```. I've done that in my 'use_gtk_button' (without the '_v2') branch. The implementation of '_v2' mimics the previous behavior much better though.

Thanks :)