### PR TITLE
fix(battery): ignore non-system power supplies

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -107,6 +107,15 @@ void waybar::modules::Battery::refreshBatteries() {
         std::ifstream(node.path() / "type") >> type;
 
         if (!type.compare("Battery")) {
+          // Ignore non-system power supplies unless explicitly requested
+          if (!bat_defined && fs::exists(node.path() / "scope")) {
+            std::string scope;
+            std::ifstream(node.path() / "scope") >> scope;
+            if (g_ascii_strcasecmp(scope.data(), "device") == 0) {
+              continue;
+            }
+          }
+
           check_map[node.path()] = true;
           auto search = batteries_.find(node.path());
           if (search == batteries_.end()) {


### PR DESCRIPTION
Linux power_supply sysfs interface allows checking if the battery powers the whole system or a specific device/tree of devices with `scope` attribute[1]. We can use it to skip the non-system power supplies in the battery module and avoid adding HIDs or other peripheral devices to the total.

The logic is based on UPower, where it is assumed that "Unknown" devices or devices without a `scope` are system power supplies.

[1]: https://lore.kernel.org/lkml/alpine.LNX.2.00.1201031556460.24984@pobox.suse.cz/T/