### PR TITLE
Show hidden bar

### DIFF
--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -44,6 +44,7 @@ class BarIpcClient {
   Ipc ipc_;
 
   swaybar_config bar_config_;
+  std::string modifier_reset_;
   bool visible_by_mode_ = false;
   bool visible_by_modifier_ = false;
   bool visible_by_urgency_ = false;

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -34,6 +34,7 @@ class BarIpcClient {
   void onCmd(const struct Ipc::ipc_response&);
   void onConfigUpdate(const swaybar_config& config);
   void onVisibilityUpdate(bool visible_by_modifier);
+  void onModeUpdate(bool visible_by_modifier);
   void onUrgencyUpdate(bool visible_by_urgency);
   void update();
 
@@ -42,10 +43,12 @@ class BarIpcClient {
   Ipc ipc_;
 
   swaybar_config bar_config_;
+  bool visible_by_mode_ = false;
   bool visible_by_modifier_ = false;
   bool visible_by_urgency_ = false;
   std::atomic<bool> modifier_no_action_ = false;
 
+  SafeSignal<bool> signal_mode_;
   SafeSignal<bool> signal_visible_;
   SafeSignal<bool> signal_urgency_;
   SafeSignal<swaybar_config> signal_config_;

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <atomic>
 #include <string>
 
 #include "modules/sway/ipc/client.hpp"
@@ -43,6 +44,7 @@ class BarIpcClient {
   swaybar_config bar_config_;
   bool visible_by_modifier_ = false;
   bool visible_by_urgency_ = false;
+  std::atomic<bool> modifier_no_action_ = false;
 
   SafeSignal<bool> signal_visible_;
   SafeSignal<bool> signal_urgency_;

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -37,6 +37,7 @@ class BarIpcClient {
   void onModeUpdate(bool visible_by_modifier);
   void onUrgencyUpdate(bool visible_by_urgency);
   void update();
+  bool isModuleEnabled(std::string name);
 
   Bar& bar_;
   util::JsonParser parser_;

--- a/include/modules/sway/bar.hpp
+++ b/include/modules/sway/bar.hpp
@@ -30,8 +30,10 @@ class BarIpcClient {
  private:
   void onInitialConfig(const struct Ipc::ipc_response& res);
   void onIpcEvent(const struct Ipc::ipc_response&);
+  void onCmd(const struct Ipc::ipc_response&);
   void onConfigUpdate(const swaybar_config& config);
   void onVisibilityUpdate(bool visible_by_modifier);
+  void onUrgencyUpdate(bool visible_by_urgency);
   void update();
 
   Bar& bar_;
@@ -40,8 +42,10 @@ class BarIpcClient {
 
   swaybar_config bar_config_;
   bool visible_by_modifier_ = false;
+  bool visible_by_urgency_ = false;
 
   SafeSignal<bool> signal_visible_;
+  SafeSignal<bool> signal_urgency_;
   SafeSignal<swaybar_config> signal_config_;
 };
 

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -77,6 +77,13 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	Selects one of the preconfigured display modes. This is an equivalent of the sway-bar(5) *mode* command and supports the same values: *dock*, *hide*, *invisible*, *overlay*. ++
 	Note: *hide* and *invisible* modes may be not as useful without Sway IPC.
 
+modifier-reset ++
+	typeof: string ++
+	default: *press*
+	Defines the timing of modifier key to reset the bar visibility.
+	To reset the visibility of the bar with the press of the modifier key use *press*.
+	Use *release* to reset the visibility upon the release of the modifier key and only if no other action happened while the key was pressed. This prevents hiding the bar when the modifier is used to switch a workspace, change binding mode or start a keybinding.
+
 *exclusive* ++
 	typeof: bool ++
 	default: *true* ++

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -21,9 +21,11 @@ BarIpcClient::BarIpcClient(waybar::Bar& bar) : bar_{bar} {
 
   signal_config_.connect(sigc::mem_fun(*this, &BarIpcClient::onConfigUpdate));
   signal_visible_.connect(sigc::mem_fun(*this, &BarIpcClient::onVisibilityUpdate));
+  signal_urgency_.connect(sigc::mem_fun(*this, &BarIpcClient::onUrgencyUpdate));
 
-  ipc_.subscribe(R"(["bar_state_update", "barconfig_update"])");
+  ipc_.subscribe(R"(["bar_state_update", "barconfig_update", "workspace"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &BarIpcClient::onIpcEvent));
+  ipc_.signal_cmd.connect(sigc::mem_fun(*this, &BarIpcClient::onCmd));
   // Launch worker
   ipc_.setWorker([this] {
     try {
@@ -61,20 +63,63 @@ void BarIpcClient::onInitialConfig(const struct Ipc::ipc_response& res) {
 void BarIpcClient::onIpcEvent(const struct Ipc::ipc_response& res) {
   try {
     auto payload = parser_.parse(res.payload);
-    if (auto id = payload["id"]; id.isString() && id.asString() != bar_.bar_id) {
-      spdlog::trace("swaybar ipc: ignore event for {}", id.asString());
-      return;
-    }
-    if (payload.isMember("visible_by_modifier")) {
-      // visibility change for hidden bar
-      signal_visible_(payload["visible_by_modifier"].asBool());
-    } else {
-      // configuration update
-      auto config = parseConfig(payload);
-      signal_config_(std::move(config));
+    switch (res.type) {
+      case IPC_EVENT_WORKSPACE:
+        if (payload.isMember("change")) {
+          // only check and send signal if the workspace update reason was because of a urgent
+          // change
+          if (payload["change"] == "urgent") {
+            auto urgent = payload["current"]["urgent"];
+            if (urgent.asBool()) {
+              // Event for a new urgency, update the visibly
+              signal_urgency_(true);
+            } else if (!urgent.asBool() && visible_by_urgency_) {
+              // Event clearing an urgency, bar is visible, check if another workspace still has
+              // the urgency hint set
+              ipc_.sendCmd(IPC_GET_WORKSPACES);
+            }
+          }
+        }
+        break;
+      case IPC_EVENT_BAR_STATE_UPDATE:
+      case IPC_EVENT_BARCONFIG_UPDATE:
+        if (auto id = payload["id"]; id.isString() && id.asString() != bar_.bar_id) {
+          spdlog::trace("swaybar ipc: ignore event for {}", id.asString());
+          return;
+        }
+        if (payload.isMember("visible_by_modifier")) {
+          // visibility change for hidden bar
+          signal_visible_(payload["visible_by_modifier"].asBool());
+        } else {
+          // configuration update
+          auto config = parseConfig(payload);
+          signal_config_(std::move(config));
+        }
+        break;
     }
   } catch (const std::exception& e) {
     spdlog::error("BarIpcClient::onEvent {}", e.what());
+  }
+}
+
+void BarIpcClient::onCmd(const struct Ipc::ipc_response& res) {
+  if (res.type == IPC_GET_WORKSPACES) {
+    try {
+      auto payload = parser_.parse(res.payload);
+      for (auto& ws : payload) {
+        if (ws["urgent"].asBool()) {
+          spdlog::debug("Found workspace {} with urgency set. Stopping search.", ws["name"]);
+          // Found one workspace with urgency set, signal bar visibility
+          signal_urgency_(true);
+          return;
+        }
+      }
+      // Command to get workspaces was sent after a change in workspaces was based on "urgent",
+      // if no workspace has this flag set to true, all flags must be cleared.
+      signal_urgency_(false);
+    } catch (const std::exception& e) {
+      spdlog::error("Bar: {}", e.what());
+    }
   }
 }
 
@@ -86,13 +131,19 @@ void BarIpcClient::onConfigUpdate(const swaybar_config& config) {
 }
 
 void BarIpcClient::onVisibilityUpdate(bool visible_by_modifier) {
-  spdlog::debug("visiblity update for {}: {}", bar_.bar_id, visible_by_modifier);
+  spdlog::debug("visibility update for {}: {}", bar_.bar_id, visible_by_modifier);
   visible_by_modifier_ = visible_by_modifier;
   update();
 }
 
+void BarIpcClient::onUrgencyUpdate(bool visible_by_urgency) {
+  spdlog::debug("urgency update for {}: {}", bar_.bar_id, visible_by_urgency);
+  visible_by_urgency_ = visible_by_urgency;
+  update();
+}
+
 void BarIpcClient::update() {
-  bool visible = visible_by_modifier_;
+  bool visible = visible_by_modifier_ || visible_by_urgency_;
   if (bar_config_.mode == "invisible") {
     visible = false;
   } else if (bar_config_.mode != "hide" || bar_config_.hidden_state != "hide") {


### PR DESCRIPTION
- Show bar if a workspace becomes urgent
- Clear urgency hint with modifier press
- Show bar on sway mode

Feedback on the coding is welcome, not sure with regards to the signal and ipc creation.

I followed the comment in [swaybar](https://github.com/swaywm/sway/blob/master/swaybar/ipc.c#L450) to implement the behavior to hide the bar again after the modifier is pressed.
But my implementation might differ a bit as it will show the bar again if multiple workspaces have the urgency hint, the bar is hidden again, and then one of the urgent workspaces is focused. For me this makes sense as it will give a notification that other workspaces sill have the urgency hint.