### PR TITLE
Add option to wlr/workspaces to sort workspaces by number

### DIFF
--- a/include/modules/wlr/workspace_manager.hpp
+++ b/include/modules/wlr/workspace_manager.hpp
@@ -152,6 +152,7 @@ class WorkspaceManager : public AModule {
 
   bool sort_by_name_ = true;
   bool sort_by_coordinates_ = true;
+  bool sort_by_number_ = false;
   bool all_outputs_ = false;
   bool active_only_ = false;
   bool creation_delayed_ = false;

--- a/man/waybar-wlr-workspaces.5.scd
+++ b/man/waybar-wlr-workspaces.5.scd
@@ -33,6 +33,11 @@ Addressed by *wlr/workspaces*
 	Note that if both  *sort-by-name* and *sort-by-coordinates* are true sort by name will be first.
 	If both are false - sort by id will be performed.
 
+*sort-by-number*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, workspace names will be sorted numerically. Takes presedence over any other sort-by option.
+
 *all-outputs*: ++
 	typeof: bool ++
 	default: false ++
@@ -75,7 +80,8 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"5": "",
 		"focused": "",
 		"default": ""
-	}
+	},
+	"sort-by-number": true
 }
 ```
 

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -45,9 +45,8 @@ uint Window::getActiveWorkspaceID(std::string monitorName) {
   assert(cmd.exit_code == 0);
   Json::Value json = parser_.parse(cmd.out);
   assert(json.isArray());
-  auto monitor = std::find_if(json.begin(), json.end(), [&](Json::Value monitor){
-    return monitor["name"] == monitorName;
-  });
+  auto monitor = std::find_if(json.begin(), json.end(),
+                              [&](Json::Value monitor) { return monitor["name"] == monitorName; });
   assert(monitor != std::end(json));
   return (*monitor)["activeWorkspace"]["id"].as<uint>();
 }
@@ -57,7 +56,7 @@ std::string Window::getLastWindowTitle(uint workspaceID) {
   assert(cmd.exit_code == 0);
   Json::Value json = parser_.parse(cmd.out);
   assert(json.isArray());
-  auto workspace = std::find_if(json.begin(), json.end(), [&](Json::Value workspace){
+  auto workspace = std::find_if(json.begin(), json.end(), [&](Json::Value workspace) {
     return workspace["id"].as<uint>() == workspaceID;
   });
   assert(workspace != std::end(json));

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -32,6 +32,11 @@ WorkspaceManager::WorkspaceManager(const std::string &id, const waybar::Bar &bar
     sort_by_coordinates_ = config_sort_by_coordinates.asBool();
   }
 
+  auto config_sort_by_number = config_["sort-by-number"];
+  if (config_sort_by_number.isBool()) {
+    sort_by_number_ = config_sort_by_number.asBool();
+  }
+
   auto config_all_outputs = config_["all-outputs"];
   if (config_all_outputs.isBool()) {
     all_outputs_ = config_all_outputs.asBool();
@@ -61,6 +66,12 @@ auto WorkspaceManager::workspace_comparator() const
     auto is_name_less = lhs->get_name() < rhs->get_name();
     auto is_name_eq = lhs->get_name() == rhs->get_name();
     auto is_coords_less = lhs->get_coords() < rhs->get_coords();
+    auto is_number_less = std::stoi(lhs->get_name()) < std::stoi(rhs->get_name());
+
+    if (sort_by_number_) {
+      return is_number_less;
+    }
+
     if (sort_by_name_) {
       if (sort_by_coordinates_) {
         return is_name_eq ? is_coords_less : is_name_less;


### PR DESCRIPTION
#1691 didn't work for me. This pull request fixes #1596, by adding the option "sort-by-number" to wlr/workspaces, which takes precedence over any other sort-by option if set to true.

Example config
```json
"wlr/workspaces": {
  "sort-by-number": true,
}
```
The icons can still be changed using
```json
"format-icons": {
  "1": "a",
  "2": "b",
  "3": "c",
  "urgent": "d",
  "active": "e",
  "default": "f"
}
```
and the sorting will still be done according to the actual workspace numbers.