### PR TITLE
Added a basic hyprland/language module

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -24,6 +24,7 @@
 #ifdef HAVE_HYPRLAND
 #include "modules/hyprland/backend.hpp"
 #include "modules/hyprland/window.hpp"
+#include "modules/hyprland/language.hpp"
 #endif
 #if defined(__linux__) && !defined(NO_FILESYSTEM)
 #include "modules/battery.hpp"

--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -1,0 +1,28 @@
+#include <fmt/format.h>
+
+#include "ALabel.hpp"
+#include "bar.hpp"
+#include "modules/hyprland/backend.hpp"
+#include "util/json.hpp"
+
+namespace waybar::modules::hyprland {
+
+class Language : public waybar::ALabel {
+public:
+  Language(const std::string&, const waybar::Bar&, const Json::Value&);
+  ~Language() = default;
+
+  auto update() -> void;
+
+private:
+  void onEvent(const std::string&);
+
+  void initLanguage();
+
+  std::mutex mutex_;
+  const Bar& bar_;
+  util::JsonParser parser_;
+  std::string layoutName_;
+};
+
+}

--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -18,6 +18,7 @@ private:
   void onEvent(const std::string&);
 
   void initLanguage();
+  std::string getShortFrom(const std::string&);
 
   std::mutex mutex_;
   const Bar& bar_;

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -1,0 +1,43 @@
+waybar-hyprland-language(5)
+
+# NAME
+
+waybar - hyprland language module
+
+# DESCRIPTION
+
+The *language* module displays the currently selected language.
+
+# CONFIGURATION
+
+Addressed by *hyprland/language*
+
+*format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how information should be displayed. On {} the currently selected language is displayed.
+
+*format-<lang>* ++
+    typeof: string++
+    Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
+
+*keyboard-name*: ++
+    typeof: string ++
+    Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "AT Translated set..." is recommended.
+
+
+
+# EXAMPLES
+
+```
+"hyprland/language": {
+    "format": "Lang: {}"
+    "format-us": "AMERICA, HELL YEAH!" // For American English
+    "format-tr": "As bayrakları" // For Turkish
+    "keyboard-name": "AT Translated Set 2 keyboard"
+}
+```
+
+# STYLE
+
+- *#language*

--- a/meson.build
+++ b/meson.build
@@ -205,6 +205,7 @@ if true
     add_project_arguments('-DHAVE_HYPRLAND', language: 'cpp')
     src_files += 'src/modules/hyprland/backend.cpp'
     src_files += 'src/modules/hyprland/window.cpp'
+    src_files += 'src/modules/hyprland/language.cpp'
 endif
 
 if libnl.found() and libnlgen.found()

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -61,6 +61,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "hyprland/window") {
       return new waybar::modules::hyprland::Window(id, bar_, config_[name]);
     }
