### PR TITLE
Battery: "Plugged" status for TLP settings

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -470,7 +470,9 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       }
     }
 
-    if (!adapter_.empty() && status == "Discharging") {
+    // Give `Plugged` higher priority over `Not charging`.
+    // So in a setting where TLP is used, `Plugged` is shown when the threshold is reached
+    if (!adapter_.empty() && (status == "Discharging" || status == "Not charging")) {
       bool online;
       std::string current_status;
       std::ifstream(adapter_ / "online") >> online;


### PR DESCRIPTION
When using TLP for threshold, "Not charging" is still being shown, instead of "Plugged".
I don't think it was fixed as mentioned in https://github.com/Alexays/Waybar/issues/1560#issuecomment-1293083222

This should cover:
https://github.com/Alexays/Waybar/issues/253
https://github.com/Alexays/Waybar/issues/1560

Side note: my adapter does not have `/status`, so `current_status` on [L477](https://github.com/Alexays/Waybar/blob/master/src/modules/battery.cpp#L477) will always be empty. This logic is also present at two other places, so I'm not sure if I understand it.I can open a separate issue if it's relevant (Lenovo laptop, Arch).
```cpp
std::getline(std::ifstream(adapter_ / "status"), current_status);
```
