### PR TITLE
move Glib ustring format helper to utils

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <fmt/format.h>
+#include <glibmm/ustring.h>
 
 class pow_format {
   public:
@@ -83,6 +84,16 @@ namespace fmt {
               , fmt::arg("padding", pow ? "" : s.binary_ ? "  " : " ")
             );
         }
+    };
+
+
+    // Glib ustirng support
+    template <>
+    struct formatter<Glib::ustring> : formatter<std::string> {
+      template <typename FormatContext>
+      auto format(const Glib::ustring& value, FormatContext& ctx) {
+        return formatter<std::string>::format(value, ctx);
+      }
     };
 }
 

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -8,13 +8,7 @@
 #include <fstream>
 #include <map>
 
-template <>
-struct fmt::formatter<Glib::ustring> : formatter<std::string> {
-  template <typename FormatContext>
-  auto format(const Glib::ustring& value, FormatContext& ctx) {
-    return formatter<std::string>::format(value, ctx);
-  }
-};
+#include "util/format.hpp"
 
 template <>
 struct fmt::formatter<Glib::VariantBase> : formatter<std::string> {


### PR DESCRIPTION
this formatter is useful for other modules
which want to print Glib exceptions messages