### PR TITLE
[hyprland/window] Fix crash on quickly switching workspaces

### DIFF
--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -59,7 +59,10 @@ std::string Window::getLastWindowTitle(uint workspaceID) {
   auto workspace = std::find_if(json.begin(), json.end(), [&](Json::Value workspace) {
     return workspace["id"].as<uint>() == workspaceID;
   });
-  assert(workspace != std::end(json));
+
+  if (workspace != std::end(json)) {
+    return "";
+  }
   return (*workspace)["lastwindowtitle"].as<std::string>();
 }
 


### PR DESCRIPTION
Fixes #1732

The hyprland/window widget had an assertion ensuring that the output from hyprctl matched the currently selected workspace id. However this assertion fails if workspaces are switched too quickly, causing the selected workspace to differ in id from the one in hyprctl, failing this assertion which then crashes the entire program.

This fix simply changes this assertion into an if statement, and if a mismatch is found, empty string is returned as the window name.