### PR TITLE
Retain instance name css class for custom modules

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -30,6 +30,7 @@ class Custom : public ALabel {
 
   const std::string name_;
   std::string text_;
+  std::string id_;
   std::string alt_;
   std::string tooltip_;
   std::vector<std::string> class_;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -4,7 +4,12 @@
 
 waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
                                 const Json::Value& config)
-    : ALabel(config, "custom-" + name, id, "{}"), name_(name), fp_(nullptr), pid_(-1) {
+    : ALabel(config, "custom-" + name, id, "{}"),
+      name_(name),
+      id_(id),
+      percentage_(0),
+      fp_(nullptr),
+      pid_(-1) {
   dp.emit();
   if (interval_.count() > 0) {
     delayWorker();
@@ -140,6 +145,7 @@ auto waybar::modules::Custom::update() -> void {
       }
       auto classes = label_.get_style_context()->list_classes();
       for (auto const& c : classes) {
+        if (c == id_) continue;
         label_.get_style_context()->remove_class(c);
       }
       for (auto const& c : class_) {


### PR DESCRIPTION
When adding a custom module with a name, e.g.:

```jsonc
{
  ...,
  "custom/foo#bar": { },
  ...
}
```

The custom module does not retain the `bar` class as it should, because all the classes are replaced with the runtime output:

https://github.com/Alexays/Waybar/blob/1b4a7b02f46c1bce2eafdde2a76f4a3adec6620e/src/modules/custom.cpp#L141-L147

Avoid removing the module instance name class so css class behavior is consistent between all modules.