### PR TITLE
normalize capacity by number of batteries

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -495,7 +495,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
     float calculated_capacity{0.0f};
     if (total_capacity_exists) {
       if (total_capacity > 0.0f)
-        calculated_capacity = (float)total_capacity;
+        calculated_capacity = (float)total_capacity / batteries_.size();
       else if (total_energy_full_exists && total_energy_exists) {
         if (total_energy_full > 0.0f)
           calculated_capacity = ((float)total_energy * 100.0f / (float)total_energy_full);


### PR DESCRIPTION
On laptops with more than one battery the calculation of capacity is broken: the sum of capacities of batteries is displayed (and if this turns out to be bigger than a 100%, it gets clamped to 100%).

The `total_capacity` is computed as a sum over individual capacities of batteries, which can be in the range from 0% to _number of batteries_ * 100%. If `total_capacity` was calculated, the `calculated_capacity` is set to the same value. However, all values over 100% are clamped, since, as explained in the code comment:
> `// This can happen when the battery is calibrating and goes above 100%`

I propose the `calculated_capacity` should be normalized by the number of batteries.