### PR TITLE
Advertise river modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 #### Current features
 - Sway (Workspaces, Binding mode, Focused window name)
+- River (Tags, Focused window name)
 - Tray [#21](https://github.com/Alexays/Waybar/issues/21)
 - Local time
 - Battery


### PR DESCRIPTION
Waybar now has two river specific modules, so I thought it worthwhile pointing these out in the README.md as is done for sway.