### PR TITLE
#1591 river escape window and mode

### DIFF
--- a/src/modules/river/mode.cpp
+++ b/src/modules/river/mode.cpp
@@ -103,7 +103,7 @@ void Mode::handle_mode(const char *mode) {
     }
 
     label_.get_style_context()->add_class(mode);
-    label_.set_markup(fmt::format(format_, mode));
+    label_.set_markup(fmt::format(format_, Glib::Markup::escape_text(mode).raw()));
     label_.show();
   }
 

--- a/src/modules/river/window.cpp
+++ b/src/modules/river/window.cpp
@@ -106,7 +106,7 @@ void Window::handle_focused_view(const char *title) {
     label_.hide();  // hide empty labels or labels with empty format
   } else {
     label_.show();
-    label_.set_markup(fmt::format(format_, title));
+    label_.set_markup(fmt::format(format_, Glib::Markup::escape_text(title).raw()));
   }
 
   ALabel::update();


### PR DESCRIPTION
resolves #1591 

The window and mode text from river is escaped. The user's format is not, however the error will be clear.