### PR TITLE
Calendar week numbers

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -28,6 +28,7 @@ class Clock : public ALabel {
   date::year_month_day calendar_cached_ymd_{date::January / 1 / 0};
   date::months calendar_shift_{0}, calendar_shift_init_{0};
   std::string calendar_cached_text_;
+  std::string weeks_format_;
   bool is_calendar_in_tooltip_;
   bool is_timezoned_list_in_tooltip_;
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -209,15 +209,12 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
   // First week prefixed with spaces if needed.
   auto first_month_day = date::weekday(ym / 1);
-  int empty_days = (first_week_day - first_month_day).count() + 1;
-  date::sys_days last_week_day{static_cast<date::sys_days>(ym / 1) + date::days{7 - empty_days}};
+  int empty_days = (first_month_day - first_week_day).count();
+  date::sys_days last_week_day{static_cast<date::sys_days>(ym / 1) + date::days{6 - empty_days}};
 
-  if (first_week_day == date::Monday) {
-    last_week_day -= date::days{1};
-  }
   /* Print weeknumber on the left for the first row*/
   if (weeks_pos == WeeksPlacement::LEFT) {
-    os << fmt::format(weeks_format, date::format("%U", last_week_day)) << ' ';
+    os << fmt::format(weeks_format, last_week_day) << ' ';
     last_week_day += date::weeks{1};
   }
 
@@ -230,19 +227,18 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
     if (weekday != first_week_day) {
       os << ' ';
     } else if (unsigned(d) != 1) {
-      last_week_day -= date::days{1};
       if (weeks_pos == WeeksPlacement::RIGHT) {
         os << ' ';
-        os << fmt::format(weeks_format, date::format("%U", last_week_day));
+        os << fmt::format(weeks_format, last_week_day);
       }
 
       os << "\n";
 
       if (weeks_pos == WeeksPlacement::LEFT) {
-        os << fmt::format(weeks_format, date::format("%U", last_week_day));
+        os << fmt::format(weeks_format, last_week_day);
         os << ' ';
       }
-      last_week_day += date::weeks{1} + date::days{1};
+      last_week_day += date::weeks{1};
     }
     if (d == curr_day) {
       if (config_["today-format"].isString()) {
@@ -258,11 +254,9 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
     }
     /*Print weeks on the right when the endings with spaces*/
     if (weeks_pos == WeeksPlacement::RIGHT && d == last_day) {
-      last_week_day -= date::days{1};
       empty_days = 6 - (weekday - first_week_day).count();
       os << std::string(empty_days * 3 + 1, ' ');
-      os << fmt::format(weeks_format, date::format("%U", last_week_day));
-      last_week_day += date::days{1};
+      os << fmt::format(weeks_format, date::sys_days{ym / date::literals::last});
     }
   }
 


### PR DESCRIPTION
I'm sorry, but my previous PR #1868 introduced more bugs than fixed. Luckily @LukashonakV told me that the issue itself was wrong and there have to be custom format for a week number in config. 
So, I reverted almost all changes and fixed week number calculation bugs (both mine and previous). 
And now it should work fine for any locale. If there is no custom format, it will apply default format which is %U or %V depending on the first day of the week.
It fix #1874 and other bugs that have not been reported yet.
Sorry again for the previous PR. I hope this is better :)