### PR TITLE
Feature: sway/window can show 'shell' parameter

### DIFF
--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -21,7 +21,7 @@ class Window : public AIconLabel, public sigc::trackable {
  private:
   void onEvent(const struct Ipc::ipc_response&);
   void onCmd(const struct Ipc::ipc_response&);
-  std::tuple<std::size_t, int, std::string, std::string, std::string> getFocusedNode(
+  std::tuple<std::size_t, int, std::string, std::string, std::string, std::string> getFocusedNode(
       const Json::Value& nodes, std::string& output);
   void getTree();
   std::string rewriteTitle(const std::string& title);
@@ -35,6 +35,7 @@ class Window : public AIconLabel, public sigc::trackable {
   std::string app_class_;
   std::string old_app_id_;
   std::size_t app_nb_;
+  std::string shell_;
   unsigned app_icon_size_{24};
   bool update_app_icon_{true};
   std::string app_icon_name_;

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -15,7 +15,7 @@ Addressed by *sway/window*
 *format*: ++
 	typeof: string ++
 	default: {title} ++
-	The format, how information should be displayed. On {} data gets inserted.
+	The format, how information should be displayed.
 
 *rotate*: ++
 	typeof: integer ++

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -14,7 +14,7 @@ Addressed by *sway/window*
 
 *format*: ++
 	typeof: string ++
-	default: {} ++
+	default: {title} ++
 	The format, how information should be displayed. On {} data gets inserted.
 
 *rotate*: ++
@@ -79,6 +79,15 @@ Addressed by *sway/window*
 	typeof: integer ++
 	default: 24 ++
 	Option to change the size of the application icon.
+
+# FORMAT REPLACEMENTS
+
+*{title}*: The title of the focused window.
+
+*{app_id}*: The app_id of the focused window.
+
+*{shell}*: The shell of the focused window. It's 'xwayland' when the window is
+running through xwayland, otherwise it's 'xdg-shell'.
 
 # REWRITE RULES
 

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -175,8 +175,8 @@ auto Window::update() -> void {
     bar_.window.get_style_context()->remove_class("solo");
     bar_.window.get_style_context()->remove_class("empty");
   }
-  label_.set_markup(
-      fmt::format(format_, fmt::arg("title", rewriteTitle(window_)), fmt::arg("app_id", app_id_), fmt::arg("shell", shell_)));
+  label_.set_markup(fmt::format(format_, fmt::arg("title", rewriteTitle(window_)),
+                                fmt::arg("app_id", app_id_), fmt::arg("shell", shell_)));
   if (tooltipEnabled()) {
     label_.set_tooltip_text(window_);
   }
@@ -223,14 +223,12 @@ std::tuple<std::size_t, int, std::string, std::string, std::string, std::string>
                                    ? node["window_properties"]["class"].asString()
                                    : "";
 
-        const auto shell = node["shell"].isString()
-                               ? node["shell"].asString()
-                               : "";
+        const auto shell = node["shell"].isString() ? node["shell"].asString() : "";
 
         int nb = node.size();
         if (parentWorkspace != 0) nb = leafNodesInWorkspace(parentWorkspace);
-        return {nb, node["id"].asInt(), Glib::Markup::escape_text(node["name"].asString()), app_id,
-                app_class, shell};
+        return {nb, node["id"].asInt(), Glib::Markup::escape_text(node["name"].asString()),
+                app_id, app_class, shell};
       }
     }
     // iterate
@@ -250,8 +248,8 @@ std::tuple<std::size_t, int, std::string, std::string, std::string, std::string>
   return {0, -1, "", "", "", ""};
 }
 
-std::tuple<std::size_t, int, std::string, std::string, std::string, std::string> Window::getFocusedNode(
-    const Json::Value& nodes, std::string& output) {
+std::tuple<std::size_t, int, std::string, std::string, std::string, std::string>
+Window::getFocusedNode(const Json::Value& nodes, std::string& output) {
   Json::Value placeholder = 0;
   return gfnWithWorkspace(nodes, output, config_, bar_, placeholder);
 }


### PR DESCRIPTION
This is a very simple pull request, which grants the sway/window module the capability to display the 'shell' parameter from sway tree.

I personally find it very handy whenever I need to check if a certain window is running natively on Wayland or not.

I was wondering if I should also edit the manpage file for sway/window and the wiki.

Please feel free to correct my mistakes and formatting.