### PR TITLE
#1315. Add option to display week number on calendar

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -35,6 +35,8 @@ class Clock : public ALabel {
   auto weekdays_header(const date::weekday& first_dow, std::ostream& os) -> void;
   auto first_day_of_week() -> date::weekday;
   const date::time_zone* current_timezone();
+  auto print_iso_weeknum(std::ostream& os,
+                         int weeknum) -> void;
   bool is_timezone_fixed();
   auto timezones_text(std::chrono::system_clock::time_point *now) -> std::string;
 };

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -171,6 +171,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   int ws{0};    // weeks-pos: side(1 - left, 2 - right)
   int wn{0};    // weeknumber
   if (config_["week-pos"].isString()) {
+    wn = (date::sys_days{date::year_month_day{ym / 1}} - date::sys_days{date::year_month_day{ymd.year() / 1 / 1}}).count() / 7 + 1;
     if (config_["week-pos"].asString() == "left") {
       ws = 1;
       // Add paddings before the header
@@ -179,21 +180,17 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
       ws = 2;
     }
   }
-  if (ws > 0){
-    wn = (date::sys_days{date::year_month_day{ym / 1}} - date::sys_days{date::year_month_day{ymd.year() / 1 / 1}}).count() / 7 + 1;
-  }
-
   weekdays_header(first_dow, os);
-
+  /* Print weeknumber on the left for the first row*/
+  if (ws == 1) {
+    print_iso_weeknum(os, wn);
+    os << ' ';
+    ++wn;
+  }
   // First week prefixed with spaces if needed.
   auto wd = date::weekday(ym / 1);
   auto empty_days = (wd - first_dow).count();
   if (empty_days > 0) {
-    if (ws == 1) {
-      print_iso_weeknum(os, wn);
-      os << ' ';
-      ++wn;
-    }
     os << std::string(empty_days * 3 - 1, ' ');
   }
   auto last_day = (ym / date::literals::last).day();


### PR DESCRIPTION
Config example:
`"clock": {
        // "timezone": "America/New_York",
        "format": " {:%b %d %Y (%R)}",
        "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>",
        "format-alt": "{:%Y-%m-%d}",
        "today-format": "<span color='#ff6699'><b><u>{}</u></b></span>",
        "week-pos": "left",
        "week-format": "<span color='#99ffdd'><b>{}</b></span>",
        "interval": 10
    }`
Screenshots:
![ps_2022-03-24-15_33_55](https://user-images.githubusercontent.com/23121044/159918853-1ebd01a5-c96a-436b-942e-89dbebc3f8a0.png)
![ps_2022-03-24-15_34_54](https://user-images.githubusercontent.com/23121044/159918859-3393d317-7bf2-44de-b358-4f0d0ccb48d1.png)
