### PR TITLE
River Window Module

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -18,6 +18,7 @@
 #endif
 #ifdef HAVE_RIVER
 #include "modules/river/tags.hpp"
+#include "modules/river/window.hpp"
 #endif
 #if defined(__linux__) && !defined(NO_FILESYSTEM)
 #include "modules/battery.hpp"

--- a/include/modules/river/window.hpp
+++ b/include/modules/river/window.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <gtkmm/button.h>
+#include <wayland-client.h>
+
+#include "ALabel.hpp"
+#include "bar.hpp"
+#include "river-status-unstable-v1-client-protocol.h"
+#include "xdg-output-unstable-v1-client-protocol.h"
+
+namespace waybar::modules::river {
+
+class Window : public waybar::ALabel {
+ public:
+  Window(const std::string &, const waybar::Bar &, const Json::Value &);
+  ~Window();
+
+  // Handlers for wayland events
+  void handle_focused_view(const char *title);
+  void handle_focused_output(struct wl_output *output);
+  void handle_unfocused_output(struct wl_output *output);
+
+  struct zriver_status_manager_v1 *status_manager_;
+  struct wl_seat *seat_;
+
+ private:
+  const waybar::Bar &bar_;
+  struct wl_output *output_; // stores the output this module belongs to
+  struct wl_output *focused_output_; // stores the currently focused output
+  struct zriver_seat_status_v1 *seat_status_;
+};
+
+} /* namespace waybar::modules::river */

--- a/man/waybar-river-window.5.scd
+++ b/man/waybar-river-window.5.scd
@@ -1,0 +1,31 @@
+waybar-river-window(5)
+
+# NAME
+
+waybar - river window module
+
+# DESCRIPTION
+
+The *window* module displays the title of the currently focused window in river
+
+# CONFIGURATION
+
+Addressed by *river/window*
+
+*format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how information should be displayed. On {} data gets inserted.
+
+# EXAMPLES
+
+```
+"river/window": {
+    "format": "{}"
+}
+```
+
+# STYLE
+
+- *#window*
+- *window#.focused* Applied when the output this module's bar belongs to is focused.

--- a/man/waybar-river-window.5.scd
+++ b/man/waybar-river-window.5.scd
@@ -17,6 +17,34 @@ Addressed by *river/window*
 	default: {} ++
 	The format, how information should be displayed. On {} data gets inserted.
 
