### PR TITLE
Image module CSS fix

### DIFF
--- a/include/modules/image.hpp
+++ b/include/modules/image.hpp
@@ -7,6 +7,7 @@
 #include <string>
 
 #include "ALabel.hpp"
+#include "gtkmm/box.h"
 #include "util/command.hpp"
 #include "util/json.hpp"
 #include "util/sleeper_thread.hpp"
@@ -15,7 +16,7 @@ namespace waybar::modules {
 
 class Image : public AModule {
  public:
-  Image(const std::string&, const std::string&, const Json::Value&);
+  Image(const std::string&, const Json::Value&);
   auto update() -> void;
   void refresh(int /*signal*/);
 
@@ -23,6 +24,7 @@ class Image : public AModule {
   void delayWorker();
   void handleEvent();
 
+  Gtk::Box box_;
   Gtk::Image image_;
   std::string path_;
   int size_;

--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -10,8 +10,6 @@ The *image* module displays an image from a path.
 
 # CONFIGURATION
 
-Addressed by *custom/<name>*
-
 *path*: ++
 	typeof: string ++
 	The path to the image.
@@ -58,15 +56,15 @@ Addressed by *custom/<name>*
 
 # EXAMPLES
 
-## Spotify:
-
-## mpd:
-
 ```
-"image/album-art": {
+"image#album-art": {
 	"path": "/tmp/mpd_art",
 	"size": 32,
 	"interval": 5,
 	"on-click": "mpc toggle"
 }
 ```
+
+# STYLE
+
+- *#image*

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -97,6 +97,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     }
     if (ref == "disk") {
       return new waybar::modules::Disk(id, config_[name]);
+    } 
+    if (ref == "image") {
+      return new waybar::modules::Image(id, config_[name]);
     }
 #ifdef HAVE_DBUSMENU
     if (ref == "tray") {
@@ -156,8 +159,6 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     }
     if (ref.compare(0, 7, "custom/") == 0 && ref.size() > 7) {
       return new waybar::modules::Custom(ref.substr(7), id, config_[name]);
-    } else if (ref.compare(0, 6, "image/") == 0 && ref.size() > 6) {
-      return new waybar::modules::Image(ref.substr(6), id, config_[name]);
     }
   } catch (const std::exception& e) {
     auto err = fmt::format("Disabling module \"{}\", {}", name, e.what());

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -97,7 +97,7 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     }
     if (ref == "disk") {
       return new waybar::modules::Disk(id, config_[name]);
-    } 
+    }
     if (ref == "image") {
       return new waybar::modules::Image(id, config_[name]);
     }

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -1,11 +1,16 @@
 #include "modules/image.hpp"
 
-#include <spdlog/spdlog.h>
-
-waybar::modules::Image::Image(const std::string& name, const std::string& id,
+waybar::modules::Image::Image(const std::string& id,
                               const Json::Value& config)
-    : AModule(config, "image-" + name, id, "{}") {
-  event_box_.add(image_);
+    : AModule(config, "image", id),
+      box_(Gtk::ORIENTATION_HORIZONTAL, 0)
+     {
+  box_.pack_start(image_);
+  box_.set_name("image");
+  if (!id.empty()) {
+    box_.get_style_context()->add_class(id);
+  }
+  event_box_.add(box_);
 
   dp.emit();
 

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -1,10 +1,7 @@
 #include "modules/image.hpp"
 
-waybar::modules::Image::Image(const std::string& id,
-                              const Json::Value& config)
-    : AModule(config, "image", id),
-      box_(Gtk::ORIENTATION_HORIZONTAL, 0)
-     {
+waybar::modules::Image::Image(const std::string& id, const Json::Value& config)
+    : AModule(config, "image", id), box_(Gtk::ORIENTATION_HORIZONTAL, 0) {
   box_.pack_start(image_);
   box_.set_name("image");
   if (!id.empty()) {


### PR DESCRIPTION
The image module was a great contribution, I love having it in my bar. However, it didn't match the style of the rest of the repo and had a few issues that this PR addresses.

1. The current implementation does not properly attach CSS tags to itself. By running `env GTK_DEBUG=interactive waybar` one can see that the image module does not populate a name or attach any relevant style classes. This PR fixes that and brings it in parallel with styling of other waybar modules. You can now address it as `#image` in `styles.css`, and if you want duplicate modules you can define them as `image#img1`,`image#img2` and address them as `#image-img1`,`#image-img2`.
2. Documentation was not up to speed. The man page has been updated in this PR, and I'm adding the relevant wiki page as we speak.