### PR TITLE
[WIP] Module for (tabbed) sway windows

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -11,6 +11,7 @@
 #include "modules/sway/mode.hpp"
 #include "modules/sway/scratchpad.hpp"
 #include "modules/sway/window.hpp"
+#include "modules/sway/windows.hpp"
 #include "modules/sway/workspaces.hpp"
 #endif
 #ifdef HAVE_WLR

--- a/include/modules/sway/windows.hpp
+++ b/include/modules/sway/windows.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <fmt/format.h>
+#include <gtkmm/button.h>
+#include <gtkmm/label.h>
+
+#include <unordered_map>
+
+#include "AModule.hpp"
+#include "bar.hpp"
+#include "client.hpp"
+#include "modules/sway/ipc/client.hpp"
+#include "util/json.hpp"
+
+namespace waybar::modules::sway {
+
+class Windows : public AModule, public sigc::trackable {
+ public:
+  Windows(const std::string&, const waybar::Bar&, const Json::Value&);
+  ~Windows() = default;
+  auto update() -> void;
+
+ private:
+  static inline const std::string window_switch_cmd_ = "[con_id={}] focus {}";
+
+  void onCmd(const struct Ipc::ipc_response&);
+  void onEvent(const struct Ipc::ipc_response&);
+  bool filterButtons();
+  Gtk::Button& addButton(const Json::Value&);
+  void onButtonReady(const Json::Value&, Gtk::Button&);
+  std::string getIcon(const std::string&, const Json::Value&);
+  const int getCycleWindow(std::vector<Json::Value>::iterator, bool prev) const;
+  std::string trimWindowName(std::string);
+  bool handleScroll(GdkEventScroll*);
+
+  const Bar& bar_;
+  Json::Value workspace_;
+  std::vector<Json::Value> windows_;
+  Gtk::Box box_;
+  util::JsonParser parser_;
+  std::unordered_map<int, Gtk::Button> buttons_;
+  std::mutex mutex_;
+  Ipc ipc_;
+};
+
+}  // namespace waybar::modules::sway

--- a/meson.build
+++ b/meson.build
@@ -197,6 +197,7 @@ src_files += [
     'src/modules/sway/mode.cpp',
     'src/modules/sway/language.cpp',
     'src/modules/sway/window.cpp',
+    'src/modules/sway/windows.cpp',
     'src/modules/sway/workspaces.cpp',
     'src/modules/sway/scratchpad.cpp'
 ]

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -32,6 +32,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "sway/window") {
       return new waybar::modules::sway::Window(id, bar_, config_[name]);
     }
+    if (ref == "sway/windows") {
+      return new waybar::modules::sway::Windows(id, bar_, config_[name]);
+    }
     if (ref == "sway/language") {
       return new waybar::modules::sway::Language(id, config_[name]);
     }

