### PR TITLE
Add classes to individual keyboard state labels

### DIFF
--- a/man/waybar-keyboard-state.5.scd
+++ b/man/waybar-keyboard-state.5.scd
@@ -79,4 +79,9 @@ The following *format-icons* can be set.
 - *#keyboard-state*
 - *#keyboard-state label*
 - *#keyboard-state label.locked*
-
+- *#keyboard-state label.numlock*
+- *#keyboard-state label.numlock.locked*
+- *#keyboard-state label.capslock*
+- *#keyboard-state label.capslock.locked*
+- *#keyboard-state label.scrolllock*
+- *#keyboard-state label.scrolllock.locked*

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -103,12 +103,15 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
       dev_(nullptr) {
   box_.set_name("keyboard-state");
   if (config_["numlock"].asBool()) {
+    numlock_label_.get_style_context()->add_class("numlock");
     box_.pack_end(numlock_label_, false, false, 0);
   }
   if (config_["capslock"].asBool()) {
+    capslock_label_.get_style_context()->add_class("capslock");
     box_.pack_end(capslock_label_, false, false, 0);
   }
   if (config_["scrolllock"].asBool()) {
+    scrolllock_label_.get_style_context()->add_class("scrolllock");
     box_.pack_end(scrolllock_label_, false, false, 0);
   }
   if (!id.empty()) {


### PR DESCRIPTION
Allow labels for numlock/capslock/scrolllock to be styled independently by adding classes to them.

_Use case:_ unknowingly having caps lock on while entering a password is annoying --- I'd like to have the caps lock state indicator styled in red when stated is locked, but don't want num lock state indicator to also be red when state is locked.