### PR TITLE
Set default minimal width of buttons to zero

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -40,6 +40,8 @@ button {
     /* Avoid rounded borders under each button name */
     border: none;
     border-radius: 0;
+    /* https://github.com/Alexays/Waybar/issues/1731 */
+    min-width: 0;
 }
 
 /* https://github.com/Alexays/Waybar/wiki/FAQ#the-workspace-buttons-have-a-strange-hover-effect */


### PR DESCRIPTION
Seems like GTK labels have no intrinsic minimal width while buttons do. Probably because they should stay clickable with an empty label.
As a result, even if all margins, padding and borders of buttons are removed the label inside the buttons may still be padded if they are too short. Setting the minimal width of buttons to zero fixes this issue.

This PR sets the ``min-width`` of buttons to zero in the default config, resolving #1731 for future adopters of Waybar.

