### PR TITLE
ISSUE#1877 Calendar week numbers

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -33,6 +33,8 @@ class Clock : public ALabel {
 
   bool handleScroll(GdkEventScroll* e);
 
+  std::string weeks_format_;
+  int weeks_format_left_gaps{0};
   auto calendar_text(const waybar_time& wtime) -> std::string;
   auto weekdays_header(const date::weekday& first_dow, std::ostream& os) -> void;
   auto first_day_of_week() -> date::weekday;

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -500,7 +500,8 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
     } else if (status == "Discharging" && total_power_exists && total_energy_exists) {
       if (total_power != 0) time_remaining = (float)total_energy / total_power;
     } else if (status == "Charging" && time_to_full_now_exists) {
-      if (time_to_full_now_exists && (time_to_full_now != 0)) time_remaining = -(float)time_to_full_now / 1000.0f;
+      if (time_to_full_now_exists && (time_to_full_now != 0))
+        time_remaining = -(float)time_to_full_now / 1000.0f;
       // If we've turned positive it means the battery is past 100% and so just report that as no
       // time remaining
       if (time_remaining > 0.0f) time_remaining = 0.0f;

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -240,7 +240,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
       os << '\n';
 
-      print_wd = {ym / d};
+      print_wd = (ym / d);
 
       if (weeks_pos == WeeksSide::LEFT) {
         os << fmt::format(weeks_format_, print_wd) << ' ';

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -5,8 +5,8 @@
 
 #include <ctime>
 #include <iomanip>
-#include <sstream>
 #include <regex>
+#include <sstream>
 #include <type_traits>
 
 #include "util/ustring_clen.hpp"
@@ -76,8 +76,11 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
   }
 
   if (config_["format-calendar-weeks"].isString()) {
-    weeks_format_ = std::regex_replace(config_["format-calendar-weeks"].asString(), std::regex("\\{\\}"), (first_day_of_week() == date::Monday) ? "{:%V}" : "{:%U}");
-    weeks_format_left_gaps = std::regex_replace(weeks_format_, std::regex(".*<b>|</b>.*|\\{.?+\\}"), "").length();
+    weeks_format_ =
+        std::regex_replace(config_["format-calendar-weeks"].asString(), std::regex("\\{\\}"),
+                           (first_day_of_week() == date::Monday) ? "{:%V}" : "{:%U}");
+    weeks_format_left_gaps =
+        std::regex_replace(weeks_format_, std::regex(".*<b>|</b>.*|\\{.?+\\}"), "").length();
   } else {
     weeks_format_ = "";
   }
@@ -192,7 +195,6 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
 
   std::stringstream os;
 
-
   enum class WeeksSide {
     LEFT,
     RIGHT,
@@ -213,7 +215,7 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   weekdays_header(first_dow, os);
 
   // First week day prefixed with spaces if needed.
-  date::sys_days print_wd{ym/1};
+  date::sys_days print_wd{ym / 1};
   auto wd{date::weekday{print_wd}};
   auto empty_days = (wd - first_dow).count();
 
@@ -231,14 +233,14 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
   for (auto d{date::day{1}}; d <= last_day; ++d, ++wd) {
     if (wd != first_dow) {
       os << ' ';
-    } else if (unsigned(d)!= 1) {
+    } else if (unsigned(d) != 1) {
       if (weeks_pos == WeeksSide::RIGHT) {
         os << ' ' << fmt::format(weeks_format_, print_wd);
       }
 
       os << '\n';
 
-      print_wd = {ym/d};
+      print_wd = {ym / d};
 
       if (weeks_pos == WeeksSide::LEFT) {
         os << fmt::format(weeks_format_, print_wd) << ' ';

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -80,7 +80,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
         std::regex_replace(config_["format-calendar-weeks"].asString(), std::regex("\\{\\}"),
                            (first_day_of_week() == date::Monday) ? "{:%V}" : "{:%U}");
     weeks_format_left_gaps =
-        std::regex_replace(weeks_format_, std::regex(".*<b>|</b>.*|\\{.?+\\}"), "").length();
+        std::regex_replace(weeks_format_, std::regex("</?[^>]+>|\\{.*\\}"), "").length();
   } else {
     weeks_format_ = "";
   }

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -6,6 +6,7 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <regex>
 #include <type_traits>
 
 #include "util/ustring_clen.hpp"
@@ -72,6 +73,13 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     locale_ = std::locale(config_["locale"].asString());
   } else {
     locale_ = std::locale("");
+  }
+
+  if (config_["format-calendar-weeks"].isString()) {
+    weeks_format_ = std::regex_replace(config_["format-calendar-weeks"].asString(), std::regex("\\{\\}"), (first_day_of_week() == date::Monday) ? "{:%V}" : "{:%U}");
+    weeks_format_left_gaps = std::regex_replace(weeks_format_, std::regex(".*<b>|</b>.*|\\{.?+\\}"), "").length();
+  } else {
+    weeks_format_ = "";
   }
 
   thread_ = [this] {
@@ -180,70 +188,63 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
                           ? date::day{0}
                           : ymd.day()};
   const date::year_month ym{ymd.year(), ymd.month()};
-  const auto weeks_format{config_["format-calendar-weeks"].isString()
-                              ? config_["format-calendar-weeks"].asString()
-                              : ""};
+  const auto first_dow = first_day_of_week();
 
   std::stringstream os;
 
-  const date::weekday first_week_day = first_day_of_week();
 
-  enum class WeeksPlacement {
+  enum class WeeksSide {
     LEFT,
     RIGHT,
     HIDDEN,
   };
-  WeeksPlacement weeks_pos = WeeksPlacement::HIDDEN;
+  WeeksSide weeks_pos = WeeksSide::HIDDEN;
 
   if (config_["calendar-weeks-pos"].isString()) {
     if (config_["calendar-weeks-pos"].asString() == "left") {
-      weeks_pos = WeeksPlacement::LEFT;
+      weeks_pos = WeeksSide::LEFT;
       // Add paddings before the header
-      os << std::string(4, ' ');
+      os << std::string(3 + weeks_format_left_gaps, ' ');
     } else if (config_["calendar-weeks-pos"].asString() == "right") {
-      weeks_pos = WeeksPlacement::RIGHT;
+      weeks_pos = WeeksSide::RIGHT;
     }
   }
 
-  weekdays_header(first_week_day, os);
+  weekdays_header(first_dow, os);
 
-  // First week prefixed with spaces if needed.
-  auto first_month_day = date::weekday(ym / 1);
-  int empty_days = (first_week_day - first_month_day).count() + 1;
-  date::sys_days last_week_day{static_cast<date::sys_days>(ym / 1) + date::days{7 - empty_days}};
+  // First week day prefixed with spaces if needed.
+  date::sys_days print_wd{ym/1};
+  auto wd{date::weekday{print_wd}};
+  auto empty_days = (wd - first_dow).count();
 
-  if (first_week_day == date::Monday) {
-    last_week_day -= date::days{1};
-  }
   /* Print weeknumber on the left for the first row*/
-  if (weeks_pos == WeeksPlacement::LEFT) {
-    os << fmt::format(weeks_format, date::format("%U", last_week_day)) << ' ';
-    last_week_day += date::weeks{1};
+  if (weeks_pos == WeeksSide::LEFT) {
+    os << fmt::format(weeks_format_, print_wd) << ' ';
   }
 
   if (empty_days > 0) {
     os << std::string(empty_days * 3 - 1, ' ');
   }
+
   const auto last_day = (ym / date::literals::last).day();
-  auto weekday = first_month_day;
-  for (auto d = date::day(1); d <= last_day; ++d, ++weekday) {
-    if (weekday != first_week_day) {
+
+  for (auto d{date::day{1}}; d <= last_day; ++d, ++wd) {
+    if (wd != first_dow) {
       os << ' ';
-    } else if (unsigned(d) != 1) {
-      last_week_day -= date::days{1};
-      if (weeks_pos == WeeksPlacement::RIGHT) {
-        os << ' ';
-        os << fmt::format(weeks_format, date::format("%U", last_week_day));
+    } else if (unsigned(d)!= 1) {
+      if (weeks_pos == WeeksSide::RIGHT) {
+        os << ' ' << fmt::format(weeks_format_, print_wd);
       }
 
-      os << "\n";
+      os << '\n';
 
-      if (weeks_pos == WeeksPlacement::LEFT) {
-        os << fmt::format(weeks_format, date::format("%U", last_week_day));
-        os << ' ';
+      print_wd = {ym/d};
+
+      if (weeks_pos == WeeksSide::LEFT) {
+        os << fmt::format(weeks_format_, print_wd) << ' ';
       }
-      last_week_day += date::weeks{1} + date::days{1};
     }
+
     if (d == curr_day) {
       if (config_["today-format"].isString()) {
         auto today_format = config_["today-format"].asString();
@@ -257,12 +258,13 @@ auto waybar::modules::Clock::calendar_text(const waybar_time& wtime) -> std::str
       os << date::format("%e", d);
     }
     /*Print weeks on the right when the endings with spaces*/
-    if (weeks_pos == WeeksPlacement::RIGHT && d == last_day) {
-      last_week_day -= date::days{1};
-      empty_days = 6 - (weekday - first_week_day).count();
-      os << std::string(empty_days * 3 + 1, ' ');
-      os << fmt::format(weeks_format, date::format("%U", last_week_day));
-      last_week_day += date::days{1};
+    if (weeks_pos == WeeksSide::RIGHT && d == last_day) {
+      empty_days = 6 - (wd.c_encoding() - first_dow.c_encoding());
+      if (empty_days > 0) {
+        os << std::string(empty_days * 3, ' ');
+      }
+
+      os << ' ' << fmt::format(weeks_format_, print_wd);
     }
   }
 
@@ -291,7 +293,7 @@ auto waybar::modules::Clock::weekdays_header(const date::weekday& first_week_day
     const std::string pad(2 - clen, ' ');
     res << pad << wd_ustring;
   } while (++wd != first_week_day);
-  res << "\n";
+  res << '\n';
 
   if (config_["format-calendar-weekdays"].isString()) {
     os << fmt::format(config_["format-calendar-weekdays"].asString(), res.str());
@@ -315,7 +317,7 @@ auto waybar::modules::Clock::timezones_text(std::chrono::system_clock::time_poin
       timezone = date::current_zone();
     }
     wtime = {locale_, date::make_zoned(timezone, date::floor<std::chrono::seconds>(*now))};
-    os << fmt::format(format_, wtime) << "\n";
+    os << fmt::format(format_, wtime) << '\n';
   }
   return os.str();
 }

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -102,7 +102,6 @@ void waybar::modules::MPD::setLabel() {
     } else {
       label_.hide();
     }
-    
 
     if (tooltipEnabled()) {
       std::string tooltip_format;

--- a/src/modules/sndio.cpp
+++ b/src/modules/sndio.cpp
@@ -117,7 +117,6 @@ auto Sndio::update() -> void {
     label_.set_markup(text);
     label_.show();
   }
-  
 
   ALabel::update();
 }


### PR DESCRIPTION
1. Let's do code simpler
2. Week format using regexp. Needs when user provide additional characters in format string and need to align week days according
3. Week format has got default formats: ":%U",":%V"
4. Week number is based on the first day of the week now. The output is the same as of date library now.
5. Avoiding of unnecessary operations
----
![Waybar_clock](https://user-images.githubusercontent.com/23121044/206859959-4dfd91bb-5194-497b-be47-5ca01485549f.gif)

