### PR TITLE
mediaplayer.py: Exit properly on SIGPIPE

### DIFF
--- a/resources/custom_modules/mediaplayer.py
+++ b/resources/custom_modules/mediaplayer.py
@@ -110,6 +110,7 @@ def main():
 
     signal.signal(signal.SIGINT, signal_handler)
     signal.signal(signal.SIGTERM, signal_handler)
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
     for player in manager.props.player_names:
         if arguments.player is not None and arguments.player != player.name:


### PR DESCRIPTION
Handle the Broken Pipe error thrown by `sys.stdout.flush()` (as Python ignores SIGPIPE by default), when piping `mediaplayer.py` to `head -n0` for example.