### PR TITLE
Fix crashes when using named workspaces in Hyprland

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -18,8 +18,8 @@ class Window : public waybar::ALabel,
   auto update() -> void;
 
  private:
-  uint getActiveWorkspaceID(std::string);
-  std::string getLastWindowTitle(uint);
+  int getActiveWorkspaceID(std::string);
+  std::string getLastWindowTitle(int);
   void onEvent(const std::string&);
 
   bool separate_outputs;

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -49,7 +49,7 @@ auto Window::update() -> void {
   ALabel::update();
 }
 
-uint Window::getActiveWorkspaceID(std::string monitorName) {
+int Window::getActiveWorkspaceID(std::string monitorName) {
   auto cmd = waybar::util::command::exec("hyprctl monitors -j");
   assert(cmd.exit_code == 0);
   Json::Value json = parser_.parse(cmd.out);
@@ -59,16 +59,16 @@ uint Window::getActiveWorkspaceID(std::string monitorName) {
   if (monitor == std::end(json)) {
     return 0;
   }
-  return (*monitor)["activeWorkspace"]["id"].as<uint>();
+  return (*monitor)["activeWorkspace"]["id"].as<int>();
 }
 
-std::string Window::getLastWindowTitle(uint workspaceID) {
+std::string Window::getLastWindowTitle(int workspaceID) {
   auto cmd = waybar::util::command::exec("hyprctl workspaces -j");
   assert(cmd.exit_code == 0);
   Json::Value json = parser_.parse(cmd.out);
   assert(json.isArray());
   auto workspace = std::find_if(json.begin(), json.end(), [&](Json::Value workspace) {
-    return workspace["id"].as<uint>() == workspaceID;
+    return workspace["id"].as<int>() == workspaceID;
   });
 
   if (workspace == std::end(json)) {

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <stdexcept>
 #include <vector>
 
 #include "gtkmm/widget.h"
@@ -66,10 +67,13 @@ auto WorkspaceManager::workspace_comparator() const
     auto is_name_less = lhs->get_name() < rhs->get_name();
     auto is_name_eq = lhs->get_name() == rhs->get_name();
     auto is_coords_less = lhs->get_coords() < rhs->get_coords();
-    auto is_number_less = std::stoi(lhs->get_name()) < std::stoi(rhs->get_name());
 
     if (sort_by_number_) {
-      return is_number_less;
+      try {
+        auto is_number_less = std::stoi(lhs->get_name()) < std::stoi(rhs->get_name());
+        return is_number_less;
+      } catch (std::invalid_argument) {
+      }
     }
 
     if (sort_by_name_) {


### PR DESCRIPTION
Fixes #1794 and #1803.

The first crash occurs when trying to parse the ID of a workspace as an uint, since named workspaces has negative IDs (starting from -1337). This is fixed by using ints for workspace IDs instead of uints.

The second crash occurs when converting a workspace name that isn't a number to an integer. This is fixed by wrapping std::stoi in a try block and only sorting by number, when both names can successfully be converted to integers. When one of the workspaces being compared isn't a number it will fallback to whatever other sorting method is enabled.