### PR TITLE
Implement hyprland submap module

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -26,6 +26,7 @@
 #include "modules/hyprland/backend.hpp"
 #include "modules/hyprland/language.hpp"
 #include "modules/hyprland/window.hpp"
+#include "modules/hyprland/submap.hpp"
 #endif
 #if defined(__FreeBSD__) || (defined(__linux__) && !defined(NO_FILESYSTEM))
 #include "modules/battery.hpp"

--- a/include/modules/hyprland/submap.hpp
+++ b/include/modules/hyprland/submap.hpp
@@ -1,0 +1,25 @@
+#include <fmt/format.h>
+#include "ALabel.hpp"
+#include "bar.hpp"
+#include "modules/hyprland/backend.hpp"
+#include "util/json.hpp"
+
+namespace waybar::modules::hyprland {
+
+class Submap : public waybar::ALabel, public EventHandler {
+ public:
+  Submap(const std::string&, const waybar::Bar&, const Json::Value&);
+  ~Submap();
+
+  auto update() -> void;
+
+ private:
+  void onEvent(const std::string&);
+
+  std::mutex mutex_;
+  const Bar& bar_;
+  util::JsonParser parser_;
+  std::string submap_;
+};
+
+}  // namespace waybar::modules::hyprland

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -23,7 +23,7 @@ Addressed by *hyprland/language*
 
 *keyboard-name*: ++
     typeof: string ++
-    Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "AT Translated set..." is recommended.
+    Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
 
 
@@ -32,9 +32,9 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
     "format": "Lang: {}"
-    "format-us": "AMERICA, HELL YEAH!" // For American English
-    "format-tr": "As bayrakları" // For Turkish
-    "keyboard-name": "AT Translated Set 2 keyboard"
+    "format-en": "AMERICA, HELL YEAH!"
+    "format-tr": "As bayrakları"
+    "keyboard-name": "at-translated-set-2-keyboard"
 }
 ```
 

--- a/man/waybar-hyprland-submap.5.scd
+++ b/man/waybar-hyprland-submap.5.scd
@@ -1,0 +1,82 @@
+waybar-hyprland-submap(5)
+
+# NAME
+
+waybar - hyprland submap module
+
+# DESCRIPTION
+
+The *submap* module displays the currently active submap similar to *sway/mode*.
+
+# CONFIGURATION
+
+Addressed by *hyprland/submap*
+
+*format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how information should be displayed. On {} the currently active submap is displayed.
+
+*rotate*: ++
+	typeof: integer ++
+	Positive value to rotate the text label.
+
+*max-length*: ++
+	typeof: integer ++
+	The maximum length in character the module should display.
+
+*min-length*: ++
+    typeof: integer ++
+    The minimum length in characters the module should take up.
+
+*align*: ++
+    typeof: float ++
+    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+
+*on-click*: ++
+	typeof: string ++
+	Command to execute when clicked on the module.
+
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
+
+*on-click-right*: ++
+	typeof: string ++
+	Command to execute when you right clicked on the module.
+
+*on-update*: ++
+	typeof: string ++
+	Command to execute when the module is updated.
+
+*on-scroll-up*: ++
+	typeof: string ++
+	Command to execute when scrolling up on the module.
+
+*on-scroll-down*: ++
+	typeof: string ++
+	Command to execute when scrolling down on the module.
+
+*smooth-scrolling-threshold*: ++
+	typeof: double ++
+	Threshold to be used when scrolling.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
+
+# EXAMPLES
+
+```
+"hyprland/submap": {
+    "format": "✌️ {}",
+    "max-length": 8,
+    "tooltip": false
+}
+```
+
+# STYLE
+
+- *#submap*

--- a/meson.build
+++ b/meson.build
@@ -220,6 +220,7 @@ if true
     src_files += 'src/modules/hyprland/backend.cpp'
     src_files += 'src/modules/hyprland/window.cpp'
     src_files += 'src/modules/hyprland/language.cpp'
+    src_files += 'src/modules/hyprland/submap.cpp'
 endif
 
 if libnl.found() and libnlgen.found()

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -67,6 +67,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "hyprland/language") {
       return new waybar::modules::hyprland::Language(id, bar_, config_[name]);
     }
+    if (ref == "hyprland/submap") {
+      return new waybar::modules::hyprland::Submap(id, bar_, config_[name]);
+    }
 #endif
     if (ref == "idle_inhibitor") {
       return new waybar::modules::IdleInhibitor(id, bar_, config_[name]);

--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -1,5 +1,7 @@
 #include "modules/hyprland/submap.hpp"
+
 #include <spdlog/spdlog.h>
+
 #include <util/sanitize_str.hpp>
 
 namespace waybar::modules::hyprland {

--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -1,0 +1,60 @@
+#include "modules/hyprland/submap.hpp"
+#include <spdlog/spdlog.h>
+#include <util/sanitize_str.hpp>
+
+namespace waybar::modules::hyprland {
+
+Submap::Submap(const std::string& id, const Bar& bar, const Json::Value& config)
+    : ALabel(config, "submap", id, "{}", 0, true), bar_(bar) {
+  modulesReady = true;
+
+  if (!gIPC.get()) {
+    gIPC = std::make_unique<IPC>();
+  }
+
+  label_.hide();
+  ALabel::update();
+
+  // register for hyprland ipc
+  gIPC->registerForIPC("submap", this);
+}
+
+Submap::~Submap() {
+  gIPC->unregisterForIPC(this);
+  // wait for possible event handler to finish
+  std::lock_guard<std::mutex> lg(mutex_);
+}
+
+auto Submap::update() -> void {
+  std::lock_guard<std::mutex> lg(mutex_);
+
+  if (submap_.empty()) {
+    event_box_.hide();
+  } else {
+    label_.set_markup(fmt::format(format_, submap_));
+    if (tooltipEnabled()) {
+      label_.set_tooltip_text(submap_);
+    }
+    event_box_.show();
+  }
+  // Call parent update
+  ALabel::update();
+}
+
+void Submap::onEvent(const std::string& ev) {
+  std::lock_guard<std::mutex> lg(mutex_);
+
+  if (ev.find("submap") == std::string::npos) {
+    return;
+  }
+
+  auto submapName = ev.substr(ev.find_last_of('>') + 1);
+  submapName = waybar::util::sanitize_string(submapName);
+
+  submap_ = submapName;
+
+  spdlog::debug("hyprland submap onevent with {}", submap_);
+
+  dp.emit();
+}
+}  // namespace waybar::modules::hyprland


### PR DESCRIPTION
* Implemented `hyprland/submap` module (similar to *sway/mode*)
* Fixed `hyprland/language` module docs
  
Sorry about multiple changes in one go as I forgot to create branches on my fork. The latter is just some fixes for the docs of the language module