### PR TITLE
sway,feat: allow alphabetical sort

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -73,6 +73,10 @@ Addressed by *sway/workspaces*
     typeof: bool ++
     Whether to disable *workspace_auto_back_and_forth* when clicking on workspaces. If this is set to *true*, clicking on a workspace you are already on won't do anything, even if *workspace_auto_back_and_forth* is enabled in the Sway configuration.
 
+*alphabetical_sort*: ++
+    typeof: bool ++
+    Whether to sort workspaces alphabetically. Please note this can make "swaymsg workspace prev/next" move to workspaces inconsistent with the ordering shown in Waybar.
+
 # FORMAT REPLACEMENTS
 
 *{value}*: Name of the workspace, as defined by sway.

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -130,6 +130,10 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
         // In a first pass, the maximum "num" value is computed to enqueue
         // unnumbered workspaces behind numbered ones when computing the sort
         // attribute.
+        //
+        // Note: if the 'alphabetical_sort' option is true, the user is in 
+        // agreement that the "workspace prev/next" commands may not follow
+        // the order displayed in Waybar.
         int max_num = -1;
         for (auto &workspace : workspaces_) {
           max_num = std::max(workspace["num"].asInt(), max_num);
@@ -143,16 +147,19 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
           }
         }
         std::sort(workspaces_.begin(), workspaces_.end(),
-                  [](const Json::Value &lhs, const Json::Value &rhs) {
+                  [this](const Json::Value &lhs, const Json::Value &rhs) {
                     auto lname = lhs["name"].asString();
                     auto rname = rhs["name"].asString();
                     int l = lhs["sort"].asInt();
                     int r = rhs["sort"].asInt();
 
-                    if (l == r) {
+                    if (l == r || config_["alphabetical_sort"].asBool()) {
                       // In case both integers are the same, lexicographical
                       // sort. The code above already ensure that this will only
                       // happend in case of explicitly numbered workspaces.
+                      //
+                      // Additionally, if the config specifies to sort workspaces
+                      // alphabetically do this here.
                       return lname < rname;
                     }
 


### PR DESCRIPTION
for users who do not utilize any form of "workspace prev/next" commands, it can be very handle to sort the workspaces alphabetically.

this commit adds a new "alphabetical_sort" to the `sway/workspaces` module which allows the module to alway sort workspaces alphabetically.

this docs are updated to warn the user of the implications involved.

Signed-off-by: Louis DeLosSantos <louis.delos@gmail.com>

I understand that this PR may not be welcome, since the comments in the code look like a good amount of effort was put into having Waybar *not* act like this. Feel free to push back and I'll just maintain this in my fork.