### PR TITLE
Add total bandwidth formatting options

### DIFF
--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -153,6 +153,10 @@ Addressed by *network*
 
 *{bandwidthDownOctets}*: Instant down speed in octets/seconds.
 
+*{bandwidthUpBytes}*: Instant up speed in bytes/seconds.
+
+*{bandwidthDownByes}*: Instant down speed in bytes/seconds.
+
 *{icon}*: Icon, as defined in *format-icons*.
 
 # EXAMPLES

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -149,13 +149,19 @@ Addressed by *network*
 
 *{bandwidthDownBits}*: Instant down speed in bits/seconds.
 
+*{bandwidthTotalBits}*: Instant total speed in bits/seconds.
+
 *{bandwidthUpOctets}*: Instant up speed in octets/seconds.
 
 *{bandwidthDownOctets}*: Instant down speed in octets/seconds.
 
+*{bandwidthTotalOctets}*: Instant total speed in octets/seconds.
+
 *{bandwidthUpBytes}*: Instant up speed in bytes/seconds.
 
-*{bandwidthDownByes}*: Instant down speed in bytes/seconds.
+*{bandwidthDownBytes}*: Instant down speed in bytes/seconds.
+
+*{bandwidthTotalBytes}*: Instant total speed in bytes/seconds.
 
 *{icon}*: Icon, as defined in *format-icons*.
 

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -339,10 +339,13 @@ auto waybar::modules::Network::update() -> void {
       fmt::arg("icon", getIcon(signal_strength_, state_)),
       fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / interval_.count(), "b/s")),
       fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / interval_.count(), "b/s")),
+      fmt::arg("bandwidthTotalBits", pow_format((bandwidth_up + bandwidth_down) * 8ull / interval_.count(), "b/s")),
       fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / interval_.count(), "o/s")),
       fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / interval_.count(), "o/s")),
+      fmt::arg("bandwidthTotalOctets", pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "o/s")),
       fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / interval_.count(), "B/s")),
-      fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")));
+      fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")),
+      fmt::arg("bandwidthTotalBytes", pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "B/s")));
   if (text.compare(label_.get_label()) != 0) {
     label_.set_markup(text);
     if (text.empty()) {
@@ -366,10 +369,13 @@ auto waybar::modules::Network::update() -> void {
           fmt::arg("bandwidthDownBits",
                    pow_format(bandwidth_down * 8ull / interval_.count(), "b/s")),
           fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / interval_.count(), "b/s")),
+          fmt::arg("bandwidthTotalBits", pow_format((bandwidth_up + bandwidth_down) * 8ull / interval_.count(), "b/s")),
           fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / interval_.count(), "o/s")),
           fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / interval_.count(), "o/s")),
+          fmt::arg("bandwidthTotalOctets", pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "o/s")),
           fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / interval_.count(), "B/s")),
-          fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")));
+          fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / interval_.count(), "B/s")),
+          fmt::arg("bandwidthTotalBytes", pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "B/s")));
       if (label_.get_tooltip_text() != tooltip_text) {
         label_.set_tooltip_text(tooltip_text);
       }


### PR DESCRIPTION
This PR adds total bandwidth (`bandwidthTotalBits`, `bandwidthTotalOctets` and `bandwidthTotalBytes`) to the network module.

I have decided against adding a variable at the top of the `update()` method, mostly because it seems calculations are being done on demand if the format is actually requested, but this can be moved if I am interpreting it wrong.

I have also updated the man page, which was missing bytes up/down too.