### PR TITLE
get_desktop_app_info: fix crash on failed DesktopAppInfo::create

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -102,8 +102,11 @@ Glib::RefPtr<Gio::DesktopAppInfo> get_desktop_app_info(const std::string &app_id
         desktop_file = desktop_list[0][i];
       } else {
         auto tmp_info = Gio::DesktopAppInfo::create(desktop_list[0][i]);
-        auto startup_class = tmp_info->get_startup_wm_class();
+        if (!tmp_info)
+          // see https://github.com/Alexays/Waybar/issues/1446
+          continue;
 
+        auto startup_class = tmp_info->get_startup_wm_class();
         if (startup_class == app_id) {
           desktop_file = desktop_list[0][i];
           break;


### PR DESCRIPTION
Even though it makes little sense for this call to fail, it sometimes randomly does, and takes down waybar with it.

Fixes the crash from #1446, but does not bring icons back

As the issue occurs randomly, I plan on running this patch for a while to see if the issue goes away. I will mark the pull request as ready when confident the patch indeed works.