### PR TITLE
Add battery left-pad for better formatting

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -279,7 +279,11 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
   if (config_["format-time"].isString()) {
     format = config_["format-time"].asString();
   }
-  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes));
+  std::string minutes_str = std::to_string(minutes);
+  if (minutes_str.length() == 1) {
+    minutes_str = "0" + minutes_str;
+  }
+  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes_str));
 }
 
 auto waybar::modules::Battery::update() -> void {


### PR DESCRIPTION
Previously, if the minutes in the battery indicator was a single digit number, it would format strangely: "2:7" for two hours and seven minutes. This has been bugging me, so I have decided to fix it. I have added a very simple left-pad format into the function, so that two hours and seven minutes would appear as "2:07".