### PR TITLE
Update man page clock module - tooltip

### DIFF
--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -86,6 +86,11 @@ The *clock* module displays the current date and time.
 	typeof: double ++
 	Threshold to be used when scrolling.
 
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 View all valid format options in *strftime(3)*.
 
 # FORMAT REPLACEMENTS


### PR DESCRIPTION
Add tooltip documentation to the clock man page now that disabling it works.
(forgot to do this in #1418, as mentioned in #1414)