### PR TITLE
Fix build with fmt 8.1.0

### DIFF
--- a/Dockerfiles/alpine
+++ b/Dockerfiles/alpine
@@ -2,4 +2,4 @@
 
 FROM alpine:latest
 
-RUN apk add --no-cache git meson alpine-sdk libinput-dev wayland-dev wayland-protocols mesa-dev libxkbcommon-dev eudev-dev pixman-dev gtkmm3-dev jsoncpp-dev pugixml-dev libnl3-dev pulseaudio-dev libmpdclient-dev sndio-dev scdoc libxkbcommon
+RUN apk add --no-cache git meson alpine-sdk libinput-dev wayland-dev wayland-protocols mesa-dev libxkbcommon-dev eudev-dev pixman-dev gtkmm3-dev jsoncpp-dev pugixml-dev libnl3-dev pulseaudio-dev libmpdclient-dev sndio-dev scdoc libxkbcommon tzdata

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -1,21 +1,14 @@
 #pragma once
 
-#include <fmt/format.h>
-#if FMT_VERSION < 60000
-#include <fmt/time.h>
-#else
-#include <fmt/chrono.h>
-#endif
 #include <date/tz.h>
 #include "ALabel.hpp"
 #include "util/sleeper_thread.hpp"
 
-namespace waybar::modules {
+namespace waybar {
 
-struct waybar_time {
-  std::locale locale;
-  date::zoned_seconds ztime;
-};
+struct waybar_time;
+
+namespace modules {
 
 const std::string kCalendarPlaceholder = "calendar";
 
@@ -43,4 +36,5 @@ class Clock : public ALabel {
   bool is_timezone_fixed();
 };
 
-}  // namespace waybar::modules
+}  // namespace modules
+}  // namespace waybar

--- a/include/util/waybar_time.hpp
+++ b/include/util/waybar_time.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <fmt/format.h>
+#if FMT_VERSION < 60000
+#include <fmt/time.h>
+#else
+#include <fmt/chrono.h>
+#endif
+#include <date/tz.h>
+
+namespace waybar {
+
+struct waybar_time {
+  std::locale         locale;
+  date::zoned_seconds ztime;
+};
+
+}  // namespace waybar
+
+template <>
+struct fmt::formatter<waybar::waybar_time> : fmt::formatter<std::tm> {
+  template <typename FormatContext>
+  auto format(const waybar::waybar_time& t, FormatContext& ctx) {
+#if FMT_VERSION >= 80000
+    auto& tm_format = specs;
+#endif
+    return format_to(ctx.out(), "{}", date::format(t.locale, fmt::to_string(tm_format), t.ztime));
+  }
+};

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ is_netbsd = host_machine.system() == 'netbsd'
 is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