+*rotate*: ++
+	typeof: integer ++
+	Positive value to rotate the text label.
+
+*max-length*: ++
+	typeof: integer ++
+	The maximum length in character the module should display.
+
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
+*on-click*: ++
+	typeof: string ++
+	Command to execute when clicked on the module.
+
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
+*on-click-right*: ++
+	typeof: string ++
+	Command to execute when you right clicked on the module.
+
 # EXAMPLES
 
 ```

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -45,6 +45,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "river/tags") {
       return new waybar::modules::river::Tags(id, bar_, config_[name]);
     }
+    if (ref == "river/window") {
+      return new waybar::modules::river::Window(id, bar_, config_[name]);
+    }
 #endif
     if (ref == "idle_inhibitor") {
       return new waybar::modules::IdleInhibitor(id, bar_, config_[name]);

--- a/src/modules/river/window.cpp
+++ b/src/modules/river/window.cpp
@@ -1,14 +1,11 @@
 #include "modules/river/window.hpp"
 
-#include <gtkmm/button.h>
-#include <gtkmm/label.h>
 #include <spdlog/spdlog.h>
 #include <wayland-client.h>
 
 #include <algorithm>
 
 #include "client.hpp"
-#include "xdg-output-unstable-v1-client-protocol.h"
 
 namespace waybar::modules::river {
 
@@ -99,11 +96,11 @@ void Window::handle_focused_view(const char *title) {
   // last focused view, and will get blank labels until they are brought into focus at least once.
   if (focused_output_ != output_) return;
 
-  if (std::strcmp(title, "") == 0) {
-    label_.hide();  // hide empty labels
+  if (std::strcmp(title, "") == 0 || format_.empty()) {
+    label_.hide();  // hide empty labels or labels with empty format
   } else {
     label_.show();
-    label_.set_markup(title);
+    label_.set_markup(fmt::format(format_, title));
   }
 
   ALabel::update();

--- a/src/modules/river/window.cpp
+++ b/src/modules/river/window.cpp
@@ -1,0 +1,127 @@
+#include "modules/river/window.hpp"
+
+#include <gtkmm/button.h>
+#include <gtkmm/label.h>
+#include <spdlog/spdlog.h>
+#include <wayland-client.h>
+
+#include <algorithm>
+
+#include "client.hpp"
+#include "xdg-output-unstable-v1-client-protocol.h"
+
+namespace waybar::modules::river {
+
+static void listen_focused_view(void *data, struct zriver_seat_status_v1 *zriver_seat_status_v1,
+                                const char *title) {
+  static_cast<Window *>(data)->handle_focused_view(title);
+}
+
+static void listen_focused_output(void *data, struct zriver_seat_status_v1 *zriver_seat_status_v1,
+                                  struct wl_output *output) {
+  static_cast<Window *>(data)->handle_focused_output(output);
+}
+
+static void listen_unfocused_output(void *data, struct zriver_seat_status_v1 *zriver_seat_status_v1,
+                                    struct wl_output *output) {
+  static_cast<Window *>(data)->handle_unfocused_output(output);
+}
+
+static const zriver_seat_status_v1_listener seat_status_listener_impl{
+    .focused_output = listen_focused_output,
+    .unfocused_output = listen_unfocused_output,
+    .focused_view = listen_focused_view,
+};
+
+static void handle_global(void *data, struct wl_registry *registry, uint32_t name,
+                          const char *interface, uint32_t version) {
+  if (std::strcmp(interface, zriver_status_manager_v1_interface.name) == 0) {
+    version = std::min<uint32_t>(version, 2);
+    static_cast<Window *>(data)->status_manager_ = static_cast<struct zriver_status_manager_v1 *>(
+        wl_registry_bind(registry, name, &zriver_status_manager_v1_interface, version));
+  }
+
+  if (std::strcmp(interface, wl_seat_interface.name) == 0) {
+    version = std::min<uint32_t>(version, 1);
+    static_cast<Window *>(data)->seat_ = static_cast<struct wl_seat *>(
+        wl_registry_bind(registry, name, &wl_seat_interface, version));
+  }
+}
+
+static void handle_global_remove(void *data, struct wl_registry *registry, uint32_t name) {
+  /* Ignore event */
+}
+
+static const wl_registry_listener registry_listener_impl = {.global = handle_global,
+                                                            .global_remove = handle_global_remove};
+
+Window::Window(const std::string &id, const waybar::Bar &bar, const Json::Value &config)
+    : waybar::ALabel(config, "window", id, "{}", 30),
+      status_manager_{nullptr},
+      seat_{nullptr},
+      bar_(bar),
+      seat_status_{nullptr} {
+  struct wl_display *display = Client::inst()->wl_display;
+  struct wl_registry *registry = wl_display_get_registry(display);
+  wl_registry_add_listener(registry, &registry_listener_impl, this);
+  wl_display_roundtrip(display);
+
+  output_ = gdk_wayland_monitor_get_wl_output(bar_.output->monitor->gobj());
+
+  if (!status_manager_) {
+    spdlog::error("river_status_manager_v1 not advertised");
+    return;
+  }
+
+  if (!seat_) {
+    spdlog::error("wl_seat not advertised");
+  }
+
+  label_.hide();  // hide the label until populated
+  ALabel::update();
+
+  seat_status_ = zriver_status_manager_v1_get_river_seat_status(status_manager_, seat_);
+  zriver_seat_status_v1_add_listener(seat_status_, &seat_status_listener_impl, this);
+
+  zriver_status_manager_v1_destroy(status_manager_);
+}
+
+Window::~Window() {
+  if (seat_status_) {
+    zriver_seat_status_v1_destroy(seat_status_);
+  }
+}
+
+void Window::handle_focused_view(const char *title) {
+  // don't change the label on unfocused outputs.
+  // this makes the current output report its currently focused view, and unfocused outputs will
+  // report their last focused views. when freshly starting the bar, unfocused outputs don't have a
+  // last focused view, and will get blank labels until they are brought into focus at least once.
+  if (focused_output_ != output_) return;
+
+  if (std::strcmp(title, "") == 0) {
+    label_.hide();  // hide empty labels
+  } else {
+    label_.show();
+    label_.set_markup(title);
+  }
+
+  ALabel::update();
+}
+
+void Window::handle_focused_output(struct wl_output *output) {
+  if (output_ == output) {  // if we focused the output this bar belongs to
+    label_.get_style_context()->add_class("focused");
+    ALabel::update();
+  }
+  focused_output_ = output;
+}
+
+void Window::handle_unfocused_output(struct wl_output *output) {
+  if (output_ == output) {  // if we unfocused the output this bar belongs to
+    label_.get_style_context()->remove_class("focused");
+    ALabel::update();
+  }
+}
+
+} /* namespace waybar::modules::river */


### PR DESCRIPTION
This PR adds a module to report the currently focused window under river using the `zriver_seat_status_v1` interface.

- The module can be styled depending on if it is located on the currently focused output or not.
- Instances of this module on unfocused outputs will retain their output's last focused window title (the window that _will_ be focused if focus moves to that output).
- There is no support for icons since river's protocol only supplies window titles.

Since this is the first time I've written code for Wayland, I'm not entirely sure if this is the best way to do things, but it seems to work as expected.

![swappy-20220519_160158](https://user-images.githubusercontent.com/25140503/169395096-918eb6a2-5f7f-444b-a08a-1355e5bef500.png)