### PR TITLE
Battery module. Gamepads support

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -154,6 +154,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
     uint32_t    total_energy = 0;  // μWh
     uint32_t    total_energy_full = 0;
     uint32_t    total_energy_full_design = 0;
+    uint32_t    total_capacity{0};
     std::string status = "Unknown";
     for (auto const& item : batteries_) {
       auto bat = item.first;
@@ -161,6 +162,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       uint32_t    energy_full;
       uint32_t    energy_now;
       uint32_t    energy_full_design;
+      uint32_t    capacity{0};
       std::string _status;
       std::getline(std::ifstream(bat / "status"), _status);
 
@@ -188,11 +190,18 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
         energy_now = ((uint64_t)charge_now * (uint64_t)voltage_now) / 1000000;
         energy_full = ((uint64_t)charge_full * (uint64_t)voltage_now) / 1000000;
         energy_full_design = ((uint64_t)charge_full_design * (uint64_t)voltage_now) / 1000000;
+      } // Gamepads such as PS Dualshock provide the only capacity
+        else if (fs::exists(bat / "energy_now") && fs::exists(bat / "energy_full")) {
+          std::ifstream(bat / "power_now") >> power_now;
+          std::ifstream(bat / "energy_now") >> energy_now;
+          std::ifstream(bat / "energy_full") >> energy_full;
+          std::ifstream(bat / "energy_full_design") >> energy_full_design;
       } else {
-        std::ifstream(bat / "power_now") >> power_now;
-        std::ifstream(bat / "energy_now") >> energy_now;
-        std::ifstream(bat / "energy_full") >> energy_full;
-        std::ifstream(bat / "energy_full_design") >> energy_full_design;
+        std::ifstream(bat / "capacity") >> capacity;
+        power_now          = 0;
+        energy_now         = 0;
+        energy_full        = 0;
+        energy_full_design = 0;
       }
 
       // Show the "smallest" status among all batteries
@@ -203,6 +212,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       total_energy += energy_now;
       total_energy_full += energy_full;
       total_energy_full_design += energy_full_design;
+      total_capacity += capacity;
     }
     if (!adapter_.empty() && status == "Discharging") {
       bool online;
@@ -222,7 +232,12 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
         time_remaining = 0.0f;
       }
     }
-    float capacity = ((float)total_energy * 100.0f / (float) total_energy_full);
+    float capacity{0.0f};
+    if(total_energy_full > 0.0f) {
+      capacity = ((float)total_energy * 100.0f / (float) total_energy_full);
+    } else {
+      capacity = (float)total_capacity;
+    }
     // Handle design-capacity
     if (config_["design-capacity"].isBool() ? config_["design-capacity"].asBool() : false) {
         capacity = ((float)total_energy * 100.0f / (float) total_energy_full_design);

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -118,9 +118,10 @@ void waybar::modules::Battery::refreshBatteries() {
   }
   if (batteries_.empty()) {
     if (config_["bat"].isString()) {
-      throw std::runtime_error("No battery named " + config_["bat"].asString());
+      spdlog::warn("No battery named {}", config_["bat"].asString());
+    } else {
+      spdlog::warn("No batteries.");
     }
-    throw std::runtime_error("No batteries.");
   }
 
   // Remove any batteries that are no longer present and unwatch them
@@ -283,6 +284,10 @@ const std::string waybar::modules::Battery::formatTimeRemaining(float hoursRemai
 }
 
 auto waybar::modules::Battery::update() -> void {
+  if (batteries_.empty()) {
+    event_box_.hide();
+    return;
+  }
   auto [capacity, time_remaining, status, power] = getInfos();
   if (status == "Unknown") {
     status = getAdapterStatus(capacity);


### PR DESCRIPTION
Standard battery module doesn't support of the gamepads such as PS Dualshock are connected over bluetooth . Moreover this module crashes waybar in case when wrong battery info is provided in the json .config. 
Current two commits bring next fixes:
1. Do not propagate raised exception when physical device disappeared in the system. When wrong config or the gamepad was unplugged and device is removed from the /sys/classes the module just is set to invisible mode. Once device is back, module will print info just after provided delay.
2. Gamepad devices are recognized in the linux such a power_supply class but with the limited information about devices. For example PS Dualshock provides the only capacity, status. For such devices module does not do capacity estimation and uses provided capacity by the gamepad controller as is.