### PR TITLE
sway/language: Load exotic xkb rules too

### DIFF
--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -179,8 +179,7 @@ auto Language::init_layouts_map(const std::vector<std::string>& used_layouts) ->
 }
 
 Language::XKBContext::XKBContext() {
-  context_ = rxkb_context_new(RXKB_CONTEXT_NO_DEFAULT_INCLUDES);
-  rxkb_context_include_path_append_default(context_);
+  context_ = rxkb_context_new(RXKB_CONTEXT_LOAD_EXOTIC_RULES);
   rxkb_context_parse_default_ruleset(context_);
 }
 


### PR DESCRIPTION
Hi.

I am using the `EurKEY` (`eu`) keyboard layout, which apparently is an "exotic" one.

Since waybar does not load the exotic ones, there is nothing displayed in the bar for the language module.

See my comment https://github.com/Alexays/Waybar/pull/1406#issuecomment-1059074832