### PR TITLE
exec runs after on-* events

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -25,6 +25,7 @@ class AModule : public IModule {
   SCROLL_DIR getScrollDir(GdkEventScroll *e);
   bool tooltipEnabled();
 
+  std::vector<int> pid_children_;
   const std::string name_;
   const Json::Value &config_;
   Gtk::EventBox event_box_;
@@ -33,7 +34,6 @@ class AModule : public IModule {
   virtual bool handleScroll(GdkEventScroll *);
 
  private:
-  std::vector<int> pid_;
   gdouble distance_scrolled_y_;
   gdouble distance_scrolled_x_;
   static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -35,7 +35,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
 }
 
 AModule::~AModule() {
-  for (const auto& pid : pid_) {
+  for (const auto& pid : pid_children_) {
     if (pid != -1) {
       killpg(pid, SIGTERM);
     }
@@ -45,7 +45,7 @@ AModule::~AModule() {
 auto AModule::update() -> void {
   // Run user-provided update handler if configured
   if (config_["on-update"].isString()) {
-    pid_.push_back(util::command::forkExec(config_["on-update"].asString()));
+    pid_children_.push_back(util::command::forkExec(config_["on-update"].asString()));
   }
 }
 
@@ -62,7 +62,7 @@ bool AModule::handleToggle(GdkEventButton* const& e) {
   }
 
   if (!format.empty()) {
-    pid_.push_back(util::command::forkExec(format));
+    pid_children_.push_back(util::command::forkExec(format));
   }
   dp.emit();
   return true;
@@ -123,9 +123,9 @@ AModule::SCROLL_DIR AModule::getScrollDir(GdkEventScroll* e) {
 bool AModule::handleScroll(GdkEventScroll* e) {
   auto dir = getScrollDir(e);
   if (dir == SCROLL_DIR::UP && config_["on-scroll-up"].isString()) {
-    pid_.push_back(util::command::forkExec(config_["on-scroll-up"].asString()));
+    pid_children_.push_back(util::command::forkExec(config_["on-scroll-up"].asString()));
   } else if (dir == SCROLL_DIR::DOWN && config_["on-scroll-down"].isString()) {
-    pid_.push_back(util::command::forkExec(config_["on-scroll-down"].asString()));
+    pid_children_.push_back(util::command::forkExec(config_["on-scroll-down"].asString()));
   }
   dp.emit();
   return true;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -27,6 +27,9 @@ waybar::modules::Custom::~Custom() {
 
 void waybar::modules::Custom::delayWorker() {
   thread_ = [this] {
+    std::for_each(this->pid_children_.cbegin(), this->pid_children_.cend(),
+      [](int i){ wait(&i); });
+
     bool can_update = true;
     if (config_["exec-if"].isString()) {
       output_ = util::command::execNoRead(config_["exec-if"].asString());


### PR DESCRIPTION
This is a fix for issue #1681. `exec` now runs after `on-click`, `on-click-right`, `on-*` events.

Test sample:

```json
  "custom/camera": {
    "exec": "notify-send exec; echo exec",
    "interval": "once",
    "on-click": "notify-send on-click && sleep 5",
    "exec-on-event": true,
    "tooltip": false,
    "format": "{icon}",
    "format-icons": ["→"]
  },
```

`on-click` runs, and after 5 seconds `exec` runs.