### PR TITLE
Sway/window: Only update icon from main thread

### DIFF
--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -25,6 +25,7 @@ class Window : public AIconLabel, public sigc::trackable {
                                                                         std::string& output);
   void getTree();
   std::string rewriteTitle(const std::string& title);
+  void updateAppIconName();
   void updateAppIcon();
 
   const Bar& bar_;
@@ -33,6 +34,8 @@ class Window : public AIconLabel, public sigc::trackable {
   std::string app_id_;
   std::string old_app_id_;
   std::size_t app_nb_;
+  bool update_app_icon_{true};
+  std::string app_icon_name_;
   util::JsonParser parser_;
   std::mutex mutex_;
   Ipc ipc_;


### PR DESCRIPTION
If Gtk objects get updated from another thread than the main thread, GTK
can get confused. This is a regression of bcadf64031ee0520212aa8f092f5ac14122cd924.

Fixes #1464, #1474

EDIT: I'm not entirely sure it will solve #1464.