### PR TITLE
fix: match sway workspace order with sway one

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -69,10 +69,6 @@ Addressed by *sway/workspaces*
     typeof: string ++
     Command to execute when the module is updated.
 
-*numeric-first*: ++
-    typeof: bool ++
-    Whether to put workspaces starting with numbers before workspaces that do not start with a number.
-
 *disable-auto-back-and-forth*: ++
     typeof: bool ++
     Whether to disable *workspace_auto_back_and_forth* when clicking on workspaces. If this is set to *true*, clicking on a workspace you are already on won't do anything, even if *workspace_auto_back_and_forth* is enabled in the Sway configuration.
@@ -120,7 +116,6 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
 "sway/workspaces": {
     "disable-scroll": true,
     "all-outputs": true,
-    "numeric-first": false,
     "format": "{name}: {icon}",
     "format-icons": {
         "1": "",


### PR DESCRIPTION
Ensure that sway workspaces are always displayed in the same order as
used internally by sway. The previous sorting code always sorted
unnumbered workspaces lexicographically. This isn't the order used by
sway internally. Therefore, commands such as "workspace next" might have
jumped arbitrarily in waybar.

This commit reworks the sorting code such that the internal order is
always obeyed. Additionally, numbered persistent workspaces are inserted
at their natural position at the front of the workspace list while
unnumbered ones are appended. This should match the expectations of
workspace ordering known from sway's behavior.

The changes make the configuration property "numeric-first" unnecessary
as this will always be the case now. There's also no reasonable way
around this behavior now. Otherwise, persistent workspaces would jump
around in the visual representation as soon as they become known to
sway.

Fixes #802