### PR TITLE
Use user-defined mode when toggling visibility rather than resetting to default

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -665,7 +665,11 @@ void waybar::Bar::onMap(GdkEventAny*) {
 
 void waybar::Bar::setVisible(bool value) {
   visible = value;
-  setMode(visible ? MODE_DEFAULT : MODE_INVISIBLE);
+  if (auto mode = config.get("mode", {}); mode.isString()) {
+    setMode(visible ? config["mode"].asString() : MODE_INVISIBLE);
+  } else {
+    setMode(visible ? MODE_DEFAULT : MODE_INVISIBLE);
+  }
 }
 
 void waybar::Bar::toggle() { setVisible(!visible); }


### PR DESCRIPTION
Fixes #958 and #491 (or at least [this comment](https://github.com/Alexays/Waybar/issues/491#issuecomment-799217823)), this way if the bar is configured to be in overlay mode, it will stay in that mode when it's re-shown after being hidden. If there's a better way to do this, let me know, I just reused the code elsewhere that retrieved the config mode in the first place