### PR TITLE
fix: Add number to shortDescripton

### DIFF
--- a/include/modules/sway/language.hpp
+++ b/include/modules/sway/language.hpp
@@ -21,6 +21,12 @@ class Language : public ALabel, public sigc::trackable {
   auto update() -> void;
 
  private:
+  enum class DispayedShortFlag {
+	  None = 0,
+	  ShortName = 1,
+	  ShortDescription = 1 << 1
+  };
+
   struct Layout {
     std::string full_name;
     std::string short_name;
@@ -53,6 +59,7 @@ class Language : public ALabel, public sigc::trackable {
   std::string tooltip_format_ = "";
   std::map<std::string, Layout> layouts_map_;
   bool is_variant_displayed;
+  std::byte displayed_short_flag = static_cast<std::byte>(DispayedShortFlag::None);
 
   util::JsonParser         parser_;
   std::mutex               mutex_;

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -20,6 +20,12 @@ const std::string Language::XKB_ACTIVE_LAYOUT_NAME_KEY = "xkb_active_layout_name
 Language::Language(const std::string& id, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true) {
   is_variant_displayed = format_.find("{variant}") != std::string::npos;
+	if (format_.find("{}") != std::string::npos || format_.find("{short}") != std::string::npos) {
+		displayed_short_flag |= static_cast<std::byte>(DispayedShortFlag::ShortName);
+	}
+	if (format_.find("{shortDescription}") != std::string::npos) {
+		displayed_short_flag |= static_cast<std::byte>(DispayedShortFlag::ShortDescription);
+	}
 	if (config.isMember("tooltip-format")) {
 		tooltip_format_ = config["tooltip-format"].asString();
 	}
@@ -155,9 +161,15 @@ auto Language::init_layouts_map(const std::vector<std::string>& used_layouts) ->
     if (short_name_to_number_map.count(used_layout->short_name) == 0) {
       short_name_to_number_map[used_layout->short_name] = 1;
     }
-
-    used_layout->short_name =
-        used_layout->short_name + std::to_string(short_name_to_number_map[used_layout->short_name]++);
+		
+		if (displayed_short_flag != static_cast<std::byte>(0)) {
+			int& number = short_name_to_number_map[used_layout->short_name];
+			used_layout->short_name =
+					used_layout->short_name + std::to_string(number);
+			used_layout->short_description =
+					used_layout->short_description + std::to_string(number);
+			++number;
+		}
   }
 }
 


### PR DESCRIPTION
Add number to the end of shortDescription if several variants for layouts and they aren't displayed.