### PR TITLE
Set Image path from executable file (Image Module)

### DIFF
--- a/include/modules/image.hpp
+++ b/include/modules/image.hpp
@@ -27,6 +27,7 @@ class Image : public AModule {
   std::string path_;
   int size_;
   int interval_;
+  util::command::res output_;
 
   util::SleeperThread thread_;
 };

--- a/include/modules/image.hpp
+++ b/include/modules/image.hpp
@@ -27,7 +27,6 @@ class Image : public AModule {
   std::string path_;
   int size_;
   int interval_;
-  util::command::res output_;
 
   util::SleeperThread thread_;
 };

--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -15,7 +15,10 @@ Addressed by *custom/<name>*
 *path*: ++
 	typeof: string ++
 	The path to the image.
-
+*exec*: ++
+	typeof: string ++
+	The path to the script, which should return image path file
+	it will only execute if the path is not set
 *size*: ++
 	typeof: integer ++
 	The width/height to render the image.

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -9,7 +9,6 @@ waybar::modules::Image::Image(const std::string& name, const std::string& id,
 
   dp.emit();
 
-  //path_ = config["path"].asString();
   size_ = config["size"].asInt();
 
   interval_ = config_["interval"].asInt();

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -44,10 +44,14 @@ auto waybar::modules::Image::update() -> void {
   {
     path_ = config_["path"].asString();
   }
-  else
+  else if(config_['exec'].isString())
   {
     output_ = util::command::exec(config_["exec"].asString());
     path_ =output_.out;
+  }
+  else
+  {
+    path_="";
   }
   if (Glib::file_test(path_, Glib::FILE_TEST_EXISTS))
     pixbuf = Gdk::Pixbuf::create_from_file(path_, size_, size_);

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -9,7 +9,7 @@ waybar::modules::Image::Image(const std::string& name, const std::string& id,
 
   dp.emit();
 
-  path_ = config["path"].asString();
+  //path_ = config["path"].asString();
   size_ = config["size"].asInt();
 
   interval_ = config_["interval"].asInt();
@@ -41,7 +41,15 @@ void waybar::modules::Image::refresh(int sig) {
 
 auto waybar::modules::Image::update() -> void {
   Glib::RefPtr<Gdk::Pixbuf> pixbuf;
-
+  if(config_["path"].isString())
+  {
+    path_ = config_["path"].asString();
+  }
+  else
+  {
+    output_ = util::command::exec(config_["exec"].asString());
+    path_ =output_.out;
+  }
   if (Glib::file_test(path_, Glib::FILE_TEST_EXISTS))
     pixbuf = Gdk::Pixbuf::create_from_file(path_, size_, size_);
   else

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -44,7 +44,7 @@ auto waybar::modules::Image::update() -> void {
   {
     path_ = config_["path"].asString();
   }
-  else if(config_['exec'].isString())
+  else if(config_["exec"].isString())
   {
     output_ = util::command::exec(config_["exec"].asString());
     path_ =output_.out;

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -39,6 +39,8 @@ void waybar::modules::Image::refresh(int sig) {
 }
 
 auto waybar::modules::Image::update() -> void {
+  util::command::res output_;
+
   Glib::RefPtr<Gdk::Pixbuf> pixbuf;
   if(config_["path"].isString())
   {


### PR DESCRIPTION
I just made a small tweak in the image module to get the image path from an executable file. Here is a sample configuration.

```
 "image/album-art": {
	  "exec":"~/.config/waybar/custom/spotify/album_art.sh",
	  "size": 32,
	  "interval": 5,  
    },
```
If there is a path config exist, then it will load the image from the path config; otherwise, it will check for an exec configuration and execute the script, which should return a file path, and then it will load the image.
Here is a simple executable file
```
#!/bin/bash
album_art=$(playerctl -p spotify metadata mpris:artUrl)
if [[ -z $album_art ]] 
then
   # spotify is dead, we should die to.
   exit
fi
curl -s  "${album_art}" --output "/tmp/cover.jpeg"
echo "/tmp/cover.jpeg"

```