### PR TITLE
feat: extend bluetooth module

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -55,8 +55,8 @@
 #include "modules/sndio.hpp"
 #endif
 #ifdef HAVE_GIO_UNIX
-#include "modules/inhibitor.hpp"
 #include "modules/bluetooth.hpp"
+#include "modules/inhibitor.hpp"
 #endif
 #include "bar.hpp"
 #include "modules/custom.hpp"

--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -56,15 +56,11 @@
 #endif
 #ifdef HAVE_GIO_UNIX
 #include "modules/inhibitor.hpp"
+#include "modules/bluetooth.hpp"
 #endif
 #include "bar.hpp"
 #include "modules/custom.hpp"
 #include "modules/temperature.hpp"
-#if defined(__linux__)
-#ifdef WANT_RFKILL
-#include "modules/bluetooth.hpp"
-#endif
-#endif
 
 namespace waybar {
 

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -1,18 +1,77 @@
 #pragma once
 
 #include "ALabel.hpp"
+#ifdef WANT_RFKILL
 #include "util/rfkill.hpp"
+#endif
+#include <gio/gio.h>
+#include <vector>
+#include <string>
+#include <optional>
 
 namespace waybar::modules {
 
 class Bluetooth : public ALabel {
+  struct AdapterInfo
+  {
+    std::string path;
+    std::string address;
+    std::string address_type;
+    // std::string name; // just use alias instead
+    std::string alias;
+    bool powered;
+    bool discoverable;
+    bool pairable;
+    bool discovering;
+  };
+
+  // NOTE: there are some properties that not all devices provide
+  struct DeviceInfo
+  {
+    std::string path;
+    std::string paired_adapter;
+    std::string address;
+    std::string address_type;
+    // std::optional<std::string> name; // just use alias instead
+    std::string alias;
+    std::optional<std::string> icon;
+    bool paired;
+    bool trusted;
+    bool blocked;
+    bool connected;
+    bool services_resolved;
+    // TODO: make experimental in waybar as it is also a experimental feature in bluez
+    std::optional<unsigned char> battery_percentage;
+  };
+
  public:
   Bluetooth(const std::string&, const Json::Value&);
   ~Bluetooth() = default;
   auto update() -> void;
 
  private:
+  static auto onInterfaceAddedOrRemoved(GDBusObjectManager*, GDBusObject*, GDBusInterface*, gpointer) -> void;
+  static auto onInterfaceProxyPropertiesChanged(GDBusObjectManagerClient*, GDBusObjectProxy*, GDBusProxy*, GVariant*, const gchar* const*, gpointer) -> void;
+
+  auto getDeviceBatteryPercentage(GDBusObject*) -> std::optional<unsigned char>;
+  auto getDeviceProperties(GDBusObject*, DeviceInfo&) -> bool;
+  auto getAdapterProperties(GDBusObject*, AdapterInfo&) -> bool;
+
+  auto findCurAdapter(AdapterInfo&) -> bool;
+  auto findConnectedDevices(const std::string&, std::vector<DeviceInfo>&) -> void;
+
+
+#ifdef WANT_RFKILL
   util::Rfkill rfkill_;
+#endif
+  const std::unique_ptr<GDBusObjectManager, void (*)(GDBusObjectManager*)> manager_;
+
+  std::string state_;
+  AdapterInfo cur_adapter_;
+  std::vector<DeviceInfo> connected_devices_;
+  DeviceInfo cur_focussed_device_;
+
+  std::vector<std::string> device_preference_;
 };
 
 }  // namespace waybar::modules

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -12,7 +12,7 @@
 namespace waybar::modules {
 
 class Bluetooth : public ALabel {
-  struct AdapterInfo
+  struct ControllerInfo
   {
     std::string path;
     std::string address;
@@ -29,7 +29,7 @@ class Bluetooth : public ALabel {
   struct DeviceInfo
   {
     std::string path;
-    std::string paired_adapter;
+    std::string paired_controller;
     std::string address;
     std::string address_type;
     // std::optional<std::string> name; // just use alias instead
@@ -55,9 +55,9 @@ class Bluetooth : public ALabel {
 
   auto getDeviceBatteryPercentage(GDBusObject*) -> std::optional<unsigned char>;
   auto getDeviceProperties(GDBusObject*, DeviceInfo&) -> bool;
-  auto getAdapterProperties(GDBusObject*, AdapterInfo&) -> bool;
+  auto getControllerProperties(GDBusObject*, ControllerInfo&) -> bool;
 
-  auto findCurAdapter(AdapterInfo&) -> bool;
+  auto findCurController(ControllerInfo&) -> bool;
   auto findConnectedDevices(const std::string&, std::vector<DeviceInfo>&) -> void;
 
 
@@ -67,7 +67,7 @@ class Bluetooth : public ALabel {
   const std::unique_ptr<GDBusObjectManager, void (*)(GDBusObjectManager*)> manager_;
 
   std::string state_;
-  AdapterInfo cur_adapter_;
+  ControllerInfo cur_controller_;
   std::vector<DeviceInfo> connected_devices_;
   DeviceInfo cur_focussed_device_;
   std::string device_enumerate_;

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -70,6 +70,7 @@ class Bluetooth : public ALabel {
   AdapterInfo cur_adapter_;
   std::vector<DeviceInfo> connected_devices_;
   DeviceInfo cur_focussed_device_;
+  std::string device_enumerate_;
 
   std::vector<std::string> device_preference_;
 };

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -40,7 +40,7 @@ class Bluetooth : public ALabel {
     bool blocked;
     bool connected;
     bool services_resolved;
-    // TODO: make experimental in waybar as it is also a experimental feature in bluez
+    // NOTE: experimental feature in bluez
     std::optional<unsigned char> battery_percentage;
   };
 

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -5,15 +5,15 @@
 #include "util/rfkill.hpp"
 #endif
 #include <gio/gio.h>
-#include <vector>
-#include <string>
+
 #include <optional>
+#include <string>
+#include <vector>
 
 namespace waybar::modules {
 
 class Bluetooth : public ALabel {
-  struct ControllerInfo
-  {
+  struct ControllerInfo {
     std::string path;
     std::string address;
     std::string address_type;
@@ -26,8 +26,7 @@ class Bluetooth : public ALabel {
   };
 
   // NOTE: there are some properties that not all devices provide
-  struct DeviceInfo
-  {
+  struct DeviceInfo {
     std::string path;
     std::string paired_controller;
     std::string address;
@@ -50,8 +49,11 @@ class Bluetooth : public ALabel {
   auto update() -> void;
 
  private:
-  static auto onInterfaceAddedOrRemoved(GDBusObjectManager*, GDBusObject*, GDBusInterface*, gpointer) -> void;
-  static auto onInterfaceProxyPropertiesChanged(GDBusObjectManagerClient*, GDBusObjectProxy*, GDBusProxy*, GVariant*, const gchar* const*, gpointer) -> void;
+  static auto onInterfaceAddedOrRemoved(GDBusObjectManager*, GDBusObject*, GDBusInterface*,
+                                        gpointer) -> void;
+  static auto onInterfaceProxyPropertiesChanged(GDBusObjectManagerClient*, GDBusObjectProxy*,
+                                                GDBusProxy*, GVariant*, const gchar* const*,
+                                                gpointer) -> void;
 
   auto getDeviceBatteryPercentage(GDBusObject*) -> std::optional<unsigned char>;
   auto getDeviceProperties(GDBusObject*, DeviceInfo&) -> bool;
@@ -59,7 +61,6 @@ class Bluetooth : public ALabel {
 
   auto findCurController(ControllerInfo&) -> bool;
   auto findConnectedDevices(const std::string&, std::vector<DeviceInfo>&) -> void;
-
 
 #ifdef WANT_RFKILL
   util::Rfkill rfkill_;

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -114,6 +114,15 @@ Addressed by *bluetooth*
 	typeof: string ++
 	This format is used when the selected connected device, defined by the config option *format-device-preference*, provides is battery percentage. This needs the experimental features of bluez to be enabled to work.
 
+*tooltip-format-enumerate-connected*: ++
+	typeof: string ++
+	This format is used to define how each connected device should be displayed within the *device_enumerate* format replacement in the tooltip menu.
+
+*tooltip-format-enumerate-connected-battery*: ++
+	typeof: string ++
+	This format is used to define how each connected device with a battery should be displayed within the *device_enumerate* format replacement in the tooltip menu. When this config option is not defined, the *tooltip-format-enumerate-connected* format will be used also for the connected devices with a battery.
+
+
 # FORMAT REPLACEMENTS
 
 *{status}*: Status of the bluetooth device.
@@ -134,25 +143,31 @@ Addressed by *bluetooth*
 
 *{device_battery_percentage}*: Battery percentage of the current selected device if available. Only use in the *format-connected-battery* and *tooltip-format-connected-battery*.
 
-# EXAMPLES
+*{device_enumerate}*: Show a list of all connected devices in the tooltip, each on a seperate line. Only applicable in the *connected* state. Define the format of each device with the *tooltip-format-enumerate-connected* or/and *tooltip-format-enumerate-connected-battery* config options.
 
-```
-"bluetooth": {
-	"format": " {status}",
-        "format-connected": " {device_alias}",
-        "format-connected-battery": " {device_battery_percentage}%",
-	"tooltip-format": "{adapter_alias} {adapter_address}"
-}
-```
+# EXAMPLES
 
 ```
 "bluetooth": {
 	// "adapter-alias": "adapter1", // specify the adapter alias (name) if there are more than 1 on the system
 	"format": " {status}",
-        "format-connected": " {num_connections} connected",
-	// TODO: make it so that it shows all connected devices in the tooltip
-        // "tooltip-format-connected": "{device_alias}",
-        // "tooltip-format-connected-battery": "{device_alias} {device_battery_percentage}%",
+	"format-connected": " {num_connections} connected",
+	"tooltip-format": "{adapter_alias}\t{adapter_address}",
+	"tooltip-format-connected": "{adapter_alias}\t{adapter_address}\n\n{device_enumerate}",
+	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
+	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%"
+}
+```
+
+```
+"bluetooth": {
+	"format": " {status}",
+        "format-connected": " {device_alias}",
+        "format-connected-battery": " {device_alias} {device_battery_percentage}%",
+        // "format-device-preference": [ "alias1", "alias2" ], // preference list deciding which device to show in format-connected format-connected-battery
+	"tooltip-format": "{adapter_alias}\t{adapter_address}\n\n{num_connections} connected\n\n{device_enumerate}",
+	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
+	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%"
 }
 ```
 

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -6,15 +6,18 @@ waybar - bluetooth module
 
 # DESCRIPTION
 
-The *bluetooth* module displays information about the bluetooth adapter and its connections.
+The *bluetooth* module displays information about the bluetooth controller and its connections.
 
 # CONFIGURATION
 
 Addressed by *bluetooth*
 
-*adapter-alias*: ++
+*controller*: ++
 	typeof: string ++
-	Use the adapter with the defined alias (name). Otherwise select a random adapter to display. Recommended to define when there is more than 1 adapter available to the system (use ```bluetoothctl show``` to show all available adapters).
+	Use the controller with the defined alias (name). Otherwise select a
+	random controller to display. Recommended to define when there is more
+	than 1 controller available to the system (use ```bluetoothctl show```
+	to show all available controller).
 
 *format-device-preference*: ++
 	typeof: array ++
@@ -27,19 +30,19 @@ Addressed by *bluetooth*
 
 *format-disabled*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is disabled.
+	This format is used when the displayed controller is disabled.
 
 *format-off*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is turned off.
+	This format is used when the displayed controller is turned off.
 
 *format-on*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is turned on with no devices connected.
+	This format is used when the displayed controller is turned on with no devices connected.
 
 *format-connected*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is connected to at least 1 device.
+	This format is used when the displayed controller is connected to at least 1 device.
 
 *format-connected-battery*: ++
 	typeof: string ++
@@ -96,19 +99,19 @@ Addressed by *bluetooth*
 
 *tooltip-format-disabled*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is disabled.
+	This format is used when the displayed controller is disabled.
 
 *tooltip-format-off*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is turned off.
+	This format is used when the displayed controller is turned off.
 
 *tooltip-format-on*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is turned on with no devices connected.
+	This format is used when the displayed controller is turned on with no devices connected.
 
 *tooltip-format-connected*: ++
 	typeof: string ++
-	This format is used when the displayed adapter is connected to at least 1 device.
+	This format is used when the displayed controller is connected to at least 1 device.
 
 *tooltip-format-connected-battery*: ++
 	typeof: string ++
@@ -127,13 +130,14 @@ Addressed by *bluetooth*
 
 *{status}*: Status of the bluetooth device.
 
-*{num_connections}*: Number of connections the selected adapter has.
+*{num_connections}*: Number of connections the selected controller has.
 
-*{adapter_address}*: Address of the selected adapter.
+*{controller_address}*: Address of the selected controller.
 
-*{adapter_address_type}*: Address type of the selected adapter.
+*{controller_address_type}*: Address type of the selected controller.
 
-*{adapter_alias}*: Alias of the selected adapter. By default equal to the *adapter_name* but can be changed by the user when there are conflicts.
+*{controller_alias}*: Alias of the selected controller. By default equal to the
+*controller_name* but can be changed by the user when there are conflicts.
 
 *{device_address}*: Address of the current selected selected connected device.
 
@@ -149,11 +153,11 @@ Addressed by *bluetooth*
 
 ```
 "bluetooth": {
-	// "adapter-alias": "adapter1", // specify the adapter alias (name) if there are more than 1 on the system
+	// "controller": "controller1", // specify the controller alias (name) if there are more than 1 on the system
 	"format": " {status}",
 	"format-connected": " {num_connections} connected",
-	"tooltip-format": "{adapter_alias}\t{adapter_address}",
-	"tooltip-format-connected": "{adapter_alias}\t{adapter_address}\n\n{device_enumerate}",
+	"tooltip-format": "{controller_alias}\t{controller_address}",
+	"tooltip-format-connected": "{controller_alias}\t{controller_address}\n\n{device_enumerate}",
 	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
 	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%"
 }
@@ -165,7 +169,7 @@ Addressed by *bluetooth*
         "format-connected": " {device_alias}",
         "format-connected-battery": " {device_alias} {device_battery_percentage}%",
         // "format-device-preference": [ "alias1", "alias2" ], // preference list deciding which device to show in format-connected format-connected-battery
-	"tooltip-format": "{adapter_alias}\t{adapter_address}\n\n{num_connections} connected\n\n{device_enumerate}",
+	"tooltip-format": "{controller_alias}\t{controller_address}\n\n{num_connections} connected\n\n{device_enumerate}",
 	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
 	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%"
 }

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -6,21 +6,44 @@ waybar - bluetooth module
 
 # DESCRIPTION
 
-The *bluetooth* module displays information about the status of the device's bluetooth device.
+The *bluetooth* module displays information about the bluetooth adapter and its connections.
 
 # CONFIGURATION
 
 Addressed by *bluetooth*
 
+*adapter-alias*: ++
+	typeof: string ++
+	Use the adapter with the defined alias (name). Otherwise select a random adapter to display. Recommended to define when there is more than 1 adapter available to the system (use ```bluetoothctl show``` to show all available adapters).
+
+*format-device-preference*: ++
+	typeof: array ++
+	A ranking of bluetooth devices, addressed by their alias (name). The order is *first displayed* to *last displayed*. If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device. A devices alias can be manually changed using the ```bluetoothctl set-alias``` command.
+
 *format*: ++
 	typeof: string  ++
-	default: *{icon}* ++
+	default: * {status}* ++
 	The format, how information should be displayed. This format is used when other formats aren't specified.
 
-*format-icons*: ++
-	typeof: array/object ++
-	Based on the device status, the corresponding icon gets selected. ++
-	The order is *low* to *high*. Or by the state if it is an object.
+*format-disabled*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is disabled.
+
+*format-off*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is turned off.
+
+*format-on*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is turned on with no devices connected.
+
+*format-connected*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is connected to at least 1 device.
+
+*format-connected-battery*: ++
+	typeof: string ++
+	This format is used when the selected connected device, defined by the config option *format-device-preference*, provides is battery percentage. This needs the experimental features of bluez to be enabled to work.
 
 *rotate*: ++
 	typeof: integer ++
@@ -71,23 +94,65 @@ Addressed by *bluetooth*
 	typeof: string ++
 	The format, how information should be displayed in the tooltip. This format is used when other formats aren't specified.
 
+*tooltip-format-disabled*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is disabled.
+
+*tooltip-format-off*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is turned off.
+
+*tooltip-format-on*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is turned on with no devices connected.
+
+*tooltip-format-connected*: ++
+	typeof: string ++
+	This format is used when the displayed adapter is connected to at least 1 device.
+
+*tooltip-format-connected-battery*: ++
+	typeof: string ++
+	This format is used when the selected connected device, defined by the config option *format-device-preference*, provides is battery percentage. This needs the experimental features of bluez to be enabled to work.
+
 # FORMAT REPLACEMENTS
 
 *{status}*: Status of the bluetooth device.
 
-*{icon}*: Icon, as defined in *format-icons*.
+*{num_connections}*: Number of connections the selected adapter has.
+
+*{adapter_address}*: Address of the selected adapter.
+
+*{adapter_address_type}*: Address type of the selected adapter.
+
+*{adapter_alias}*: Alias of the selected adapter. By default equal to the *adapter_name* but can be changed by the user when there are conflicts.
+
+*{device_address}*: Address of the current selected selected connected device.
+
+*{device_address_type}*: Address type of the current selected selected connected device.
+
+*{device_alias}*: Alias of the current selected connected device. By default equal to the *device_name* but can be changed by the user when there are conflicts.
+
+*{device_battery_percentage}*: Battery percentage of the current selected device if available. Only use in the *format-connected-battery* and *tooltip-format-connected-battery*.
 
 # EXAMPLES
 
 ```
 "bluetooth": {
-	"format": "{icon}",
-	"format-alt": "bluetooth: {status}",
-	"format-icons": {
-		"enabled": "",
-		"disabled": ""
-	},
-	"tooltip-format": "{}"
+	"format": " {status}",
+        "format-connected": " {device_alias}",
+        "format-connected-battery": " {device_battery_percentage}%",
+	"tooltip-format": "{adapter_alias} {adapter_address}"
+}
+```
+
+```
+"bluetooth": {
+	// "adapter-alias": "adapter1", // specify the adapter alias (name) if there are more than 1 on the system
+	"format": " {status}",
+        "format-connected": " {num_connections} connected",
+	// TODO: make it so that it shows all connected devices in the tooltip
+        // "tooltip-format-connected": "{device_alias}",
+        // "tooltip-format-connected-battery": "{device_alias} {device_battery_percentage}%",
 }
 ```
 
@@ -95,3 +160,9 @@ Addressed by *bluetooth*
 
 - *#bluetooth*
 - *#bluetooth.disabled*
+- *#bluetooth.off*
+- *#bluetooth.on*
+- *#bluetooth.connected*
+- *#bluetooth.discoverable*
+- *#bluetooth.discovering*
+- *#bluetooth.pairable*

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -161,6 +161,7 @@ At the time of writing, the experimental features of BlueZ need to be turned on,
 "bluetooth": {
 	// "controller": "controller1", // specify the alias of the controller if there are more than 1 on the system
 	"format": " {status}",
+	"format-disabled": "", // an empty format will hide the module
 	"format-connected": " {num_connections} connected",
 	"tooltip-format": "{controller_alias}\\t{controller_address}",
 	"tooltip-format-connected": "{controller_alias}\\t{controller_address}\\n\\n{device_enumerate}",

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -6,7 +6,7 @@ waybar - bluetooth module
 
 # DESCRIPTION
 
-The *bluetooth* module displays information about the bluetooth controller and its connections.
+The *bluetooth* module displays information about a bluetooth controller and its connections.
 
 # CONFIGURATION
 
@@ -14,14 +14,12 @@ Addressed by *bluetooth*
 
 *controller*: ++
 	typeof: string ++
-	Use the controller with the defined alias (name). Otherwise select a
-	random controller to display. Recommended to define when there is more
-	than 1 controller available to the system (use ```bluetoothctl show```
-	to show all available controller).
+	Use the controller with the defined alias. Otherwise a random controller is used. Recommended to define when there is more than 1 controller available to the system.
 
 *format-device-preference*: ++
 	typeof: array ++
-	A ranking of bluetooth devices, addressed by their alias (name). The order is *first displayed* to *last displayed*. If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device. A devices alias can be manually changed using the ```bluetoothctl set-alias``` command.
+	A ranking of bluetooth devices, addressed by their alias. The order is from *first displayed* to *last displayed*. ++
+	If this config option is not defined or none of the devices in the list are connected, it will fall back to showing the last connected device.
 
 *format*: ++
 	typeof: string  ++
@@ -43,10 +41,6 @@ Addressed by *bluetooth*
 *format-connected*: ++
 	typeof: string ++
 	This format is used when the displayed controller is connected to at least 1 device.
-
-*format-connected-battery*: ++
-	typeof: string ++
-	This format is used when the selected connected device, defined by the config option *format-device-preference*, provides is battery percentage. This needs the experimental features of bluez to be enabled to work.
 
 *rotate*: ++
 	typeof: integer ++
@@ -113,65 +107,77 @@ Addressed by *bluetooth*
 	typeof: string ++
 	This format is used when the displayed controller is connected to at least 1 device.
 
-*tooltip-format-connected-battery*: ++
-	typeof: string ++
-	This format is used when the selected connected device, defined by the config option *format-device-preference*, provides is battery percentage. This needs the experimental features of bluez to be enabled to work.
-
 *tooltip-format-enumerate-connected*: ++
 	typeof: string ++
 	This format is used to define how each connected device should be displayed within the *device_enumerate* format replacement in the tooltip menu.
-
-*tooltip-format-enumerate-connected-battery*: ++
-	typeof: string ++
-	This format is used to define how each connected device with a battery should be displayed within the *device_enumerate* format replacement in the tooltip menu. When this config option is not defined, the *tooltip-format-enumerate-connected* format will be used also for the connected devices with a battery.
-
 
 # FORMAT REPLACEMENTS
 
 *{status}*: Status of the bluetooth device.
 
-*{num_connections}*: Number of connections the selected controller has.
+*{num_connections}*: Number of connections the displayed controller has.
 
-*{controller_address}*: Address of the selected controller.
+*{controller_address}*: Address of the displayed controller.
 
-*{controller_address_type}*: Address type of the selected controller.
+*{controller_address_type}*: Address type of the displayed controller.
 
-*{controller_alias}*: Alias of the selected controller. By default equal to the
-*controller_name* but can be changed by the user when there are conflicts.
+*{controller_alias}*: Alias of the displayed controller.
 
-*{device_address}*: Address of the current selected selected connected device.
+*{device_address}*: Address of the displayed device.
 
-*{device_address_type}*: Address type of the current selected selected connected device.
+*{device_address_type}*: Address type of the displayed device.
 
-*{device_alias}*: Alias of the current selected connected device. By default equal to the *device_name* but can be changed by the user when there are conflicts.
+*{device_alias}*: Alias of the displayed device.
 
-*{device_battery_percentage}*: Battery percentage of the current selected device if available. Only use in the *format-connected-battery* and *tooltip-format-connected-battery*.
+*{device_enumerate}*: Show a list of all connected devices, each on a seperate line. Define the format of each device with the *tooltip-format-enumerate-connected* ++
+and/or *tooltip-format-enumerate-connected-battery* config options. Can only be used in the tooltip related format options.
 
-*{device_enumerate}*: Show a list of all connected devices in the tooltip, each on a seperate line. Only applicable in the *connected* state. Define the format of each device with the *tooltip-format-enumerate-connected* or/and *tooltip-format-enumerate-connected-battery* config options.
+# EXPERIMENTAL BATTERY PERCENTAGE FEATURE
+
+At the time of writing, the experimental features of BlueZ need to be turned on, for the battery percentage options listed below to work.
+
+## FORMAT REPLACEMENT
+
+*{device_battery_percentage}*: Battery percentage of the displayed device if available. Use only in the config options defined below.
+
+## CONFIGURATION
+
+*format-connected-battery*: ++
+	typeof: string ++
+	This format is used when the displayed device provides its battery percentage.
+
+*tooltip-format-connected-battery*: ++
+	typeof: string ++
+	This format is used when the displayed device provides its battery percentage.
+
+*tooltip-format-enumerate-connected-battery*: ++
+	typeof: string ++
+	This format is used to define how each connected device with a battery should be displayed within the *device_enumerate* format replacement option. ++
+	When this config option is not defined, it will fall back on the *tooltip-format-enumerate-connected* config option.
 
 # EXAMPLES
 
 ```
 "bluetooth": {
-	// "controller": "controller1", // specify the controller alias (name) if there are more than 1 on the system
+	// "controller": "controller1", // specify the alias of the controller if there are more than 1 on the system
 	"format": " {status}",
 	"format-connected": " {num_connections} connected",
-	"tooltip-format": "{controller_alias}\t{controller_address}",
-	"tooltip-format-connected": "{controller_alias}\t{controller_address}\n\n{device_enumerate}",
-	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
-	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%"
+	"tooltip-format": "{controller_alias}\\t{controller_address}",
+	"tooltip-format-connected": "{controller_alias}\\t{controller_address}\\n\\n{device_enumerate}",
+	"tooltip-format-enumerate-connected": "{device_alias}\\t{device_address}"
 }
 ```
 
 ```
 "bluetooth": {
 	"format": " {status}",
-        "format-connected": " {device_alias}",
-        "format-connected-battery": " {device_alias} {device_battery_percentage}%",
-        // "format-device-preference": [ "alias1", "alias2" ], // preference list deciding which device to show in format-connected format-connected-battery
-	"tooltip-format": "{controller_alias}\t{controller_address}\n\n{num_connections} connected\n\n{device_enumerate}",
-	"tooltip-format-enumerate-connected": "{device_alias}\t{device_address}",
-	"tooltip-format-enumerate-connected-battery": "{device_alias}\t{device_address}\t{device_battery_percentage}%"
+	"format-connected": " {device_alias}",
+	"format-connected-battery": " {device_alias} {device_battery_percentage}%",
+	// "format-device-preference": [ "device1", "device2" ], // preference list deciding the displayed device
+	"tooltip-format": "{controller_alias}\\t{controller_address}\\n\\n{num_connections} connected",
+	"tooltip-format-connected": "{controller_alias}\\t{controller_address}\\n\\n{num_connections} connected\\n\\n{device_enumerate}",
+	"tooltip-format-enumerate-connected": "{device_alias}\\t{device_address}",
+	"tooltip-format-enumerate-connected-battery": "{device_alias}\\t{device_address}\\t{device_battery_percentage}%"
 }
 ```
 

--- a/meson.build
+++ b/meson.build
@@ -253,16 +253,14 @@ endif
 if (giounix.found() and not get_option('logind').disabled())
     add_project_arguments('-DHAVE_GIO_UNIX', language: 'cpp')
     src_files += 'src/modules/inhibitor.cpp'
+    src_files += 'src/modules/bluetooth.cpp'
 endif
 
-if get_option('rfkill').enabled()
-    if is_linux
-        add_project_arguments('-DWANT_RFKILL', language: 'cpp')
-        src_files += files(
-            'src/modules/bluetooth.cpp',
-            'src/util/rfkill.cpp'
-        )
-    endif
+if get_option('rfkill').enabled() and is_linux
+    add_project_arguments('-DWANT_RFKILL', language: 'cpp')
+    src_files += files(
+        'src/util/rfkill.cpp'
+    )
 endif
 
 if tz_dep.found()

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -101,11 +101,11 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     }
 #endif
 #ifdef HAVE_GIO_UNIX
-    if (ref == "inhibitor") {
-      return new waybar::modules::Inhibitor(id, bar_, config_[name]);
-    }
     if (ref == "bluetooth") {
       return new waybar::modules::Bluetooth(id, config_[name]);
+    }
+    if (ref == "inhibitor") {
+      return new waybar::modules::Inhibitor(id, bar_, config_[name]);
     }
 #endif
     if (ref == "temperature") {

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -104,17 +104,13 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "inhibitor") {
       return new waybar::modules::Inhibitor(id, bar_, config_[name]);
     }
-#endif
-    if (ref == "temperature") {
-      return new waybar::modules::Temperature(id, config_[name]);
-    }
-#if defined(__linux__)
-#ifdef WANT_RFKILL
     if (ref == "bluetooth") {
       return new waybar::modules::Bluetooth(id, config_[name]);
     }
 #endif
-#endif
+    if (ref == "temperature") {
+      return new waybar::modules::Temperature(id, config_[name]);
+    }
     if (ref.compare(0, 7, "custom/") == 0 && ref.size() > 7) {
       return new waybar::modules::Custom(ref.substr(7), id, config_[name]);
     }

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -171,6 +171,8 @@ auto waybar::modules::Bluetooth::update() -> void {
     tooltip_format = config_["tooltip-format"].asString();
   }
 
+  format_.empty() ? event_box_.hide() : event_box_.show();
+
   auto update_style_context = [this](const std::string& style_class, bool in_next_state) {
     if (in_next_state && !label_.get_style_context()->has_class(style_class)) {
       label_.get_style_context()->add_class(style_class);

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -206,22 +206,18 @@ auto waybar::modules::Bluetooth::update() -> void {
     if (tooltip_enumerate_connections_ || tooltip_enumerate_connections_battery_) {
       std::stringstream ss;
       for (DeviceInfo dev : connected_devices_) {
-        if (tooltip_enumerate_connections_battery_ && dev.battery_percentage.has_value()) {
+        if ((tooltip_enumerate_connections_battery_ && dev.battery_percentage.has_value()) || tooltip_enumerate_connections_) {
           ss << "\n";
-          ss << fmt::format(config_["tooltip-format-enumerate-connected-battery"].asString(),
+          std::string enumerate_format = (tooltip_enumerate_connections_battery_ && dev.battery_percentage.has_value()) ? config_["tooltip-format-enumerate-connected-battery"].asString() : config_["tooltip-format-enumerate-connected"].asString();
+          ss << fmt::format(enumerate_format,
                 fmt::arg("device_address", dev.address),
                 fmt::arg("device_address_type", dev.address_type),
                 fmt::arg("device_alias", dev.alias),
                 fmt::arg("device_battery_percentage", dev.battery_percentage.value_or(0)));
-        } else if (tooltip_enumerate_connections_) {
-          ss << "\n";
-          ss << fmt::format(config_["tooltip-format-enumerate-connected"].asString(),
-                fmt::arg("device_address", dev.address),
-                fmt::arg("device_address_type", dev.address_type),
-                fmt::arg("device_alias", dev.alias));
         }
       }
       device_enumerate_ = ss.str();
+      // don't start the connected devices text with a new line
       if (!device_enumerate_.empty()) {
         device_enumerate_.erase(0, 1);
       }


### PR DESCRIPTION
Resolves #688 
Goal is to show selected bluetooth adapter and its connections. Still a work in progress.

TODO:
- [x] adapter information
    - [x] use config field with name to select an adapter or select one randomly if config field not defined (adapter-alias)
    - [x] add format replacements for label and tooltip
    - [x] add new styling classes
- [x] connected devices
    - [x] add format replacement for label for 1 connected device
        - [x] select either the last connected device for this or from a predefined config option to rank which connected device to display (format-device-preference)
    - [x] make possible to show information of all connected devices in the tooltip
    - [x] experimental bluez battery percentage
        - [x] add format replacement for connected device battery percentage (if available)
        - [x] show as experimental feature in waybar-bluetooth man page
- [x] update the module only when signaled from the bluez D-Bus bus or when the rfkill state has changed (if enabled).
- [x] update doc when all features finished
- [x] fix style so it matches the project style

I also noticed that there is no entry for the bluetooth module in the wiki. So that should also maybe be added.

Possible future improvements not part of this merge request:
- show icon field of the connected bluetooth device when available using a config defined icon theme/size
- have format-icons for the connected device battery percentage
- change the selected connected device that appears in the main label changeable via scrolling or clicking?? Don't know how that would interact with the current format-device-preferences or show the latest connection model.
- also enumerate disconnected devices in the tooltip (e.g. by adding a tooltip-format-enumerate-paired option)