### PR TITLE
sni: Use the pixmap if for the given icon name an icon could not be found

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -345,7 +345,7 @@ Glib::RefPtr<Gdk::Pixbuf> Item::getIconPixbuf() {
   }
 
   if (icon_name.empty()) {
-    spdlog::error("Item '{}': No icon name or pixmap given.", id, icon_name);
+    spdlog::error("Item '{}': No icon name or pixmap given.", id);
   } else {
     spdlog::error("Item '{}': Could not find an icon named '{}' and no pixmap given.", id, icon_name);
   }

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -319,14 +319,15 @@ void Item::updateImage() {
 
 Glib::RefPtr<Gdk::Pixbuf> Item::getIconPixbuf() {
   try {
+    if (icon_pixmap) {
+      return icon_pixmap;
+    }
     if (!icon_name.empty()) {
       std::ifstream temp(icon_name);
       if (temp.is_open()) {
         return Gdk::Pixbuf::create_from_file(icon_name);
       }
       return getIconByName(icon_name, getScaledIconSize());
-    } else if (icon_pixmap) {
-      return icon_pixmap;
     }
   } catch (Glib::Error& e) {
     spdlog::error("Item '{}': {}", id, static_cast<std::string>(e.what()));

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -300,10 +300,6 @@ void Item::updateImage() {
   auto pixbuf = getIconPixbuf();
   auto scaled_icon_size = getScaledIconSize();
 
-  if (!pixbuf) {
-    pixbuf = getIconByName("image-missing", getScaledIconSize());
-  }
-
   // If the loaded icon is not square, assume that the icon height should match the
   // requested icon size, but the width is allowed to be different. As such, if the
   // height of the image does not match the requested icon size, resize the icon such that

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -335,7 +335,7 @@ Glib::RefPtr<Gdk::Pixbuf> Item::getIconPixbuf() {
       // Will throw if it can not find an icon.
       return getIconByName(icon_name, getScaledIconSize());
     } catch (Glib::Error& e) {
-      spdlog::info("Item '{}': {}", id, static_cast<std::string>(e.what()));
+      spdlog::trace("Item '{}': {}", id, static_cast<std::string>(e.what()));
     }
   }
 


### PR DESCRIPTION
For me this fixes the issue of Nextcloud showing a missing tray icon. (I do not think that there is an open issue in regards to this.)

I am not sure if there the pixmap given should always be preferred though; I guess this "breaks" theming by not allowing to override the pixmap given from the application with your own theme.


I guess the following may be better:
After checking for the icon name, fall back to the pixmap if it was not found?

*So, if other behavior would be preferred, I could try to implement it accordingly.*

---

Anyway. Currently there is suboptimal behavior when
* an icon name is given
* a pixmap is given
* there is no globally installed icon for the given icon name

because it will then show the "missing icon" icon even though it could use the pixmap.