### PR TITLE
use moon phases for backlight format-icons

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -96,7 +96,7 @@
     "backlight": {
         // "device": "acpi_video1",
         "format": "{percent}% {icon}",
-        "format-icons": ["", ""]
+        "format-icons": ["", "", "", "", "", "", "", "", ""]
     },
     "battery": {
         "states": {


### PR DESCRIPTION
Supersedes https://github.com/Alexays/Waybar/pull/873

uses symbols instead of emoji

@Synthetica9 @roland-rollo