### PR TITLE
Remove border effect on hover

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -34,6 +34,14 @@ window#waybar.chromium {
     border: none;
 }
 
+button {
+    /* Use box-shadow instead of border so the text isn't offset */
+    box-shadow: inset 0 -3px transparent;
+    /* Avoid rounded borders under each button name */
+    border: none;
+    border-radius: 0;
+}
+
 /* https://github.com/Alexays/Waybar/wiki/FAQ#the-workspace-buttons-have-a-strange-hover-effect */
 button:hover {
     background: inherit;
@@ -44,11 +52,6 @@ button:hover {
     padding: 0 5px;
     background-color: transparent;
     color: #ffffff;
-    /* Use box-shadow instead of border so the text isn't offset */
-    box-shadow: inset 0 -3px transparent;
-    /* Avoid rounded borders under each workspace name */
-    border: none;
-    border-radius: 0;
 }
 
 #workspaces button:hover {


### PR DESCRIPTION
Moves the ``border = none;`` attribute from workspace buttons to the global scope. The hover effects on all buttons are now consistent in the default stylesheet.

Resolves problem discussed in #1120.