### PR TITLE
fix: cpu_load pushed twice to the vector

### DIFF
--- a/src/modules/cpu/common.cpp
+++ b/src/modules/cpu/common.cpp
@@ -39,7 +39,6 @@ auto waybar::modules::Cpu::update() -> void {
     auto icons = std::vector<std::string>{state};
     fmt::dynamic_format_arg_store<fmt::format_context> store;
     store.push_back(fmt::arg("load", cpu_load));
-    store.push_back(fmt::arg("load", cpu_load));
     store.push_back(fmt::arg("usage", total_usage));
     store.push_back(fmt::arg("icon", getIcon(total_usage, icons)));
     store.push_back(fmt::arg("max_frequency", max_frequency));


### PR DESCRIPTION
cpu_load is pushed twice to the vector, introduced in: https://github.com/Alexays/Waybar/pull/1253

This MR removes the duplicated line so it's only pushes once per iteration. 