### PR TITLE
Allow sink in addition to source for pulse icon

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -211,7 +211,7 @@ static const std::array<std::string, 9> ports = {
 };
 
 const std::vector<std::string> waybar::modules::Pulseaudio::getPulseIcon() const {
-  std::vector<std::string> res = {default_source_name_};
+  std::vector<std::string> res = {current_sink_name_, default_source_name_};
   std::string nameLC = port_name_ + form_factor_;
   std::transform(nameLC.begin(), nameLC.end(), nameLC.begin(), ::tolower);
   for (auto const &port : ports) {


### PR DESCRIPTION
A previous build fix changed the logic for per-device pulseaudio icon selection and used the source name instead of sink.

As some users might be using it based on source, I have added the sink in addition to the existing one.