### PR TITLE
Mark memory used by zfs arc as free in memory

### DIFF
--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -15,11 +15,11 @@ auto waybar::modules::Memory::update() -> void {
   unsigned long memfree;
   if (meminfo_.count("MemAvailable")) {
     // New kernels (3.4+) have an accurate available memory field.
-    memfree = meminfo_["MemAvailable"];
+    memfree = meminfo_["MemAvailable"] + meminfo_["zfs_size"];
   } else {
     // Old kernel; give a best-effort approximation of available memory.
     memfree = meminfo_["MemFree"] + meminfo_["Buffers"] + meminfo_["Cached"] +
-              meminfo_["SReclaimable"] - meminfo_["Shmem"];
+              meminfo_["SReclaimable"] - meminfo_["Shmem"] + meminfo_["zfs_size"];
   }
 
   if (memtotal > 0 && memfree >= 0) {

--- a/src/modules/memory/linux.cpp
+++ b/src/modules/memory/linux.cpp
@@ -1,8 +1,29 @@
 #include "modules/memory.hpp"
 
+static unsigned zfsArcSize() {
+  std::ifstream zfs_arc_stats{"/proc/spl/kstat/zfs/arcstats"};
+
+  if (zfs_arc_stats.is_open()) {
+    std::string   name;
+    std::string   type;
+    unsigned long data{0};
+
+    std::string line;
+    while (std::getline(zfs_arc_stats, line)) {
+      std::stringstream(line) >> name >> type >> data;
+
+      if (name == "size") {
+        return data / 1024;  // convert to kB
+      }
+    }
+  }
+
+  return 0;
+}
+
 void waybar::modules::Memory::parseMeminfo() {
   const std::string data_dir_ = "/proc/meminfo";
-  std::ifstream info(data_dir_);
+  std::ifstream     info(data_dir_);
   if (!info.is_open()) {
     throw std::runtime_error("Can't open " + data_dir_);
   }
@@ -17,4 +38,6 @@ void waybar::modules::Memory::parseMeminfo() {
     int64_t     value = std::stol(line.substr(posDelim + 1));
     meminfo_[name] = value;
   }
+
+  meminfo_["zfs_size"] = zfsArcSize();
 }


### PR DESCRIPTION
ZFS is using a custom cache implementation (the Adaptive replacement cache) that the kernel sees as used memory. This makes it look like memory is exhausted and almost never showing below 50%. However, the ZFS kernel module evicts the cache as memory pressure rises like the normal cache and therefore should be shown as a normal cache.

This patch very rudimentarily implements this for Linux. I'm unsure if this needs to be implemented for BSD too, as i don't have a BSD system around.

I'm happy to adapt this patch as necessary.