-fmt = dependency('fmt', version : ['>=5.3.0'], fallback : ['fmt', 'fmt_dep'])
+fmt = dependency('fmt', version : ['>=7.0.0'], fallback : ['fmt', 'fmt_dep'])
 spdlog = dependency('spdlog', version : ['>=1.8.5'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -6,12 +6,13 @@
 #include <sstream>
 #include <type_traits>
 #include "util/ustring_clen.hpp"
+#include "util/waybar_time.hpp"
 #ifdef HAVE_LANGINFO_1STDAY
 #include <langinfo.h>
 #include <locale.h>
 #endif
 
-using waybar::modules::waybar_time;
+using waybar::waybar_time;
 
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     : ALabel(config, "clock", id, "{:%H:%M}", 60, false, false, true),
@@ -227,14 +228,3 @@ auto waybar::modules::Clock::first_day_of_week() -> date::weekday {
 #endif
   return date::Sunday;
 }
-
-template <>
-struct fmt::formatter<waybar_time> : fmt::formatter<std::tm> {
-  template <typename FormatContext>
-  auto format(const waybar_time& t, FormatContext& ctx) {
-#if FMT_VERSION >= 80000
-	auto& tm_format = specs;
-#endif
-    return format_to(ctx.out(), "{}", date::format(t.locale, fmt::to_string(tm_format), t.ztime));
-  }
-};

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -1,10 +1,16 @@
 #include "modules/clock.hpp"
 
-#include <time.h>
 #include <spdlog/spdlog.h>
+#if FMT_VERSION < 60000
+#include <fmt/time.h>
+#else
+#include <fmt/chrono.h>
+#endif
 
+#include <ctime>
 #include <sstream>
 #include <type_traits>
+
 #include "util/ustring_clen.hpp"
 #include "util/waybar_time.hpp"
 #ifdef HAVE_LANGINFO_1STDAY

--- a/test/SafeSignal.cpp
+++ b/test/SafeSignal.cpp
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_RUNNER
 #include "util/SafeSignal.hpp"
 
 #include <glibmm.h>
@@ -137,9 +136,4 @@ TEST_CASE_METHOD(GlibTestsFixture, "SafeSignal copy/move counter", "[signal][thr
   });
   producer.join();
   REQUIRE(count == NUM_EVENTS);
-}
-
-int main(int argc, char* argv[]) {
-  Glib::init();
-  return Catch::Session().run(argc, argv);
 }

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -1,4 +1,3 @@
-#define CATCH_CONFIG_MAIN
 #include "config.hpp"
 
 #include <catch2/catch.hpp>

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,0 +1,26 @@
+#define CATCH_CONFIG_RUNNER
+#include <glibmm.h>
+#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/spdlog.h>
+
+#include <catch2/catch.hpp>
+#include <catch2/catch_reporter_tap.hpp>
+#include <memory>
+
+int main(int argc, char* argv[]) {
+  Catch::Session session;
+  Glib::init();
+
+  session.applyCommandLine(argc, argv);
+  const auto  logger = spdlog::default_logger();
+  const auto& reporter_name = session.config().getReporterName();
+  if (reporter_name == "tap") {
+    spdlog::set_pattern("# [%l] %v");
+  } else if (reporter_name == "compact") {
+    logger->sinks().clear();
+  } else {
+    logger->sinks().assign({std::make_shared<spdlog::sinks::stderr_sink_st>()});
+  }
+
+  return session.run();
+}

--- a/test/meson.build
+++ b/test/meson.build
@@ -6,13 +6,21 @@ test_dep = [
     jsoncpp,
     spdlog,
 ]
