### PR TITLE
custom: Change external binary output format to TAB instead of newline

### DIFF
--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -124,11 +124,11 @@ This should look like this:
 
 The *class* parameter also accepts an array of strings.
 
-If nothing or an invalid option is specified, Waybar expects i3blocks style output. Values are *newline* separated.
+If nothing or an invalid option is specified, Waybar expects *Tab* delemited output.
 This should look like this:
 
 ```
-$text\\n$tooltip\\n$class*
+$text\\t$tooltip\\t$class\\n*
 ```
 
 *class* is a CSS class, to apply different styles in *style.css*

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -165,7 +165,7 @@ void waybar::modules::Custom::parseOutputRaw() {
   std::istringstream output(output_.out);
   std::string line;
   int i = 0;
-  while (getline(output, line)) {
+  while (getline(output, line, '\t')) {
     if (i == 0) {
       if (config_["escape"].isBool() && config_["escape"].asBool()) {
         text_ = Glib::Markup::escape_text(line);


### PR DESCRIPTION
Custom command output is handled with:
`getline(&buff, &len, fp_) == -1)`
it means that output cannot contain parameters with newline delimiter. So, no matter to have parsing with:
`while (getline(output, line)) {`
and new line changed to TAB