### PR TITLE
man: document icon in sway/window module

### DIFF
--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -70,6 +70,11 @@ Addressed by *sway/window*
 	typeof: object ++
 	Rules to rewrite window title. See *rewrite rules*.
 
+*icon*: ++
+	typeof: bool ++
+	default: true ++
+	Option to hide the application icon.
+
 # REWRITE RULES
 
 *rewrite* is an object where keys are regular expressions and values are


### PR DESCRIPTION
Default changed in bcadf64031ee0520212aa8f092f5ac14122cd924 and it
wasn't documented.

I was surprised about the change in the recent release and didn't find anything in the man-page.

Relevant change is here: https://github.com/grmat/Waybar/commit/bcadf64031ee0520212aa8f092f5ac14122cd924#diff-502183048a020c02261fe9061cae986f05fbe87113c79dd5257952b0b60a3a24R25