### PR TITLE
Adjust max wifi strength that is possible

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -789,8 +789,8 @@ void waybar::modules::Network::parseSignal(struct nlattr **bss) {
     // signalstrength in dBm from mBm
     signal_strength_dbm_ = nla_get_s32(bss[NL80211_BSS_SIGNAL_MBM]) / 100;
 
-    // WiFi-hardware usually operates in the range -90 to -20dBm.
-    const int hardwareMax = -20;
+    // WiFi-hardware usually operates in the range -90 to -30dBm.
+    const int hardwareMax = -30;
     const int hardwareMin = -90;
     const int strength =
       ((signal_strength_dbm_ - hardwareMin) / double{hardwareMax - hardwareMin}) * 100;


### PR DESCRIPTION
By definition, the best possible signal strength is -30dBm, so having -20dBm here doesn't make sense

Reference (can Ctrl+F for -30dBm): 
https://eyenetworks.no/en/wifi-signal-strength/
https://www.metageek.com/training/resources/wifi-signal-strength-basics/

As a small note, signal strengths in the -30s and -40s dBm actually is __not__ good - it is too strong and can cause errors between hosts and a receiver. Often, the maximum desirable levels are in the -50s dBm. Thinking about creating a seperate pull request to adjust the signalStrength value to account for this? Thoughts?