### PR TITLE
Support per-device icon in pulseaudio

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -14,7 +14,7 @@ class ALabel : public AModule {
   virtual ~ALabel() = default;
   virtual auto        update() -> void;
   virtual std::string getIcon(uint16_t, const std::string &alt = "", uint16_t max = 0);
-  virtual std::string getIcon(uint16_t, std::vector<std::string> &alts, uint16_t max = 0);
+  virtual std::string getIcon(uint16_t, const std::vector<std::string> &alts, uint16_t max = 0);
 
  protected:
   Gtk::Label                 label_;

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -24,7 +24,7 @@ class Pulseaudio : public ALabel {
   static void volumeModifyCb(pa_context*, int, void*);
 
   bool              handleScroll(GdkEventScroll* e);
-  const std::string getPortIcon() const;
+  const std::vector<std::string> getPulseIcon() const;
 
   pa_threaded_mainloop* mainloop_;
   pa_mainloop_api*      mainloop_api_;

--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -109,6 +109,9 @@ Additionally you can control the volume by scrolling *up* or *down* while the cu
 # ICONS:
 
 The following strings for *format-icons* are supported.
+
+- the device name
+
 If they are found in the current PulseAudio port name, the corresponding icons will be selected.
 
 - *default* (Shown, when no other port is found)
@@ -131,6 +134,7 @@ If they are found in the current PulseAudio port name, the corresponding icons w
 	"format-bluetooth": "{volume}% {icon}",
 	"format-muted": "",
 	"format-icons": {
+		"alsa_output.pci-0000_00_1f.3.analog-stereo": "",
 		"headphones": "",
 		"handsfree": "",
 		"headset": "",

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -76,7 +76,7 @@ std::string ALabel::getIcon(uint16_t percentage, const std::string& alt, uint16_
   return "";
 }
 
-std::string ALabel::getIcon(uint16_t percentage, std::vector<std::string>& alts, uint16_t max) {
+std::string ALabel::getIcon(uint16_t percentage, const std::vector<std::string>& alts, uint16_t max) {
   auto format_icons = config_["format-icons"];
   if (format_icons.isObject()) {
     std::string _alt = "default";

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -194,15 +194,17 @@ static const std::array<std::string, 9> ports = {
     "phone",
 };
 
-const std::string waybar::modules::Pulseaudio::getPortIcon() const {
+const std::vector<std::string> waybar::modules::Pulseaudio::getPulseIcon() const {
+  std::vector<std::string> res = {default_sink_name_};
   std::string nameLC = port_name_ + form_factor_;
   std::transform(nameLC.begin(), nameLC.end(), nameLC.begin(), ::tolower);
   for (auto const &port : ports) {
     if (nameLC.find(port) != std::string::npos) {
-      return port;
+      res.push_back(port);
+      return res;
     }
   }
-  return port_name_;
+  return res;
 }
 
 auto waybar::modules::Pulseaudio::update() -> void {
@@ -252,7 +254,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
                                 fmt::arg("format_source", format_source),
                                 fmt::arg("source_volume", source_volume_),
                                 fmt::arg("source_desc", source_desc_),
-                                fmt::arg("icon", getIcon(volume_, getPortIcon()))));
+                                fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
   getState(volume_);
   
   if (tooltipEnabled()) {
@@ -267,7 +269,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
         fmt::arg("format_source", format_source),
         fmt::arg("source_volume", source_volume_),
         fmt::arg("source_desc", source_desc_),
-        fmt::arg("icon", getIcon(volume_, getPortIcon()))));
+        fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
     } else {
       label_.set_tooltip_text(desc_);
     }


### PR DESCRIPTION
Should implement https://github.com/Alexays/Waybar/issues/1121

Allow device name (such as alsa_output.pci-0000_00_1f.3.analog-stereo) to be used as key in pulseaudio format-icon configuration.