### PR TITLE
Allow the calendar month scrolling to be inverted

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -136,7 +136,7 @@ bool waybar::modules::Clock::handleScroll(GdkEventScroll* e) {
   auto dir = AModule::getScrollDir(e);
 
   // Shift calendar date
-  if (calendar_shift_init_.count() > 0) {
+  if (calendar_shift_init_.count() != 0) {
     if (dir == SCROLL_DIR::UP)
       calendar_shift_ += calendar_shift_init_;
     else
@@ -170,7 +170,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
   if (calendar_cached_ymd_ == ymd) return calendar_cached_text_;
 
-  const auto curr_day{(calendar_shift_init_.count() > 0 && calendar_shift_.count() != 0)
+  const auto curr_day{(calendar_shift_init_.count() != 0 && calendar_shift_.count() != 0)
                           ? date::day{0}
                           : ymd.day()};
   const date::year_month ym{ymd.year(), ymd.month()};


### PR DESCRIPTION
#1646  introduced scrolling for the calendar tooltip. It seems, however, that this was hardcoded so that scroll up would go to the next month and scroll down would go to the previous month. This is the opposite of what is intuitive for me, so I tried assigning the integer -1 to the month increment, but there is a bounds check to make sure the integer is greater than zero. I think this bounds check is unnecessary, and allowing negative numbers lets the user easily invert scrolling so that up can go to the previous month and down go to the next month.
