### PR TITLE
Language: Add layout as class name

### DIFF
--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -120,7 +120,9 @@ auto Language::update() -> void {
 }
 
 auto Language::set_current_layout(std::string current_layout) -> void {
+  label_.get_style_context()->remove_class(layout_.short_name);
   layout_ = layouts_map_[current_layout];
+  label_.get_style_context()->add_class(layout_.short_name);
 }
 
 auto Language::init_layouts_map(const std::vector<std::string>& used_layouts) -> void {


### PR DESCRIPTION
A few days ago I opened [this issue](https://github.com/Alexays/Waybar/issues/1615).

Basically it is about adding the layout as class name to the module to allow for more styles without the need of creating a clunky custom module.

I've finally managed to get the code working so I though on trying to push it 😄.