### PR TITLE
network: calculate bandwidth for current interface

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -42,7 +42,7 @@ waybar::modules::Network::readBandwidthUsage() {
     std::string ifacename;
     iss >> ifacename;      // ifacename contains "eth0:"
     ifacename.pop_back();  // remove trailing ':'
-    if (!checkInterface(ifacename)) {
+    if (ifacename != ifname_) {
       continue;
     }
 


### PR DESCRIPTION
There was discussion on #1392 about implementing matching interface cycling to the network module, but as that is a more complex feature, this will patch the issue for the current single interface mode.

Tested working with `network.interface: <undefined>/null/"enp*"/"enp6s0"`