### PR TITLE
libfmt >=8.0.0 compatibility

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -35,7 +35,11 @@ namespace fmt {
             // The rationale for ignoring it is that the only reason to specify
             // an alignment and a with is to get a fixed width bar, and ">" is
             // sufficient in this implementation.
+#if FMT_VERSION < 80000
             width = parse_nonnegative_int(it, end, ctx);
+#else
+            width = detail::parse_nonnegative_int(it, end, -1);
+#endif
           }
           return it;
         }

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -196,6 +196,9 @@ template <>
 struct fmt::formatter<waybar_time> : fmt::formatter<std::tm> {
   template <typename FormatContext>
   auto format(const waybar_time& t, FormatContext& ctx) {
+#if FMT_VERSION >= 80000
+	auto& tm_format = specs;
+#endif
     return format_to(ctx.out(), "{}", date::format(t.locale, fmt::to_string(tm_format), t.ztime));
   }
 };


### PR DESCRIPTION
Attempting to fix compatibility with libfmt-8.0.0 mentioned in #1143 and https://bugs.gentoo.org/797649. I don't really have any idea what I'm doing in C++, so criticism welcome (and probably necessary).

The issue with parse_nonnegative_int comes from the libfmt change [here](https://github.com/fmtlib/fmt/commit/e421d527), where the third argument becomes an integer. Previously on error the function returned -1, now it returns the third argument, which I've changed to -1 here. I'm unsure about side effects of the ctx object no longer being passed into `parse_nonnegative_int`. This function was also moved from `fmt/format.h` to `fmt/core.h` and namespaces seem to have changed along the way, so specifying `fmt::detail::` makes it compile (for me) but not sure if there's a better way.

`tm_format` was also apparently moved out of libfmt's public API. Declare it similarly here. This seems to work at runtime for me.