### PR TITLE
group module: configurable orientation

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -12,7 +12,7 @@ namespace waybar {
 
 class Group : public AModule {
  public:
-  Group(const std::string&, const Bar&, const Json::Value&);
+  Group(const std::string&, const std::string&, const Json::Value&, bool);
   ~Group() = default;
   auto update() -> void;
   operator Gtk::Widget&();

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -242,6 +242,7 @@ A module group is defined by specifying a module named "group/some-group-name". 
 	"modules-right": ["group/hardware", "clock"],
 
 	"group/hardware": {
+		"orientation": "vertical",
 		"modules": [
 			"cpu",
 			"memory",
@@ -252,6 +253,8 @@ A module group is defined by specifying a module named "group/some-group-name". 
 	...
 }
 ```
+
+Valid options for the (optional) "orientation" property are: "horizontal", "vertical", "inherit", and "orthogonal" (default).
 
 # SUPPORTED MODULES
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -742,7 +742,13 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
         AModule* module;
 
         if (ref.compare(0, 6, "group/") == 0 && ref.size() > 6) {
-          auto group_module = new waybar::Group(ref, *this, config[ref]);
+          auto hash_pos = ref.find('#');
+          auto id_name = ref.substr(6, hash_pos - 6);
+          auto class_name = hash_pos != std::string::npos ? ref.substr(hash_pos + 1) : "";
+
+          auto parent = group ? group : &this->box_;
+          auto vertical = parent->get_orientation() == Gtk::ORIENTATION_VERTICAL;
+          auto group_module = new waybar::Group(id_name, class_name, config[ref], vertical);
           getModules(factory, ref, &group_module->box);
           module = group_module;
         } else {
@@ -764,11 +770,11 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
             modules_right_.emplace_back(module_sp);
           }
         }
-        module->dp.connect([module, name] {
+        module->dp.connect([module, ref] {
           try {
             module->update();
           } catch (const std::exception& e) {
-            spdlog::error("{}: {}", name.asString(), e.what());
+            spdlog::error("{}: {}", ref, e.what());
           }
         });
       } catch (const std::exception& e) {

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -6,9 +6,30 @@
 
 namespace waybar {
 
-Group::Group(const std::string& name, const Bar& bar, const Json::Value& config)
-    : AModule(config, name, "", false, false),
-      box{bar.vertical ? Gtk::ORIENTATION_HORIZONTAL : Gtk::ORIENTATION_VERTICAL, 0} {}
+Group::Group(const std::string& name, const std::string& id, const Json::Value& config,
+             bool vertical)
+    : AModule(config, name, id, false, false),
+      box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0} {
+  box.set_name(name_);
+  if (!id.empty()) {
+    box.get_style_context()->add_class(id);
+  }
+
+  // default orientation: orthogonal to parent
+  auto orientation =
+      config_["orientation"].empty() ? "orthogonal" : config_["orientation"].asString();
+  if (orientation == "inherit") {
+    // keep orientation passed
+  } else if (orientation == "orthogonal") {
+    box.set_orientation(vertical ? Gtk::ORIENTATION_HORIZONTAL : Gtk::ORIENTATION_VERTICAL);
+  } else if (orientation == "vertical") {
+    box.set_orientation(Gtk::ORIENTATION_VERTICAL);
+  } else if (orientation == "horizontal") {
+    box.set_orientation(Gtk::ORIENTATION_HORIZONTAL);
+  } else {
+    throw std::runtime_error("Invalid orientation value: " + orientation);
+  }
+}
 
 auto Group::update() -> void {
   // noop


### PR DESCRIPTION
currently, the orientation of group modules is always the opposite of the bar. Change it so that:

* the default orientation of the group module is always the opposite of its parent, even for nested groups
* the orientation can be overridden in the config
* css ID and class are set for the group element

Motivation:

I would like to set styling for sets of modules so that they are visually grouped. Some of this can be simulated by enumerating style settings for each module, but many things are not possible when all the modules' elements are siblings of each other 

The module group functionality is a bit is a bit inflexible and only really viable for a specific use case. This hopefully makes it more generally useful