### PR TITLE
Possibility to use different format-icons profiles

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -80,6 +80,16 @@ std::string ALabel::getIcon(uint16_t percentage, const std::string& alt, uint16_
 
 std::string ALabel::getIcon(uint16_t percentage, const std::vector<std::string>& alts, uint16_t max) {
   auto format_icons = config_["format-icons"];
+  for(const auto& iconsSet : alts) {
+    if(!iconsSet.empty()) {
+      std::string idx{"format-icons-" + iconsSet};
+      if((config_[idx].isString() || config_[idx].isArray())) {
+        format_icons = config_[idx];
+        break;
+      }
+    }
+  }
+
   if (format_icons.isObject()) {
     std::string _alt = "default";
     for (const auto& alt : alts) {


### PR DESCRIPTION
The fix is pretty simple. In case when the module provides an array of icon profiles getIcon method does searching the current set of icons needs to be displayed. By default is used: format-icons.
Example:
![ps_2022-03-15-13_32_14](https://user-images.githubusercontent.com/23121044/158359045-57abd9d5-928a-4bf6-ae62-d1ea66b9cbc8.png)
Config example:
`"battery": {
        "bat": "BAT0",
        "states": {
            // "good": 95,
            "warning": 30,
            "critical": 15
        },
        "format-charging": "{icon} {capacity}% ",
        "format": "{icon} {capacity}%",
        "format-plugged": "{capacity}% ",
        "format-full": "{capacity}% ",
        // "format-good": "", // An empty format will hide the module
        "format-icons": ["","","","",""],
        "format-icons-charging": ["","","","","","",""],
        "tooltip": true
    },`