### PR TITLE
battery module usb-c reporting Plugged when discharging

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -207,7 +207,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       bool online;
       std::ifstream(adapter_ / "online") >> online;
       if (online) {
-        status = "Plugged";
+        status = "Discharging";
       }
     }
     float time_remaining = 0;


### PR DESCRIPTION
Current battery adaptor check neglected the case when plugged a device in through a usb type-c shared with power supply, in this case even if the adaptor is online, if you don't plug the power in it will still be discharging. The current logic marked above case as "Plugged" thus module will think it is plugged even though it is actually discharging. Discharging should always be discharging regardless of the adaptor status. This patch fixed above issue.