### PR TITLE
Issue#1545. Calendar scrolling opportunity

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -48,10 +48,10 @@ class AModule : public IModule {
       {std::make_pair(3, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-right"},
       {std::make_pair(8, GdkEventType::GDK_BUTTON_PRESS), "on-click-backward"},
       {std::make_pair(8, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-backward"},
-      {std::make_pair(8, GdkEventType::GDK_2BUTTON_PRESS), "on-triple-click-backward"},
+      {std::make_pair(8, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-backward"},
       {std::make_pair(9, GdkEventType::GDK_BUTTON_PRESS), "on-click-forward"},
       {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-forward"},
-      {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-triple-click-forward"}};
+      {std::make_pair(9, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-forward"}};
 };
 
 }  // namespace waybar

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -25,8 +25,9 @@ class Clock : public ALabel {
   std::locale locale_;
   std::vector<const date::time_zone*> time_zones_;
   int current_time_zone_idx_;
-  date::year_month_day cached_calendar_ymd_ = date::January / 1 / 0;
-  std::string cached_calendar_text_;
+  date::year_month_day calendar_cached_ymd_{date::January / 1 / 0};
+  date::months calendar_shift_{0}, calendar_shift_init_{0};
+  std::string calendar_cached_text_;
   bool is_calendar_in_tooltip_;
   bool is_timezoned_list_in_tooltip_;
 
@@ -39,6 +40,5 @@ class Clock : public ALabel {
   bool is_timezone_fixed();
   auto timezones_text(std::chrono::system_clock::time_point* now) -> std::string;
 };
-
 }  // namespace modules
 }  // namespace waybar

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -61,6 +61,13 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     }
   }
 
+  if (is_calendar_in_tooltip_) {
+    if (config_["on-scroll"][kCalendarPlaceholder].isInt()) {
+      calendar_shift_init_ =
+          date::months{config_["on-scroll"].get(kCalendarPlaceholder, 0).asInt()};
+    }
+  }
+
   if (config_["locale"].isString()) {
     locale_ = std::locale(config_["locale"].asString());
   } else {
@@ -89,8 +96,8 @@ bool waybar::modules::Clock::is_timezone_fixed() {
 auto waybar::modules::Clock::update() -> void {
   auto time_zone = current_timezone();
   auto now = std::chrono::system_clock::now();
-  waybar_time wtime = {locale_,
-                       date::make_zoned(time_zone, date::floor<std::chrono::seconds>(now))};
+  waybar_time wtime = {locale_, date::make_zoned(time_zone, date::floor<std::chrono::seconds>(now) +
+                                                                calendar_shift_)};
   std::string text = "";
   if (!is_timezone_fixed()) {
     // As date dep is not fully compatible, prefer fmt
@@ -104,14 +111,10 @@ auto waybar::modules::Clock::update() -> void {
 
   if (tooltipEnabled()) {
     if (config_["tooltip-format"].isString()) {
-      std::string calendar_lines = "";
-      std::string timezoned_time_lines = "";
-      if (is_calendar_in_tooltip_) {
-        calendar_lines = calendar_text(wtime);
-      }
-      if (is_timezoned_list_in_tooltip_) {
-        timezoned_time_lines = timezones_text(&now);
-      }
+      std::string calendar_lines{""};
+      std::string timezoned_time_lines{""};
+      if (is_calendar_in_tooltip_) calendar_lines = calendar_text(wtime);
+      if (is_timezoned_list_in_tooltip_) timezoned_time_lines = timezones_text(&now);
       auto tooltip_format = config_["tooltip-format"].asString();
       text =
           fmt::format(tooltip_format, wtime, fmt::arg(kCalendarPlaceholder.c_str(), calendar_lines),
@@ -131,20 +134,30 @@ bool waybar::modules::Clock::handleScroll(GdkEventScroll* e) {
   }
 
   auto dir = AModule::getScrollDir(e);
-  if (dir != SCROLL_DIR::UP && dir != SCROLL_DIR::DOWN) {
-    return true;
-  }
-  if (time_zones_.size() == 1) {
-    return true;
-  }
 
-  auto nr_zones = time_zones_.size();
-  if (dir == SCROLL_DIR::UP) {
-    size_t new_idx = current_time_zone_idx_ + 1;
-    current_time_zone_idx_ = new_idx == nr_zones ? 0 : new_idx;
+  // Shift calendar date
+  if (calendar_shift_init_.count() > 0) {
+    if (dir == SCROLL_DIR::UP)
+      calendar_shift_ += calendar_shift_init_;
+    else
+      calendar_shift_ -= calendar_shift_init_;
   } else {
-    current_time_zone_idx_ =
-        current_time_zone_idx_ == 0 ? nr_zones - 1 : current_time_zone_idx_ - 1;
+    // Change time zone
+    if (dir != SCROLL_DIR::UP && dir != SCROLL_DIR::DOWN) {
+      return true;
+    }
+    if (time_zones_.size() == 1) {
+      return true;
+    }
+
+    auto nr_zones = time_zones_.size();
+    if (dir == SCROLL_DIR::UP) {
+      size_t new_idx = current_time_zone_idx_ + 1;
+      current_time_zone_idx_ = new_idx == nr_zones ? 0 : new_idx;
+    } else {
+      current_time_zone_idx_ =
+          current_time_zone_idx_ == 0 ? nr_zones - 1 : current_time_zone_idx_ - 1;
+    }
   }
 
   update();
@@ -153,13 +166,14 @@ bool waybar::modules::Clock::handleScroll(GdkEventScroll* e) {
 
 auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::string {
   const auto daypoint = date::floor<date::days>(wtime.ztime.get_local_time());
-  const auto ymd = date::year_month_day(daypoint);
-  if (cached_calendar_ymd_ == ymd) {
-    return cached_calendar_text_;
-  }
+  const auto ymd{date::year_month_day{daypoint}};
 
-  const date::year_month ym(ymd.year(), ymd.month());
-  const auto curr_day = ymd.day();
+  if (calendar_cached_ymd_ == ymd) return calendar_cached_text_;
+
+  const auto curr_day{(calendar_shift_init_.count() > 0 && calendar_shift_.count() != 0)
+                          ? date::day{0}
+                          : ymd.day()};
+  const date::year_month ym{ymd.year(), ymd.month()};
   const auto week_format{config_["format-calendar-weekdays"].isString()
                              ? config_["format-calendar-weekdays"].asString()
                              : ""};
@@ -243,8 +257,8 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   }
 
   auto result = os.str();
-  cached_calendar_ymd_ = ymd;
-  cached_calendar_text_ = result;
+  calendar_cached_ymd_ = ymd;
+  calendar_cached_text_ = result;
   return result;
 }
 


### PR DESCRIPTION
Hi @Alexays , there is a small improvement to have scrolling ability on calendar #1545

1. For clock module added general event section "on-scroll"
2. Added subsection: "calendar" which stores int value as an months count for scrolling.

It's implemented not as event on mouse button clicks but through scrolling event which it seems to me more logically. In case when users wants to have both : calendar scrolling and timezone scrolling it's quite simple to extend "on-scroll" block

My config looks like:

```json
"clock": {
        // "timezone": "America/New_York",
        "format": " {:%b %d %Y (%R)}",
        "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>",
        "format-alt": "{:%Y-%m-%d}",
        "today-format": "<span color='#ff6699'><b><u>{}</u></b></span>",
        "calendar-weeks-pos": "right",
        "format-calendar": "<span color='#ecc6d9'><b>{}</b></span>",
        "format-calendar-weeks": "<span color='#99ffdd'><b>W{:%V}</b></span>",
        "format-calendar-weekdays": "<span color='#ffcc66'><b>{}</b></span>",
        "interval": 10,
        "on-scroll": {
                       "calendar": 1
                     }
        }
```