### PR TITLE
Fix sway/language to handle xkb_layout command

### DIFF
--- a/include/modules/sway/language.hpp
+++ b/include/modules/sway/language.hpp
@@ -5,6 +5,7 @@
 
 #include <map>
 #include <string>
+#include <unordered_map>
 
 #include "ALabel.hpp"
 #include "bar.hpp"
@@ -30,28 +31,38 @@ class Language : public ALabel, public sigc::trackable {
   class XKBContext {
    public:
 	   XKBContext();
+	   XKBContext(const XKBContext&) = delete;
+	   XKBContext(XKBContext&&) = delete;
 	   ~XKBContext();
-	   auto next_layout() -> Layout*;
+	   bool first();
+	   bool next();
+	   std::string full_name();
+	   std::string short_name();
+	   std::string variant();
    private:
 	rxkb_context* context_ = nullptr;
 	rxkb_layout* xkb_layout_ = nullptr;
-	Layout* layout_ = nullptr;
+  };
+
+  struct Identifier {
+    std::string full_name;
+    unsigned event_count = 0U;
   };
 
   void onEvent(const struct Ipc::ipc_response&);
   void onCmd(const struct Ipc::ipc_response&);
 
-  auto set_current_layout(std::string current_layout) -> void;
-  auto init_layouts_map(const std::vector<std::string>& used_layouts) -> void;
+  auto init_layouts_map() -> void;
 
   const static std::string XKB_LAYOUT_NAMES_KEY;
   const static std::string XKB_ACTIVE_LAYOUT_NAME_KEY;
-  
+
   Layout                        layout_;
-  std::string tooltip_format_ = "";
+  std::string chosen_identifier_;
+  std::string tooltip_format_;
   std::map<std::string, Layout> layouts_map_;
+  std::unordered_map<std::string, Identifier> identifiers_map_;
   XKBContext xkb_context_;
-  bool is_variant_displayed;
 
   util::JsonParser         parser_;
   std::mutex               mutex_;


### PR DESCRIPTION
This change fixes a few issues:

- Fix to handle users changing layouts via "absolute" commands like:
    `swaymsg input type:keyboard xkb_layout es`
  which previously evaluated {long}, {short}, {variant} as empty.
  Only "relative" commands like:
    `swaymsg input type:keyboard xkb_switch_layout next`
  were handled.
  Previously, layout information was only stored internally if it was
  one of the available layouts on the device with the most such layouts.
  Even though memory was allocated (and leaked, see below) for every possible
  configurable layout, it wasn't stored internally in a way we could
  look up later. Now, all are stored internally for later lookup, and
  leaks plugged.

- Simplify how layouts are stored internally, and how events are handled.
  I admit I didn't understand the modifications to short_name to append
  an integer and the lookup by short name logic, but I have removed it.
  To simplify and reduce (but not eliminate) the incidence of the observed
  layout flickering when a stream of events are coming in,
  the following heuristic is applied:
  - initially, pick the "identifier" that has the most layouts, if any.
  - keep track of the `event_count`, i.e., how many times `full_name`
    has changed for each identifier.
  - when handling events, if the new `event_count` is greater than that
    of the previously chosen identifier, switch to the new identifier.

- Fix the above memory leaks of all Layout instances, one for every
  layout configured on the system.

- Fix potential data race due to lack of lock in `update()`.
  It is called from a different thread than `onCmd` and `onEvent`.
  Also take the lock in the constructor, to guarantee config occurs before IPC.

- Handle errors in parsing the default xkb ruleset config.
  The result is that we can't enumerate any layouts though.

- Remove unused layout_ member in XKBContext.