### PR TITLE
bar: Fix crash when unplugging HDMI

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -112,14 +112,14 @@ class Bar {
   Gtk::Box                                      center_;
   Gtk::Box                                      right_;
   Gtk::Box                                      box_;
-  std::vector<std::unique_ptr<waybar::AModule>> modules_left_;
-  std::vector<std::unique_ptr<waybar::AModule>> modules_center_;
-  std::vector<std::unique_ptr<waybar::AModule>> modules_right_;
+  std::vector<std::shared_ptr<waybar::AModule>> modules_left_;
+  std::vector<std::shared_ptr<waybar::AModule>> modules_center_;
+  std::vector<std::shared_ptr<waybar::AModule>> modules_right_;
 #ifdef HAVE_SWAY
   using BarIpcClient = modules::sway::BarIpcClient;
   std::unique_ptr<BarIpcClient> _ipc_client;
 #endif
-  std::vector<std::unique_ptr<waybar::AModule>> modules_all_;
+  std::vector<std::shared_ptr<waybar::AModule>> modules_all_;
 };
 
 }  // namespace waybar

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -735,18 +735,19 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos, Gtk
           module = factory.makeModule(ref);
         }
 
-        modules_all_.emplace_back(module);
+        std::shared_ptr<AModule> module_sp(module);
+        modules_all_.emplace_back(module_sp);
         if (group) {
           group->pack_start(*module, false, false);
         } else {
           if (pos == "modules-left") {
-            modules_left_.emplace_back(module);
+            modules_left_.emplace_back(module_sp);
           }
           if (pos == "modules-center") {
-            modules_center_.emplace_back(module);
+            modules_center_.emplace_back(module_sp);
           }
           if (pos == "modules-right") {
-            modules_right_.emplace_back(module);
+            modules_right_.emplace_back(module_sp);
           }
         }
         module->dp.connect([module, &name] {


### PR DESCRIPTION
There is a double delete situation which causes a SIGSEGV to happen
during destruction of bar.

This was introduced by the group feature patch.

The same object pointer is stored in two different vectors of
unique_ptr<AModule> element. Replace with shared_ptr to handle
reference counting correctly and avoid double delete.