### PR TITLE
Fix kbName initialization

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -49,7 +49,7 @@ auto Language::update() -> void {
 
 void Language::onEvent(const std::string& ev) {
   std::lock_guard<std::mutex> lg(mutex_);
-  auto kbName = ev.substr(ev.find_last_of('>') + 1, ev.find_first_of(','));
+  std::string kbName(begin(ev) + ev.find_last_of('>') + 1, begin(ev) + ev.find_first_of(','));
   auto layoutName = ev.substr(ev.find_first_of(',') + 1);
 
   if (config_.isMember("keyboard-name") && kbName != config_["keyboard-name"].asString())


### PR DESCRIPTION
Second argument of substr is the length of the substring, _not_ the position. With positions, it's better to do like this.

Example:
```sh
[2023-01-29 13:08:00.927] [debug] hyprland IPC received activelayout>>ITE Tech. Inc. ITE Device(8910) Keyboard,Russian (with Ukrainian-Belorussian layout)
[2023-01-29 13:08:00.927] [debug] kbName is ITE Tech. Inc. ITE Device(8910) Keyboard,Russian (with
```

After the fix it's correct:
```sh
[2023-01-29 13:11:11.408] [debug] hyprland IPC received activelayout>>ITE Tech. Inc. ITE Device(8910) Keyboard,Russian (with Ukrainian-Belorussian layout)
[2023-01-29 13:11:11.408] [debug] kbName is ITE Tech. Inc. ITE Device(8910) Keyboard
```