### PR TITLE
Clarify less than/greater than in warning.

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -13,10 +13,10 @@
 
 namespace waybar {
 static constexpr const char* MIN_HEIGHT_MSG =
-    "Requested height: {} exceeds the minimum height: {} required by the modules";
+    "Requested height: {} is less than the minimum height: {} required by the modules";
 
 static constexpr const char* MIN_WIDTH_MSG =
-    "Requested width: {} exceeds the minimum width: {} required by the modules";
+    "Requested width: {} is less than the minimum width: {} required by the modules";
 
 static constexpr const char* BAR_SIZE_MSG = "Bar configured (width: {}, height: {}) for output: {}";
 


### PR DESCRIPTION
I was seeing "[warning] Requested height: 20 exceeds the minimum height: 30 required..."
Lines 114-134 are relevant; 133 overrides the requested height with the minimum height when GTK wants more pixels to work with. So, the code is behaving as expected, and "less than" matches the code's logic.