### PR TITLE
Add GitHub CI jobs on Linux

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0.1.3 # aka FreeBSD 12.2
+      uses: vmactions/freebsd-vm@v0.1.4 # aka FreeBSD 12.2
       with:
         usesh: true
         prepare: |

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Test in FreeBSD VM
-      uses: vmactions/freebsd-vm@v0.0.9 # aka FreeBSD 12.2
+      uses: vmactions/freebsd-vm@v0.1.3 # aka FreeBSD 12.2
       with:
         usesh: true
         prepare: |

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,0 +1,25 @@
+name: linux
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        distro:
+          - alpine
+          - archlinux
+          - debian
+          - fedora
+          - opensuse
+
+    runs-on: ubuntu-latest
+    container:
+      image: alexays/waybar:${{ matrix.distro }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: configure
+        run: meson -Dman-pages=enabled build
+      - name: build
+        run: ninja -C build

--- a/Dockerfiles/fedora
+++ b/Dockerfiles/fedora
@@ -1,7 +1,12 @@
 # vim: ft=Dockerfile
 
-FROM fedora:32
+FROM fedora:latest
 
-RUN dnf install sway meson git libinput-devel wayland-devel wayland-protocols-devel pugixml-devel egl-wayland-devel mesa-libEGL-devel mesa-libGLES-devel mesa-libgbm-devel libxkbcommon-devel libudev-devel pixman-devel gtkmm30-devel jsoncpp-devel scdoc -y && \
-    dnf group install "C Development Tools and Libraries" -y && \
+RUN dnf install -y @c-development git-core meson scdoc 'pkgconfig(date)' \
+    'pkgconfig(dbusmenu-gtk3-0.4)' 'pkgconfig(fmt)' 'pkgconfig(gdk-pixbuf-2.0)' \
+    'pkgconfig(gio-unix-2.0)' 'pkgconfig(gtk-layer-shell-0)' 'pkgconfig(gtkmm-3.0)' \
+    'pkgconfig(jsoncpp)' 'pkgconfig(libinput)' 'pkgconfig(libmpdclient)' \
+    'pkgconfig(libnl-3.0)' 'pkgconfig(libnl-genl-3.0)' 'pkgconfig(libpulse)' \
+    'pkgconfig(libudev)' 'pkgconfig(pugixml)' 'pkgconfig(sigc++-2.0)' 'pkgconfig(spdlog)' \
+    'pkgconfig(wayland-client)' 'pkgconfig(wayland-cursor)' 'pkgconfig(wayland-protocols)' && \
     dnf clean all -y


### PR DESCRIPTION
Travis CI jobs haven't been running for months and FreeBSD was failing due to an ntp sync issues. It's time to do something about that :)

@Alexays, if you are going to merge that, please update the container images. And maybe it's time to delete .travis.yml and any other leftovers of Travis CI integration.

***
Another option I considered is to move everything to https://builds.sr.ht/. That'll certainly make FreeBSD jobs faster, avoiding the abomination of spinning a FreeBSD VM on a MacOS builder.
SourceHut is currently moving to a paid subscription model though and may require $20/year subscription in the future. I don't know the current status, but we can always ping Drew or Simon if that sounds interesting.