### PR TITLE
Recognize outputs with 'bluez' in monitor name as bluetooth class

### DIFF
--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -260,7 +260,8 @@ auto waybar::modules::Pulseaudio::update() -> void {
   if (!alt_) {
     std::string format_name = "format";
     if (monitor_.find("a2dp_sink") != std::string::npos ||  // PulseAudio
-        monitor_.find("a2dp-sink") != std::string::npos) {  // PipeWire
+        monitor_.find("a2dp-sink") != std::string::npos ||  // PipeWire
+        monitor_.find("bluez") != std::string::npos) {
       format_name = format_name + "-bluetooth";
       button_.get_style_context()->add_class("bluetooth");
     } else {


### PR DESCRIPTION
Using Fedora 37 with pipewire 0.3.60 a bluetooth connected headset is not correctly assigned with the bluetooth class.

The device is recognized as `monitor_source_name = bluez_output.38_18_4C_BD_21_24.1.monitor` thus the check for containing `a2dp_sink` fails.

This PR adds an additional check for the `bluez` substring in the `monitor_source_name`.