### PR TITLE
Add reverse scrolling config option for pulseaudio module

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -79,6 +79,13 @@ bool waybar::modules::Pulseaudio::handleScroll(GdkEventScroll *e) {
   if (dir == SCROLL_DIR::NONE) {
     return true;
   }
+  if (config_["reverse-scrolling"].asInt() == 1){
+    if (dir == SCROLL_DIR::UP) {
+      dir = SCROLL_DIR::DOWN;
+    } else if (dir == SCROLL_DIR::DOWN) {
+      dir = SCROLL_DIR::UP;
+    }
+  }
   double      volume_tick = static_cast<double>(PA_VOLUME_NORM) / 100;
   pa_volume_t change = volume_tick;
   pa_cvolume  pa_volume = pa_volume_;


### PR DESCRIPTION
When natural scrolling is enabled, the behavior of scrolling on pulseaudio
module is reversed, i.e. scrolling up reduces the volume, which is not expected.
This commit reverses the direction of scroll variable if "reverse-scrolling" is set to 1 in the config file like below.
`pulseaudio {
  "reverse-scrolling": 1
}`
resolves #1220 