### PR TITLE
Use g_memdup2 instead of g_memdup

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -287,7 +287,11 @@ Glib::RefPtr<Gdk::Pixbuf> Item::extractPixBuf(GVariant* variant) {
           if (array != nullptr) {
             g_free(array);
           }
+#if GLIB_MAJOR_VERSION >= 2 && GLIB_MINOR_VERSION >= 68
           array = static_cast<guchar*>(g_memdup2(data, size));
+#else
+          array = static_cast<guchar*>(g_memdup(data, size));
+#endif
           lwidth = width;
           lheight = height;
         }

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -287,7 +287,7 @@ Glib::RefPtr<Gdk::Pixbuf> Item::extractPixBuf(GVariant* variant) {
           if (array != nullptr) {
             g_free(array);
           }
-          array = static_cast<guchar*>(g_memdup(data, size));
+          array = static_cast<guchar*>(g_memdup2(data, size));
           lwidth = width;
           lheight = height;
         }


### PR DESCRIPTION
This fixes the following compiler warning:

```
[89/91] Compiling C++ object ....p/src_modules_sni_item.cpp.
../src/modules/sni/item.cpp: In member function ‘Glib::RefPtr<Gdk::Pixbuf> waybar::modules::SNI::Item::extractPixBuf(GVariant*)’:
../src/modules/sni/item.cpp:290:48: warning: ‘void* g_memdup(gconstpointer, guint)’ is deprecated: Use 'g_memdup2' instead [-Wdeprecated-declarations]
  290 |           array = static_cast<guchar*>(g_memdup(data, size));
      |                                        ~~~~~~~~^~~~~~~~~~~~
In file included from /usr/include/glib-2.0/glib.h:82,
                 from /usr/include/glib-2.0/gobject/gbinding.h:28,
                 from /usr/include/glib-2.0/glib-object.h:22,
                 from /usr/include/glib-2.0/gio/gioenums.h:2,
                 from /usr/include/glib-2.0/gio/giotypes.h:2,
                 from /usr/include/glib-2.0/gio/gio.h:26,
                 from protocol/dbus-status-notifier-item.h:1,
                 from ../include/modules/sni/item.hpp:3,
                 from ../src/modules/sni/item.cpp:1:
/usr/include/glib-2.0/glib/gstrfuncs.h:257:23: note: declared here
  257 | gpointer              g_memdup         (gconstpointer mem,
      |                       ^~~~~~~~
```

It seems that the code in `item.cpp` is indeed passing a `gsize` to `g_memdup` rather than the expected `guint`. The new function takes a `gsize` instead.

See: https://discourse.gnome.org/t/port-your-module-from-g-memdup-to-g-memdup2-now/5538