### PR TITLE
feat: add icon support to the wireplumber module

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -156,8 +156,8 @@ auto waybar::modules::Wireplumber::update() -> void {
     label_.get_style_context()->remove_class("muted");
   }
 
-  std::string markup =
-      fmt::format(format, fmt::arg("node_name", node_name_), fmt::arg("volume", volume_));
+  std::string markup = fmt::format(format, fmt::arg("node_name", node_name_),
+                                   fmt::arg("volume", volume_), fmt::arg("icon", getIcon(volume_)));
   label_.set_markup(markup);
 
   getState(volume_);
@@ -169,7 +169,8 @@ auto waybar::modules::Wireplumber::update() -> void {
 
     if (!tooltip_format.empty()) {
       label_.set_tooltip_text(fmt::format(tooltip_format, fmt::arg("node_name", node_name_),
-                                          fmt::arg("volume", volume_)));
+                                          fmt::arg("volume", volume_),
+                                          fmt::arg("icon", getIcon(volume_))));
     } else {
       label_.set_tooltip_text(node_name_);
     }


### PR DESCRIPTION
Adds basic icon support for the wireplumber module.

This can be achieved by using `{icon}` in the `format` config and pairing it with the `format-icons` config as well.

Example:

```
"wireplumber": {
    "format": "{volume}% {icon}",
    "format-icons": ["", "", ""]
}
```

Adding because #1811 indicated it wasn't supported.