### PR TITLE
fix(tray): fix visibility of Passive items

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -62,6 +62,7 @@ Item::Item(const std::string& bn, const std::string& op, const Json::Value& conf
   event_box.signal_button_press_event().connect(sigc::mem_fun(*this, &Item::handleClick));
   event_box.signal_scroll_event().connect(sigc::mem_fun(*this, &Item::handleScroll));
   // initial visibility
+  event_box.show_all();
   event_box.set_visible(show_passive_);
 
   cancellable_ = Gio::Cancellable::create();

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -35,11 +35,8 @@ void Tray::onRemove(std::unique_ptr<Item>& item) {
 }
 
 auto Tray::update() -> void {
-  if (box_.get_children().empty()) {
-    box_.hide();
-  } else {
-    box_.show_all();
-  }
+  // Show tray only when items are availale
+  box_.set_visible(!box_.get_children().empty());
   // Call parent update
   AModule::update();
 }


### PR DESCRIPTION
`show_all` call from `Tray::update` attempts to walk the widget tree and
make every widget visible. Since we control individual tray item
visibility based on a `Status` SNI property, we don't want that to happen.

Modify `Tray::update` to control the visibility of a whole tray module
only and ensure that the children of `Item` are still visible when
necessary.

***
Fixes the issue described in https://github.com/Alexays/Waybar/pull/1145#issuecomment-922361054.
The code didn't change since the initial fix, I just was too ~~lazy~~busy to format the commit message and send the PR :smiley: 