-
-waybar_test = executable(
-    'waybar_test',
+test_src = files(
     'main.cpp',
     'SafeSignal.cpp',
     'config.cpp',
     '../src/config.cpp',
+)
+
+if tz_dep.found()
+  test_dep += tz_dep
+  test_src += files('waybar_time.cpp')
+endif
+
+waybar_test = executable(
+    'waybar_test',
+    test_src,
     dependencies: test_dep,
     include_directories: test_inc,
 )

--- a/test/meson.build
+++ b/test/meson.build
@@ -7,29 +7,18 @@ test_dep = [
     spdlog,
 ]
 
-config_test = executable(
-    'config_test',
+waybar_test = executable(
+    'waybar_test',
+    'main.cpp',
+    'SafeSignal.cpp',
     'config.cpp',
     '../src/config.cpp',
     dependencies: test_dep,
     include_directories: test_inc,
 )
 
-safesignal_test = executable(
-    'safesignal_test',
-    'SafeSignal.cpp',
-    dependencies: test_dep,
-    include_directories: test_inc,
-)
-
 test(
-    'Configuration test',
-    config_test,
-    workdir: meson.source_root(),
-)
-
-test(
-    'SafeSignal test',
-    safesignal_test,
+    'waybar',
+    waybar_test,
     workdir: meson.source_root(),
 )

--- a/test/waybar_time.cpp
+++ b/test/waybar_time.cpp
@@ -1,0 +1,90 @@
+#include "util/waybar_time.hpp"
+
+#include <date/date.h>
+#include <date/tz.h>
+
+#include <catch2/catch.hpp>
+#include <chrono>
+#include <stdexcept>
+
+using namespace std::literals::chrono_literals;
+
+/*
+ * Check that the date/time formatter with locale and timezone support is working as expected.
+ */
+
+const date::zoned_time<std::chrono::seconds> TEST_TIME = date::make_zoned(
+    "UTC", date::local_days{date::Monday[1] / date::January / 2022} + 13h + 4min + 5s);
+
+TEST_CASE("Format UTC time", "[clock][util]") {
+  waybar::waybar_time tm{std::locale("C"), TEST_TIME};
+
+  REQUIRE(fmt::format("{}", tm).empty());  // no format specified
+  REQUIRE(fmt::format("{:%c %Z}", tm) == "Mon Jan  3 13:04:05 2022 UTC");
+  REQUIRE(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+
+  /* Test a few locales that are most likely to be present */
+  SECTION("US locale") {
+    try {
+      tm.locale = std::locale("en_US");
+
+      REQUIRE(fmt::format("{}", tm).empty());  // no format specified
+      REQUIRE_THAT(fmt::format("{:%c}", tm),   // HowardHinnant/date#704
+                   Catch::Matchers::StartsWith("Mon 03 Jan 2022 01:04:05 PM"));
+      REQUIRE(fmt::format("{:%x %X}", tm) == "01/03/2022 01:04:05 PM");
+      REQUIRE(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+    } catch (const std::runtime_error&) {
+      // locale not found; ignore
+    }
+  }
+  SECTION("GB locale") {
+    try {
+      tm.locale = std::locale("en_GB");
+
+      REQUIRE(fmt::format("{}", tm).empty());  // no format specified
+      REQUIRE_THAT(fmt::format("{:%c}", tm),   // HowardHinnant/date#704
+                   Catch::Matchers::StartsWith("Mon 03 Jan 2022 13:04:05"));
+      REQUIRE(fmt::format("{:%x %X}", tm) == "03/01/22 13:04:05");
+      REQUIRE(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+    } catch (const std::runtime_error&) {
+      // locale not found; ignore
+    }
+  }
+}
+
+TEST_CASE("Format zoned time", "[clock][util]") {
+  waybar::waybar_time tm{std::locale("C"), date::make_zoned("America/New_York", TEST_TIME)};
+
+  REQUIRE(fmt::format("{}", tm).empty());  // no format specified
+  REQUIRE(fmt::format("{:%c %Z}", tm) == "Mon Jan  3 08:04:05 2022 EST");
+  REQUIRE(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+
+  /* Test a few locales that are most likely to be present */
+  SECTION("US locale") {
+    try {
+      tm.locale = std::locale("en_US");
+
+      REQUIRE(fmt::format("{}", tm).empty());  // no format specified
+      REQUIRE_THAT(fmt::format("{:%c}", tm),   // HowardHinnant/date#704
+                   Catch::Matchers::StartsWith("Mon 03 Jan 2022 08:04:05 AM"));
+      REQUIRE(fmt::format("{:%x %X}", tm) == "01/03/2022 08:04:05 AM");
+      REQUIRE(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+    } catch (const std::runtime_error&) {
+      // locale not found; ignore
+    }
+  }
+
+  SECTION("GB locale") {
+    try {
+      tm.locale = std::locale("en_GB");
+
+      REQUIRE(fmt::format("{}", tm).empty());  // no format specified
+      REQUIRE_THAT(fmt::format("{:%c}", tm),   // HowardHinnant/date#704
+                   Catch::Matchers::StartsWith("Mon 03 Jan 2022 08:04:05"));
+      REQUIRE(fmt::format("{:%x %X}", tm) == "03/01/22 08:04:05");
+      REQUIRE(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+    } catch (const std::runtime_error&) {
+      // locale not found; ignore
+    }
+  }
+}


### PR DESCRIPTION
 * Stop using `fmt::formatter<std::tm>` implementation details
 * Add tests for the `waybar_time` formatter

Tests might be a bit fragile as the `date::format` output depends on an underlying STL locale implementation. Any difference there is a bug though, and things are working on two stdlib implementations I tested.

Alpine build fails as the tests require timezone data. Dockerfile change in the top commit should address that.

Fixes #1368, #1379