### PR TITLE
Last weekday applies Unix fmt

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -36,7 +36,6 @@ class Clock : public ALabel {
   auto weekdays_header(const date::weekday& first_dow, std::ostream& os) -> void;
   auto first_day_of_week() -> date::weekday;
   const date::time_zone* current_timezone();
-  auto print_iso_weeknum(std::ostream& os, int weeknum) -> void;
   bool is_timezone_fixed();
   auto timezones_text(std::chrono::system_clock::time_point* now) -> std::string;
 };

--- a/meson.build
+++ b/meson.build
@@ -79,8 +79,8 @@ is_netbsd = host_machine.system() == 'netbsd'
 is_openbsd = host_machine.system() == 'openbsd'
 
 thread_dep = dependency('threads')
-fmt = dependency('fmt', version : ['>=7.0.0'], fallback : ['fmt', 'fmt_dep'])
-spdlog = dependency('spdlog', version : ['>=1.8.5'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=true'])
+fmt = dependency('fmt', version : ['>=8.1.1'], fallback : ['fmt', 'fmt_dep'])
+spdlog = dependency('spdlog', version : ['>=1.10.0'], fallback : ['spdlog', 'spdlog_dep'], default_options : ['external_fmt=enabled'])
 wayland_client = dependency('wayland-client')
 wayland_cursor = dependency('wayland-cursor')
 wayland_protos = dependency('wayland-protocols')

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -165,18 +165,19 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
   const date::year_month ym(ymd.year(), ymd.month());
   const auto curr_day = ymd.day();
+  const auto week_format{config_["format-calendar-weekdays"].isString()
+                             ? config_["format-calendar-weekdays"].asString()
+                             : ""};
+  const auto wn_format{config_["format-calendar-weeks"].isString()
+                           ? config_["format-calendar-weeks"].asString()
+                           : ""};
 
   std::stringstream os;
 
   const auto first_dow = first_day_of_week();
   int ws{0};  // weeks-pos: side(1 - left, 2 - right)
-  int wn{0};  // weeknumber
+
   if (config_["calendar-weeks-pos"].isString()) {
-    wn = (date::sys_days{date::year_month_day{ym / 1}} -
-          date::sys_days{date::year_month_day{ymd.year() / 1 / 1}})
-                 .count() /
-             7 +
-         1;
     if (config_["calendar-weeks-pos"].asString() == "left") {
       ws = 1;
       // Add paddings before the header
@@ -187,15 +188,22 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   }
 
   weekdays_header(first_dow, os);
-  /* Print weeknumber on the left for the first row*/
-  if (ws == 1) {
-    print_iso_weeknum(os, wn);
-    os << ' ';
-    ++wn;
-  }
+
   // First week prefixed with spaces if needed.
   auto wd = date::weekday(ym / 1);
   auto empty_days = (wd - first_dow).count();
+  date::sys_days lwd{static_cast<date::sys_days>(ym / 1) + date::days{7 - empty_days}};
+
+  if (first_dow == date::Monday) {
+    lwd -= date::days{1};
+  }
+  /* Print weeknumber on the left for the first row*/
+  if (ws == 1) {
+    os << fmt::format(wn_format, lwd);
+    os << ' ';
+    lwd += date::weeks{1};
+  }
+
   if (empty_days > 0) {
     os << std::string(empty_days * 3 - 1, ' ');
   }
@@ -206,16 +214,16 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
     } else if (unsigned(d) != 1) {
       if (ws == 2) {
         os << ' ';
-        print_iso_weeknum(os, wn);
-        ++wn;
+        os << fmt::format(wn_format, lwd);
+        lwd += date::weeks{1};
       }
 
       os << '\n';
 
       if (ws == 1) {
-        print_iso_weeknum(os, wn);
+        os << fmt::format(wn_format, lwd);
         os << ' ';
-        ++wn;
+        lwd += date::weeks{1};
       }
     }
     if (d == curr_day) {
@@ -234,7 +242,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
       empty_days = 6 - (wd.c_encoding() - first_dow.c_encoding());
       if (empty_days > 0) {
         os << std::string(empty_days * 3 + 1, ' ');
-        print_iso_weeknum(os, wn);
+        os << fmt::format(wn_format, lwd);
       }
     }
   }
@@ -289,16 +297,6 @@ auto waybar::modules::Clock::timezones_text(std::chrono::system_clock::time_poin
     os << fmt::format(format_, wtime) << "\n";
   }
   return os.str();
-}
-
-auto waybar::modules::Clock::print_iso_weeknum(std::ostream& os, int weeknum) -> void {
-  std::stringstream res;
-  res << std::setfill('0') << std::setw(2) << weeknum;
-
-  if (config_["format-calendar-weeks"].isString()) {
-    os << fmt::format(config_["format-calendar-weeks"].asString(), res.str());
-  } else
-    os << res.str();
 }
 
 #ifdef HAVE_LANGINFO_1STDAY

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,13 +1,12 @@
 [wrap-file]
