### PR TITLE
Hide module if text resolves to being empty. Issue #699

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -96,7 +96,13 @@ void waybar::modules::MPD::setLabel() {
     auto format = config_["format-disconnected"].isString()
                       ? config_["format-disconnected"].asString()
                       : "disconnected";
-    label_.set_markup(format);
+    if(format.empty()) {
+      label_.set_markup(format);
+      label_.show();
+    } else {
+      label_.hide();
+    }
+    
 
     if (tooltipEnabled()) {
       std::string tooltip_format;
@@ -107,9 +113,8 @@ void waybar::modules::MPD::setLabel() {
       label_.set_tooltip_text(tooltip_format);
     }
     return;
-  } else {
-    label_.get_style_context()->remove_class("disconnected");
   }
+  label_.get_style_context()->remove_class("disconnected");
 
   auto format = format_;
   Glib::ustring artist, album_artist, album, title;
@@ -169,7 +174,7 @@ void waybar::modules::MPD::setLabel() {
   if (config_["title-len"].isInt()) title = title.substr(0, config_["title-len"].asInt());
 
   try {
-    label_.set_markup(fmt::format(
+    auto text = fmt::format(
         format, fmt::arg("artist", artist.raw()), fmt::arg("albumArtist", album_artist.raw()),
         fmt::arg("album", album.raw()), fmt::arg("title", title.raw()), fmt::arg("date", date),
         fmt::arg("volume", volume), fmt::arg("elapsedTime", elapsedTime),
@@ -177,7 +182,13 @@ void waybar::modules::MPD::setLabel() {
         fmt::arg("queueLength", queue_length), fmt::arg("stateIcon", stateIcon),
         fmt::arg("consumeIcon", consumeIcon), fmt::arg("randomIcon", randomIcon),
         fmt::arg("repeatIcon", repeatIcon), fmt::arg("singleIcon", singleIcon),
-        fmt::arg("filename", filename)));
+        fmt::arg("filename", filename));
+    if(text.empty()) {
+      label_.hide();
+    } else {
+      label_.show();
+      label_.set_markup(text);
+    }
   } catch (fmt::format_error const& e) {
     spdlog::warn("mpd: format error: {}", e.what());
   }

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -96,7 +96,7 @@ void waybar::modules::MPD::setLabel() {
     auto format = config_["format-disconnected"].isString()
                       ? config_["format-disconnected"].asString()
                       : "disconnected";
-    if(format.empty()) {
+    if (format.empty()) {
       label_.set_markup(format);
       label_.show();
     } else {
@@ -183,7 +183,7 @@ void waybar::modules::MPD::setLabel() {
         fmt::arg("consumeIcon", consumeIcon), fmt::arg("randomIcon", randomIcon),
         fmt::arg("repeatIcon", repeatIcon), fmt::arg("singleIcon", singleIcon),
         fmt::arg("filename", filename));
-    if(text.empty()) {
+    if (text.empty()) {
       label_.hide();
     } else {
       label_.show();

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -299,7 +299,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
       format, fmt::arg("desc", desc_), fmt::arg("volume", volume_),
       fmt::arg("format_source", format_source), fmt::arg("source_volume", source_volume_),
       fmt::arg("source_desc", source_desc_), fmt::arg("icon", getIcon(volume_, getPulseIcon())));
-  if(text.empty()) {
+  if (text.empty()) {
     label_.hide();
   } else {
     label_.set_markup(text);

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -295,10 +295,16 @@ auto waybar::modules::Pulseaudio::update() -> void {
     }
   }
   format_source = fmt::format(format_source, fmt::arg("volume", source_volume_));
-  label_.set_markup(fmt::format(
+  auto text = fmt::format(
       format, fmt::arg("desc", desc_), fmt::arg("volume", volume_),
       fmt::arg("format_source", format_source), fmt::arg("source_volume", source_volume_),
-      fmt::arg("source_desc", source_desc_), fmt::arg("icon", getIcon(volume_, getPulseIcon()))));
+      fmt::arg("source_desc", source_desc_), fmt::arg("icon", getIcon(volume_, getPulseIcon())));
+  if(text.empty()) {
+    label_.hide();
+  } else {
+    label_.set_markup(text);
+    label_.show();
+  }
   getState(volume_);
 
   if (tooltipEnabled()) {

--- a/src/modules/sndio.cpp
+++ b/src/modules/sndio.cpp
@@ -111,7 +111,7 @@ auto Sndio::update() -> void {
   }
 
   auto text = fmt::format(format, fmt::arg("volume", vol), fmt::arg("raw_value", volume_));
-  if(text.empty()) {
+  if (text.empty()) {
     label_.hide();
   } else {
     label_.set_markup(text);

--- a/src/modules/sndio.cpp
+++ b/src/modules/sndio.cpp
@@ -110,7 +110,14 @@ auto Sndio::update() -> void {
     label_.get_style_context()->remove_class("muted");
   }
 
-  label_.set_markup(fmt::format(format, fmt::arg("volume", vol), fmt::arg("raw_value", volume_)));
+  auto text = fmt::format(format, fmt::arg("volume", vol), fmt::arg("raw_value", volume_));
+  if(text.empty()) {
+    label_.hide();
+  } else {
+    label_.set_markup(text);
+    label_.show();
+  }
+  
 
   ALabel::update();
 }


### PR DESCRIPTION
Hides mdp/pulseaudio/sndio module if it's text resolves to being empty. 
Should close #699.