### PR TITLE
fix #1431: audio output does not update on unplug

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -54,7 +54,9 @@ void waybar::modules::Pulseaudio::contextStateCb(pa_context *c, void *data) {
           c,
           static_cast<enum pa_subscription_mask>(static_cast<int>(PA_SUBSCRIPTION_MASK_SERVER) |
                                                  static_cast<int>(PA_SUBSCRIPTION_MASK_SINK) |
-                                                 static_cast<int>(PA_SUBSCRIPTION_MASK_SOURCE)),
+                                                 static_cast<int>(PA_SUBSCRIPTION_MASK_SINK_INPUT) |
+                                                 static_cast<int>(PA_SUBSCRIPTION_MASK_SOURCE) |
+                                                 static_cast<int>(PA_SUBSCRIPTION_MASK_SOURCE_OUTPUT)),
           nullptr,
           nullptr);
       break;
@@ -121,8 +123,12 @@ void waybar::modules::Pulseaudio::subscribeCb(pa_context *                 conte
     pa_context_get_server_info(context, serverInfoCb, data);
   } else if (facility == PA_SUBSCRIPTION_EVENT_SINK) {
     pa_context_get_sink_info_by_index(context, idx, sinkInfoCb, data);
+  } else if (facility == PA_SUBSCRIPTION_EVENT_SINK_INPUT) {
+    pa_context_get_sink_info_list(context, sinkInfoCb, data);
   } else if (facility == PA_SUBSCRIPTION_EVENT_SOURCE) {
     pa_context_get_source_info_by_index(context, idx, sourceInfoCb, data);
+  } else if (facility == PA_SUBSCRIPTION_EVENT_SOURCE_OUTPUT) {
+    pa_context_get_source_info_list(context, sourceInfoCb, data);
   }
 }
 
@@ -279,7 +285,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
                                 fmt::arg("source_desc", source_desc_),
                                 fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
   getState(volume_);
-  
+
   if (tooltipEnabled()) {
     if (tooltip_format.empty() && config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();


### PR DESCRIPTION
Fixes https://github.com/Alexays/Waybar/issues/1431

It seems like when unplugging the audio output briefly switches to the `IDLE` state, and then back to `RUNNING`, but the change to RUNNING is not detected because it does not trigger the `PA_SUBSCRIPTION_MASK_SINK`.
But the `PA_SUBSCRIPTION_MASK_SINK_INPUT` is triggered (I assume because the playback is reattached to the think, but honestly I have no idea; this is the first time working the pulse api).

I added the same code for the `SOURCE`, but I don't know if it is necessary.

Also, it might be undesirable to listen to all sink input changes for performance reasons (though this also doesn't happen very often), but I don't see another way of detecting the `IDLE -> RUNNING` change.

Another approach might be to just use the default source/sink, because in theory there could be multiple `RUNNING` outputs. Though I assume you had a reason for not doing that.