### PR TITLE
Valid format options

### DIFF
--- a/Dockerfiles/alpine
+++ b/Dockerfiles/alpine
@@ -2,4 +2,4 @@
 
 FROM alpine:latest
 
-RUN apk add --no-cache git meson alpine-sdk libinput-dev wayland-dev wayland-protocols mesa-dev libxkbcommon-dev eudev-dev pixman-dev gtkmm3-dev jsoncpp-dev pugixml-dev libnl3-dev pulseaudio-dev libmpdclient-dev sndio-dev scdoc libxkbcommon tzdata
+RUN apk add --no-cache fmt git meson alpine-sdk libinput-dev wayland-dev wayland-protocols mesa-dev libxkbcommon-dev eudev-dev pixman-dev gtkmm3-dev jsoncpp-dev pugixml-dev libnl3-dev pulseaudio-dev libmpdclient-dev sndio-dev scdoc libxkbcommon tzdata

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -36,7 +36,6 @@ class Clock : public ALabel {
   auto weekdays_header(const date::weekday& first_dow, std::ostream& os) -> void;
   auto first_day_of_week() -> date::weekday;
   const date::time_zone* current_timezone();
-  auto print_iso_weeknum(std::ostream& os, int weeknum) -> void;
   bool is_timezone_fixed();
   auto timezones_text(std::chrono::system_clock::time_point* now) -> std::string;
 };

--- a/meson.build
+++ b/meson.build
@@ -79,7 +79,7 @@ is_netbsd = host_machine.system() == 'netbsd'
 is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
-fmt = dependency('fmt', version : ['>=7.0.0'], fallback : ['fmt', 'fmt_dep'])
+fmt = dependency('fmt', version : ['>=8.0.0'], fallback : ['fmt', 'fmt_dep'])
 spdlog = dependency('spdlog', version : ['>=1.8.5'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -165,7 +165,9 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
   const date::year_month ym(ymd.year(), ymd.month());
   const auto curr_day = ymd.day();
-  const auto week_format{config_["format-calendar-weekdays"].isString() ? config_["format-calendar-weekdays"].asString():""};
+  const auto week_format{config_["format-calendar-weekdays"].isString()
+                             ? config_["format-calendar-weekdays"].asString()
+                             : ""};
 
   std::stringstream os;
 
@@ -189,7 +191,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   auto empty_days = (wd - first_dow).count();
   date::sys_days lwd{static_cast<date::sys_days>(ym / 1) + date::days{7 - empty_days}};
 
-  if(first_dow == date::Monday){
+  if(first_dow == date::Monday) {
     lwd -= date::days{1};
   }
   /* Print weeknumber on the left for the first row*/

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -191,7 +191,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   auto empty_days = (wd - first_dow).count();
   date::sys_days lwd{static_cast<date::sys_days>(ym / 1) + date::days{7 - empty_days}};
 
-  if(first_dow == date::Monday) {
+  if (first_dow == date::Monday) {
     lwd -= date::days{1};
   }
   /* Print weeknumber on the left for the first row*/

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -168,6 +168,9 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   const auto week_format{config_["format-calendar-weekdays"].isString()
                              ? config_["format-calendar-weekdays"].asString()
                              : ""};
+  const auto wn_format{config_["format-calendar-weeks"].isString()
+                             ? config_["format-calendar-weeks"].asString()
+                             : ""};
 
   std::stringstream os;
 
@@ -196,7 +199,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   }
   /* Print weeknumber on the left for the first row*/
   if (ws == 1) {
-    os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
+    os << fmt::format(wn_format, lwd);
     os << ' ';
     lwd += date::weeks{1};
   }
@@ -211,14 +214,14 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
     } else if (unsigned(d) != 1) {
       if (ws == 2) {
         os << ' ';
-        os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
+        os << fmt::format(wn_format, lwd);
         lwd += date::weeks{1};
       }
 
       os << '\n';
 
       if (ws == 1) {
-        os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
+        os << fmt::format(wn_format, lwd);
         os << ' ';
         lwd += date::weeks{1};
       }
@@ -239,7 +242,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
       empty_days = 6 - (wd.c_encoding() - first_dow.c_encoding());
       if (empty_days > 0) {
         os << std::string(empty_days * 3 + 1, ' ');
-        os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
+        os << fmt::format(wn_format, lwd);
       }
     }
   }

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -165,18 +165,14 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
   const date::year_month ym(ymd.year(), ymd.month());
   const auto curr_day = ymd.day();
+  const auto week_format{config_["format-calendar-weekdays"].isString() ? config_["format-calendar-weekdays"].asString():""};
 
   std::stringstream os;
 
   const auto first_dow = first_day_of_week();
   int ws{0};  // weeks-pos: side(1 - left, 2 - right)
-  int wn{0};  // weeknumber
+
   if (config_["calendar-weeks-pos"].isString()) {
-    wn = (date::sys_days{date::year_month_day{ym / 1}} -
-          date::sys_days{date::year_month_day{ymd.year() / 1 / 1}})
-                 .count() /
-             7 +
-         1;
     if (config_["calendar-weeks-pos"].asString() == "left") {
       ws = 1;
       // Add paddings before the header
@@ -187,15 +183,22 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   }
 
   weekdays_header(first_dow, os);
-  /* Print weeknumber on the left for the first row*/
-  if (ws == 1) {
-    print_iso_weeknum(os, wn);
-    os << ' ';
-    ++wn;
-  }
+
   // First week prefixed with spaces if needed.
   auto wd = date::weekday(ym / 1);
   auto empty_days = (wd - first_dow).count();
+  date::sys_days lwd{static_cast<date::sys_days>(ym / 1) + date::days{7 - empty_days}};
+
+  if(first_dow == date::Monday){
+    lwd -= date::days{1};
+  }
+  /* Print weeknumber on the left for the first row*/
+  if (ws == 1) {
+    os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
+    os << ' ';
+    lwd += date::weeks{1};
+  }
+
   if (empty_days > 0) {
     os << std::string(empty_days * 3 - 1, ' ');
   }
@@ -206,16 +209,16 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
     } else if (unsigned(d) != 1) {
       if (ws == 2) {
         os << ' ';
-        print_iso_weeknum(os, wn);
-        ++wn;
+        os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
+        lwd += date::weeks{1};
       }
 
       os << '\n';
 
       if (ws == 1) {
-        print_iso_weeknum(os, wn);
+        os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
         os << ' ';
-        ++wn;
+        lwd += date::weeks{1};
       }
     }
     if (d == curr_day) {
@@ -234,7 +237,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
       empty_days = 6 - (wd.c_encoding() - first_dow.c_encoding());
       if (empty_days > 0) {
         os << std::string(empty_days * 3 + 1, ' ');
-        print_iso_weeknum(os, wn);
+        os << fmt::format(config_["format-calendar-weeks"].asString(), lwd);
       }
     }
   }
