### PR TITLE
Fixing memory leak on update UPower tooltip

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,12 @@ int main(int argc, char* argv[]) {
       waybar::Client::inst()->reset();
     });
 
+    std::signal(SIGINT, [](int /*signal*/) {
+      spdlog::info("Quitting.");
+      reload = false;
+      waybar::Client::inst()->reset();
+    });
+
     for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
       std::signal(sig, [](int sig) {
         for (auto& bar : waybar::Client::inst()->bars) {

--- a/src/modules/upower/upower_tooltip.cpp
+++ b/src/modules/upower/upower_tooltip.cpp
@@ -29,7 +29,7 @@ UPowerTooltip::~UPowerTooltip() {}
 uint UPowerTooltip::updateTooltip(Devices& devices) {
   // Removes all old devices
   for (auto child : contentBox->get_children()) {
-    child->~Widget();
+    delete child;
   }
 
   uint deviceCount = 0;


### PR DESCRIPTION
To view the leak in the class build with

`meson -Dbuildtype=debug -Db_sanitize=address -Doptimization=g build`

And then run with

`ASAN_OPTIONS=detect_leaks=1 ./build/waybar --config=upower_config`

Let waybar run for a few minutes and then kill with CTRL-C

when the program is finished it will output a

```

=================================================================
==940640==ERROR: LeakSanitizer: detected memory leaks

```

which will have a section of


```

Direct leak of 9280 byte(s) in 116 object(s) allocated from:
    #0 0x5a54c8 in operator new(unsigned long) ($HOME/Downloads/Waybar-0.9.17/build/waybar+0x5a54c8) (BuildId: 49a838544ce922121a44b057290a7f693645b7d6)
    #1 0x7c9bfb in waybar::modules::upower::UPowerTooltip::updateTooltip(std::unordered_map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>, UpDevice*, std::hash<std::__cxx11::basic
_string<char, std::char_traits<char>, std::allocator<char>>>, std::equal_to<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, std::allocator<std::pair<std::__cxx11::basic_string<cha
r, std::char_traits<char>, std::allocator<char>> const, UpDevice*>>>&) $HOME/Downloads/Waybar-0.9.17/build/../src/modules/upower/upower_tooltip.cpp:43:21
    #2 0x7c380c in waybar::modules::upower::UPower::update() $HOME/Downloads/Waybar-0.9.17/build/../src/modules/upower/upower.cpp:313:41
    #3 0x63769d in waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Gtk::Box*)::$_0::operator()() const $HOME/Downloads/
Waybar-0.9.17/build/../src/bar.cpp:769:21
    #4 0x63769d in sigc::adaptor_functor<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Gtk::Box*)::$_0>::operator()() const
 /usr/include/sigc++-2.0/sigc++/adaptors/adaptor_trait.h:256:12
    #5 0x63769d in sigc::internal::slot_call0<waybar::Bar::getModules(waybar::Factory const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&, Gtk::Box*)::$_0, void>::call_it
(sigc::internal::slot_rep*) /usr/include/sigc++-2.0/sigc++/functors/slot.h:136:14
    #6 0x7f1ad24dd029 in Glib::DispatchNotifier::pipe_io_handler(Glib::IOCondition) (/lib64/libglibmm-2.4.so.1+0x5e029) (BuildId: 495541b077c0a2484cc909b0108aa29bf429f7fb)

```

showing that there's a leak at upower_tooltip.cpp:43:21

Rebuild with the change to delete the children and running the same will show the above leak report is no longer happening


(Note: AddressSanitizer's reporting only works when the program exits normally. Since SIGINT isn't handled it's leading to an abnormal exit. To aide in testing, I added an additional
signal handler, which in general should work as a generic way to safely shut down waybar)
