### PR TITLE
Fix binary pow formatting for values between 1000 and 1024

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -56,7 +56,9 @@ struct formatter<pow_format> {
       fraction /= base;
     }
 
-    auto max_width = 4            // coeff in {:.3g} format
+    auto number_width = 5            // coeff in {:.1f} format
+                        + s.binary_; // potential 4th digit before the decimal point
+    auto max_width = number_width
                      + 1          // prefix from units array
                      + s.binary_  // for the 'i' in GiB.
                      + s.unit_.length();
@@ -69,15 +71,16 @@ struct formatter<pow_format> {
       case '<':
         return format_to(ctx.out(), "{:<{}}", fmt::format("{}", s), max_width);
       case '=':
-        format = "{coefficient:<4.3g}{padding}{prefix}{unit}";
+        format = "{coefficient:<{number_width}.1f}{padding}{prefix}{unit}";
         break;
       case 0:
       default:
-        format = "{coefficient:.3g}{prefix}{unit}";
+        format = "{coefficient:.1f}{prefix}{unit}";
         break;
     }
     return format_to(
         ctx.out(), format, fmt::arg("coefficient", fraction),
+        fmt::arg("number_width", number_width),
         fmt::arg("prefix", std::string() + units[pow] + ((s.binary_ && pow) ? "i" : "")),
         fmt::arg("unit", s.unit_),
         fmt::arg("padding", pow         ? ""


### PR DESCRIPTION
The current implementation of `pow_format` slips into scientific notation when it's formatting a number between 1000 and 1024 in binary mode (for instance, waybar is currently telling me I have `1.02e+03GiB` of disk space free). This PR uses the `f` presentation type instead of `g` to avoid this. Unfortunately, in fixed-point mode, the precision value only controls the number of digits after the decimal point, not the total number of significant figures. I went with `.1f` as a reasonable compromise, and adjusted the padding accordingly to account for having numbers up to 5 characters long in decimal mode, or up to 6 characters long in binary mode (`1023.9`).