### PR TITLE
fix: Use locale when formatting clock

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -99,7 +99,7 @@ auto waybar::modules::Clock::update() -> void {
     // As date dep is not fully compatible, prefer fmt
     tzset();
     auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
-    text = fmt::format(format_, localtime);
+    text = fmt::format(locale_, format_, localtime);
   } else {
     text = fmt::format(format_, wtime);
   }


### PR DESCRIPTION
Fixes #1393

When formatting the clock, pass the locale to the fmt function.