### PR TITLE
Clock. Formating simplify

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -49,7 +49,7 @@ class Clock : public ALabel {
   CldMode cldMode_{CldMode::MONTH};
   uint cldMonCols_{3}; // Count of the month in the row
   int cldMonColLen_{20}; // Length of the month column
-  int cldWnLen_{2}; // Length of the week number
+  int cldWnLen_{3}; // Length of the week number
   date::year_month_day cldYearShift_;
   date::year_month cldMonShift_;
   date::months cldCurrShift_{0};


### PR DESCRIPTION
Signed-off-by: Viktar Lukashonak <myxabeer@gmail.com>

Hi @Alexays , during [ISSUE#1321](https://github.com/Alexays/Waybar/issues/1321) investigation I've found one small minor bug. In order to avoid unmanaged string formatting in called functions... string formatting moved to the caller functionality + bug with the initial clock configuration (when weeks position are defined and weeks format not and vise versa) is fixed.