### PR TITLE
Add battery format-time option for zero-padded minutes

### DIFF
--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -114,9 +114,10 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 
 The *battery* module allows you to define how time should be formatted via *format-time*.
 
-The two arguments are:
+The three arguments are:
 *{H}*: Hours
 *{M}*: Minutes
+*{m}*: Zero-padded minutes
 
 # CUSTOM FORMATS
 

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -308,7 +308,8 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
   if (config_["format-time"].isString()) {
     format = config_["format-time"].asString();
   }
-  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes));
+  std::string zero_pad_minutes = fmt::format("{:02d}", minutes);
+  return fmt::format(format, fmt::arg("H", full_hours), fmt::arg("M", minutes), fmt::arg("m", zero_pad_minutes));
 }
 
 auto waybar::modules::Battery::update() -> void {


### PR DESCRIPTION
Currently using, e.g., `"format-time": "{H}:{M}"` results in output that looks weird for minutes < 10. For example if there are 2 hours and 3 minutes of time remaining it is displayed as `2:3`.

This PR adds a `"{m}"` format option that displays minutes always as two digits. Thus we'd have `2:03`, which is much nicer.

I considered casting the time remaining as a time object so that fmt Chrono Formatting (`"%H:%M"`, etc.) could be used, but that would be a breaking change.

p.s. I think I added documentation in all the right places (besides the github wiki), but please let me  know if I missed somewhere.