### PR TITLE
pulseaudio: avoid retaining outdated form factor

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -190,6 +190,8 @@ void waybar::modules::Pulseaudio::sinkInfoCb(pa_context * /*context*/, const pa_
     pa->port_name_ = i->active_port != nullptr ? i->active_port->name : "Unknown";
     if (auto ff = pa_proplist_gets(i->proplist, PA_PROP_DEVICE_FORM_FACTOR)) {
       pa->form_factor_ = ff;
+    } else {
+      pa->form_factor_ = "";
     }
     pa->dp.emit();
   }


### PR DESCRIPTION
when the module fails to get the pulseaudio device form factor, the module persists the existing value, resulting in the incorrect format-icon being used to format the label on device changes.

reset the form factor value so that the icon lookup properly falls back to "default" when missing