### PR TITLE
sway/window: Add heuristics for finding icons

### DIFF
--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -21,8 +21,8 @@ class Window : public AIconLabel, public sigc::trackable {
  private:
   void onEvent(const struct Ipc::ipc_response&);
   void onCmd(const struct Ipc::ipc_response&);
-  std::tuple<std::size_t, int, std::string, std::string> getFocusedNode(const Json::Value& nodes,
-                                                                        std::string& output);
+  std::tuple<std::size_t, int, std::string, std::string, std::string> getFocusedNode(
+      const Json::Value& nodes, std::string& output);
   void getTree();
   std::string rewriteTitle(const std::string& title);
   void updateAppIconName();
@@ -32,6 +32,7 @@ class Window : public AIconLabel, public sigc::trackable {
   std::string window_;
   int windowId_;
   std::string app_id_;
+  std::string app_class_;
   std::string old_app_id_;
   std::size_t app_nb_;
   bool update_app_icon_{true};


### PR DESCRIPTION
This adds heuristics for finding the application's icon.

This will not find every icon, but a lot more than currently. I found issues with RenderDoc and JDownloader. But I guess these applications are legacy/X11 applications where icons can only be found with the help of Xlib.

Are you accepting this or would you rather like to adopt an approach like described [here](https://github.com/Alexays/Waybar/issues/1473#issuecomment-1065840022)? I'm unsure if we would have found the icons of the mentioned applications above with this approach.