-directory = fmt-7.1.3
-
-source_url = https://github.com/fmtlib/fmt/archive/7.1.3.tar.gz
-source_filename = fmt-7.1.3.tar.gz
-source_hash = 5cae7072042b3043e12d53d50ef404bbb76949dad1de368d7f993a15c8c05ecc
-
-patch_url = https://github.com/mesonbuild/fmt/releases/download/7.1.3-1/fmt.zip
-patch_filename = fmt-7.1.3-1-wrap.zip
-patch_hash = 6eb951a51806fd6ffd596064825c39b844c1fe1799840ef507b61a53dba08213
+directory = fmt-8.1.1
+source_url = https://github.com/fmtlib/fmt/archive/8.1.1.tar.gz
+source_filename = fmt-8.1.1.tar.gz
+source_hash = 3d794d3cf67633b34b2771eb9f073bde87e846e0d395d254df7b211ef1ec7346
+patch_filename = fmt_8.1.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_8.1.1-1/get_patch
+patch_hash = 6035a67c7a8c90bed74c293c7265c769f47a69816125f7566bccb8e2543cee5e
 
 [provide]
 fmt = fmt_dep
+

--- a/subprojects/spdlog.wrap
+++ b/subprojects/spdlog.wrap
@@ -1,11 +1,13 @@
 [wrap-file]
-directory = spdlog-1.8.5
-source_url = https://github.com/gabime/spdlog/archive/v1.8.5.tar.gz
-source_filename = v1.8.5.tar.gz
-source_hash = 944d0bd7c763ac721398dca2bb0f3b5ed16f67cef36810ede5061f35a543b4b8
-patch_url = https://wrapdb.mesonbuild.com/v1/projects/spdlog/1.8.5/1/get_zip
-patch_filename = spdlog-1.8.5-1-wrap.zip
-patch_hash = 3c38f275d5792b1286391102594329e98b17737924b344f98312ab09929b74be
+directory = spdlog-1.10.0
+source_url = https://github.com/gabime/spdlog/archive/v1.10.0.tar.gz
+source_filename = v1.10.0.tar.gz
+source_hash = 697f91700237dbae2326b90469be32b876b2b44888302afbc7aceb68bcfe8224
+patch_filename = spdlog_1.10.0-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/spdlog_1.10.0-3/get_patch
+patch_hash = 5bb07b4af1e971817d4b886efbe077aaf6c36d72d3d7e461bbcf6631f3725704
+wrapdb_version = 1.10.0-3
 
 [provide]
 spdlog = spdlog_dep
+


### PR DESCRIPTION
Solves ISSUE#1565

1. Week number actually is presented as a last day of the week.
2. User now can define any time format to it. Actually the goal is to provide to user an opportunity to use both: :%V or :%U format. But there is not any limits and can be used any time format.
3. Example:
   1. "format-calendar-weeks": "<span color='#99ffdd'><b>W{:%V}</b></span>",
   2. "format-calendar-weeks": "<span color='#99ffdd'><b>W{:%V %Y-%m-%d}</b></span>",