### PR TITLE
avoid use-after-free in lambda

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -750,7 +750,7 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos, Gtk
             modules_right_.emplace_back(module_sp);
           }
         }
-        module->dp.connect([module, &name] {
+        module->dp.connect([module, name] {
           try {
             module->update();
           } catch (const std::exception& e) {


### PR DESCRIPTION
Fixes #1449.
Fixes #1439.
Fixes #1402.

The problem here is that if a custom module's JSON fails to parse, then the exception handling code will attempt to log the module name after it's been freed. This may cause `name.asString()` to throw an exception. This commit fixes the issue by capturing the name by value.

Valgrind output before the change:

<details>

```
valgrind ./build/waybar -c config.json
==94675== Memcheck, a memory error detector
==94675== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==94675== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==94675== Command: ./build/waybar -c config.json
==94675==
==94675== Warning: ignored attempt to set SIGRT32 handler in sigaction();
==94675==          the SIGRT32 signal is used internally by Valgrind
[2022-03-03 19:50:33.668] [info] Using configuration file config.json
[2022-03-03 19:50:33.781] [info] Using CSS file /home/euclio/.config/waybar/style.css
[2022-03-03 19:50:34.337] [warning] module sway/workspaces: Disabling module "sway/workspaces", Socket path is empty
[2022-03-03 19:50:34.400] [warning] module sway/mode: Disabling module "sway/mode", Socket path is empty
[2022-03-03 19:50:34.572] [warning] For a functional tray you must have libappindicator-* installed and export XDG_CURRENT_DESKTOP=Unity
sh: line 1: swaylay: command not found
[2022-03-03 19:50:34.632] [warning] module idle_inhibitor: Disabling module "idle_inhibitor", idle-inhibit not available
[2022-03-03 19:50:34.739] [error] keyboard stopped unexpectedly, is it endless?
[2022-03-03 19:50:35.355] [warning] As using a timezone, some format args may be missing as the date library haven't got a release since 2018.
sh: line 1: /home/euclio/.config/waybar/modules/powermenu.sh: No such file or directory
==94675== Invalid read of size 1
==94675==    at 0x492DDC0: Json::Value::type() const (in /usr/lib/libjsoncpp.so.25)
==94675==    by 0x4934D6E: Json::Value::asString[abi:cxx11]() const (in /usr/lib/libjsoncpp.so.25)
==94675==    by 0x1688AB: waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Gtk::Box*)::{lambda()#1}::operator()() const (bar.cpp:757)
==94675==    by 0x169BCF: sigc::adaptor_functor<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Gtk::Box*)::{lambda()#1}>::operator()() const (adaptor_trait.h:256)
==94675==    by 0x169A26: sigc::internal::slot_call0<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Gtk::Box*)::{lambda()#1}, void>::call_it(sigc::internal::slot_rep*) (slot.h:136)
==94675==    by 0x5A6EB39: Glib::DispatchNotifier::pipe_io_handler(Glib::IOCondition) (in /usr/lib/libglibmm-2.4.so.1.3.0)
==94675==    by 0x5A7555B: Glib::IOSource::dispatch(sigc::slot_base*) (in /usr/lib/libglibmm-2.4.so.1.3.0)
==94675==    by 0x5A6E7D6: Glib::Source::dispatch_vfunc(_GSource*, int (*)(void*), void*) (in /usr/lib/libglibmm-2.4.so.1.3.0)
==94675==    by 0x5B7CEE2: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.7000.4)
==94675==    by 0x5BD30F8: ??? (in /usr/lib/libglib-2.0.so.0.7000.4)
==94675==    by 0x5B7A454: g_main_context_iteration (in /usr/lib/libglib-2.0.so.0.7000.4)
==94675==    by 0x592D6ED: g_application_run (in /usr/lib/libgio-2.0.so.0.7000.4)
==94675==  Address 0xa0176f8 is 1,416 bytes inside an unallocated block of size 1,744 in arena "client"
==94675==
==94675== Invalid read of size 8
==94675==    at 0x4934D90: Json::Value::asString[abi:cxx11]() const (in /usr/lib/libjsoncpp.so.25)
==94675==    by 0x1688AB: waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Gtk::Box*)::{lambda()#1}::operator()() const (bar.cpp:757)
==94675==    by 0x169BCF: sigc::adaptor_functor<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Gtk::Box*)::{lambda()#1}>::operator()() const (adaptor_trait.h:256)
==94675==    by 0x169A26: sigc::internal::slot_call0<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, Gtk::Box*)::{lambda()#1}, void>::call_it(sigc::internal::slot_rep*) (slot.h:136)
==94675==    by 0x5A6EB39: Glib::DispatchNotifier::pipe_io_handler(Glib::IOCondition) (in /usr/lib/libglibmm-2.4.so.1.3.0)
==94675==    by 0x5A7555B: Glib::IOSource::dispatch(sigc::slot_base*) (in /usr/lib/libglibmm-2.4.so.1.3.0)
==94675==    by 0x5A6E7D6: Glib::Source::dispatch_vfunc(_GSource*, int (*)(void*), void*) (in /usr/lib/libglibmm-2.4.so.1.3.0)
==94675==    by 0x5B7CEE2: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.7000.4)
==94675==    by 0x5BD30F8: ??? (in /usr/lib/libglib-2.0.so.0.7000.4)
==94675==    by 0x5B7A454: g_main_context_iteration (in /usr/lib/libglib-2.0.so.0.7000.4)
==94675==    by 0x592D6ED: g_application_run (in /usr/lib/libgio-2.0.so.0.7000.4)
==94675==    by 0x17CC49: waybar::Client::main(int, char**) (client.cpp:242)
==94675==  Address 0xa0176f0 is 1,408 bytes inside an unallocated block of size 1,744 in arena "client"
==94675==
[2022-03-03 19:50:37.791] [error] : * Line 1, Column 1
  Syntax error: value, object or array expected.

[2022-03-03 19:50:37.831] [error] : * Line 1, Column 1
  Syntax error: value, object or array expected.

[2022-03-03 19:50:42.682] [info] Bar configured (width: 1920, height: 28) for output: eDP-1
```

</details>

Valgrind reports no issues after this commit.