### PR TITLE
Network Module Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ libdbusmenu-gtk3 [Tray module]
 libmpdclient [MPD module]
 libsndio [sndio module]
 libevdev [KeyboardState module]
+xkbregistry
 ```
 
 **Build dependencies**
@@ -101,7 +102,8 @@ sudo apt install \
   libsigc++-2.0-dev \
   libspdlog-dev \
   libwayland-dev \
-  scdoc
+  scdoc \
+  libxkbregistry-dev
 ```
 
 

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -73,6 +73,7 @@ class Network : public ALabel {
   int         cidr_;
   int32_t     signal_strength_dbm_;
   uint8_t     signal_strength_;
+  std::string signal_strength_app_;
   float       frequency_;
   uint32_t    route_priority;
 

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -73,7 +73,7 @@ class Network : public ALabel {
   int         cidr_;
   int32_t     signal_strength_dbm_;
   uint8_t     signal_strength_;
-  uint32_t    frequency_;
+  float       frequency_;
   uint32_t    route_priority;
 
   util::SleeperThread thread_;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -88,7 +88,7 @@ waybar::modules::Network::Network(const std::string &id, const Json::Value &conf
 #ifdef WANT_RFKILL
       rfkill_{RFKILL_TYPE_WLAN},
 #endif
-      frequency_(0) {
+      frequency_(0.0) {
 
   // Start with some "text" in the module's label_, update() will then
   // update it. Since the text should be different, update() will be able
@@ -336,7 +336,7 @@ auto waybar::modules::Network::update() -> void {
       fmt::arg("ipaddr", ipaddr_),
       fmt::arg("gwaddr", gwaddr_),
       fmt::arg("cidr", cidr_),
-      fmt::arg("frequency", frequency_),
+      fmt::arg("frequency", fmt::format("{:.1f}", frequency_)),
       fmt::arg("icon", getIcon(signal_strength_, state_)),
       fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / interval_.count(), "b/s")),
       fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / interval_.count(), "b/s")),
@@ -365,7 +365,7 @@ auto waybar::modules::Network::update() -> void {
           fmt::arg("ipaddr", ipaddr_),
           fmt::arg("gwaddr", gwaddr_),
           fmt::arg("cidr", cidr_),
-          fmt::arg("frequency", frequency_),
+          fmt::arg("frequency", fmt::format("{:.1f}", frequency_)),
           fmt::arg("icon", getIcon(signal_strength_, state_)),
           fmt::arg("bandwidthDownBits",
                    pow_format(bandwidth_down * 8ull / interval_.count(), "b/s")),
@@ -403,7 +403,7 @@ void waybar::modules::Network::clearIface() {
   cidr_ = 0;
   signal_strength_dbm_ = 0;
   signal_strength_ = 0;
-  frequency_ = 0;
+  frequency_ = 0.0;
 }
 
 int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
@@ -470,7 +470,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
             net->essid_.clear();
             net->signal_strength_dbm_ = 0;
             net->signal_strength_ = 0;
-            net->frequency_ = 0;
+            net->frequency_ = 0.0;
           }
         }
         net->carrier_ = carrier.value();
@@ -806,8 +806,8 @@ void waybar::modules::Network::parseSignal(struct nlattr **bss) {
 
 void waybar::modules::Network::parseFreq(struct nlattr **bss) {
   if (bss[NL80211_BSS_FREQUENCY] != nullptr) {
-    // in MHz
-    frequency_ = nla_get_u32(bss[NL80211_BSS_FREQUENCY]);
+    // in GHz
+    frequency_ = (double) nla_get_u32(bss[NL80211_BSS_FREQUENCY]) / 1000;
   }
 }
 

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -331,6 +331,7 @@ auto waybar::modules::Network::update() -> void {
       fmt::arg("essid", essid_),
       fmt::arg("signaldBm", signal_strength_dbm_),
       fmt::arg("signalStrength", signal_strength_),
+      fmt::arg("signalStrengthApp", signal_strength_app_),
       fmt::arg("ifname", ifname_),
       fmt::arg("netmask", netmask_),
       fmt::arg("ipaddr", ipaddr_),
@@ -360,6 +361,7 @@ auto waybar::modules::Network::update() -> void {
           fmt::arg("essid", essid_),
           fmt::arg("signaldBm", signal_strength_dbm_),
           fmt::arg("signalStrength", signal_strength_),
+          fmt::arg("signalStrengthApp", signal_strength_app_),
           fmt::arg("ifname", ifname_),
           fmt::arg("netmask", netmask_),
           fmt::arg("ipaddr", ipaddr_),
@@ -403,6 +405,7 @@ void waybar::modules::Network::clearIface() {
   cidr_ = 0;
   signal_strength_dbm_ = 0;
   signal_strength_ = 0;
+  signal_strength_app_.clear();
   frequency_ = 0.0;
 }
 
@@ -470,6 +473,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
             net->essid_.clear();
             net->signal_strength_dbm_ = 0;
             net->signal_strength_ = 0;
+            net->signal_strength_app_.clear();
             net->frequency_ = 0.0;
           }
         }
@@ -798,6 +802,20 @@ void waybar::modules::Network::parseSignal(struct nlattr **bss) {
     const int strength =
         100 - ((abs(signal_strength_dbm_ - hardwareOptimum) / double{hardwareOptimum - hardwareMin}) * 100);
     signal_strength_ = std::clamp(strength, 0, 100);  
+
+    if (signal_strength_dbm_ >= -50) {
+      signal_strength_app_ = "Great Connectivity";
+    } else if (signal_strength_dbm_ >= -60) {
+      signal_strength_app_ = "Good Connectivity";
+    } else if (signal_strength_dbm_ >= -67) {
+      signal_strength_app_ = "Streaming";
+    } else if (signal_strength_dbm_ >= -70) {
+      signal_strength_app_ = "Web Surfing";
+    } else if (signal_strength_dbm_ >= -80) {
+      signal_strength_app_ = "Basic Connectivity";
+    } else {
+      signal_strength_app_ = "Poor Connectivity";
+    }
   }
   if (bss[NL80211_BSS_SIGNAL_UNSPEC] != nullptr) {
     signal_strength_ = nla_get_u8(bss[NL80211_BSS_SIGNAL_UNSPEC]);


### PR DESCRIPTION
This pull request contains a series of enhancements to the network module, separated out by commit. #3 and #4 on this list would require updates to the Wiki as well.

1. But first, a build dependency issue. Versions >=0.9.0 often do not build on Debian with the existing build dependencies. "xkbregistry" is required, but not supplied using the current list of Debian packages on the READme. I added the "libxkbregistry-dev" package to the READme under the command to install all required dependencies for Ubuntu.

2. Signal strength calculation. The previous calculated percentage was just a raw scale from -30dBm to -90dBm. While -30dBm is the strongest possible signal for wifi, if a signal is too strong, it can overwhelm receiving circuity that is designed to pick up and process a certain signal level. I changed the percentage calculation to set -45dBm as the optimal level, with signals that are strong or weaker than that calculated as less than 100% signal strength.

3. Signal strength application. Added a format replacement for the network module, "signalStrengthApp". This just displays what your connectivity is and what applications you may be able to handle at current network signal strength, i.e "streaming" or "web surfing".

4. Frequency. Wifi frequency is commonly referenced in GHz in the 802.11 IEEE Standard. I changed the frequency format replacement from MHz to GHz. 