### PR TITLE
fix: battery time remaining

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -505,12 +505,12 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
 
     float time_remaining{0.0f};
     if (status == "Discharging" && time_to_empty_now_exists) {
-      if (time_to_empty_now != 0) time_remaining = (float)time_to_empty_now / 1000.0f;
+      if (time_to_empty_now != 0) time_remaining = (float)time_to_empty_now / 3600.0f;
     } else if (status == "Discharging" && total_power_exists && total_energy_exists) {
       if (total_power != 0) time_remaining = (float)total_energy / total_power;
     } else if (status == "Charging" && time_to_full_now_exists) {
       if (time_to_full_now_exists && (time_to_full_now != 0))
-        time_remaining = -(float)time_to_full_now / 1000.0f;
+        time_remaining = -(float)time_to_full_now / 3600.0f;
       // If we've turned positive it means the battery is past 100% and so just report that as no
       // time remaining
       if (time_remaining > 0.0f) time_remaining = 0.0f;


### PR DESCRIPTION
time is reported in second and should be divided by 3600 and not 1000.

should fix: https://github.com/Alexays/Waybar/pull/1867#pullrequestreview-1246756355