### PR TITLE
Don't search "Keyboard at" from hyprland/language

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -85,7 +85,6 @@ void Language::initLanguage() {
 
   try {
     auto searcher = INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
-    searcher = searcher.substr(searcher.find("Keyboard at"));
     searcher = searcher.substr(searcher.find("keymap:") + 7);
     searcher = searcher.substr(0, searcher.find_first_of("\n\t"));
 


### PR DESCRIPTION
The current output form of `hyprctl devices` is like this:
```
        Keyboard at 6f80ad70:
                ITE Tech. Inc. ITE Device(8910) Keyboard
                        rules: r "", m "", l "us,ru", v "", o "grp:alt_shift_toggle"
                        active keymap: Russian
                        main: no
```

That is, `Keyboard at` goes _before_ the keyboard name, so looking for `Keyboard at` only makes it skip to the keyboard _after_ the one that the user specified (or crash if it's the last keyboard in the list).