--- a/src/modules/sway/bar.cpp
+++ b/src/modules/sway/bar.cpp
@@ -24,12 +24,16 @@ BarIpcClient::BarIpcClient(waybar::Bar& bar) : bar_{bar} {
   subscribe_events.append("barconfig_update");
 
   bool has_mode = isModuleEnabled("sway/mode");
+  bool has_windows = isModuleEnabled("sway/windows");
   bool has_workspaces = isModuleEnabled("sway/workspaces");
 
   if (has_mode) {
     subscribe_events.append("mode");
   }
-  if (has_workspaces) {
+  if (has_windows) {
+    subscribe_events.append("window");
+  }
+  if (has_workspaces||has_windows) {
     subscribe_events.append("workspace");
   }
   if (has_mode || has_workspaces) {

--- a/src/modules/sway/windows.cpp
+++ b/src/modules/sway/windows.cpp
@@ -1,0 +1,275 @@
+#include "modules/sway/windows.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+//TODO Integrate with window class.
+
+namespace waybar::modules::sway {
+
+Windows::Windows(const std::string &id, const Bar &bar, const Json::Value &config)
+    : AModule(config, "windows", id, false, !config["disable-scroll"].asBool()),
+      bar_(bar),
+      box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+  box_.set_name("windows");
+  if (!id.empty()) {
+    box_.get_style_context()->add_class(id);
+  }
+  event_box_.add(box_);
+  ipc_.subscribe(R"(["window", "workspace"])");
+  ipc_.signal_event.connect(sigc::mem_fun(*this, &Windows::onEvent));
+  ipc_.signal_cmd.connect(sigc::mem_fun(*this, &Windows::onCmd));
+  ipc_.sendCmd(IPC_GET_WORKSPACES);
+  ipc_.sendCmd(IPC_GET_TREE);
+  if (config["enable-bar-scroll"].asBool()) {
+    auto &window = const_cast<Bar &>(bar_).window;
+    window.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
+    window.signal_scroll_event().connect(sigc::mem_fun(*this, &Windows::handleScroll));
+  }
+  // Launch worker
+  ipc_.setWorker([this] {
+    try {
+      ipc_.handleEvent();
+    } catch (const std::exception &e) {
+      spdlog::error("Windows: {}", e.what());
+    }
+  });
+}
+
+void Windows::onEvent(const struct Ipc::ipc_response &res) {
+  try {
+    //For some reason, the "tree" shows all workspaces as "unfocused", at least for me.
+    //So we need to determine the currently focused workspace first using an additional command.
+    ipc_.sendCmd(IPC_GET_WORKSPACES);
+    ipc_.sendCmd(IPC_GET_TREE);
+  } catch (const std::exception &e) {
+    spdlog::error("Windows: {}", e.what());
+  }
+}
+
+void Windows::onCmd(const struct Ipc::ipc_response &res) {
+  if (res.type == IPC_GET_WORKSPACES)  {
+    try {
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+    	auto payload = parser_.parse(res.payload);
+	workspace_ = (* std::find_if(payload.begin(), payload.end(),
+		[&](const auto &workspace) {
+			return workspace["focused"].asBool();
+		}));
+      }
+      dp.emit();
+    } catch (const std::exception &e) {
+      spdlog::error("Windows: {}", e.what());
+    }
+  } else if (res.type == IPC_GET_TREE) {
+    try {
+      {
+        std::lock_guard<std::mutex> lock(mutex_);
+	//There is only one root node.
+        auto payload = parser_.parse(res.payload)["nodes"];
+	//The subtree that represents the output the bar is being drawn on. An "all-outputs" setting does not make sense here.
+        auto our_output_tree = (* std::find_if(payload.begin(), payload.end(),
+                     [&](const auto &output) {
+                       return output["name"].asString() == bar_.output->name;
+                     }))["nodes"];
+	//Essentially the same, only now we are looking for the node tree of the currently focused workspace.
+	
+	//TODO Multi-layout support (such as adding floating nodes to the pile if the config says so)
+	//Right now, floating nodes will be entirely ignored, we simply pick the first layout
+	//on this workspace and go from there. This is dirty and needs changing.
+        auto our_workspace_tree = (* std::find_if(our_output_tree.begin(), our_output_tree.end(),
+                     [&](const auto &workspace) {
+			     return workspace["id"].asInt() == workspace_["id"].asInt();
+		     }))["nodes"][0]["nodes"];
+        windows_.clear();
+	std::copy(our_workspace_tree.begin(), our_workspace_tree.end(), std::back_inserter(windows_));
+      }
+      dp.emit();
+    } catch (const std::exception &e) {
+      spdlog::error("Windows: {}", e.what());
+    }
+  }
+}
+
+bool Windows::filterButtons() {
+  bool needReorder = false;
+  for (auto it = buttons_.begin(); it != buttons_.end();) {
+    auto win = std::find_if(windows_.begin(), windows_.end(),
+                           [it](const auto &node) { return node["id"].asInt() == it->first; });
+    if (win == windows_.end() || (*win)["output"].asString() != bar_.output->name) {
+      it = buttons_.erase(it);
+      needReorder = true;
+    } else {
+      ++it;
+    }
+  }
+  return needReorder;
+}
+
+auto Windows::update() -> void {
+  std::lock_guard<std::mutex> lock(mutex_);
+  bool needReorder = filterButtons();
+  for (auto it = windows_.begin(); it != windows_.end(); ++it) {
+    auto bit = buttons_.find((*it)["id"].asInt());
+    if (bit == buttons_.end()) {
+      needReorder = true;
+    }
+    auto &button = bit == buttons_.end() ? addButton(*it) : bit->second;
+    if ((*it)["focused"].asBool()) {
+      button.get_style_context()->add_class("focused");
+    } else {
+      button.get_style_context()->remove_class("focused");
+    }
+    if ((*it)["visible"].asBool()) {
+      button.get_style_context()->add_class("visible");
+    } else {
+      button.get_style_context()->remove_class("visible");
+    }
+    if ((*it)["sticky"].asBool()) {
+      button.get_style_context()->add_class("sticky");
+    } else {
+      button.get_style_context()->remove_class("sticky");
+    }
+    if ((*it)["urgent"].asBool()) {
+      button.get_style_context()->add_class("urgent");
+    } else {
+      button.get_style_context()->remove_class("urgent");
+    }
+    if (needReorder) {
+      box_.reorder_child(button, it - windows_.begin());
+    }
+    std::string output = (*it)["name"].asString();
+    if (config_["format"].isString()) {
+      auto format = config_["format"].asString();
+      output = fmt::format(format, fmt::arg("icon", getIcon(output, *it)),
+                           fmt::arg("value", output), fmt::arg("name", trimWindowName(output)),
+                           fmt::arg("index", (*it)["num"].asString()));
+    } else {
+      output = trimWindowName(output);
+    }
+    if (!config_["disable-markup"].asBool()) {
+      static_cast<Gtk::Label *>(button.get_children()[0])->set_markup(output);
+    } else {
+      button.set_label(output);
+    }
+    onButtonReady(*it, button);
+  }
+  // Call parent update
+  AModule::update();
+}
+
+Gtk::Button &Windows::addButton(const Json::Value &node) {
+  auto pair = buttons_.emplace(node["id"].asInt(), node["title"].asString());
+  auto &&button = pair.first->second;
+  box_.pack_start(button, false, false, 0);
+  button.set_name("sway-window-" + node["id"].asString());
+  button.set_relief(Gtk::RELIEF_NONE);
+  if (!config_["disable-click"].asBool()) {
+    button.signal_pressed().connect([this, node] {
+      try {
+        ipc_.sendCmd(IPC_COMMAND, fmt::format(window_switch_cmd_,
+                                                node["id"].asInt()));
+      } catch (const std::exception &e) {
+        spdlog::error("Windows: {}", e.what());
+      }
+    });
+  }
+  return button;
+}
+
+//TODO make this better
+std::string Windows::getIcon(const std::string &name, const Json::Value &node) {
+  if (node["app_id"].isNull()){
+    if (node.isMember("window_properties")) {
+      auto cls = node["window_properties"]["class"];
+      if (!cls.isNull() && config_["format-icons"][cls.asString()].isString()) {
+        return config_["format-icons"][cls.asString()].asString();
+      }
+    }
+  } else if (config_["format-icons"].isMember(node["app_id"].asString())){
+    return config_["format-icons"][node["app_id"].asString()].asString();
+  }
+  return config_["format-icons"]["default"].asString();
+}
+
+bool Windows::handleScroll(GdkEventScroll *e) {
+  if (gdk_event_get_pointer_emulated((GdkEvent *)e)) {
+    /**
+     * Ignore emulated scroll events on window
+     */
+    return false;
+  }
+  auto dir = AModule::getScrollDir(e);
+  if (dir == SCROLL_DIR::NONE) {
+    return true;
+  }
+  int id;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = std::find_if(windows_.begin(), windows_.end(),
+                           [](const auto &window) { return window["focused"].asBool(); });
+    if (it == windows_.end()) {
+      return true;
+    }
+    if (dir == SCROLL_DIR::DOWN || dir == SCROLL_DIR::RIGHT) {
+      id = getCycleWindow(it, false);
+    } else if (dir == SCROLL_DIR::UP || dir == SCROLL_DIR::LEFT) {
+      id = getCycleWindow(it, true);
+    } else {
+      return true;
+    }
+    if (id == (*it)["id"].asInt()) {
+      return true;
+    }
+  }
+  try {
+    ipc_.sendCmd(IPC_COMMAND, fmt::format(window_switch_cmd_, id));
+  } catch (const std::exception &e) {
+    spdlog::error("Windows: {}", e.what());
+  }
+  return true;
+}
+
+const int Windows::getCycleWindow(std::vector<Json::Value>::iterator it,
+                                                bool prev) const {
+  if (prev && it == windows_.begin() && !config_["disable-scroll-wraparound"].asBool()) {
+    return (*(--windows_.end()))["id"].asInt();
+  }
+  if (prev && it != windows_.begin())
+    --it;
+  else if (!prev && it != windows_.end())
+    ++it;
+  if (!prev && it == windows_.end()) {
+    if (config_["disable-scroll-wraparound"].asBool()) {
+      --it;
+    } else {
+      return (*(windows_.begin()))["id"].asInt();
+    }
+  }
+  return (*it)["id"].asInt();
+}
+
+std::string Windows::trimWindowName(std::string name) {
+  if (config_["max-title-length"].asInt() >= 0){
+    return name.substr(config_["max-title-length"].asInt());
+  }
+  return name;
+}
+
+void Windows::onButtonReady(const Json::Value &node, Gtk::Button &button) {
+  if (config_["current-only"].asBool()) {
+    if (node["focused"].asBool()) {
+      button.show();
+    } else {
+      button.hide();
+    }
+  } else {
+    button.show();
+  }
+}
+
+}  // namespace waybar::modules::sway


### PR DESCRIPTION
This is an extremely WIP module for tabbed sway windows.

I'm a huge fan of the "tabbed" layout, but I dislike the default title bar and wish to change it. However, sway doesn't offer a whole lot of configuration for that (and it's obviously out of scope for sway) so, to match with the style of my other waybar, I wish to add a new module for sway windows. It's mainly thought for the tabbed layout but it's probably viable for other layouts as well.

Right now, it's very rudimentary. There's a bunch of stuff that I'd like to change:

- Merge my new module with the existing "window" module, keeping the default config in a way that would not alter the current functionality, just "optionally expand" it, if you know what I mean.
- Improve the "getIcon" method, as it currently relies on icon fonts and the user specifying every single icon.
- Add "multi-layout"-support, especially support for floating windows.

It's usable right now, though I wouldn't really advise it. It's basically a ripped-off version of the workspaces class.

Please excuse my poor C++ code, this is one of the first things I'm actually writing in C++. If you find any issues, feel more than free to tell me.