### PR TITLE
battery: read status with spaces

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -161,7 +161,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       uint32_t    energy_now;
       uint32_t    energy_full_design;
       std::string _status;
-      std::ifstream(bat / "status") >> _status;
+      std::getline(std::ifstream(bat / "status"), _status);
 
       // Some battery will report current and charge in μA/μAh.
       // Scale these by the voltage to get μW/μWh.


### PR DESCRIPTION
According to the [sysfs class power ABI], `/sys/class/power_supply/<supply_name>/status` may contain "Not charging".  This is already handled by `status_gt()` and `update()` (where `' '` is converted to `'-'` for use in config keys) but was not being read due to `skipws`.  Read with `std::getline()` to handle this case.

[sysfs class power ABI]: https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-power

Fixes: #1139

Thanks for considering,
Kevin