### PR TITLE
fixes bluetooth module

### DIFF
--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -42,6 +42,12 @@ Addressed by *bluetooth*
 	typeof: string ++
 	This format is used when the displayed controller is connected to at least 1 device.
 
+*format-icons*: ++
+	typeof: array/object ++
+	Based on the current battery percentage (see section *EXPERIMENTAL BATTERY PERCENTAGE FEATURE*), the corresponding icon gets selected. ++
+	The order is *low* to *high*. Will only show the current battery percentage icon in the *\*-connected-battery* config options. ++
+	Or by the state if it is an object. It will fall back to the enabled state if its derivatives are not defined (on, off, connected).
+
 *rotate*: ++
 	typeof: integer ++
 	Positive value to rotate the text label.
@@ -114,6 +120,8 @@ Addressed by *bluetooth*
 # FORMAT REPLACEMENTS
 
 *{status}*: Status of the bluetooth device.
+
+*{icon}*: Icon, as defined in *format-icons*.
 
 *{num_connections}*: Number of connections the displayed controller has.
 

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -152,11 +152,22 @@ auto waybar::modules::Bluetooth::update() -> void {
 #ifdef WANT_RFKILL
   if (rfkill_.getState()) state = "disabled";
 #endif
+  bool battery_available = state == "connected" && cur_focussed_device_.battery_percentage.has_value();
+
+#ifdef WANT_RFKILL
+  // also adds enabled icon if icon for state is not defined
+  std::vector<std::string> states = { state, rfkill_.getState() ? "disabled" : "enabled" };
+  std::string icon = getIcon(0, states);
+#else
+  std::string icon = getIcon(0, state);
+#endif
+  std::string icon_label = icon;
+  std::string icon_tooltip = icon;
 
   if (!alt_) {
-    if (state == "connected" && cur_focussed_device_.battery_percentage.has_value() &&
-        config_["format-connected-battery"].isString()) {
+    if (battery_available && config_["format-connected-battery"].isString()) {
       format_ = config_["format-connected-battery"].asString();
+      icon_label = getIcon(cur_focussed_device_.battery_percentage.value_or(0));
     } else if (config_["format-" + state].isString()) {
       format_ = config_["format-" + state].asString();
     } else if (config_["format"].isString()) {
@@ -167,6 +178,7 @@ auto waybar::modules::Bluetooth::update() -> void {
   }
   if (battery_available && config_["tooltip-format-connected-battery"].isString()) {
     tooltip_format = config_["tooltip-format-connected-battery"].asString();
+    icon_tooltip = getIcon(cur_focussed_device_.battery_percentage.value_or(0));
   } else if (config_["tooltip-format-" + state].isString()) {
     tooltip_format = config_["tooltip-format-" + state].asString();
   } else if (config_["tooltip-format"].isString()) {
@@ -199,6 +211,7 @@ auto waybar::modules::Bluetooth::update() -> void {
       fmt::arg("device_address", cur_focussed_device_.address),
       fmt::arg("device_address_type", cur_focussed_device_.address_type),
       fmt::arg("device_alias", cur_focussed_device_.alias),
+      fmt::arg("icon", icon_label),
       fmt::arg("device_battery_percentage", cur_focussed_device_.battery_percentage.value_or(0))));
 
   if (tooltipEnabled()) {
@@ -211,14 +224,19 @@ auto waybar::modules::Bluetooth::update() -> void {
         if ((tooltip_enumerate_connections_battery_ && dev.battery_percentage.has_value()) ||
             tooltip_enumerate_connections_) {
           ss << "\n";
-          std::string enumerate_format =
-              (tooltip_enumerate_connections_battery_ && dev.battery_percentage.has_value())
-                  ? config_["tooltip-format-enumerate-connected-battery"].asString()
-                  : config_["tooltip-format-enumerate-connected"].asString();
+          std::string enumerate_format;
+          std::string enumerate_icon;
+          if (tooltip_enumerate_connections_battery_ && dev.battery_percentage.has_value()) {
+            enumerate_format = config_["tooltip-format-enumerate-connected-battery"].asString();
+            enumerate_icon = getIcon(dev.battery_percentage.value_or(0));
+          } else {
+            enumerate_format = config_["tooltip-format-enumerate-connected"].asString();
+          }
           ss << fmt::format(
               enumerate_format, fmt::arg("device_address", dev.address),
               fmt::arg("device_address_type", dev.address_type),
               fmt::arg("device_alias", dev.alias),
+              fmt::arg("icon", enumerate_icon),
               fmt::arg("device_battery_percentage", dev.battery_percentage.value_or(0)));
         }
       }
@@ -237,6 +255,7 @@ auto waybar::modules::Bluetooth::update() -> void {
         fmt::arg("device_address", cur_focussed_device_.address),
         fmt::arg("device_address_type", cur_focussed_device_.address_type),
         fmt::arg("device_alias", cur_focussed_device_.alias),
+        fmt::arg("icon", icon_tooltip),
         fmt::arg("device_battery_percentage", cur_focussed_device_.battery_percentage.value_or(0)),
         fmt::arg("device_enumerate", device_enumerate_)));
   }

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -152,11 +152,12 @@ auto waybar::modules::Bluetooth::update() -> void {
 #ifdef WANT_RFKILL
   if (rfkill_.getState()) state = "disabled";
 #endif
-  bool battery_available = state == "connected" && cur_focussed_device_.battery_percentage.has_value();
+  bool battery_available =
+      state == "connected" && cur_focussed_device_.battery_percentage.has_value();
 
 #ifdef WANT_RFKILL
   // also adds enabled icon if icon for state is not defined
-  std::vector<std::string> states = { state, rfkill_.getState() ? "disabled" : "enabled" };
+  std::vector<std::string> states = {state, rfkill_.getState() ? "disabled" : "enabled"};
   std::string icon = getIcon(0, states);
 #else
   std::string icon = getIcon(0, state);
@@ -210,8 +211,7 @@ auto waybar::modules::Bluetooth::update() -> void {
       fmt::arg("controller_alias", cur_controller_.alias),
       fmt::arg("device_address", cur_focussed_device_.address),
       fmt::arg("device_address_type", cur_focussed_device_.address_type),
-      fmt::arg("device_alias", cur_focussed_device_.alias),
-      fmt::arg("icon", icon_label),
+      fmt::arg("device_alias", cur_focussed_device_.alias), fmt::arg("icon", icon_label),
       fmt::arg("device_battery_percentage", cur_focussed_device_.battery_percentage.value_or(0))));
 
   if (tooltipEnabled()) {
@@ -235,8 +235,7 @@ auto waybar::modules::Bluetooth::update() -> void {
           ss << fmt::format(
               enumerate_format, fmt::arg("device_address", dev.address),
               fmt::arg("device_address_type", dev.address_type),
-              fmt::arg("device_alias", dev.alias),
-              fmt::arg("icon", enumerate_icon),
+              fmt::arg("device_alias", dev.alias), fmt::arg("icon", enumerate_icon),
               fmt::arg("device_battery_percentage", dev.battery_percentage.value_or(0)));
         }
       }
@@ -254,8 +253,7 @@ auto waybar::modules::Bluetooth::update() -> void {
         fmt::arg("controller_alias", cur_controller_.alias),
         fmt::arg("device_address", cur_focussed_device_.address),
         fmt::arg("device_address_type", cur_focussed_device_.address_type),
-        fmt::arg("device_alias", cur_focussed_device_.alias),
-        fmt::arg("icon", icon_tooltip),
+        fmt::arg("device_alias", cur_focussed_device_.alias), fmt::arg("icon", icon_tooltip),
         fmt::arg("device_battery_percentage", cur_focussed_device_.battery_percentage.value_or(0)),
         fmt::arg("device_enumerate", device_enumerate_)));
   }

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -165,7 +165,9 @@ auto waybar::modules::Bluetooth::update() -> void {
       format_ = default_format_;
     }
   }
-  if (config_["tooltip-format-" + state].isString()) {
+  if (battery_available && config_["tooltip-format-connected-battery"].isString()) {
+    tooltip_format = config_["tooltip-format-connected-battery"].asString();
+  } else if (config_["tooltip-format-" + state].isString()) {
     tooltip_format = config_["tooltip-format-" + state].asString();
   } else if (config_["tooltip-format"].isString()) {
     tooltip_format = config_["tooltip-format"].asString();


### PR DESCRIPTION
- fixes non-existing ```tooltip-format-connected-battery```
- adds back ```format-icons```, which also adds the enabled state as a fallback if one of its derivative states is not defined (on, off, connected). This makes sure old bluetooth configs are fully supported and cause no crashes. (see #1574 #1569). This also supports showing an icon for the battery percentage in the ```*-connected-battery``` format options.

This would avoid further breakage if a new release is made for people who still need to upgrade and have an old bluetooth config.