### PR TITLE
hyprland/submap: run initial render on startup

### DIFF
--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -19,6 +19,7 @@ Submap::Submap(const std::string& id, const Bar& bar, const Json::Value& config)
 
   // register for hyprland ipc
   gIPC->registerForIPC("submap", this);
+  dp.emit();
 }
 
 Submap::~Submap() {


### PR DESCRIPTION
Without this, the module is rendered incorrectly on waybar startup, and will only be rendered when user triggers a submap (which is quite rare). I've noticed that some other modules also run `dp.emit()` in their constructor, presumably for the same purpose.