### PR TITLE
Add 1 to songPosition in the MPD module

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -129,7 +129,7 @@ void waybar::modules::MPD::setLabel() {
     album = getTag(MPD_TAG_ALBUM);
     title = getTag(MPD_TAG_TITLE);
     date = getTag(MPD_TAG_DATE);
-    song_pos = mpd_status_get_song_pos(status_.get());
+    song_pos = mpd_status_get_song_pos(status_.get()) + 1;
     volume = mpd_status_get_volume(status_.get());
     if (volume < 0) {
       volume = 0;


### PR DESCRIPTION
Pretty self-explanatory single-line change. Currently the song position is zero-indexed, which aside from not really looking good when you're playing song 0 of 1, doesn't match `mpc`'s interface (e.g. `mpc play 0` errors).