### PR TITLE
sway-language: ignore events with empty layout

### DIFF
--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -45,7 +45,9 @@ void Language::onEvent(const struct Ipc::ipc_response& res) {
     auto payload = parser_.parse(res.payload)["input"];
     if (payload["type"].asString() == "keyboard") {
         auto layout_name = payload["xkb_active_layout_name"].asString().substr(0,2);
-        lang_ = Glib::Markup::escape_text(layout_name);
+        if (!layout_name.empty()) {
+            lang_ = Glib::Markup::escape_text(layout_name);
+        }
     }
     dp.emit();
   } catch (const std::exception& e) {


### PR DESCRIPTION
When using e.g. [wtype](https://github.com/atx/wtype), which also sends events to emulate keyboard presses, this confuses Waybar and incorrectly hides the module. This fix will ensure compatibility with `wtype`, simply ignoring events where layout is not set, and only reacting on events which actually change the keyboard layout.