### PR TITLE
fixed memory module not rounding numbers

### DIFF
--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -31,17 +31,17 @@ auto waybar::modules::Memory::update() -> void {
   }
 
   if (memtotal > 0 && memfree >= 0) {
-    auto total_ram_gigabytes = memtotal / std::pow(1024, 2);
-    auto total_swap_gigabytes = swaptotal / std::pow(1024, 2);
+    float total_ram_gigabytes = 0.01*round(memtotal / 10485.76); // 100*10485.76 = 2^20 = 1024^2 = GiB/KiB
+    float total_swap_gigabytes = 0.01*round(swaptotal / 10485.76);
     int used_ram_percentage = 100 * (memtotal - memfree) / memtotal;
     int used_swap_percentage = 0;
     if (swaptotal && swapfree) {
       used_swap_percentage = 100 * (swaptotal - swapfree) / swaptotal;
     }
-    auto used_ram_gigabytes = (memtotal - memfree) / std::pow(1024, 2);
-    auto used_swap_gigabytes = (swaptotal - swapfree) / std::pow(1024, 2);
-    auto available_ram_gigabytes = memfree / std::pow(1024, 2);
-    auto available_swap_gigabytes = swapfree / std::pow(1024, 2);
+    float used_ram_gigabytes = 0.01*round((memtotal - memfree) / 10485.76);
+    float used_swap_gigabytes = 0.01*round((swaptotal - swapfree) / 10485.76);
+    float available_ram_gigabytes = 0.01*round(memfree / 10485.76);
+    float available_swap_gigabytes = 0.01*round(swapfree / 10485.76);
 
     auto format = format_;
     auto state = getState(used_ram_percentage);


### PR DESCRIPTION
While configuring Waybar i noticed that the values for `{used}` `{total}` `{free}` `{swapUsed}` `{swapTotal}` and  `{swapFree}` in the memory module don't get rounded, resulting in a really long and ugly floating point number in the output:
![20221022_02h00m10s_grim](https://user-images.githubusercontent.com/74491719/197308620-cd9970be-ca88-4e73-a71a-33155e8369a0.png)

so i wrote a quick fix that rounds all the numbers to 2 digits:
![20221022_02h25m51s_grim](https://user-images.githubusercontent.com/74491719/197308648-a53b0669-5957-4d78-8fae-9d0891b060aa.png)

tested on NixOS 22.11pre418904.db25c4da285 with Hyprland

my changes also use `float` instead of `auto` because it is less ambiguous and remove the redundant calls of `std::pow(1024,2)`