### PR TITLE
fix(network): dont escape essid in tooltip

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -383,10 +383,10 @@ auto waybar::modules::Network::update() -> void {
           fmt::arg("bandwidthTotalBytes",
                    pow_format((bandwidth_up + bandwidth_down) / interval_.count(), "B/s")));
       if (label_.get_tooltip_text() != tooltip_text) {
-        label_.set_tooltip_text(tooltip_text);
+        label_.set_tooltip_markup(tooltip_text);
       }
     } else if (label_.get_tooltip_text() != text) {
-      label_.set_tooltip_text(text);
+      label_.set_tooltip_markup(text);
     }
   }
 


### PR DESCRIPTION
Like #1256 , but escape by calling `set_tooltip_markup()`, because the
label text uses `set_markup()`.