### PR TITLE
Waybar. Issue#1068. Double/Triple events

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -7,6 +7,8 @@
 
 #include "IModule.hpp"
 
+#include <map>
+
 namespace waybar {
 
 class AModule : public IModule {
@@ -36,6 +38,23 @@ class AModule : public IModule {
   std::vector<int> pid_;
   gdouble          distance_scrolled_y_;
   gdouble          distance_scrolled_x_;
+  static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{
+    {std::make_pair(1, GdkEventType::GDK_BUTTON_PRESS),  "on-click"},
+    {std::make_pair(1, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click"},
+    {std::make_pair(1, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click"},
+    {std::make_pair(2, GdkEventType::GDK_BUTTON_PRESS),  "on-click-middle"},
+    {std::make_pair(2, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-middle"},
+    {std::make_pair(2, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-middle"},
+    {std::make_pair(3, GdkEventType::GDK_BUTTON_PRESS),  "on-click-right"},
+    {std::make_pair(3, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-right"},
+    {std::make_pair(3, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-right"},
+    {std::make_pair(8, GdkEventType::GDK_BUTTON_PRESS),  "on-click-backward"},
+    {std::make_pair(8, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-backward"},
+    {std::make_pair(8, GdkEventType::GDK_2BUTTON_PRESS), "on-triple-click-backward"},
+    {std::make_pair(9, GdkEventType::GDK_BUTTON_PRESS),  "on-click-forward"},
+    {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-forward"},
+    {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-triple-click-forward"}
+  };
 };
 
 }  // namespace waybar

--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -7,8 +7,6 @@
 
 #include "IModule.hpp"
 
-#include <map>
-
 namespace waybar {
 
 class AModule : public IModule {


### PR DESCRIPTION
Added opportunity of the double/triple mouse events according https://github.com/Alexays/Waybar/issues/1068
It's better do not mix different types of clicks per button (Gdk for triple click raises single and double click before triple click)

1. on-double-click
2. on-triple-click
3. on-double-click-middle
4. on-triple-click-middle
5. on-double-click-right
6. on-triple-click-right
7. on-double-click-backward
8. on-triple-click-backward
9. on-double-click-forward
10. on-triple-click-forward