### PR TITLE
Add module group feature

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -73,7 +73,7 @@ class Bar {
  private:
   void onMap(GdkEventAny *);
   auto setupWidgets() -> void;
-  void getModules(const Factory &, const std::string &);
+  void getModules(const Factory &, const std::string &, Gtk::Box*);
   void setupAltFormatKeyForModule(const std::string &module_name);
   void setupAltFormatKeyForModuleList(const char *module_list_name);
 
@@ -86,6 +86,7 @@ class Bar {
   std::vector<std::unique_ptr<waybar::AModule>> modules_left_;
   std::vector<std::unique_ptr<waybar::AModule>> modules_center_;
   std::vector<std::unique_ptr<waybar::AModule>> modules_right_;
+  std::vector<std::unique_ptr<waybar::AModule>> modules_all_;
 };
 
 }  // namespace waybar

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <gtkmm/widget.h>
+#include <gtkmm/box.h>
+#include <json/json.h>
+#include "AModule.hpp"
+#include "bar.hpp"
+#include "factory.hpp"
+
+namespace waybar {
+
+class Group : public AModule {
+ public:
+  Group(const std::string&, const Bar&, const Json::Value&);
+  ~Group() = default;
+  auto update() -> void;
+  operator Gtk::Widget &();
+  Gtk::Box box;
+};
+
+}  // namespace waybar

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -203,6 +203,28 @@ When positioning Waybar on the left or right side of the screen, sometimes it's 
 
 Valid options for the "rotate" property are: 0, 90, 180 and 270.
 
+## Grouping modules
+
+Module groups allow stacking modules in the direction orthogonal to the bar direction. When the bar is positioned on the top or bottom of the screen, modules in a group are stacked vertically. Likewise, when positioned on the left or right, modules in a group are stacked horizontally.
+
+A module group is defined by specifying a module named "group/some-group-name". The group must also be configured with a list of contained modules. Example:
+
+```
+{
+	"modules-right": ["group/hardware", "clock"],
+
+	"group/hardware": {
+		"modules": [
+			"cpu",
+			"memory",
+			"battery"
+		]
+	},
+
+	...
+}
+```
+
 # SUPPORTED MODULES
 
 - *waybar-backlight(5)*

--- a/meson.build
+++ b/meson.build
@@ -150,6 +150,7 @@ src_files = files(
     'src/bar.cpp',
     'src/client.cpp',
     'src/config.cpp',
+    'src/group.cpp',
     'src/util/ustring_clen.cpp'
 )
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -1,0 +1,19 @@
+#include "group.hpp"
+#include <fmt/format.h>
+#include <util/command.hpp>
+
+namespace waybar {
+
+Group::Group(const std::string& name, const Bar& bar, const Json::Value& config)
+    : AModule(config, name, "", false, false),
+      box{bar.vertical ? Gtk::ORIENTATION_HORIZONTAL : Gtk::ORIENTATION_VERTICAL, 0}
+    {
+}
+
+auto Group::update() -> void {
+  // noop
+}
+
+Group::operator Gtk::Widget&() { return box; }
+
+}  // namespace waybar


### PR DESCRIPTION
This PR adds a module group feature. A module group contains multiple modules and renders them orthogonal to the bar direction (ie stacked vertically for a horizontal bar and vice versa).

My use case for it is that I want a vertical bar but I want some modules to share the same row on the bar. This may sound like a waste of screen space but I'm using waybar as an overlay that is most often hidden, and show on demand. A screenshot of my setup follows, volume/brightness bars are implemented each with two modules (one for the icon, one for the bar) placed in a group. Progress bars use CSS linear gradients as their background.

![image](https://user-images.githubusercontent.com/127842/139647653-7ae6f66f-cf2a-4990-b494-4f69f97f89b9.png)

The way a group is configured is as follows:

```json
{
  "modules_left": [
    "module_a",
    "group/mygroup",
    "module_b"
  ],

  "group/mygroup": {
    "modules": [
      "module_c",
      "module_d"
    ]
  }
}
```

I chose to list modules in a "modules" key to leave space for future additional options for groups (eg. alignment and so on - which would probably be useful for right/bottom-positioned bars). The implementation does not prevent nested groups, but that's currently not very useful as a group direction is orthogonal to the bar, not to its parent.

Please note that I have no significant experience with c++ whatsoever, so my code may leave a lot to be desired. I've been using it as a daily driver for quite some time though so I'm hoping any remaining issues are mostly architecture/style/good practices related.

Let me know what you think.