### PR TITLE
Fix incorrect tray icon scaling

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -66,7 +66,9 @@ class Item : public sigc::trackable {
 
   void                      updateImage();
   Glib::RefPtr<Gdk::Pixbuf> extractPixBuf(GVariant* variant);
+  Glib::RefPtr<Gdk::Pixbuf> getIconPixbuf();
   Glib::RefPtr<Gdk::Pixbuf> getIconByName(const std::string& name, int size);
+  double                    getScaledIconSize();
   static void               onMenuDestroyed(Item* self, GObject* old_menu_pointer);
   void                      makeMenu();
   bool                      handleClick(GdkEventButton* const& /*ev*/);


### PR DESCRIPTION
This PR fixes https://github.com/Alexays/Waybar/issues/1175 and refactors the code around updating the image to separate fetching the correct pixmap and scaling the pixmap.

The root cause of https://github.com/Alexays/Waybar/issues/1175 is that for certain icons, such as the network manager wireless signal icons, the requested icon size may not be available (the network manager applet only supplies a 22x22 pixel version of the wireless signal icon). There is some logic in `updateImage` for proportionally scaling the icon pixbuf if it did not match the requested icon size. However, the code branch in `updateImage` where the icon was loaded using `getIconByName` did not apply this resize logic, resulting in situations where, e.g., the pixbuf is too small.

In this PR, `updateImage` has been updated to apply the logic for proportionally resizing the icon pixbuf to all pixbufs. Additionally, the logic for fetching the correct pixbuf for a given item has been factored out into `getIconPixbuf`.

Side note, it does appear that the network manager applet [supplies "symbolic" SVG icons](https://gitlab.gnome.org/GNOME/network-manager-applet/-/merge_requests/84), which are scalable monochrome icons, but it's not clear to me how to use these symbolic icons in the Waybar tray module.

### Screenshot (2.0 scale factor)
![screenshot](https://user-images.githubusercontent.com/363815/127755904-b8a86014-4971-4754-a57d-3156c57287ee.png)
