### PR TITLE
modules/custom: Fix non-json return-type processing

### DIFF
--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -31,6 +31,7 @@ class Network : public ALabel {
   static int handleEvents(struct nl_msg*, void*);
   static int handleEventsDone(struct nl_msg*, void*);
   static int handleScan(struct nl_msg*, void*);
+  static int handleInfo(struct nl_msg*, void*);
 
   void askForStateDump(void);
 
@@ -52,6 +53,7 @@ class Network : public ALabel {
   sa_family_t family_;
   struct sockaddr_nl nladdr_ = {0};
   struct nl_sock* sock_ = nullptr;
+  struct nl_sock* sock2_ = nullptr;
   struct nl_sock* ev_sock_ = nullptr;
   int efd_;
   int ev_fd_;

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -124,11 +124,11 @@ This should look like this:
 
 The *class* parameter also accepts an array of strings.
 
-If nothing or an invalid option is specified, Waybar expects i3blocks style output. Values are *newline* separated.
+If nothing or an invalid option is specified, Waybar expects *Tab* delemited output.
 This should look like this:
 
 ```
-$text\\n$tooltip\\n$class*
+$text\\t$tooltip\\t$class\\n*
 ```
 
 *class* is a CSS class, to apply different styles in *style.css*

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -162,7 +162,7 @@ void waybar::modules::Custom::parseOutputRaw() {
   std::istringstream output(output_.out);
   std::string line;
   int i = 0;
-  while (getline(output, line)) {
+  while (getline(output, line, '\t')) {
     if (i == 0) {
       if (config_["escape"].isBool() && config_["escape"].asBool()) {
         text_ = Glib::Markup::escape_text(line);


### PR DESCRIPTION
modules/custom currently incorrectly process a non-json return-type, as waybar::modules::Custom::parseOutputRaw() consumes *newline* separated format, but waybar::modules::Custom::continuousWorker() produces only one line output at once.

This pull request change separation from '\n' to '\t' and fixes the defect.