### PR TITLE
Fix GTK crash due to wlr/workspace module upon reconnecting monitor

### DIFF
--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -9,6 +9,7 @@
 #include <stdexcept>
 #include <vector>
 
+#include "client.hpp"
 #include "gtkmm/widget.h"
 #include "modules/wlr/workspace_manager_binding.hpp"
 
@@ -166,8 +167,20 @@ WorkspaceManager::~WorkspaceManager() {
     return;
   }
 
-  zext_workspace_manager_v1_destroy(workspace_manager_);
-  workspace_manager_ = nullptr;
+  wl_display *display = Client::inst()->wl_display;
+
+  // Send `stop` request and wait for one roundtrip. This is not quite correct as 
+  // the protocol encourages us to wait for the .finished event, but it should work
+  // with wlroots workspace manager implementation.
+  zext_workspace_manager_v1_stop(workspace_manager_);
+  wl_display_roundtrip(display);
+
+  // If the .finished handler is still not executed, destroy the workspace manager here.
+  if (workspace_manager_) {
+    spdlog::warn("Foreign toplevel manager destroyed before .finished event");
+    zext_workspace_manager_v1_destroy(workspace_manager_);
+    workspace_manager_ = nullptr;
+  }
 }
 
 auto WorkspaceManager::remove_workspace_group(uint32_t id) -> void {


### PR DESCRIPTION
This pull request fixes abnormal termination of waybar when using the wlr/workspace module and reconnecting a monitor.

Currently the behavior of disconnecting a monitor is the following: The workspace manager is destroyed immediately, but the compositor can send further messages. This results in GTK exiting with the following error message:

```
Gdk-Message: 16:01:27.831: Error reading events from display: Invalid argument
```

This pull request adds sending a stop request to instruct the compositor not to send any further messages. This is the same principle used in b79301a5bd.

Fixes #1783.
