### PR TITLE
Yet another swaybar ipc implementation

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Test in FreeBSD VM
       uses: vmactions/freebsd-vm@v0.1.5 # aka FreeBSD 13.0
       with:
+        mem: 2048
         usesh: true
         prepare: |
           export CPPFLAGS=-isystem/usr/local/include LDFLAGS=-L/usr/local/lib # sndio

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -8,6 +8,9 @@
 #include <gtkmm/window.h>
 #include <json/json.h>
 
+#include <memory>
+#include <vector>
+
 #include "AModule.hpp"
 #include "xdg-output-unstable-v1-client-protocol.h"
 
@@ -43,6 +46,12 @@ struct bar_mode {
   bool      visible;
 };
 
+#ifdef HAVE_SWAY
+namespace modules::sway {
+class BarIpcClient;
+}
+#endif  // HAVE_SWAY
+
 class BarSurface {
  protected:
   BarSurface() = default;
@@ -68,7 +77,7 @@ class Bar {
 
   Bar(struct waybar_output *w_output, const Json::Value &);
   Bar(const Bar &) = delete;
-  ~Bar() = default;
+  ~Bar();
 
   void setMode(const std::string_view &);
   void setVisible(bool visible);
@@ -81,6 +90,10 @@ class Bar {
   bool                  visible = true;
   bool                  vertical = false;
   Gtk::Window           window;
+
+#ifdef HAVE_SWAY
+  std::string bar_id;
+#endif
 
  private:
   void onMap(GdkEventAny *);
@@ -102,6 +115,10 @@ class Bar {
   std::vector<std::unique_ptr<waybar::AModule>> modules_left_;
   std::vector<std::unique_ptr<waybar::AModule>> modules_center_;
   std::vector<std::unique_ptr<waybar::AModule>> modules_right_;
+#ifdef HAVE_SWAY
+  using BarIpcClient = modules::sway::BarIpcClient;
+  std::unique_ptr<BarIpcClient> _ipc_client;
+#endif
 };
 
 }  // namespace waybar

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -78,7 +78,6 @@ class Bar {
   struct waybar_output *output;
   Json::Value           config;
   struct wl_surface    *surface;
-  bool                  exclusive = true;
   bool                  visible = true;
   bool                  vertical = false;
   Gtk::Window           window;
@@ -96,7 +95,6 @@ class Bar {
   std::string  last_mode_{MODE_DEFAULT};
 
   std::unique_ptr<BarSurface>                   surface_impl_;
-  bar_layer                                     layer_;
   Gtk::Box                                      left_;
   Gtk::Box                                      center_;
   Gtk::Box                                      right_;

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -36,6 +36,13 @@ struct bar_margins {
   int left = 0;
 };
 
+struct bar_mode {
+  bar_layer layer;
+  bool      exclusive;
+  bool      passthrough;
+  bool      visible;
+};
+
 class BarSurface {
  protected:
   BarSurface() = default;
@@ -54,18 +61,23 @@ class BarSurface {
 
 class Bar {
  public:
+  using bar_mode_map = std::map<std::string_view, struct bar_mode>;
+  static const bar_mode_map     PRESET_MODES;
+  static const std::string_view MODE_DEFAULT;
+  static const std::string_view MODE_INVISIBLE;
+
   Bar(struct waybar_output *w_output, const Json::Value &);
   Bar(const Bar &) = delete;
   ~Bar() = default;
 
-  void setMode(const std::string &);
+  void setMode(const std::string_view &);
   void setVisible(bool visible);
   void toggle();
   void handleSignal(int);
 
   struct waybar_output *output;
   Json::Value           config;
-  struct wl_surface *   surface;
+  struct wl_surface    *surface;
   bool                  exclusive = true;
   bool                  visible = true;
   bool                  vertical = false;
@@ -77,6 +89,11 @@ class Bar {
   void getModules(const Factory &, const std::string &);
   void setupAltFormatKeyForModule(const std::string &module_name);
   void setupAltFormatKeyForModuleList(const char *module_list_name);
+  void setMode(const bar_mode &);
+
+  /* Copy initial set of modes to allow customization */
+  bar_mode_map configured_modes = PRESET_MODES;
+  std::string  last_mode_{MODE_DEFAULT};
 
   std::unique_ptr<BarSurface>                   surface_impl_;
   bar_layer                                     layer_;

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -58,6 +58,7 @@ class Bar {
   Bar(const Bar &) = delete;
   ~Bar() = default;
 
+  void setMode(const std::string &);
   void setVisible(bool visible);
   void toggle();
   void handleSignal(int);

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -29,6 +29,7 @@ class Client {
   struct zwp_idle_inhibit_manager_v1 *idle_inhibit_manager = nullptr;
   std::vector<std::unique_ptr<Bar>>   bars;
   Config                              config;
+  std::string                         bar_id;
 
  private:
   Client() = default;

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -18,7 +18,6 @@ struct swaybar_config {
   std::string id;
   std::string mode;
   std::string hidden_state;
-  std::string position;
 };
 
 /**

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <string>
+
+#include "modules/sway/ipc/client.hpp"
+#include "util/SafeSignal.hpp"
+#include "util/json.hpp"
+
+namespace waybar {
+
+class Bar;
+
+namespace modules::sway {
+
+/*
+ * Supported subset of i3/sway IPC barconfig object
+ */
+struct swaybar_config {
+  std::string id;
+  std::string mode;
+  std::string hidden_state;
+  std::string position;
+};
+
+/**
+ * swaybar IPC client
+ */
+class BarIpcClient {
+ public:
+  BarIpcClient(waybar::Bar& bar);
+
+ private:
+  void onInitialConfig(const struct Ipc::ipc_response& res);
+  void onIpcEvent(const struct Ipc::ipc_response&);
+  void onConfigUpdate(const swaybar_config& config);
+  void onVisibilityUpdate(bool visible_by_modifier);
+
+  Bar&             bar_;
+  util::JsonParser parser_;
+  Ipc              ipc_;
+
+  swaybar_config bar_config_;
+
+  SafeSignal<bool>           signal_visible_;
+  SafeSignal<swaybar_config> signal_config_;
+};
+
+}  // namespace modules::sway
+}  // namespace waybar

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -33,12 +33,14 @@ class BarIpcClient {
   void onIpcEvent(const struct Ipc::ipc_response&);
   void onConfigUpdate(const swaybar_config& config);
   void onVisibilityUpdate(bool visible_by_modifier);
+  void update();
 
   Bar&             bar_;
   util::JsonParser parser_;
   Ipc              ipc_;
 
   swaybar_config bar_config_;
+  bool           visible_by_modifier_ = false;
 
   SafeSignal<bool>           signal_visible_;
   SafeSignal<swaybar_config> signal_config_;

--- a/include/util/SafeSignal.hpp
+++ b/include/util/SafeSignal.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <glibmm/dispatcher.h>
+#include <sigc++/signal.h>
+
+#include <functional>
+#include <mutex>
+#include <queue>
+#include <tuple>
+#include <type_traits>
+
+namespace waybar {
+
+/**
+ * Thread-safe signal wrapper.
+ * Uses Glib::Dispatcher to pass events to another thread and locked queue to pass the arguments.
+ */
+template <typename... Args>
+struct SafeSignal : sigc::signal<void(std::decay_t<Args>...)> {
+ public:
+  SafeSignal() { dp_.connect(sigc::mem_fun(*this, &SafeSignal::handle_event)); }
+
+  template <typename... EmitArgs>
+  void emit(EmitArgs&&... args) {
+    {
+      std::unique_lock lock(mutex_);
+      queue_.emplace(std::forward<EmitArgs>(args)...);
+    }
+    dp_.emit();
+  }
+
+  template <typename... EmitArgs>
+  inline void operator()(EmitArgs&&... args) {
+    emit(std::forward<EmitArgs>(args)...);
+  }
+
+ protected:
+  using signal_t = sigc::signal<void(std::decay_t<Args>...)>;
+  using arg_tuple_t = std::tuple<std::decay_t<Args>...>;
+  // ensure that unwrapped methods are not accessible
+  using signal_t::emit_reverse;
+  using signal_t::make_slot;
+
+  void handle_event() {
+    auto fn = signal_t::make_slot();
+    for (std::unique_lock lock(mutex_); !queue_.empty(); lock.lock()) {
+      auto args = queue_.front();
+      queue_.pop();
+      lock.unlock();
+      std::apply(fn, args);
+    }
+  }
+
+  Glib::Dispatcher        dp_;
+  std::mutex              mutex_;
+  std::queue<arg_tuple_t> queue_;
+};
+
+}  // namespace waybar

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -79,12 +79,12 @@ Also a minimal example configuration can be found on the at the bottom of this m
 
 *exclusive* ++
 	typeof: bool ++
-	default: *true* unless the layer is set to *overlay* ++
+	default: *true* ++
 	Option to request an exclusive zone from the compositor. Disable this to allow drawing application windows underneath or on top of the bar.
 
 *passthrough* ++
 	typeof: bool ++
-	default: *false* unless the layer is set to *overlay* ++
+	default: *false* ++
 	Option to pass any pointer events to the window under the bar.
 	Intended to be used with either *top* or *overlay* layers and without exclusive zone.
 

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -94,6 +94,16 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	Option to disable the use of gtk-layer-shell for popups.
 	Only functional if compiled with gtk-layer-shell support.
 
+*ipc* ++
+	typeof: bool ++
+	default: false ++
+	Option to subscribe to the Sway IPC bar configuration and visibility events and control waybar with *swaymsg bar* commands. ++
+	Requires *bar_id* value from sway configuration to be either passed with the *-b* commandline argument or specified with the *id* option.
+
+*id* ++
+	typeof: string ++
+	*bar_id* for the Sway IPC. Use this if you need to override the value passed with the *-b bar_id* commandline argument for the specific bar instance.
+
 *include* ++
 	typeof: string|array ++
 	Paths to additional configuration files.

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -72,6 +72,11 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	typeof: string ++
 	Optional name added as a CSS class, for styling multiple waybars.
 
+*mode* ++
+	typeof: string ++
+	Selects one of the preconfigured display modes. This is an equivalent of the sway-bar(5) *mode* command and supports the same values: *dock*, *hide*, *invisible*, *overlay*. ++
+	Note: *hide* and *invisible* modes may be not as useful without Sway IPC.
+
 *exclusive* ++
 	typeof: bool ++
 	default: *true* unless the layer is set to *overlay* ++

--- a/meson.build
+++ b/meson.build
@@ -177,6 +177,7 @@ endif
 add_project_arguments('-DHAVE_SWAY', language: 'cpp')
 src_files += [
     'src/modules/sway/ipc/client.cpp',
+    'src/modules/sway/bar.cpp',
     'src/modules/sway/mode.cpp',
     'src/modules/sway/language.cpp',
     'src/modules/sway/window.cpp',

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -562,13 +562,21 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
 }
 
 void waybar::Bar::setMode(const std::string_view& mode) {
+  using namespace std::literals::string_literals;
+
+  auto style = window.get_style_context();
+  /* remove styles added by previous setMode calls */
+  style->remove_class("mode-"s + last_mode_);
+
   auto it = configured_modes.find(mode);
   if (it != configured_modes.end()) {
     last_mode_ = mode;
+    style->add_class("mode-"s + last_mode_);
     setMode(it->second);
   } else {
     spdlog::warn("Unknown mode \"{}\" requested", mode);
     last_mode_ = MODE_DEFAULT;
+    style->add_class("mode-"s + last_mode_);
     setMode(configured_modes.at(MODE_DEFAULT));
   }
 }

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -61,6 +61,7 @@ const Bar::bar_mode_map Bar::PRESET_MODES = {  //
 
 const std::string_view Bar::MODE_DEFAULT = "default";
 const std::string_view Bar::MODE_INVISIBLE = "invisible";
+const std::string_view DEFAULT_BAR_ID = "bar-0";
 
 #ifdef HAVE_GTK_LAYER_SHELL
 struct GLSSurfaceImpl : public BarSurface, public sigc::trackable {
@@ -556,7 +557,14 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     if (auto id = config["id"]; id.isString()) {
       bar_id = id.asString();
     }
-    _ipc_client = std::make_unique<BarIpcClient>(*this);
+    if (bar_id.empty()) {
+      bar_id = DEFAULT_BAR_ID;
+    }
+    try {
+      _ipc_client = std::make_unique<BarIpcClient>(*this);
+    } catch (const std::exception& exc) {
+      spdlog::warn("Failed to open bar ipc connection: {}", exc.what());
+    }
   }
 #endif
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -199,7 +199,6 @@ int waybar::Client::main(int argc, char *argv[]) {
   bool        show_version = false;
   std::string config_opt;
   std::string style_opt;
-  std::string bar_id;
   std::string log_level;
   auto        cli = clara::detail::Help(show_help) |
              clara::detail::Opt(show_version)["-v"]["--version"]("Show version") |

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -1,0 +1,92 @@
+#include "modules/sway/bar.hpp"
+
+#include <fmt/ostream.h>
+#include <spdlog/spdlog.h>
+
+#include "bar.hpp"
+#include "modules/sway/ipc/ipc.hpp"
+
+namespace waybar::modules::sway {
+
+BarIpcClient::BarIpcClient(waybar::Bar& bar) : bar_{bar} {
+  {
+    sigc::connection handle =
+        ipc_.signal_cmd.connect(sigc::mem_fun(*this, &BarIpcClient::onInitialConfig));
+    ipc_.sendCmd(IPC_GET_BAR_CONFIG, bar_.bar_id);
+
+    handle.disconnect();
+  }
+
+  signal_config_.connect(sigc::mem_fun(*this, &BarIpcClient::onConfigUpdate));
+  signal_visible_.connect(sigc::mem_fun(*this, &BarIpcClient::onVisibilityUpdate));
+
+  ipc_.subscribe(R"(["bar_state_update", "barconfig_update"])");
+  ipc_.signal_event.connect(sigc::mem_fun(*this, &BarIpcClient::onIpcEvent));
+  // Launch worker
+  ipc_.setWorker([this] {
+    try {
+      ipc_.handleEvent();
+    } catch (const std::exception& e) {
+      spdlog::error("BarIpcClient::handleEvent {}", e.what());
+    }
+  });
+}
+
+struct swaybar_config parseConfig(const Json::Value& payload) {
+  swaybar_config conf;
+  if (auto id = payload["id"]; id.isString()) {
+    conf.id = id.asString();
+  }
+  if (auto mode = payload["mode"]; mode.isString()) {
+    conf.mode = mode.asString();
+  }
+  if (auto hs = payload["hidden_state"]; hs.isString()) {
+    conf.hidden_state = hs.asString();
+  }
+  if (auto position = payload["position"]; position.isString()) {
+    conf.position = position.asString();
+  }
+  return conf;
+}
+
+void BarIpcClient::onInitialConfig(const struct Ipc::ipc_response& res) {
+  try {
+    auto payload = parser_.parse(res.payload);
+    auto config = parseConfig(payload);
+    onConfigUpdate(config);
+  } catch (const std::exception& e) {
+    spdlog::error("BarIpcClient::onInitialConfig {}", e.what());
+  }
+}
+
+void BarIpcClient::onIpcEvent(const struct Ipc::ipc_response& res) {
+  try {
+    auto payload = parser_.parse(res.payload);
+    if (auto id = payload["id"]; id.isString() && id.asString() != bar_.bar_id) {
+      spdlog::trace("swaybar ipc: ignore event for {}", id.asString());
+      return;
+    }
+    if (payload.isMember("visible_by_modifier")) {
+      // visibility change for hidden bar
+      signal_visible_(payload["visible_by_modifier"].asBool());
+    } else {
+      // configuration update
+      auto config = parseConfig(payload);
+      signal_config_(config);
+    }
+  } catch (const std::exception& e) {
+    spdlog::error("BarIpcClient::onEvent {}", e.what());
+  }
+}
+
+void BarIpcClient::onConfigUpdate(const swaybar_config& config) {
+  spdlog::info("config update: {} {} {}", config.id, config.mode, config.position);
+  // TODO: pass config to bars
+}
+
+void BarIpcClient::onVisibilityUpdate(bool visible_by_modifier) {
+  spdlog::trace("visiblity update: {}", visible_by_modifier);
+  // TODO: pass visibility to bars
+}
+
+}  // namespace waybar::modules::sway

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -71,7 +71,7 @@ void BarIpcClient::onIpcEvent(const struct Ipc::ipc_response& res) {
     } else {
       // configuration update
       auto config = parseConfig(payload);
-      signal_config_(config);
+      signal_config_(std::move(config));
     }
   } catch (const std::exception& e) {
     spdlog::error("BarIpcClient::onEvent {}", e.what());

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -82,12 +82,23 @@ void BarIpcClient::onIpcEvent(const struct Ipc::ipc_response& res) {
 void BarIpcClient::onConfigUpdate(const swaybar_config& config) {
   spdlog::info("config update: {} {} {}", config.id, config.mode, config.position);
   bar_config_ = config;
-  bar_.setMode(bar_config_.mode);
+  update();
 }
 
 void BarIpcClient::onVisibilityUpdate(bool visible_by_modifier) {
   spdlog::trace("visiblity update: {}", visible_by_modifier);
-  // TODO: pass visibility to bars
+  visible_by_modifier_ = visible_by_modifier;
+  update();
+}
+
+void BarIpcClient::update() {
+  bool visible = visible_by_modifier_;
+  if (bar_config_.mode == "invisible") {
+    visible = false;
+  } else if (bar_config_.mode != "hide" || bar_config_.hidden_state != "hide") {
+    visible = true;
+  }
+  bar_.setMode(visible ? bar_config_.mode : Bar::MODE_INVISIBLE);
 }
 
 }  // namespace waybar::modules::sway

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -43,9 +43,6 @@ struct swaybar_config parseConfig(const Json::Value& payload) {
   if (auto hs = payload["hidden_state"]; hs.isString()) {
     conf.hidden_state = hs.asString();
   }
-  if (auto position = payload["position"]; position.isString()) {
-    conf.position = position.asString();
-  }
   return conf;
 }
 
@@ -80,13 +77,17 @@ void BarIpcClient::onIpcEvent(const struct Ipc::ipc_response& res) {
 }
 
 void BarIpcClient::onConfigUpdate(const swaybar_config& config) {
-  spdlog::info("config update: {} {} {}", config.id, config.mode, config.position);
+  spdlog::info("config update for {}: id {}, mode {}, hidden_state {}",
+               bar_.bar_id,
+               config.id,
+               config.mode,
+               config.hidden_state);
   bar_config_ = config;
   update();
 }
 
 void BarIpcClient::onVisibilityUpdate(bool visible_by_modifier) {
-  spdlog::trace("visiblity update: {}", visible_by_modifier);
+  spdlog::debug("visiblity update for {}: {}", bar_.bar_id, visible_by_modifier);
   visible_by_modifier_ = visible_by_modifier;
   update();
 }

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -81,7 +81,8 @@ void BarIpcClient::onIpcEvent(const struct Ipc::ipc_response& res) {
 
 void BarIpcClient::onConfigUpdate(const swaybar_config& config) {
   spdlog::info("config update: {} {} {}", config.id, config.mode, config.position);
-  // TODO: pass config to bars
+  bar_config_ = config;
+  bar_.setMode(bar_config_.mode);
 }
 
 void BarIpcClient::onVisibilityUpdate(bool visible_by_modifier) {

--- a/test/GlibTestsFixture.hpp
+++ b/test/GlibTestsFixture.hpp
@@ -7,6 +7,11 @@ class GlibTestsFixture : public sigc::trackable {
  public:
   GlibTestsFixture() : main_loop_{Glib::MainLoop::create()} {}
 
+  void setTimeout(int timeout) {
+    Glib::signal_timeout().connect_once([]() { throw std::runtime_error("Test timed out"); },
+                                        timeout);
+  }
+
   void run(std::function<void()> fn) {
     Glib::signal_idle().connect_once(fn);
     main_loop_->run();

--- a/test/GlibTestsFixture.hpp
+++ b/test/GlibTestsFixture.hpp
@@ -1,0 +1,19 @@
+#pragma once
+#include <glibmm/main.h>
+/**
+ * Minimal Glib application to be used for tests that require Glib main loop
+ */
+class GlibTestsFixture : public sigc::trackable {
+ public:
+  GlibTestsFixture() : main_loop_{Glib::MainLoop::create()} {}
+
+  void run(std::function<void()> fn) {
+    Glib::signal_idle().connect_once(fn);
+    main_loop_->run();
+  }
+
+  void quit() { main_loop_->quit(); }
+
+ protected:
+  Glib::RefPtr<Glib::MainLoop> main_loop_;
+};

--- a/test/SafeSignal.cpp
+++ b/test/SafeSignal.cpp
@@ -1,0 +1,63 @@
+#define CATCH_CONFIG_RUNNER
+#include "util/SafeSignal.hpp"
+
+#include <glibmm.h>
+
+#include <catch2/catch.hpp>
+#include <thread>
+
+#include "GlibTestsFixture.hpp"
+
+using namespace waybar;
+/**
+ * Basic sanity test for SafeSignal:
+ * check that type deduction works, events are delivered and the order is right
+ * Running this with -fsanitize=thread should not fail
+ */
+TEST_CASE_METHOD(GlibTestsFixture, "SafeSignal basic functionality", "[signal][thread][util]") {
+  const int NUM_EVENTS = 100;
+  int       count = 0;
+  int       last_value = 0;
+
+  SafeSignal<int, std::string> test_signal;
+
+  const auto  main_tid = std::this_thread::get_id();
+  std::thread producer;
+
+  // timeout the test in 500ms
+  Glib::signal_timeout().connect_once([]() { throw std::runtime_error("Test timed out"); }, 500);
+
+  test_signal.connect([&](auto val, auto str) {
+    static_assert(std::is_same<int, decltype(val)>::value);
+    static_assert(std::is_same<std::string, decltype(str)>::value);
+    // check that we're in the same thread as the main loop
+    REQUIRE(std::this_thread::get_id() == main_tid);
+    // check event order
+    REQUIRE(val == last_value + 1);
+
+    last_value = val;
+    if (++count >= NUM_EVENTS) {
+      this->quit();
+    };
+  });
+
+  run([&]() {
+    // check that events from the same thread are delivered and processed synchronously
+    test_signal.emit(1, "test");
+    REQUIRE(count == 1);
+
+    // start another thread and generate events
+    producer = std::thread([&]() {
+      for (auto i = 2; i <= NUM_EVENTS; ++i) {
+        test_signal.emit(i, "test");
+      }
+    });
+  });
+  producer.join();
+  REQUIRE(count == NUM_EVENTS);
+}
+
+int main(int argc, char* argv[]) {
+  Glib::init();
+  return Catch::Session().run(argc, argv);
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,6 +2,7 @@ test_inc = include_directories('../include')
 test_dep = [
     catch2,
     fmt,
+    gtkmm,
     jsoncpp,
     spdlog,
 ]
@@ -14,8 +15,21 @@ config_test = executable(
     include_directories: test_inc,
 )
 
+safesignal_test = executable(
+    'safesignal_test',
+    'SafeSignal.cpp',
+    dependencies: test_dep,
+    include_directories: test_inc,
+)
+
 test(
     'Configuration test',
     config_test,
+    workdir: meson.source_root(),
+)
+
+test(
+    'SafeSignal test',
+    safesignal_test,
     workdir: meson.source_root(),
 )


### PR DESCRIPTION
This feature makes waybar a client for the Sway bar IPC protocol and allows controlling some aspects of the bar behavior with  `swaymsg`

Documentation: [i3 bar display modes](https://i3wm.org/docs/userguide.html#_display_mode), [`sway-bar(5)`](https://github.com/swaywm/sway/blob/master/sway/sway-bar.5.scd)

## Quickstart
#### Prerequisites:
* Sway
* Single bar configuration block (i.e. `$XDG_CONFIG_HOME/config/waybar` is a JSON object)
* The bar is started from the sway config with `swaybar_command waybar`

#### Configuration
1.  Add `"ipc": true` to the waybar configuration
1. Set the desired `mode`, `hidden_state` and `modifier` in **the same** bar configuration block as `swaybar_command`   
    *  Sway will assign the default identifier `bar-0` to the only bar instance and run waybar as `/usr/bin/waybar -b bar-0`
    *  Waybar will read one bar configuration; create a bar; connect to the sway IPC with the bar id `bar-0` provided via commandline argument and get the initial configuration
    *  Only after that waybar will create a window with the mode specified in the sway config.
1. Control the bar mode/visibility with `swaymsg bar mode <mode> bar-0`, `swaymsg bar hidden_state <show|hide> bar-0` (note the trailing `bar_id` syntax)

## Multiple bars

Your `$XDG_CONFIG_HOME/config/waybar` is a JSON array with multiple bars defined.
* If you don't want a particular bar instance to be controlled via IPC, simply don't add the `ipc` option to the corresponding config block. It will default to disabled.
* If you want the bar instance to be controlled with the `id` from sway config (the one specified in the `bar` config block with `swaybar_command waybar`) - add only `"ipc": true`. Sway will pass the bar_id and the bar instance will use that value.
* If you want the bar instance to be controlled with a separate bar `id` (i.e. you have two bar configuration blocks in the sway config), set the `id` in the waybar config for the corresponding bar instance (`"id": "bar-1"`) and then use this identifier for the `swaymsg` command invocation: `swaymsg bar mode hide bar-1`

### Example configuration:
<details>
<summary>$XDG_CONFIG_HOME/sway/config</summary>

```
bar  {
        # will asssign id 'bar-0' by default
	swaybar_command /path/to/waybar
	mode dock
	position top
}

# the id can be set with `bar <id> { ... }` or with the `bar { id <id>; ... }`
# if you don't specify the id explicitly, sway will assign `bar-1`
bar bar-1 {
        # placeholder command, so that sway could create the configuration but won't run an actual second bar instance
	swaybar_command /bin/true
	mode hide
	position bottom
}
```
</details>

<details>
<summary>$XDG_CONFIG_HOME/waybar/config</summary>

```
[
{ // bar id is passed via `-b bar-0` commandline argument from sway
  // will react only to the events for "bar-0" or for any bar
	"ipc": true,
	"position": "top",
	...
},
{ // bar id is explicitly set to "bar-1"
  // will react only to the events for "bar-1" or for any bar
	"id": "bar-1",
	"ipc": true,
	"position": "bottom",
	...
}
]
```
</details>

The `bar_id` parameter is required for IPC subscription.

Test commands (note the trailing `bar_id` syntax. `bar <bar-id> mode ...` is broken in sway and will modify config for **all** the defined bars - https://github.com/swaywm/sway/pull/6680):
```sh
swaymsg bar mode dock bar-1
swaymsg bar mode hide bar-1
swaymsg bar hidden_state show bar-1
swaymsg bar hidden_state hide bar-1
swaymsg bar mode overlay bar-0
...
```

## Non-blocking issues:

 * [x] Defaults for `bar_id` - do we want to assume `bar-0` or to take the first entry from `get_bar_config` result if it's not set explicitly?
       `bar-0` is assumed if no other value is passed. The swaybar IPC client will try to get the initial configuration for the bar_id and disable itself if the sway config does not have the bar with that id.
 * [x] `setVisible` should be controlled either via signals or via IPC. Allowing both at the same time makes things messy and inconsistent.
       `setVisible` was changed to switch between `invisible` and `default` modes. That addressed most of the problems, the only remaining is to remember the last visible mode and use it instead of the `default`.
 * [x] Copy/move optimizations for SafeSignal
 * [ ] D-Bus method for changing mode or visibility when sway IPC is not available (but definitely not in this PR)
 * [x] Support for custom modes/mode configuration overrides; <details><summary>example:</summary>

   ```
   "modes": {
     "dock": {
       "layer": "top"
     },
     // show overlay bar over fullscreen applications
     "overlay": {
       "layer": "overlay"
     },
     // hide bar under the current window instead of making it invisible
     "invisible": {
       "passthrough": false,
       "visible": true
     } 
   }
   ```
   </details>