### PR TITLE
Allow any module to implement signal handling

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -15,6 +15,7 @@ class AModule : public IModule {
           bool enable_scroll = false);
   virtual ~AModule();
   virtual auto update() -> void;
+  virtual auto refresh(int) -> void {};
   virtual operator Gtk::Widget &();
 
   Glib::Dispatcher dp;

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -725,10 +725,7 @@ void waybar::Bar::setupAltFormatKeyForModuleList(const char* module_list_name) {
 
 void waybar::Bar::handleSignal(int signal) {
   for (auto& module : modules_all_) {
-    auto* custom = dynamic_cast<waybar::modules::Custom*>(module.get());
-    if (custom != nullptr) {
-      custom->refresh(signal);
-    }
+    module->refresh(signal);
   }
 }
 


### PR DESCRIPTION
The new image module (#1397) implements signal handling, which is useful for telling the bar the file has changed and should be redrawn. However, that doesn't work, since the ```refresh()``` method only gets called for custom modules.