### PR TITLE
Add config option to ignore Pulseaudio Sinks

### DIFF
--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -101,6 +101,10 @@ Additionally you can control the volume by scrolling *up* or *down* while the cu
 	default: 100 ++
 	The maximum volume that can be set, in percentage.
 
+*ignored-sinks*: ++
+	typeof: array ++
+	Sinks in this list will not be shown as the active sink by Waybar. Entries should be the sink's description field.
+
 # FORMAT REPLACEMENTS
 
 *{desc}*: Pulseaudio port's description, for bluetooth it'll be the device name.

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -170,6 +170,15 @@ void waybar::modules::Pulseaudio::sinkInfoCb(pa_context * /*context*/, const pa_
   if (i == nullptr) return;
 
   auto pa = static_cast<waybar::modules::Pulseaudio *>(data);
+
+  if (pa->config_["ignored-sinks"].isArray()) {
+    for (const auto& ignored_sink : pa->config_["ignored-sinks"]) {
+      if (ignored_sink.asString() == i->description) {
+        return;
+      }
+    }
+  }
+
   if (pa->current_sink_name_ == i->name) {
     if (i->state != PA_SINK_RUNNING) {
       pa->current_sink_running_ = false;


### PR DESCRIPTION
This adds a new config option, `ignored-sinks`, for the Pulseaudio module, which can be used to stop certain sinks (in my case the EasyEffects sink) from appearing. This is needed as these sinks are always running, and so hijack the volume indicator in the bar.

Example config:
``` json
"pulseaudio": {
    "ignored-sinks": ["EasyEffects Sink"]
}
```