### PR TITLE
Add cpu usage for every core

### DIFF
--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -19,11 +19,11 @@ class Cpu : public ALabel {
   auto update() -> void;
 
  private:
-  double                                  getCpuLoad();
-  std::tuple<uint16_t, std::string>       getCpuUsage();
-  std::tuple<float, float, float>         getCpuFrequency();
-  std::vector<std::tuple<size_t, size_t>> parseCpuinfo();
-  std::vector<float>                      parseCpuFrequencies();
+  double                                         getCpuLoad();
+  std::tuple<std::vector<uint16_t>, std::string> getCpuUsage();
+  std::tuple<float, float, float>                getCpuFrequency();
+  std::vector<std::tuple<size_t, size_t>>        parseCpuinfo();
+  std::vector<float>                             parseCpuFrequencies();
 
   std::vector<std::tuple<size_t, size_t>> prev_times_;
 

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -82,7 +82,9 @@ The *cpu* module displays the current cpu utilization.
 
 *{load}*: Current cpu load.
 
-*{usage}*: Current cpu usage.
+*{usage}*: Current overall cpu usage.
+
+*{usage*{n}*}*: Current cpu core n usage. Cores are numbered from zero, so first core will be {usage0} and 4th will be {usage3}.
 
 *{avg_frequency}*: Current cpu average frequency (based on all cores) in GHz.
 
@@ -90,7 +92,13 @@ The *cpu* module displays the current cpu utilization.
 
 *{min_frequency}*: Current cpu min frequency (based on the core with the lowest frequency) in GHz.
 
-# EXAMPLE
+*{icon}*: Icon for overall cpu usage.
+
+*{icon*{n}*}*: Icon for cpu core n usage. Use like {icon0}.
+
+# EXAMPLES
+
+Basic configuration:
 
 ```
 "cpu": {
@@ -98,6 +106,16 @@ The *cpu* module displays the current cpu utilization.
 	"format": "{}% ",
 	"max-length": 10
 }
+```
+
+Cpu usage per core rendered as icons:
+
+```
+"cpu": {
+	"interval": 1,
+	"format": "{icon0}{icon1}{icon2}{icon3} {usage:>2}% ",
+	"format-icons": ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"],
+},
 ```
 
 # STYLE

--- a/src/modules/cpu/common.cpp
+++ b/src/modules/cpu/common.cpp
@@ -1,5 +1,14 @@
 #include "modules/cpu.hpp"
 
+// In the 80000 version of fmt library authors decided to optimize imports
+// and moved declarations required for fmt::dynamic_format_arg_store in new
+// header fmt/args.h
+#if (FMT_VERSION >= 80000)
+#include <fmt/args.h>
+#else
+#include <fmt/core.h>
+#endif
+
 waybar::modules::Cpu::Cpu(const std::string& id, const Json::Value& config)
     : ALabel(config, "cpu", id, "{usage}%", 10) {
   thread_ = [this] {
@@ -17,7 +26,8 @@ auto waybar::modules::Cpu::update() -> void {
     label_.set_tooltip_text(tooltip);
   }
   auto format = format_;
-  auto state = getState(cpu_usage);
+  auto total_usage = cpu_usage.empty() ? 0 : cpu_usage[0];
+  auto state = getState(total_usage);
   if (!state.empty() && config_["format-" + state].isString()) {
     format = config_["format-" + state].asString();
   }
@@ -27,13 +37,22 @@ auto waybar::modules::Cpu::update() -> void {
   } else {
     event_box_.show();
     auto icons = std::vector<std::string>{state};
-    label_.set_markup(fmt::format(format,
-                                  fmt::arg("load", cpu_load),
-                                  fmt::arg("usage", cpu_usage),
-                                  fmt::arg("icon", getIcon(cpu_usage, icons)),
-                                  fmt::arg("max_frequency", max_frequency),
-                                  fmt::arg("min_frequency", min_frequency),
-                                  fmt::arg("avg_frequency", avg_frequency)));
+    fmt::dynamic_format_arg_store<fmt::format_context> store;
+    store.push_back(fmt::arg("load", cpu_load));
+    store.push_back(fmt::arg("load", cpu_load));
+    store.push_back(fmt::arg("usage", total_usage));
+    store.push_back(fmt::arg("icon", getIcon(total_usage, icons)));
+    store.push_back(fmt::arg("max_frequency", max_frequency));
+    store.push_back(fmt::arg("min_frequency", min_frequency));
+    store.push_back(fmt::arg("avg_frequency", avg_frequency));
+    for (size_t i = 1; i < cpu_usage.size(); ++i) {
+	    auto core_i = i - 1;
+	    auto core_format = fmt::format("usage{}", core_i);
+	    store.push_back(fmt::arg(core_format.c_str(), cpu_usage[i]));
+	    auto icon_format = fmt::format("icon{}", core_i);
+	    store.push_back(fmt::arg(icon_format.c_str(), getIcon(cpu_usage[i], icons)));
+    }
+    label_.set_markup(fmt::vformat(format, store));
   }
 
   // Call parent update
@@ -48,14 +67,14 @@ double waybar::modules::Cpu::getCpuLoad() {
   throw std::runtime_error("Can't get Cpu load");
 }
 
-std::tuple<uint16_t, std::string> waybar::modules::Cpu::getCpuUsage() {
+std::tuple<std::vector<uint16_t>, std::string> waybar::modules::Cpu::getCpuUsage() {
   if (prev_times_.empty()) {
     prev_times_ = parseCpuinfo();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
   }
   std::vector<std::tuple<size_t, size_t>> curr_times = parseCpuinfo();
   std::string                             tooltip;
-  uint16_t                                usage = 0;
+  std::vector<uint16_t>                   usage;
   for (size_t i = 0; i < curr_times.size(); ++i) {
     auto [curr_idle, curr_total] = curr_times[i];
     auto [prev_idle, prev_total] = prev_times_[i];
@@ -63,11 +82,11 @@ std::tuple<uint16_t, std::string> waybar::modules::Cpu::getCpuUsage() {
     const float delta_total = curr_total - prev_total;
     uint16_t    tmp = 100 * (1 - delta_idle / delta_total);
     if (i == 0) {
-      usage = tmp;
       tooltip = fmt::format("Total: {}%", tmp);
     } else {
       tooltip = tooltip + fmt::format("\nCore{}: {}%", i - 1, tmp);
     }
+    usage.push_back(tmp);
   }
   prev_times_ = curr_times;
   return {usage, tooltip};


### PR DESCRIPTION
This is a second attempt to merge #1250. I have added conditional check on fmt version as was suggested by @alebastr.

I checked their commit history and found that separation of headers was made about time when 7.1.3 was released, but this change was actually introduced only in 8.0.0. Seems to be correct.

Also I moved header inclusion in cpp file, because this compliant with google-style mention in the README. 

