### PR TITLE
Ellipsize song info when too long

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -147,10 +147,53 @@ void waybar::modules::MPD::setLabel() {
   std::string repeatIcon = getOptionIcon("repeat", repeatActivated);
   bool        singleActivated = mpd_status_get_single(status_.get());
   std::string singleIcon = getOptionIcon("single", singleActivated);
-  if (config_["artist-len"].isInt()) artist = artist.substr(0, config_["artist-len"].asInt());
-  if (config_["album-artist-len"].isInt()) album_artist = album_artist.substr(0, config_["album-artist-len"].asInt());
-  if (config_["album-len"].isInt()) album = album.substr(0, config_["album-len"].asInt());
-  if (config_["title-len"].isInt()) title = title.substr(0,config_["title-len"].asInt());
+  if (config_["artist-len"].isInt()) {
+    if (artist.length() > (config_["artist-len"].asInt() - 3U)) {
+      artist = artist.substr(0, config_["artist-len"].asInt() - 3U);
+      std::size_t found = artist.find_last_not_of(" \t\f\v\n\r");
+      if (found != std::string::npos) {
+        artist = artist.erase(found + 1).append("...");
+      } else
+        artist.clear();
+    } else
+      artist = artist.substr(0, config_["artist-len"].asInt());
+  }
+
+  if (config_["album-artist-len"].isInt()) {
+    if (album_artist.length() > (config_["album-artist-len"].asInt() - 3U)) {
+      album_artist = album_artist.substr(0, config_["album-artist-len"].asInt() - 3U);
+      std::size_t found = album_artist.find_last_not_of(" \t\f\v\n\r");
+      if (found != std::string::npos) {
+        album_artist = album_artist.erase(found + 1).append("...");
+      } else
+        album_artist.clear();
+    } else
+      album_artist = album_artist.substr(0, config_["album-artist-len"].asInt());
+  }
+
+  if (config_["album-len"].isInt()) {
+    if (album.length() > (config_["album-len"].asInt() - 3U)) {
+      album = album.substr(0, config_["album-len"].asInt() - 3U);
+      std::size_t found = album.find_last_not_of(" \t\f\v\n\r");
+      if (found != std::string::npos) {
+        album = album.erase(found + 1).append("...");
+      } else
+        album.clear();
+    } else
+      album = album.substr(0, config_["album-len"].asInt());
+  }
+
+  if (config_["title-len"].isInt()) {
+    if (title.length() > (config_["title-len"].asInt() - 3U)) {
+      title = title.substr(0, config_["title-len"].asInt() - 3U);
+      std::size_t found = title.find_last_not_of(" \t\f\v\n\r");
+      if (found != std::string::npos) {
+        title = title.erase(found + 1).append("...");
+      } else
+        title.clear();
+    } else
+      title = title.substr(0, config_["title-len"].asInt());
+  }
 
   try {
     label_.set_markup(


### PR DESCRIPTION
When artist, title, album artist, or album are truncated, trim trailing whitespace & replace last 3 characters with "..." as long as they are longer than (char limit - 3).

Currently, "max_length" being set will cause the entire "format" string to be truncated & ellipsized, but there is no way to ellipsize the individual tags. This can make it hard to tell when strings are being truncated.

e.g. with artist-len == 13 and artist == "Queens of the Stone Age"
Old behavior: artist = "Queens of the"
New behavior: artist = "Queens of..."