### PR TITLE
scale icons for HiDPI monitor

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -309,7 +309,7 @@ void Item::updateImage() {
     pixbuf = pixbuf->scale_simple(width, scaled_icon_size, Gdk::InterpType::INTERP_BILINEAR);
   }
 
-  auto surface = Gdk::Cairo::create_surface_from_pixbuf(pixbuf, 0, image.get_window());
+  auto surface = Gdk::Cairo::create_surface_from_pixbuf(pixbuf, image.get_scale_factor(), image.get_window());
   image.set(surface);
 }
 


### PR DESCRIPTION
do the same job to wlr/taskbar as [tray](https://github.com/Alexays/Waybar/pull/1174)

before:
<img src="https://user-images.githubusercontent.com/53224655/187477881-237742b2-472b-4b1e-bdff-2eceafd09d3d.png" width=65%>

after:
<img src="https://user-images.githubusercontent.com/53224655/187477900-70414de1-1533-444a-8f7f-9b16329bd520.png" width=65%>
