### PR TITLE
fix: adapt to fmt 9.0.0 breaking changes

### DIFF
--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <fmt/format.h>
-#if FMT_VERSION < 60000
-#include <fmt/time.h>
-#else
 #include <fmt/chrono.h>
-#endif
 #include <gtkmm/label.h>
 
 #include "AModule.hpp"

--- a/include/modules/simpleclock.hpp
+++ b/include/modules/simpleclock.hpp
@@ -1,11 +1,7 @@
 #pragma once
 
-#include <fmt/format.h>
-#if FMT_VERSION < 60000
-#include <fmt/time.h>
-#else
 #include <fmt/chrono.h>
-#endif
+
 #include "ALabel.hpp"
 #include "util/sleeper_thread.hpp"
 

--- a/include/util/json.hpp
+++ b/include/util/json.hpp
@@ -1,6 +1,14 @@
 #pragma once
 
+#include <fmt/ostream.h>
 #include <json/json.h>
+
+#if (FMT_VERSION >= 90000)
+
+template <>
+struct fmt::formatter<Json::Value> : ostream_formatter {};
+
+#endif
 
 namespace waybar::util {
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -1,12 +1,12 @@
 #include "client.hpp"
 
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 
 #include <iostream>
 
 #include "idle-inhibit-unstable-v1-client-protocol.h"
 #include "util/clara.hpp"
+#include "util/format.hpp"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
 waybar::Client *waybar::Client::inst() {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,6 +1,5 @@
 #include "config.hpp"
 
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 #include <wordexp.h>

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -1,15 +1,10 @@
 #include "modules/clock.hpp"
 
+#include <fmt/chrono.h>
 #include <spdlog/spdlog.h>
 
-#include <iomanip>
-#if FMT_VERSION < 60000
-#include <fmt/time.h>
-#else
-#include <fmt/chrono.h>
-#endif
-
 #include <ctime>
+#include <iomanip>
 #include <sstream>
 #include <type_traits>
 

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -10,6 +10,13 @@ namespace waybar::modules {
 }  // namespace waybar::modules
 #endif
 
+#if FMT_VERSION >= 90000
+/* Satisfy fmt 9.x deprecation of implicit conversion of enums to int */
+auto format_as(enum mpd_idle val) {
+  return static_cast<std::underlying_type_t<enum mpd_idle>>(val);
+}
+#endif
+
 namespace waybar::modules::detail {
 
 #define IDLE_RUN_NOIDLE_AND_CMD(...)                                      \

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -1,6 +1,5 @@
 #include "modules/sni/host.hpp"
 
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 
 namespace waybar::modules::SNI {

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -1,6 +1,5 @@
 #include "modules/sway/bar.hpp"
 
-#include <fmt/ostream.h>
 #include <spdlog/spdlog.h>
 
 #include <sstream>


### PR DESCRIPTION
Addresses the following breaking change:

> Disabled automatic `std::ostream` insertion operator (`operator<<`) discovery when `fmt/ostream.h` is included to prevent ODR violations. You can get the old behavior by defining `FMT_DEPRECATED_OSTREAM` but this will be removed in the next major release. Use `fmt::streamed` or `fmt::ostream_formatter` to enable formatting via `std::ostream` instead.

The patch is good enough to fix builds in distributions updating to fmt 9. WIP because it's already late and I need to give it another look tomorrow; there's one more deprecation warning I want to address:

```
../subprojects/fmt/include/fmt/core.h:1711:43: warning: 'map<mpd_idle, 0>' is deprecated [-Wdeprecated-declarations]           
  const auto& arg = arg_mapper<Context>().map(std::forward<T>(val));                                                           
                                          ^                                                                                                                                                                                                                    
../subprojects/fmt/include/fmt/core.h:1451:3: note: 'map<mpd_idle, 0>' has been explicitly marked deprecated here
  FMT_DEPRECATED FMT_CONSTEXPR FMT_INLINE auto map(const T& val)                                                               
  ^                                                                                                                                                                                                                                                                                                                                                                                                                                       
...
../src/modules/mpd/state.cpp:81:11: note: in instantiation of function template specialization 'spdlog::debug<mpd_idle &>' requested here
  spdlog::debug("mpd: Idle: recv_idle events -> {}", events);
```