### PR TITLE
style.css: add fontawesome to beginning of font list

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -1,6 +1,6 @@
 * {
     /* `otf-font-awesome` is required to be installed for icons */
-    font-family: Roboto, Helvetica, Arial, sans-serif;
+    font-family: FontAwesome, Roboto, Helvetica, Arial, sans-serif;
     font-size: 13px;
 }
 


### PR DESCRIPTION
If there is some other font installed that 1) matches the four existing font families and 2) provides its own glyph in the private use area used by Awesome, then that font's glyph will be used instead of the intended icon.

For example, the following character (U+F001, ["music"](https://fontawesome.com/icons/music?s=solid)):  ...looks like a pair of musical notes in fontawesome, but DejaVu Sans also provides a glyph, which looks like a couple of squares. DejaVu Sans matches first when "sans-serif" is requested, so its (unrelated) glyph is used.