### PR TITLE
Don't start if graphical-session is not running

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -3,6 +3,7 @@ Description=Highly customizable Wayland bar for Sway and Wlroots based composito
 Documentation=https://github.com/Alexays/Waybar/wiki/
 PartOf=graphical-session.target
 After=graphical-session.target
+Requisite=graphical-session.target
 
 [Service]
 ExecStart=@prefix@/bin/waybar


### PR DESCRIPTION
Currently waybar _can_ try to start even if there's no graphical session (and
no sway) running. Adding `Requisite=` prevents this. From `systemd.unit(5)`:

    Requisite=
       Similar to Requires=. However, if the units listed here are not started
       already, they will not be started and the starting of this unit will
       fail immediately.  Requisite= does not imply an ordering dependency,
       even if both units are started in the same transaction. Hence this
       setting should usually be combined with After=, to ensure this unit is
       not started before the other unit.

       When Requisite=b.service is used on a.service, this dependency will show
       as RequisiteOf=a.service in property listing of b.service.  RequisiteOf=
       dependency cannot be specified directly.
