### PR TITLE
fix(wireplumber): free(): invalid pointer

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -47,7 +47,7 @@ waybar::modules::Wireplumber::~Wireplumber() {
   g_clear_object(&wp_core_);
   g_clear_object(&mixer_api_);
   g_clear_object(&def_nodes_api_);
-  g_free(&default_node_name_);
+  g_free(default_node_name_);
 }
 
 void waybar::modules::Wireplumber::updateNodeName(waybar::modules::Wireplumber* self, uint32_t id) {


### PR DESCRIPTION
When freeing the `default_node_name_` pointer using `free`, the `&` operator was used to try to free the reference rather than the pointer. This caused a core dump. In order to fix this, the pointer is freed instead (ie the `&` operator is no longer used).

Fixes #1852 