### PR TITLE
[FreeBSD] Use thermal-zone

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -10,7 +10,6 @@
 
 waybar::modules::Temperature::Temperature(const std::string& id, const Json::Value& config)
     : ALabel(config, "temperature", id, "{temperatureC}°C", 10) {
-
 #if defined(__FreeBSD__)
 // try to read sysctl?
 #else
@@ -84,12 +83,12 @@ float waybar::modules::Temperature::getTemperature() {
   auto sysctl_thermal = fmt::format("hw.acpi.thermal.tz{}.temperature", zone);
 
   if (sysctlbyname(sysctl_thermal.c_str(), &temp, &size, NULL, 0) != 0) {
-    throw std::runtime_error(fmt::format("sysctl {} failed",sysctl_thermal));
+    throw std::runtime_error(fmt::format("sysctl {} failed", sysctl_thermal));
   }
-  auto temperature_c = ((float)temp-2732)/10;  
+  auto temperature_c = ((float)temp - 2732) / 10;
   return temperature_c;
 
-#else // Linux
+#else  // Linux
   std::ifstream temp(file_path_);
   if (!temp.is_open()) {
     throw std::runtime_error("Can't open " + file_path_);

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -81,8 +81,11 @@ float waybar::modules::Temperature::getTemperature() {
   int temp;
   size_t size = sizeof temp;
 
-  if (sysctlbyname("hw.acpi.thermal.tz0.temperature", &temp, &size, NULL, 0) != 0) {
-    throw std::runtime_error("sysctl hw.acpi.thermal.tz0.temperature or dev.cpu.0.temperature failed");
+  auto zone = config_["thermal-zone"].isInt() ? config_["thermal-zone"].asInt() : 0;
+  auto sysctl_thermal = fmt::format("hw.acpi.thermal.tz{}.temperature", zone);
+
+  if (sysctlbyname(sysctl_thermal.c_str(), &temp, &size, NULL, 0) != 0) {
+    throw std::runtime_error(fmt::format("sysctl {} failed",sysctl_thermal));
   }
   auto temperature_c = ((float)temp-2732)/10;  
   return temperature_c;

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -3,9 +3,7 @@
 #include <filesystem>
 
 #if defined(__FreeBSD__)
-// clang-format off
 #include <sys/sysctl.h>
-// clang-format on
 #endif
 
 waybar::modules::Temperature::Temperature(const std::string& id, const Json::Value& config)

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -4,7 +4,6 @@
 
 #if defined(__FreeBSD__)
 // clang-format off
-#include <sys/types.h>
 #include <sys/sysctl.h>
 // clang-format on
 #endif


### PR DESCRIPTION
The zone was hardcoded in #1702.
This commit allows to use the "thermal-zone"
variable.

Follow up #1702