### PR TITLE
Hide/Unhide temperature module when "format*" is empty.

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -3,11 +3,6 @@
 
 waybar::modules::Temperature::Temperature(const std::string& id, const Json::Value& config)
     : ALabel(config, "temperature", id, "{temperatureC}°C", 10) {
-  if (config_["format"].asString().empty() && config_["format-critical"].asString().empty()) {
-    throw std::runtime_error("Format configuration is not defined");
-  } else if (config_["format"].asString().empty()) {
-    format_.clear();
-  }
   if (config_["hwmon-path"].isString()) {
     file_path_ = config_["hwmon-path"].asString();
   } else if (config_["hwmon-path-abs"].isString() && config_["input-filename"].isString()) {
@@ -40,8 +35,7 @@ auto waybar::modules::Temperature::update() -> void {
     label_.get_style_context()->remove_class("critical");
   }
 
-  if(format.empty())
-  {
+  if(format.empty()) {
     event_box_.hide();
     return;
   } else {

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -3,6 +3,11 @@
 
 waybar::modules::Temperature::Temperature(const std::string& id, const Json::Value& config)
     : ALabel(config, "temperature", id, "{temperatureC}°C", 10) {
+  if (config_["format"].asString().empty() && config_["format-critical"].asString().empty()) {
+    throw std::runtime_error("Format configuration is not defined");
+  } else if (config_["format"].asString().empty()) {
+    format_.clear();
+  }
   if (config_["hwmon-path"].isString()) {
     file_path_ = config_["hwmon-path"].asString();
   } else if (config_["hwmon-path-abs"].isString() && config_["input-filename"].isString()) {
@@ -34,6 +39,15 @@ auto waybar::modules::Temperature::update() -> void {
   } else {
     label_.get_style_context()->remove_class("critical");
   }
+
+  if(format.empty())
+  {
+    event_box_.hide();
+    return;
+  } else {
+    event_box_.show();
+  }
+
   auto max_temp = config_["critical-threshold"].isInt() ? config_["critical-threshold"].asInt() : 0;
   label_.set_markup(fmt::format(format,
                                 fmt::arg("temperatureC", temperature_c),


### PR DESCRIPTION
Actually even is set `"format" : ""` waybar displays some spaces. But when user wants to have the only notification when temperature threshold is triggered it looks not so good.
Current fix does:

1. If nor `"format" : ""` neither `"format-critical" : ""` is defined - throw an exception in order to have temperature module disabled during the start process
2. If "format" is empty and critical threshold is not triggered - hide the module

config example:
```
"temperature": {
        // "thermal-zone": 2,
        // "hwmon-path": "/sys/class/hwmon/hwmon2/temp1_input",
        "format": "",
        "critical-threshold": 90,
        "format-critical": "<span font-family=\"Font Awesome 5 Free\">{icon}</span> {temperatureC}°C",
        "format-icons": ["", "", ""],
        "interval": 10
    },
```