### PR TITLE
Fix button padding

### DIFF
--- a/include/AButton.hpp
+++ b/include/AButton.hpp
@@ -2,6 +2,7 @@
 
 #include <glibmm/markup.h>
 #include <gtkmm/button.h>
+#include <gtkmm/cssprovider.h>
 #include <gtkmm/label.h>
 #include <json/json.h>
 

--- a/resources/style.css
+++ b/resources/style.css
@@ -40,8 +40,6 @@ button {
     /* Avoid rounded borders under each button name */
     border: none;
     border-radius: 0;
-    /* https://github.com/Alexays/Waybar/issues/1731 */
-    min-width: 0;
 }
 
 /* https://github.com/Alexays/Waybar/wiki/FAQ#the-workspace-buttons-have-a-strange-hover-effect */

--- a/src/AButton.cpp
+++ b/src/AButton.cpp
@@ -18,6 +18,12 @@ AButton::AButton(const Json::Value& config, const std::string& name, const std::
       default_format_(format_) {
   button_.set_name(name);
   button_.set_relief(Gtk::RELIEF_NONE);
+
+  /* https://github.com/Alexays/Waybar/issues/1731 */
+  auto css = Gtk::CssProvider::create();
+  css->load_from_data("button { min-width: 0; }");
+  button_.get_style_context()->add_provider(css, GTK_STYLE_PROVIDER_PRIORITY_USER);
+
   if (!id.empty()) {
     button_.get_style_context()->add_class(id);
   }


### PR DESCRIPTION
Buttons come with an intrinsic min-width but lack a method to alter this property. Setting the requested size to zero has also no effect on it.
The only way I found to work is to hard code the CSS into the button, added in this PR.