### PR TITLE
Improve keyboard response time and enable hotplug support

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -21,7 +21,8 @@ jobs:
           pkg install -y git #  subprojects/date
           pkg install -y catch evdev-proto gtk-layer-shell gtkmm30 jsoncpp \
             libdbusmenu libevdev libfmt libmpdclient libudev-devd meson \
-            pkgconf pulseaudio scdoc sndio spdlog wayland-protocols upower
+            pkgconf pulseaudio scdoc sndio spdlog wayland-protocols upower \
+            libinotify
         run: |
           meson build -Dman-pages=enabled
           ninja -C build

--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -3,12 +3,15 @@
 #include <fmt/chrono.h>
 #include <gtkmm/label.h>
 
+#include <unordered_map>
+
 #include "AModule.hpp"
 #include "bar.hpp"
 #include "util/sleeper_thread.hpp"
 
 extern "C" {
 #include <libevdev/libevdev.h>
+#include <libinput.h>
 }
 
 namespace waybar::modules {
@@ -20,6 +23,8 @@ class KeyboardState : public AModule {
   auto update() -> void;
 
  private:
+  auto findKeyboards() -> void;
+
   Gtk::Box box_;
   Gtk::Label numlock_label_;
   Gtk::Label capslock_label_;
@@ -34,6 +39,8 @@ class KeyboardState : public AModule {
 
   int fd_;
   libevdev* dev_;
+  struct libinput* libinput_;
+  std::unordered_map<std::string, struct libinput_device*> libinput_devices_;
 
   util::SleeperThread thread_;
 };

--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -23,7 +23,7 @@ class KeyboardState : public AModule {
   auto update() -> void;
 
  private:
-  auto findKeyboards() -> void;
+  auto tryAddDevice(const std::string&) -> void;
 
   Gtk::Box box_;
   Gtk::Label numlock_label_;
@@ -36,13 +36,12 @@ class KeyboardState : public AModule {
   const std::chrono::seconds interval_;
   std::string icon_locked_;
   std::string icon_unlocked_;
+  std::string devices_path_;
 
-  int fd_;
-  libevdev* dev_;
   struct libinput* libinput_;
   std::unordered_map<std::string, struct libinput_device*> libinput_devices_;
 
-  util::SleeperThread thread_;
+  util::SleeperThread libinput_thread_, hotplug_thread_;
 };
 
 }  // namespace waybar::modules

--- a/man/waybar-keyboard-state.5.scd
+++ b/man/waybar-keyboard-state.5.scd
@@ -13,6 +13,7 @@ You must be a member of the input group to use this module.
 # CONFIGURATION
 
 *interval*: ++
+	Deprecated, this module use event loop now, the interval has no effect.
 	typeof: integer ++
 	default: 1 ++
 	The interval, in seconds, to poll the keyboard state.

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ dbusmenu_gtk = dependency('dbusmenu-gtk3-0.4', required: get_option('dbusmenu-gt
 giounix = dependency('gio-unix-2.0', required: (get_option('dbusmenu-gtk').enabled() or get_option('logind').enabled() or get_option('upower_glib').enabled()))
 jsoncpp = dependency('jsoncpp')
 sigcpp = dependency('sigc++-2.0')
+libinotify = dependency('libinotify', required: false)
 libepoll = dependency('epoll-shim', required: false)
 libinput = dependency('libinput', required: get_option('libinput'))
 libnl = dependency('libnl-3.0', required: get_option('libnl'))
@@ -244,7 +245,7 @@ if libudev.found() and (is_linux or libepoll.found())
     src_files += 'src/modules/backlight.cpp'
 endif
 
-if libevdev.found() and (is_linux or libepoll.found()) and libinput.found()
+if libevdev.found() and (is_linux or libepoll.found()) and libinput.found() and (is_linux or libinotify.found())
     add_project_arguments('-DHAVE_LIBEVDEV', language: 'cpp')
     add_project_arguments('-DHAVE_LIBINPUT', language: 'cpp')
     src_files += 'src/modules/keyboard_state.cpp'
@@ -312,6 +313,7 @@ executable(
         upower_glib,
         libpulse,
         libudev,
+        libinotify,
         libepoll,
         libmpdclient,
         libevdev,

--- a/meson.build
+++ b/meson.build
@@ -90,6 +90,7 @@ giounix = dependency('gio-unix-2.0', required: (get_option('dbusmenu-gtk').enabl
 jsoncpp = dependency('jsoncpp')
 sigcpp = dependency('sigc++-2.0')
 libepoll = dependency('epoll-shim', required: false)
+libinput = dependency('libinput', required: get_option('libinput'))
 libnl = dependency('libnl-3.0', required: get_option('libnl'))
 libnlgen = dependency('libnl-genl-3.0', required: get_option('libnl'))
 upower_glib = dependency('upower-glib', required: get_option('upower_glib'))
@@ -243,8 +244,9 @@ if libudev.found() and (is_linux or libepoll.found())
     src_files += 'src/modules/backlight.cpp'
 endif
 
-if libevdev.found() and (is_linux or libepoll.found())
+if libevdev.found() and (is_linux or libepoll.found()) and libinput.found()
     add_project_arguments('-DHAVE_LIBEVDEV', language: 'cpp')
+    add_project_arguments('-DHAVE_LIBINPUT', language: 'cpp')
     src_files += 'src/modules/keyboard_state.cpp'
 endif
 
@@ -304,6 +306,7 @@ executable(
         gtkmm,
         dbusmenu_gtk,
         giounix,
+        libinput,
         libnl,
         libnlgen,
         upower_glib,

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,4 +1,5 @@
 option('libcxx', type : 'boolean', value : false, description : 'Build with Clang\'s libc++ instead of libstdc++ on Linux.')
+option('libinput', type: 'feature', value: 'auto', description: 'Enable libinput support for libinput related features')
 option('libnl', type: 'feature', value: 'auto', description: 'Enable libnl support for network related features')
 option('libudev', type: 'feature', value: 'auto', description: 'Enable libudev support for udev related features')
 option('libevdev', type: 'feature', value: 'auto', description: 'Enable libevdev support for evdev related features')

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -110,6 +110,10 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
   static struct libinput_interface interface = {
       [](const char* path, int flags, void* user_data) { return open(path, flags); },
       [](int fd, void* user_data) { close(fd); }};
+  if (config_["interval"].isUInt()) {
+    spdlog::warn("keyboard-state: interval is deprecated");
+  }
+
   libinput_ = libinput_path_create_context(&interface, NULL);
 
   box_.set_name("keyboard-state");


### PR DESCRIPTION
The `keyboard-state` module used the polling mechanism to get the keyboard status by the interval.
But we more like to see the indicator update immediately, just like the `pulseaudio` module.

So, I use libinput keyboard event to listen to the specific key events update when it has been triggered.
And the `thread_` now is an event loop, so the `interval` value has no effect.

This patch is still in progress, such as the wiki page and the man page aren't finished yet.

I will also add the keyboard removal function in this patch because libinput can get the remove event.
But a prerequisite for this is all the devices that needed be listened should be connected before launching waybar, or you need 
to restart waybar, see related issue #1584 .

I need some opinions about this change.