### PR TITLE
Ability to define order for taskbar tasks

### DIFF
--- a/include/modules/wlr/taskbar.hpp
+++ b/include/modules/wlr/taskbar.hpp
@@ -46,6 +46,8 @@ class Task
         INVALID = (1 << 4)
     };
 
+    Gtk::Button button_;
+
    private:
     static uint32_t global_id;
 
@@ -58,7 +60,7 @@ class Task
 
     uint32_t id_;
 
-    Gtk::Button button_;
+
     Gtk::Box content_;
     Gtk::Image icon_;
     Gtk::Label text_before_;
@@ -143,6 +145,7 @@ class Taskbar : public waybar::AModule
 
     std::vector<Glib::RefPtr<Gtk::IconTheme>> icon_themes_;
     std::unordered_set<std::string> ignore_list_;
+    std::vector<std::string> order_list_;
     std::map<std::string, std::string> app_ids_replace_map_;
 
     struct zwlr_foreign_toplevel_manager_v1 *manager_;

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -72,6 +72,10 @@ Addressed by *wlr/taskbar*
 	typeof: array ++
 	List of app_id/titles to be invisible.
 
+*ignore-list*: ++
+	typeof: array ++
+	List of app_ids in the order they should appear.
+
 *app_ids-mapping*: ++
 	typeof: object ++
 	Dictionary of app_id to be replaced with

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -806,13 +806,25 @@ Taskbar::~Taskbar()
 void Taskbar::update()
 {
   if (!order_list_.empty()) {
+    auto begin = order_list_.begin();
+    auto end = order_list.end();
+
+    // first pass - sort ordered tasks
     for (auto& task : tasks_) {
-      auto begin = order_list_.begin();
-      auto itr = std::find(begin, order_list_.end(), task->app_id());
+      auto itr = std::find(begin, end, task->app_id());
 
       if (itr != std::end(order_list_)) {
         auto index = std::distance(begin, itr);
         move_button(task->button_, index);
+      }
+    }
+
+    // second pass - push unordered to end
+    for (auto& task : tasks_) {
+      auto itr = std::find(begin, end, task->app_id());
+
+      if (itr == std::end(order_list_)) {
+        move_button(task->button_, -1);
       }
     }
   }

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -764,6 +764,13 @@ Taskbar::Taskbar(const std::string &id, const waybar::Bar &bar, const Json::Valu
         }
     }
 
+    // Load order-list
+    if (config_["order-list"].isArray()) {
+      for (auto& app_name : config_["order-list"]) {
+        order_list_.push_back(app_name.asString());
+      }
+    }
+
     // Load app_id remappings
     if (config_["app_ids-mapping"].isObject()) {
 		const Json::Value& mapping = config_["app_ids-mapping"];
@@ -798,7 +805,19 @@ Taskbar::~Taskbar()
 
 void Taskbar::update()
 {
-    for (auto& t : tasks_) {
+  if (!order_list_.empty()) {
+    for (auto& task : tasks_) {
+      auto begin = order_list_.begin();
+      auto itr = std::find(begin, order_list_.end(), task->app_id());
+
+      if (itr != std::end(order_list_)) {
+        auto index = std::distance(begin, itr);
+        move_button(task->button_, index);
+      }
+    }
+  }
+
+  for (auto& t : tasks_) {
         t->update();
     }
 


### PR DESCRIPTION
Adds a new `order-list` property to the taskbar module config which can define a set order in which tasks appear. Tasks not defined in the list will appear in the "default" order after those that are defined. Opening a program defined in the order-list will push it to the correct place.

Example:

```json
"order-list": ["firefox", "discord", "Steam", "Mailspring"],
```

With everything open:

![image](https://user-images.githubusercontent.com/5057870/149678563-e9cb5ff6-2d52-412b-b7b8-c9c7181064cb.png)

With only Firefox and Mailspring open, Mailspring is positioned directly after Firefox:

![image](https://user-images.githubusercontent.com/5057870/149678626-4f29994e-0b0e-43ce-82d2-d1e7a9bdf4ba.png)

I'm creating this as WIP because I've never written a line of C++ before this and it's an ugly hack. It's parsing the order list for every task twice per render, and I don't like that the button field has been made public. If anybody finds this useful and wants to lend a hand getting up to standard please do :)

