### PR TITLE
Reverse the tray icon order

### DIFF
--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -29,6 +29,10 @@ Addressed by *tray*
     typeof: integer ++
     Defines the spacing between the tray icons.
 
+*reverse-direction*: ++
+    typeof: bool ++
+    Defines if new app icons should be added in a reverse order
+
 *on-update*: ++
 	typeof: string ++
 	Command to execute when the module is updated.

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -25,7 +25,11 @@ Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
 }
 
 void Tray::onAdd(std::unique_ptr<Item>& item) {
-  box_.pack_end(item->event_box);
+  if (config_["reverse-direction"].isBool() && config_["reverse-direction"].asBool()) {
+    box_.pack_end(item->event_box);
+  } else {
+    box_.pack_start(item->event_box);
+  }
   dp.emit();
 }
 

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -25,7 +25,7 @@ Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
 }
 
 void Tray::onAdd(std::unique_ptr<Item>& item) {
-  box_.pack_start(item->event_box);
+  box_.pack_end(item->event_box);
   dp.emit();
 }
 


### PR DESCRIPTION
At the moment when a new appindicator is added, the icon gets added to the end which isn't very good if the tray is positioned on the right of the bar.

With `reverse-direction` set to true, new app indicators get added to the start