### PR TITLE
tray module enhancements

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -70,6 +70,12 @@ class Item : public sigc::trackable {
   static void               onMenuDestroyed(Item* self, GObject* old_menu_pointer);
   void                      makeMenu();
   bool                      handleClick(GdkEventButton* const& /*ev*/);
+  bool                      handleScroll(GdkEventScroll* const&);
+
+  // smooth scrolling threshold
+  gdouble scroll_threshold_ = 0;
+  gdouble distance_scrolled_x_ = 0;
+  gdouble distance_scrolled_y_ = 0;
 
   Glib::RefPtr<Gio::DBus::Proxy> proxy_;
   Glib::RefPtr<Gio::Cancellable> cancellable_;

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -35,7 +35,6 @@ class Item : public sigc::trackable {
   Gtk::EventBox event_box;
   std::string   category;
   std::string   id;
-  std::string   status;
 
   std::string                  title;
   std::string                  icon_name;
@@ -59,6 +58,7 @@ class Item : public sigc::trackable {
  private:
   void proxyReady(Glib::RefPtr<Gio::AsyncResult>& result);
   void setProperty(const Glib::ustring& name, Glib::VariantBase& value);
+  void setStatus(const Glib::ustring& value);
   void getUpdatedProperties();
   void processUpdatedProperties(Glib::RefPtr<Gio::AsyncResult>& result);
   void onSignal(const Glib::ustring& sender_name, const Glib::ustring& signal_name,
@@ -76,6 +76,8 @@ class Item : public sigc::trackable {
   gdouble scroll_threshold_ = 0;
   gdouble distance_scrolled_x_ = 0;
   gdouble distance_scrolled_y_ = 0;
+  // visibility of items with Status == Passive
+  bool show_passive_ = false;
 
   Glib::RefPtr<Gio::DBus::Proxy> proxy_;
   Glib::RefPtr<Gio::Cancellable> cancellable_;

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -30,7 +30,6 @@ class Item : public sigc::trackable {
   std::string   status;
 
   std::string                  title;
-  int32_t                      window_id;
   std::string                  icon_name;
   Glib::RefPtr<Gdk::Pixbuf>    icon_pixmap;
   Glib::RefPtr<Gtk::IconTheme> icon_theme;

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -11,6 +11,9 @@
 #include <libdbusmenu-gtk/dbusmenu-gtk.h>
 #include <sigc++/trackable.h>
 
+#include <set>
+#include <string_view>
+
 namespace waybar::modules::SNI {
 
 class Item : public sigc::trackable {
@@ -64,7 +67,7 @@ class Item : public sigc::trackable {
 
   Glib::RefPtr<Gio::DBus::Proxy> proxy_;
   Glib::RefPtr<Gio::Cancellable> cancellable_;
-  bool                           update_pending_;
+  std::set<std::string_view>     update_pending_;
 };
 
 }  // namespace waybar::modules::SNI

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -16,6 +16,11 @@
 
 namespace waybar::modules::SNI {
 
+struct ToolTip {
+  Glib::ustring icon_name;
+  Glib::ustring text;
+};
+
 class Item : public sigc::trackable {
  public:
   Item(const std::string&, const std::string&, const Json::Value&);
@@ -41,6 +46,7 @@ class Item : public sigc::trackable {
   std::string                  attention_movie_name;
   std::string                  icon_theme_path;
   std::string                  menu;
+  ToolTip                      tooltip;
   DbusmenuGtkMenu*             dbus_menu = nullptr;
   Gtk::Menu*                   gtk_menu = nullptr;
   /**

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -16,6 +16,10 @@ Addressed by *tray*
     typeof: integer ++
     Defines the size of the tray icons.
 
+*smooth-scrolling-threshold*: ++
+	typeof: double ++
+	Threshold to be used when scrolling.
+
 *spacing*: ++
     typeof: integer ++
     Defines the spacing between the tray icons.

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -16,6 +16,11 @@ Addressed by *tray*
     typeof: integer ++
     Defines the size of the tray icons.
 
+*show-passive-items*: ++
+    typeof: bool ++
+    default: false ++
+    Defines visibility of the tray icons with *Passive* status.
+
 *smooth-scrolling-threshold*: ++
 	typeof: double ++
 	Threshold to be used when scrolling.
@@ -41,3 +46,6 @@ Addressed by *tray*
 # STYLE
 
 - *#tray*
+- *#tray > .passive*
+- *#tray > .active*
+- *#tray > .needs-attention*

--- a/resources/style.css
+++ b/resources/style.css
@@ -195,6 +195,15 @@ label:focus {
     background-color: #2980b9;
 }
 
+#tray > .passive {
+    -gtk-icon-effect: dim;
+}
+
+#tray > .needs-attention {
+    -gtk-icon-effect: highlight;
+    background-color: #eb4d4b;
+}
+
 #idle_inhibitor {
     background-color: #2d3436;
 }

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -105,8 +105,6 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       title = get_variant<std::string>(value);
     } else if (name == "Status") {
       status = get_variant<std::string>(value);
-    } else if (name == "WindowId") {
-      window_id = get_variant<int32_t>(value);
     } else if (name == "IconName") {
       icon_name = get_variant<std::string>(value);
     } else if (name == "IconPixmap") {

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -119,6 +119,9 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       id = get_variant<std::string>(value);
     } else if (name == "Title") {
       title = get_variant<std::string>(value);
+      if (tooltip.text.empty()) {
+        event_box.set_tooltip_markup(title);
+      }
     } else if (name == "Status") {
       status = get_variant<std::string>(value);
     } else if (name == "IconName") {


### PR DESCRIPTION
Assorted enhancements for tray module.

I had to drop the tooltip icon changes with intent to finish those later, once I have a complete grasp of a possible implementation.
Need to take another look at `update_pending_` for possibility of races. Shouldn't be a blocker for the merge though, as I haven't found anything harmful so far. Only a minuscule chance of missing a property update.

### Changes:

 - Try to optimize updates by assuming that signals don't lie and could be using to infer all modified properties. A somewhat risky assumption, given how broken is an average sni client implementation, but I've seen other trays working like that.
 - Support tooltips for tray items (text only).
 - Support `Scroll`  SNI method.
 - Support `Status` property: hide `Passive` items by default; attach corresponding CSS classes to the icon.

Fixes #1138, #1150