### PR TITLE
Add environment condition to systemd service file

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -4,6 +4,8 @@ Documentation=https://github.com/Alexays/Waybar/wiki/
 PartOf=graphical-session.target
 After=graphical-session.target
 Requisite=graphical-session.target
+# ConditionEnvironment requires systemd v247 to work correctly
+ConditionEnvironment=WAYLAND_DISPLAY
 
 [Service]
 ExecStart=@prefix@/bin/waybar


### PR DESCRIPTION
Sometimes the waybar service fails to start because the wayland environment is not fully setup. I would get errors such as:

```
Sep 06 21:21:40 ansan waybar[4847]: Unable to init server: Could not connect: Connection refused
Sep 06 21:21:40 ansan waybar[4847]: cannot open display:
Sep 06 21:21:40 ansan systemd[4753]: waybar.service: Main process exited, code=exited, status=1/FAILURE
```

With this `ConditionEnvironment` we make sure systemd waits until the `WAYLAND_DISPLAY` env variable becomes available.

See the equivalent in [mako](https://github.com/emersion/mako/blob/master/contrib/systemd/mako.service#L7) which works fine all the time.