+    if (ref == "hyprland/language") {
+      return new waybar::modules::hyprland::Language(id, bar_, config_[name]);
+    }
 #endif
     if (ref == "idle_inhibitor") {
       return new waybar::modules::IdleInhibitor(id, bar_, config_[name]);

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -71,8 +71,7 @@ void Language::onEvent(const std::string& ev) {
 void Language::initLanguage() {
   const auto INPUTDEVICES = gIPC->getSocket1Reply("devices");
 
-  if (!config_.isMember("keyboard-name"))
-    return;
+  if (!config_.isMember("keyboard-name")) return;
 
   const auto KEEBNAME = config_["keyboard-name"].asString();
 

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -1,8 +1,8 @@
 #include "modules/hyprland/language.hpp"
 
 #include <spdlog/spdlog.h>
-#include <xkbcommon/xkbregistry.h>
 #include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbregistry.h>
 
 #include "modules/hyprland/backend.hpp"
 
@@ -123,7 +123,7 @@ std::string Language::getShortFrom(const std::string& fullName) {
 
     return briefName;
   }
-  
+
   rxkb_context_unref(CONTEXT);
 
   return "";

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -1,0 +1,97 @@
+#include "modules/hyprland/language.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include "modules/hyprland/backend.hpp"
+
+namespace waybar::modules::hyprland {
+
+Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
+    : ALabel(config, "language", id, "{}", 0, true), bar_(bar) {
+  modulesReady = true;
+
+  if (!gIPC.get()) {
+    gIPC = std::make_unique<IPC>();
+  }
+
+  // get the active layout when open
+  initLanguage();
+
+  label_.hide();
+  ALabel::update();
+
+  // register for hyprland ipc
+  gIPC->registerForIPC("activelayout", [&](const std::string& ev) { this->onEvent(ev); });
+}
+
+auto Language::update() -> void {
+  // fix ampersands
+  std::lock_guard<std::mutex> lg(mutex_);
+
+  if (!format_.empty()) {
+    label_.show();
+    label_.set_markup(fmt::format(format_, layoutName_));
+  } else {
+    label_.hide();
+  }
+
+  ALabel::update();
+}
+
+void Language::onEvent(const std::string& ev) {
+  std::lock_guard<std::mutex> lg(mutex_);
+  auto layoutName = ev.substr(ev.find_last_of(',') + 1);
+  auto keebName = ev.substr(0, ev.find_last_of(','));
+  keebName = keebName.substr(keebName.find_first_of('>') + 2);
+
+  if (config_.isMember("keyboard-name") && keebName != config_["keyboard-name"].asString())
+    return; // ignore
+
+  auto replaceAll = [](std::string str, const std::string& from,
+                       const std::string& to) -> std::string {
+    size_t start_pos = 0;
+    while ((start_pos = str.find(from, start_pos)) != std::string::npos) {
+      str.replace(start_pos, from.length(), to);
+      start_pos += to.length();
+    }
+    return str;
+  };
+
+  layoutName = replaceAll(layoutName, "&", "&amp;");
+
+  if (layoutName == layoutName_) return;
+
+  layoutName_ = layoutName;
+
+  spdlog::debug("hyprland language onevent with {}", layoutName);
+
+  dp.emit();
+}
+
+void Language::initLanguage() {
+    const auto INPUTDEVICES = gIPC->getSocket1Reply("devices");
+
+    if (!config_.isMember("keyboard-name"))
+      return;
+
+    const auto KEEBNAME = config_["keyboard-name"].asString();
+
+    try {
+
+      auto searcher = INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
+      searcher = searcher.substr(searcher.find("Keyboard at"));
+      searcher = searcher.substr(searcher.find("keymap:") + 7);
+      searcher = searcher.substr(0, searcher.find_first_of("\n\t"));
+
+      layoutName_ = searcher;
+
+      spdlog::debug("hyprland language initLanguage found {}", layoutName_);
+
+      dp.emit();
+
+    } catch (std::exception& e) {
+      spdlog::error("hyprland language initLanguage failed with {}", e.what());
+    }
+}
+
+}  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -27,7 +27,6 @@ Language::Language(const std::string& id, const Bar& bar, const Json::Value& con
 }
 
 auto Language::update() -> void {
-  // fix ampersands
   std::lock_guard<std::mutex> lg(mutex_);
 
   if (!format_.empty()) {

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -45,7 +45,7 @@ void Language::onEvent(const std::string& ev) {
   keebName = keebName.substr(keebName.find_first_of('>') + 2);
 
   if (config_.isMember("keyboard-name") && keebName != config_["keyboard-name"].asString())
-    return; // ignore
+    return;  // ignore
 
   auto replaceAll = [](std::string str, const std::string& from,
                        const std::string& to) -> std::string {
@@ -69,29 +69,29 @@ void Language::onEvent(const std::string& ev) {
 }
 
 void Language::initLanguage() {
-    const auto INPUTDEVICES = gIPC->getSocket1Reply("devices");
+  const auto INPUTDEVICES = gIPC->getSocket1Reply("devices");
 
-    if (!config_.isMember("keyboard-name"))
-      return;
+  if (!config_.isMember("keyboard-name"))
+    return;
 
-    const auto KEEBNAME = config_["keyboard-name"].asString();
+  const auto KEEBNAME = config_["keyboard-name"].asString();
 
-    try {
+  try {
 
-      auto searcher = INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
-      searcher = searcher.substr(searcher.find("Keyboard at"));
-      searcher = searcher.substr(searcher.find("keymap:") + 7);
-      searcher = searcher.substr(0, searcher.find_first_of("\n\t"));
+    auto searcher = INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
+    searcher = searcher.substr(searcher.find("Keyboard at"));
+    searcher = searcher.substr(searcher.find("keymap:") + 7);
+    searcher = searcher.substr(0, searcher.find_first_of("\n\t"));
 
-      layoutName_ = searcher;
+    layoutName_ = searcher;
 
-      spdlog::debug("hyprland language initLanguage found {}", layoutName_);
+    spdlog::debug("hyprland language initLanguage found {}", layoutName_);
 
-      dp.emit();
+    dp.emit();
 
-    } catch (std::exception& e) {
-      spdlog::error("hyprland language initLanguage failed with {}", e.what());
-    }
+  } catch (std::exception& e) {
+    spdlog::error("hyprland language initLanguage failed with {}", e.what());
+  }
 }
 
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -76,7 +76,6 @@ void Language::initLanguage() {
   const auto KEEBNAME = config_["keyboard-name"].asString();
 
   try {
-
     auto searcher = INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
     searcher = searcher.substr(searcher.find("Keyboard at"));
     searcher = searcher.substr(searcher.find("keymap:") + 7);


### PR DESCRIPTION
Shows the current keyboard layout (like sway/language)

config:
 - format (duh) like `"Lang: {}"`
 - `keyboard-name` for specifying a keyboard to use (recommended to use the one with `AT Translated set ...`) -> if unset, any and all will be used.

Also allows for custom formats per-language:

```
"format-us": "Burger Land",
"format-de": "Germoney",
"format-it": "Mamma mia"
```
 
 PR is le ready.
