### PR TITLE
Feature Clock: show list of time in other timezones in a tooltip

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -18,6 +18,7 @@ struct waybar_time {
 };
 
 const std::string kCalendarPlaceholder = "calendar";
+const std::string KTimezonedTimeListPlaceholder = "timezoned_time_list";
 
 class Clock : public ALabel {
  public:
@@ -33,6 +34,7 @@ class Clock : public ALabel {
   date::year_month_day cached_calendar_ymd_ = date::January/1/0;
   std::string cached_calendar_text_;
   bool is_calendar_in_tooltip_;
+  bool is_timezoned_list_in_tooltip_;
 
   bool handleScroll(GdkEventScroll* e);
 
@@ -41,6 +43,7 @@ class Clock : public ALabel {
   auto first_day_of_week() -> date::weekday;
   const date::time_zone* current_timezone();
   bool is_timezone_fixed();
+  auto timezones_text(std::chrono::_V2::system_clock::time_point *now) -> std::string;
 };
 
 }  // namespace waybar::modules

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -91,6 +91,7 @@ View all valid format options in *strftime(3)*.
 # FORMAT REPLACEMENTS
 
 *{calendar}*: Current month calendar
+*{timezoned_time_list}*: List of time in the rest timezones, if more than one timezone is set in the config
 
 # EXAMPLES
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -16,7 +16,8 @@ using waybar::modules::waybar_time;
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     : ALabel(config, "clock", id, "{:%H:%M}", 60, false, false, true),
       current_time_zone_idx_(0),
-      is_calendar_in_tooltip_(false)
+      is_calendar_in_tooltip_(false),
+      is_timezoned_list_in_tooltip_(false)
 {
   if (config_["timezones"].isArray() && !config_["timezones"].empty()) {
     for (const auto& zone_name: config_["timezones"]) {
@@ -56,6 +57,9 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
                trimmed_format.end());
     if (trimmed_format.find("{" + kCalendarPlaceholder + "}") != std::string::npos) {
       is_calendar_in_tooltip_ = true;
+    }
+    if (trimmed_format.find("{" + KTimezonedTimeListPlaceholder + "}") != std::string::npos) {
+      is_timezoned_list_in_tooltip_ = true;
     }
   }
 
@@ -101,11 +105,15 @@ auto waybar::modules::Clock::update() -> void {
   if (tooltipEnabled()) {
     if (config_["tooltip-format"].isString()) {
       std::string calendar_lines = "";
+      std::string timezoned_time_lines = "";
       if (is_calendar_in_tooltip_) {
         calendar_lines = calendar_text(wtime);
       }
+      if (is_timezoned_list_in_tooltip_) {
+        timezoned_time_lines = timezones_text(&now);
+      }
       auto tooltip_format = config_["tooltip-format"].asString();
-      text = fmt::format(tooltip_format, wtime, fmt::arg(kCalendarPlaceholder.c_str(), calendar_lines));
+      text = fmt::format(tooltip_format, wtime, fmt::arg(kCalendarPlaceholder.c_str(), calendar_lines), fmt::arg(KTimezonedTimeListPlaceholder.c_str(), timezoned_time_lines));
     }
   }
 
@@ -202,6 +210,26 @@ auto waybar::modules::Clock::weekdays_header(const date::weekday& first_dow, std
     os << pad << wd_ustring;
   } while (++wd != first_dow);
   os << "\n";
+}
+
+auto waybar::modules::Clock::timezones_text(std::chrono::_V2::system_clock::time_point *now) -> std::string {
+  if (time_zones_.size() == 1) {
+    return "";
+  }
+  std::stringstream os;
+  waybar_time wtime;
+  for (size_t time_zone_idx = 0; time_zone_idx < time_zones_.size(); ++time_zone_idx) {
+    if (static_cast<int>(time_zone_idx) == current_time_zone_idx_) {
+      continue;
+    }
+    const date::time_zone* timezone = time_zones_[time_zone_idx];
+    if (!timezone) {
+      timezone = date::current_zone();
+    }
+    wtime = {locale_, date::make_zoned(timezone, date::floor<std::chrono::seconds>(*now))};
+    os << fmt::format(format_, wtime) << "\n";
+  }
+  return os.str();
 }
 
 #ifdef HAVE_LANGINFO_1STDAY


### PR DESCRIPTION
Introducing new tooltip placeholder: {timezoned_time_list}. It will be replaced with the list of times in different time zones from the config.
I've found it useful to hover the mouse pointer on time and see time in all my timezones at once. Current timezone excluding for the list, so if you will scroll over the time module and change the active timezone, this timezone will be excluded from the list and the previous active zone will be added.

How it works for me:
![output](https://user-images.githubusercontent.com/8835673/144276993-b9fa048e-835b-4d16-bf5f-ae87fb557c4c.gif)

I know that this feature wasn't requested, but I found it very useful for me and hope it will be useful for someone else, who working remotely or have another kind of interest in other timezones.
Refactoring in #1277 was done as a preparation for this feature =)
Any feedback will be highly appreciated.