### PR TITLE
Fix wrong layout name in hyprland language module when a variant is used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *~
 vgcore.*
 /.vscode
+/.idea
 /.cache
 *.swp
 packagecache

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -49,9 +49,8 @@ auto Language::update() -> void {
 
 void Language::onEvent(const std::string& ev) {
   std::lock_guard<std::mutex> lg(mutex_);
-  auto layoutName = ev.substr(ev.find_last_of(',') + 1);
-  auto kbName = ev.substr(0, ev.find_last_of(','));
-  kbName = kbName.substr(kbName.find_first_of('>') + 2);
+  auto kbName = ev.substr(ev.find_last_of('>') + 1, ev.find_first_of(','));
+  auto layoutName = ev.substr(ev.find_first_of(',') + 1);
 
   if (config_.isMember("keyboard-name") && kbName != config_["keyboard-name"].asString())
     return;  // ignore


### PR DESCRIPTION
Fixed an issue that resulted from incorrectly parsing the event string which contains extra commas coming from the keyboard variant.

Issues #1771 and #1901 should be fixed with this.