### PR TITLE
refactor: change `enum ipc_command_type` to uint32_t

### DIFF
--- a/include/modules/sway/ipc/ipc.hpp
+++ b/include/modules/sway/ipc/ipc.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <cstdint>
+
 #define event_mask(ev) (1u << (ev & 0x7F))
 
-enum ipc_command_type {
+enum ipc_command_type : uint32_t {
   // i3 command types - see i3's I3_REPLY_TYPE constants
   IPC_COMMAND = 0,
   IPC_GET_WORKSPACES = 1,
@@ -21,16 +23,16 @@ enum ipc_command_type {
   IPC_GET_SEATS = 101,
 
   // Events sent from sway to clients. Events have the highest bits set.
-  IPC_EVENT_WORKSPACE = ((1 << 31) | 0),
-  IPC_EVENT_OUTPUT = ((1 << 31) | 1),
-  IPC_EVENT_MODE = ((1 << 31) | 2),
-  IPC_EVENT_WINDOW = ((1 << 31) | 3),
-  IPC_EVENT_BARCONFIG_UPDATE = ((1 << 31) | 4),
-  IPC_EVENT_BINDING = ((1 << 31) | 5),
-  IPC_EVENT_SHUTDOWN = ((1 << 31) | 6),
-  IPC_EVENT_TICK = ((1 << 31) | 7),
+  IPC_EVENT_WORKSPACE = ((1U << 31) | 0),
+  IPC_EVENT_OUTPUT = ((1U << 31) | 1),
+  IPC_EVENT_MODE = ((1U << 31) | 2),
+  IPC_EVENT_WINDOW = ((1U << 31) | 3),
+  IPC_EVENT_BARCONFIG_UPDATE = ((1U << 31) | 4),
+  IPC_EVENT_BINDING = ((1U << 31) | 5),
+  IPC_EVENT_SHUTDOWN = ((1U << 31) | 6),
+  IPC_EVENT_TICK = ((1U << 31) | 7),
 
   // sway-specific event types
-  IPC_EVENT_BAR_STATE_UPDATE = ((1 << 31) | 20),
-  IPC_EVENT_INPUT = ((1 << 31) | 21),
+  IPC_EVENT_BAR_STATE_UPDATE = ((1U << 31) | 20),
+  IPC_EVENT_INPUT = ((1U << 31) | 21),
 };

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -45,7 +45,7 @@ Language::Language(const std::string& id, const Json::Value& config)
 }
 
 void Language::onCmd(const struct Ipc::ipc_response& res) {
-  if (res.type != static_cast<uint32_t>(IPC_GET_INPUTS)) {
+  if (res.type != IPC_GET_INPUTS) {
     return;
   }
 
@@ -77,7 +77,7 @@ void Language::onCmd(const struct Ipc::ipc_response& res) {
 }
 
 void Language::onEvent(const struct Ipc::ipc_response& res) {
-  if (res.type != static_cast<uint32_t>(IPC_EVENT_INPUT)) {
+  if (res.type != IPC_EVENT_INPUT) {
     return;
   }
 


### PR DESCRIPTION
As we always use the enum to compare or initialize uint32_t values, it would be better to declare it with the right type. This way we could avoid `-Wnarrowing` warnings or unnecessary type casts.