### PR TITLE
Added support for {gwaddr} as a variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,8 @@ install: build
 run: build
 	./build/waybar
 
+debug-run: build
+	./build/waybar --log-level debug
+
 clean:
 	rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ install: build
 run: build
 	./build/waybar
 
-debug-run: build
+debug-run: build-debug
 	./build/waybar --log-level debug
 
 clean:

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -67,6 +67,7 @@ class Network : public ALabel {
   bool        carrier_;
   std::string ifname_;
   std::string ipaddr_;
+  std::string gwaddr_;
   std::string netmask_;
   int         cidr_;
   int32_t     signal_strength_dbm_;

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -131,6 +131,8 @@ Addressed by *network*
 
 *{ipaddr}*: The first IP of the interface.
 
+*{gwaddr}*: The default gateway for the interface
+
 *{netmask}*: The subnetmask corresponding to the IP.
 
 *{cidr}*: The subnetmask corresponding to the IP in CIDR notation.

--- a/resources/config
+++ b/resources/config
@@ -117,7 +117,8 @@
     "network": {
         // "interface": "wlp2*", // (Optional) To force the use of this interface
         "format-wifi": "{essid} ({signalStrength}%) ",
-        "format-ethernet": "{ifname}: {ipaddr}/{cidr} ",
+        "format-ethernet": "{ipaddr}/{cidr} ",
+        "tooltip-format": "{ifname} via {gwaddr} ",
         "format-linked": "{ifname} (No IP) ",
         "format-disconnected": "Disconnected ⚠",
         "format-alt": "{ifname}: {ipaddr}/{cidr}"

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -662,7 +662,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
         net->ifid_ = temp_idx;
         net->route_priority = priority;
         net->gwaddr_ = temp_gw_addr;
-        spdlog::debug("network: new default route via if{} metric {}", temp_idx, priority);
+        spdlog::debug("network: new default route via {} on if{} metric {}", temp_gw_addr, temp_idx, priority);
 
         /* Ask ifname associated with temp_idx as well as carrier status */
         struct ifinfomsg ifinfo_hdr = {

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -661,9 +661,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
         net->clearIface();
         net->ifid_ = temp_idx;
         net->route_priority = priority;
-	net->gwaddr_ = temp_gw_addr;
-	spdlog::debug("netwok: gateway {}", net->gwaddr_);
-
+        net->gwaddr_ = temp_gw_addr;
         spdlog::debug("network: new default route via if{} metric {}", temp_idx, priority);
 
         /* Ask ifname associated with temp_idx as well as carrier status */


### PR DESCRIPTION
I didn't find any way to include the gateway without altering the code. So I did. I greped all the files for `ipaddr`, hoping I catched all the conventions.

I also added a new makefile target (`debug-run`), just because I was annoyed it didn't exist already.

Having `"format-ethernet": "{ipaddr} / {cidr}", "tooltip-format": "{ifname} via {gwaddr}"` feels good and natural. Check the `resources/config` I modified.