### PR TITLE
Escape text in custom module

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -125,7 +125,7 @@ auto waybar::modules::Custom::update() -> void {
     } else {
       parseOutputRaw();
     }
-    auto str = fmt::format(format_, text_, fmt::arg("alt", alt_),
+    auto str = fmt::format(format_, Glib::Markup::escape_text(text_).raw(), fmt::arg("alt", alt_),
                            fmt::arg("icon", getIcon(percentage_, alt_)),
                            fmt::arg("percentage", percentage_));
     if (str.empty()) {


### PR DESCRIPTION
When having the following line in a custom module:
```
        "exec": "echo 'test1 & test2'",
```
running waybar results in:
```
(waybar:3775754): Gtk-WARNING **: 01:21:03.702: Failed to set text 'test1 & test2 ' from markup due to error parsing markup: Error on line 1: Entity did not end with a semicolon; most likely you used an ampersand character without intending to start an entity — escape ampersand as &amp;
```