### PR TITLE
Add support for reading the config path from env

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -14,6 +14,7 @@ namespace waybar {
 class Config {
  public:
   static const std::vector<std::string> CONFIG_DIRS;
+  static const char *CONFIG_PATH_ENV;
 
   /* Try to find any of provided names in the supported set of config directories */
   static std::optional<std::string> findConfigPath(


### PR DESCRIPTION
Please, have mercy. I am a mere go dev, and this is my first attempt at C++. I wanted to add support to reading the config path from an environment variable.

This PR adds support to reading the config base path from the environment variable `WAYBAR_CONFIG_DIR`. If it is set, but no configuration is found there, it falls back to the previous mechanism of using the default paths, without erroring.