### PR TITLE
Fix Clock crash on empty string in timezones field

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -37,6 +37,7 @@ class Clock : public ALabel {
   auto calendar_text(const waybar_time& wtime) -> std::string;
   auto weekdays_header(const date::weekday& first_dow, std::ostream& os) -> void;
   auto first_day_of_week() -> date::weekday;
+  bool setTimeZone(Json::Value zone_name);
 };
 
 }  // namespace waybar::modules

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -24,7 +24,8 @@ The *clock* module displays the current date and time.
 *timezone*: ++
 	typeof: string ++
 	default: inferred local timezone ++
-	The timezone to display the time in, e.g. America/New_York.
+	The timezone to display the time in, e.g. America/New_York. ++
+	This field will be ignored if *timezones* field is set and have at least one value.
 
 *timezones*: ++
 	typeof: list of strings ++


### PR DESCRIPTION
Fix: #911 

Also fixed timezones behavior: now Waybar starting with the first timezone in `timezones` list and falling back to the `timezone` field only if timezones omit or has no elements.