### PR TITLE
Escape ampersands

### DIFF
--- a/resources/custom_modules/mediaplayer.py
+++ b/resources/custom_modules/mediaplayer.py
@@ -43,6 +43,8 @@ def on_metadata(player, metadata, manager):
 
     if player.props.status != 'Playing' and track_info:
         track_info = ' ' + track_info
+
+    track_info = track_info.replace("&", "&amp;")
     write_output(track_info, player)
 
 


### PR DESCRIPTION
When not escaped, artists or titles with '&' in them cause nothing to be printed.