@@ -289,16 +292,6 @@ auto waybar::modules::Clock::timezones_text(std::chrono::system_clock::time_poin
     os << fmt::format(format_, wtime) << "\n";
   }
   return os.str();
-}
-
-auto waybar::modules::Clock::print_iso_weeknum(std::ostream& os, int weeknum) -> void {
-  std::stringstream res;
-  res << std::setfill('0') << std::setw(2) << weeknum;
-
-  if (config_["format-calendar-weeks"].isString()) {
-    os << fmt::format(config_["format-calendar-weeks"].asString(), res.str());
-  } else
-    os << res.str();
 }
 
 #ifdef HAVE_LANGINFO_1STDAY

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,9 +1,9 @@
 [wrap-file]
-directory = fmt-7.1.3
+directory = fmt-8.1.1
 
-source_url = https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz
-source_filename = fmt-7.1.3.tar.gz
-source_hash = 5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc
+source_url = https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz
+source_filename = fmt-8.1.1.tar.gz
+source_hash = b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9
 
 patch_url = https://github.com/mesonbuild/fmt/releases/download/7.1.3-1/fmt.zip
 patch_filename = fmt-7.1.3-1-wrap.zip

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
 directory = fmt-8.1.1
 
-source_url = https://github.com/fmtlib/fmt/archive/refs/tags/8.1.1.tar.gz
+source_url = https://github.com/fmtlib/fmt/archive/8.1.1.tar.gz
 source_filename = fmt-8.1.1.tar.gz
 source_hash = b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9
 

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -3,7 +3,7 @@ directory = fmt-8.1.1
 
 source_url = https://github.com/fmtlib/fmt/archive/8.1.1.tar.gz
 source_filename = fmt-8.1.1.tar.gz
-source_hash = b6f4ceaed0a0a24ccf575fab6c56dd50ccf6f1a9
+source_hash = 3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346
 
 patch_url = https://github.com/mesonbuild/fmt/releases/download/7.1.3-1/fmt.zip
 patch_filename = fmt-7.1.3-1-wrap.zip


### PR DESCRIPTION
* Weeknum is represented via the last day of the week

Implements [ISSUE#1565](https://github.com/Alexays/Waybar/issues/1565)
Week number now is shown is based on the last day of the week (with the correction if SU or MO is the first day of week).

Preferable config is:
`"format-calendar-weeks": "<span color='#99ffdd'><b>W{:%V}</b></span>",`
