### PR TITLE
Do not crash when a monitor is removed

### DIFF
--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <deque>
+#include <list>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -7,11 +7,19 @@
 #include <thread>
 
 namespace waybar::modules::hyprland {
+
+class EventHandler {
+public:
+  virtual void onEvent(const std::string& ev) = 0;
+  virtual ~EventHandler() = default;
+};
+
 class IPC {
  public:
   IPC() { startIPC(); }
 
-  void registerForIPC(const std::string&, std::function<void(const std::string&)>);
+  void registerForIPC(const std::string&, EventHandler*);
+  void unregisterForIPC(EventHandler*);
 
   std::string getSocket1Reply(const std::string& rq);
 
@@ -20,7 +28,7 @@ class IPC {
   void parseIPC(const std::string&);
 
   std::mutex callbackMutex;
-  std::deque<std::pair<std::string, std::function<void(const std::string&)>>> callbacks;
+  std::list<std::pair<std::string, EventHandler*>> callbacks;
 };
 
 inline std::unique_ptr<IPC> gIPC;

--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -7,10 +7,11 @@
 
 namespace waybar::modules::hyprland {
 
-class Language : public waybar::AButton {
+class Language : public waybar::AButton,
+public EventHandler {
  public:
   Language(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Language() = default;
+  ~Language();
 
   auto update() -> void;
 

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -9,10 +9,11 @@
 
 namespace waybar::modules::hyprland {
 
-class Window : public waybar::ALabel {
+class Window : public waybar::ALabel,
+ public EventHandler {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Window() = default;
+  ~Window();
 
   auto update() -> void;
 

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -95,15 +95,37 @@ void IPC::parseIPC(const std::string& ev) {
 
   for (auto& [eventname, handler] : callbacks) {
     if (eventname == request) {
-      handler(ev);
+      handler->onEvent(ev);
     }
   }
 }
 
-void IPC::registerForIPC(const std::string& ev, std::function<void(const std::string&)> fn) {
+void IPC::registerForIPC(const std::string& ev, EventHandler* ev_handler) {
+  if (!ev_handler) {
+    return;
+  }
   callbackMutex.lock();
 
-  callbacks.emplace_back(std::make_pair(ev, fn));
+  callbacks.emplace_back(std::make_pair(ev, ev_handler));
+
+  callbackMutex.unlock();
+}
+
+void IPC::unregisterForIPC(EventHandler* ev_handler) {
+    if (!ev_handler) {
+    return;
+  }
+
+  callbackMutex.lock();
+
+  for(auto it = callbacks.begin(); it != callbacks.end(); ) {
+    auto it_current = it;
+    it++;
+    auto& [eventname, handler] = *it_current;
+    if (handler == ev_handler) {
+      callbacks.erase(it_current);
+    }
+  }
 
   callbackMutex.unlock();
 }

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -25,7 +25,13 @@ Language::Language(const std::string& id, const Bar& bar, const Json::Value& con
   AButton::update();
 
   // register for hyprland ipc
-  gIPC->registerForIPC("activelayout", [&](const std::string& ev) { this->onEvent(ev); });
+  gIPC->registerForIPC("activelayout", this);
+}
+
+Language::~Language() {
+  gIPC->unregisterForIPC(this);
+  // wait for possible event handler to finish
+  std::lock_guard<std::mutex> lg(mutex_);
 }
 
 auto Language::update() -> void {


### PR DESCRIPTION
Hyprland Window could cause a crash when a monitor is removed. Especially when the "separate-outputs" option is enabled.
This happened because the Window got destructed, after which an event was sent to the Window to notify of an active window change. The Window then tried to parse JSON with a JSON parser that is already deleted, thus causing a crash.
Solution: unregister for events in the Window destructor.