### PR TITLE
Replace sleep_until with sleep_for to prevent clock from getting stuck with system time adjustment

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -74,7 +74,11 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 
   thread_ = [this] {
     dp.emit();
-    thread_.sleep_for(interval_);
+    auto now = std::chrono::system_clock::now();
+    /* difference with projected wakeup time */
+    auto diff = now.time_since_epoch() % interval_;
+    /* sleep until the next projected time */
+    thread_.sleep_for(interval_ - diff);
   };
 }
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -74,10 +74,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
 
   thread_ = [this] {
     dp.emit();
-    auto now = std::chrono::system_clock::now();
-    auto timeout = std::chrono::floor<std::chrono::seconds>(now + interval_);
-    auto diff = std::chrono::seconds(timeout.time_since_epoch().count() % interval_.count());
-    thread_.sleep_until(timeout - diff);
+    thread_.sleep_for(interval_);
   };
 }
 

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -6,10 +6,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     : ALabel(config, "clock", id, "{:%H:%M}", 60) {
   thread_ = [this] {
     dp.emit();
-    auto now = std::chrono::system_clock::now();
-    auto timeout = std::chrono::floor<std::chrono::seconds>(now + interval_);
-    auto diff = std::chrono::seconds(timeout.time_since_epoch().count() % interval_.count());
-    thread_.sleep_until(timeout - diff);
+    thread_.sleep_for(interval_);
   };
 }
 

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -6,7 +6,11 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     : ALabel(config, "clock", id, "{:%H:%M}", 60) {
   thread_ = [this] {
     dp.emit();
-    thread_.sleep_for(interval_);
+    auto now = std::chrono::system_clock::now();
+    /* difference with projected wakeup time */
+    auto diff = now.time_since_epoch() % interval_;
+    /* sleep until the next projected time */
+    thread_.sleep_for(interval_ - diff);
   };
 }
 


### PR DESCRIPTION
I think this addresses #1226 and potentially #1497.

- [x] observe the change in general
- [x] test some system time jumps
- [x] test the simple clock module

On FreeBSD, the change does not have any effect, but doesn't make it worse, either.
