### PR TITLE
Switch to more powerful, regex-based output matching

### DIFF
--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -27,9 +27,9 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	Decide if the bar is displayed in front (*top*) of the windows or behind (*bottom*)
 	them.
 
-*output* ++
-	typeof: string|array ++
-	Specifies on which screen this bar will be displayed. Exclamation mark(*!*) can be used to exclude specific output.
+*output*
+	typeof: string ++
+Specifies on which screen this bar will be displayed. String is a regular expression used to match each output *name*/*identifier* (this is the actual format of the string matched). Regular expression follows ECMA-script rules.
 
 *position* ++
 	typeof: string ++
@@ -173,7 +173,7 @@ A minimal *config* file could look like this:
 ```
 {
 	"layer": "top",
-	"output": "eDP-1",
+	"output": "eDP-1/.*",
 	"modules-left": ["sway/workspaces", "sway/mode"],
 	...
 
@@ -184,7 +184,7 @@ A minimal *config* file could look like this:
 ```
 {
 	"layer": "top",
-	"output": ["eDP-1", "VGA"],
+	"output": "(eDP-1|VGA)/.*",
 	"modules-left": ["sway/workspaces", "sway/mode"],
 	...
 }
@@ -198,12 +198,12 @@ Don't specify an output to create multiple bars on the same screen.
 ```
 [{
 	"layer": "top",
-	"output": "eDP-1",
+	"output": "eDP-1/.*",
 	"modules-left": ["sway/workspaces", "sway/mode"],
 	...
 }, {
 	"layer": "top",
-	"output": "VGA",
+	"output": "VGA/.*",
 	"modules-right": ["clock"],
 	...
 }]

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -6,6 +6,7 @@
 #include <wordexp.h>
 
 #include <fstream>
+#include <regex>
 #include <stdexcept>
 
 #include "util/json.hpp"
@@ -104,22 +105,10 @@ void Config::mergeConfig(Json::Value &a_config_, Json::Value &b_config_) {
 }
 bool isValidOutput(const Json::Value &config, const std::string &name,
                    const std::string &identifier) {
-  if (config["output"].isArray()) {
-    for (auto const &output_conf : config["output"]) {
-      if (output_conf.isString() &&
-          (output_conf.asString() == name || output_conf.asString() == identifier)) {
-        return true;
-      }
-    }
-    return false;
-  } else if (config["output"].isString()) {
-    auto config_output = config["output"].asString();
-    if (!config_output.empty()) {
-      if (config_output.substr(0, 1) == "!") {
-        return config_output.substr(1) != name && config_output.substr(1) != identifier;
-      }
-      return config_output == name || config_output == identifier;
-    }
+  if (config["output"].isString()) {
+    const std::regex re{config["output"].asString()};
+    auto name_with_identifier = fmt::format("{}/{}", name, identifier);
+    return std::regex_match(name_with_identifier, re);
   }
 
   return true;

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -110,5 +110,5 @@ TEST_CASE("Load multiple bar config with include", "[config]") {
   auto& data = conf.getConfig();
   REQUIRE(data.isArray());
   REQUIRE(data.size() == 4);
-  REQUIRE(data[0]["output"].asString() == "OUT-0");
+  REQUIRE(data[0]["output"].asString() == "OUT-0/.*");
 }

--- a/test/config/include-1.json
+++ b/test/config/include-1.json
@@ -2,6 +2,6 @@
   "layer": "top",
   "position": "bottom",
   "height": 30,
-  "output": ["HDMI-0", "DP-0"],
+  "output": "(HDMI-0|DP-0)/.*",
   "nullOption": "not null"
 }

--- a/test/config/include-multi-0.json
+++ b/test/config/include-multi-0.json
@@ -1,4 +1,4 @@
 {
-  "output": "OUT-0",
+  "output": "OUT-0/.*",
   "height": 20
 }

--- a/test/config/include-multi-2.json
+++ b/test/config/include-multi-2.json
@@ -1,4 +1,4 @@
 {
-  "output": "OUT-1",
+  "output": "OUT-1/.*",
   "height": 22
 }

--- a/test/config/include-multi-3.json
+++ b/test/config/include-multi-3.json
@@ -1,4 +1,4 @@
 {
-  "output": "OUT-3",
+  "output": "OUT-3/.*",
   "include": "test/config/include-multi-3-0.json"
 }

--- a/test/config/include-multi.json
+++ b/test/config/include-multi.json
@@ -3,11 +3,11 @@
     "include": "test/config/include-multi-0.json"
   },
   {
-    "output": "OUT-1",
+    "output": "OUT-1/.*",
     "include": "test/config/include-multi-1.json"
   },
   {
-    "output": "OUT-2",
+    "output": "OUT-2/.*",
     "include": "test/config/include-multi-2.json"
   },
   {

--- a/test/config/multi.json
+++ b/test/config/multi.json
@@ -2,24 +2,24 @@
   {
     "layer": "bottom",
     "height": 20,
-    "output": ["HDMI-0", "DP-0"]
+    "output": "(HDMI-0|DP-0)/.*"
   },
   {
     "position": "bottom",
     "layer": "top",
     "height": 21,
-    "output": ["DP-0"]
+    "output": "DP-0/.*"
   },
   {
     "position": "left",
     "layer": "overlay",
     "height": 22,
-    "output": "Fake HDMI output #1"
+    "output": ".*/Fake HDMI output #1"
   },
   {
     "position": "right",
     "layer": "overlay",
     "height": 23,
-    "output": "!HDMI-1"
+    "output": "(?!HDMI-1|HDMI-2).*?/.*"
   }
 ]

--- a/test/config/simple.json
+++ b/test/config/simple.json
@@ -1,5 +1,5 @@
 {
   "layer": "top",
   "height": 30,
-  "output": ["HDMI-0", "DP-0"]
+  "output": "(HDMI-0|DP-0)/.*"
 }


### PR DESCRIPTION
This change mainly removes one limitation: it was not possible to have multiple negative matches. Now it's easy:

```json
"output": "(?!HDMI-A-1|eDP-1).*?/.*",
```

The format of the string matched is now *name*/*identifier*, because making two separate matches wouldn't make sense from logical perspective.

It also makes the code simpler.