### PR TITLE
add skip-floating-windows option to restore old behaviour of window c…

### DIFF
--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -70,6 +70,11 @@ Addressed by *sway/window*
 	typeof: object ++
 	Rules to rewrite window title. See *rewrite rules*.
 
+*skip-floating-windows*: ++
+	typeof: bool ++
+	default: false ++
+	Skip floating nodes when counting windows present in the workspace for style classes.
+
 # REWRITE RULES
 
 *rewrite* is an object where keys are regular expressions and values are


### PR DESCRIPTION
Quick fix suggestion for https://github.com/Alexays/Waybar/issues/1399 .

This is not implementing any of the suggested new css classes. Instead, this adds a bool option
"skip-floating-windows" : true
that should restore the old behaviour if desired.

Seems to be working for both use cases.
