### PR TITLE
Some logic issues in battery.cpp

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -30,14 +30,14 @@ std::optional<std::string> tryExpandPath(const std::string base, const std::stri
     path = fs::path(base);
   }
 
-  spdlog::debug("Try expanding: {}", path);
+  spdlog::debug("Try expanding: {}", path.string());
 
   wordexp_t p;
   if (wordexp(path.c_str(), &p, 0) == 0) {
     if (access(*p.we_wordv, F_OK) == 0) {
       std::string result = *p.we_wordv;
       wordfree(&p);
-      spdlog::debug("Found config file: {}", path);
+      spdlog::debug("Found config file: {}", path.string());
       return result;
     }
     wordfree(&p);


### PR DESCRIPTION
Some of the logic in the battery module does not cover all possibilities. I've tried to reconcile this by changing the logic flow. Before if some of the `/sys/.../battery/...` files were available it was assumed that others would be although I found this to not be the case. Instead the module now checks for the existence of all files.

I've also added some extra calculations of possible variables which can be calculated from other variables (like how `charge_now` or `energy_now`, etc. can be calculated) which allows `time_remaining` to be calculated when `energy_now` or `power_now` are missing in most cases. Hopefully there isn't anything wrong in my logic, but I've been using it for a few days without any problems.