### PR TITLE
Fix hyprland language initialization issues

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -79,16 +79,26 @@ void Language::onEvent(const std::string& ev) {
 void Language::initLanguage() {
   const auto INPUTDEVICES = gIPC->getSocket1Reply("devices");
 
-  if (!config_.isMember("keyboard-name")) return;
-
   const auto KEEBNAME = config_["keyboard-name"].asString();
 
   try {
-    auto searcher = INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
-    searcher = searcher.substr(searcher.find("keymap:") + 7);
+    auto searcher = KEEBNAME.empty() ? INPUTDEVICES : INPUTDEVICES.substr(INPUTDEVICES.find(KEEBNAME) + KEEBNAME.length());
+    searcher = searcher.substr(searcher.find("keymap:") + 8);
     searcher = searcher.substr(0, searcher.find_first_of("\n\t"));
 
-    layoutName_ = searcher;
+    auto layoutName = std::string{};
+    const auto BRIEFNAME = getShortFrom(searcher);
+
+    if (config_.isMember("format-" + BRIEFNAME)) {
+      const auto PROPNAME = "format-" + BRIEFNAME;
+      layoutName = fmt::format(format_, config_[PROPNAME].asString());
+    } else {
+      layoutName = fmt::format(format_, searcher);
+    }
+
+    layoutName = waybar::util::sanitize_string(layoutName);
+
+    layoutName_ = layoutName;
 
     spdlog::debug("hyprland language initLanguage found {}", layoutName_);
 


### PR DESCRIPTION
Hi, thanks a lot for the great project!

This PR fixes two problems in `hyprland/language` module on initialization:
* Sets the layout name when the `keyboard-name` option is not set by getting the first keyboard device from hyprland config
* Modifies the layout name according to the `format-<lang>` option (Fixes #1699)

Please let me know if something else is needed.