### PR TITLE
fix: use getaddrinfo() instead of gethostbyname()

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -130,6 +130,8 @@ void IPC::unregisterForIPC(EventHandler* ev_handler) {
   callbackMutex.unlock();
 }
 
+
+
 std::string IPC::getSocket1Reply(const std::string& rq) {
   // basically hyprctl
 
@@ -140,7 +142,7 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
     return "";
   }
 
-  const auto SERVER = gethostbyname("localhost");
+  const auto SERVER = getaddrinfo("localhost", NULL, NULL, 0);
 
   if (!SERVER) {
     spdlog::error("Hyprland IPC: Couldn't get host (2)");

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -132,15 +132,20 @@ void IPC::unregisterForIPC(EventHandler* ev_handler) {
 
 std::string IPC::getSocket1Reply(const std::string& rq) {
   // basically hyprctl
-
+  
+  struct addrinfo ai_hints;
+  struct addrinfo *ai_res = NULL;
   const auto SERVERSOCKET = socket(AF_UNIX, SOCK_STREAM, 0);
 
   if (SERVERSOCKET < 0) {
     spdlog::error("Hyprland IPC: Couldn't open a socket (1)");
     return "";
   }
-
-  const auto SERVER = getaddrinfo("localhost", NULL, NULL, 0);
+  
+  memset(&ai_hints, 0, sizeof(struct addrinfo));
+  ai_hints.ai_family = AF_UNSPEC;
+  ai_hints.ai_socktype = SOCK_STREAM;
+  const auto SERVER = getaddrinfo("localhost", NULL, &ai_hints, &ai_res);
 
   if (!SERVER) {
     spdlog::error("Hyprland IPC: Couldn't get host (2)");

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -130,8 +130,6 @@ void IPC::unregisterForIPC(EventHandler* ev_handler) {
   callbackMutex.unlock();
 }
 
-
-
 std::string IPC::getSocket1Reply(const std::string& rq) {
   // basically hyprctl
 


### PR DESCRIPTION
Small fix for https://build.opensuse.org/build/X11:Wayland/openSUSE_Tumbleweed/x86_64/waybar/_log. This complies with openSUSE's packaging guidelines.

Reference: https://en.opensuse.org/openSUSE:Packaging_checks#binary-or-shlib-calls-gethostbyname

