### PR TITLE
Fix tray icon scaling on multi-display setups

### DIFF
--- a/include/modules/sni/host.hpp
+++ b/include/modules/sni/host.hpp
@@ -5,13 +5,15 @@
 #include <glibmm/refptr.h>
 #include <json/json.h>
 #include <tuple>
+#include "bar.hpp"
 #include "modules/sni/item.hpp"
 
 namespace waybar::modules::SNI {
 
 class Host {
  public:
-  Host(const std::size_t id, const Json::Value&, const std::function<void(std::unique_ptr<Item>&)>&,
+  Host(const std::size_t id, const Json::Value&, const Bar&,
+       const std::function<void(std::unique_ptr<Item>&)>&,
        const std::function<void(std::unique_ptr<Item>&)>&);
   ~Host();
 
@@ -36,6 +38,7 @@ class Host {
   GCancellable*                                     cancellable_ = nullptr;
   SnWatcher*                                        watcher_ = nullptr;
   const Json::Value&                                config_;
+  const Bar&                                        bar_;
   const std::function<void(std::unique_ptr<Item>&)> on_add_;
   const std::function<void(std::unique_ptr<Item>&)> on_remove_;
 };

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -14,6 +14,8 @@
 #include <set>
 #include <string_view>
 
+#include "bar.hpp"
+
 namespace waybar::modules::SNI {
 
 struct ToolTip {
@@ -23,7 +25,7 @@ struct ToolTip {
 
 class Item : public sigc::trackable {
  public:
-  Item(const std::string&, const std::string&, const Json::Value&);
+  Item(const std::string&, const std::string&, const Json::Value&, const Bar&);
   ~Item() = default;
 
   std::string bus_name;
@@ -56,6 +58,7 @@ class Item : public sigc::trackable {
   bool item_is_menu = true;
 
  private:
+  void onConfigure(GdkEventConfigure* ev);
   void proxyReady(Glib::RefPtr<Gio::AsyncResult>& result);
   void setProperty(const Glib::ustring& name, Glib::VariantBase& value);
   void setStatus(const Glib::ustring& value);

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -4,7 +4,7 @@
 
 namespace waybar::modules::SNI {
 
-Host::Host(const std::size_t id, const Json::Value& config,
+Host::Host(const std::size_t id, const Json::Value& config, const Bar& bar,
            const std::function<void(std::unique_ptr<Item>&)>& on_add,
            const std::function<void(std::unique_ptr<Item>&)>& on_remove)
     : bus_name_("org.kde.StatusNotifierHost-" + std::to_string(getpid()) + "-" +
@@ -13,6 +13,7 @@ Host::Host(const std::size_t id, const Json::Value& config,
       bus_name_id_(Gio::DBus::own_name(Gio::DBus::BusType::BUS_TYPE_SESSION, bus_name_,
                                        sigc::mem_fun(*this, &Host::busAcquired))),
       config_(config),
+      bar_(bar),
       on_add_(on_add),
       on_remove_(on_remove) {}
 
@@ -136,7 +137,7 @@ void Host::addRegisteredItem(std::string service) {
     return bus_name == item->bus_name && object_path == item->object_path;
   });
   if (it == items_.end()) {
-    items_.emplace_back(new Item(bus_name, object_path, config_));
+    items_.emplace_back(new Item(bus_name, object_path, config_, bar_));
     on_add_(items_.back());
   }
 }

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -7,7 +7,7 @@ Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
     : AModule(config, "tray", id),
       box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0),
       watcher_(SNI::Watcher::getInstance()),
-      host_(nb_hosts_, config, std::bind(&Tray::onAdd, this, std::placeholders::_1),
+      host_(nb_hosts_, config, bar, std::bind(&Tray::onAdd, this, std::placeholders::_1),
             std::bind(&Tray::onRemove, this, std::placeholders::_1)) {
   spdlog::warn(
       "For a functional tray you must have libappindicator-* installed and export "


### PR DESCRIPTION
Fixes another trailing issue from https://github.com/Alexays/Waybar/issues/1175#issuecomment-890679048 where the incorrect tray icon size was sometimes used on multi-display setups. This issue seems to occur only on multi-display setups, and it seems to happen when tray items are added before the bar has been properly configured for both displays. This fix adds an event handler to the `signal_configure_event` in the tray `Item` class that calls `updateImage`, which results in the image being correctly resized when the bar's window configuration changes.

Before this change, I was able to repro the issue 1/3 of the time (out of 30 tries). Afterwards, I am unable to repro.