### PR TITLE
improve nix dev shell; override the nixpkgs waybar

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,13 @@
+(
+  import
+  (
+    builtins.fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
+      sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+    }
+  )
+  {
+    src = ./.;
+  }
+)
+.defaultNix

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,10 @@
-(
-  import
+(import
   (
-    builtins.fetchTarball {
-      url = "https://github.com/edolstra/flake-compat/archive/99f1c2157fba4bfe6211a321fd0ee43199025dbf.tar.gz";
-      sha256 = "0x2jn3vrawwv9xp15674wjz9pixwjyj3j771izayl962zziivbx2";
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
     }
   )
-  {
-    src = ./.;
-  }
-)
-.defaultNix
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -6,11 +6,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1667210711,
-        "narHash": "sha256-IoErjXZAkzYWHEpQqwu/DeRNJGFdR7X2OGbkhMqMrpw=",
+        "lastModified": 1676293499,
+        "narHash": "sha256-uIOTlTxvrXxpKeTvwBI1JGDGtCxMXE3BI0LFwoQMhiQ=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "96a9dd12b8a447840cc246e17a47b81a4268bba7",
+        "rev": "71e3022e3ab20bbf1342640547ef5bc14fb43bf4",
         "type": "github"
       },
       "original": {
@@ -36,11 +36,11 @@
     },
     "flake-utils_2": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -67,11 +67,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1670152712,
-        "narHash": "sha256-LJttwIvJqsZIj8u1LxVRv82vwUtkzVqQVi7Wb8gxPS4=",
+        "lastModified": 1676300157,
+        "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "14ddeaebcbe9a25748221d1d7ecdf98e20e2325e",
+        "rev": "545c7a31e5dedea4a6d372712a18e00ce097d462",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -19,6 +19,22 @@
         "type": "github"
       }
     },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1642700792,
@@ -84,6 +100,7 @@
     "root": {
       "inputs": {
         "devshell": "devshell",
+        "flake-compat": "flake-compat",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,9 +5,13 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     devshell.url = "github:numtide/devshell";
     flake-utils.url = "github:numtide/flake-utils";
+    flake-compat = {
+      url = "github:edolstra/flake-compat";
+      flake = false;
+    };
   };
 
-  outputs = { self, flake-utils, devshell, nixpkgs }:
+  outputs = { self, flake-utils, devshell, nixpkgs, flake-compat }:
     let
       inherit (nixpkgs) lib;
       genSystems = lib.genAttrs [

--- a/flake.nix
+++ b/flake.nix
@@ -55,9 +55,10 @@
             }
           ];
           devshell.packages = with pkgs; [
-            # from nativeBuildInputs
             clang-tools
             gdb
+            # from nativeBuildInputs
+            gnumake
             meson
             ninja
             pkg-config
@@ -74,19 +75,6 @@
             at-spi2-atk atkmm cairo cairomm catch2 fmt_8 fontconfig
             gdk-pixbuf glibmm gtk3 harfbuzz pango pangomm wayland-protocols
           ]);
-          language.c.libraries = with pkgs; [
-            # runtime dependencies (normally handled by patchElf)
-            bzip2 celt dbus expat flac fontconfig freetype fribidi glibc
-            graphite2 gtk3 howard-hinnant-date icu json-glib libGL
-            libasyncns libcap libdatrie libepoxy libffi libgcrypt
-            libgpg-error libgudev libjpeg libogg libopus libpng
-            libselinux libsndfile libthai libvorbis libwacom libxml2 lz4
-            mtdev pcre pcre2 pipewire pixman pulseaudio sndio sqlite
-            tracker util-linux xorg.libX11 xorg.libXau
-            xorg.libXcomposite xorg.libXcursor xorg.libXdmcp
-            xorg.libXext xorg.libXfixes xorg.libXi xorg.libXinerama
-            xorg.libXrandr xorg.libXrender xorg.libxcb xz zlib zstd
-          ];
           env = with pkgs; [
             { name = "CPLUS_INCLUDE_PATH"; prefix = "$DEVSHELL_DIR/include"; }
             { name = "PKG_CONFIG_PATH"; prefix = "$DEVSHELL_DIR/lib/pkgconfig"; }
@@ -95,7 +83,6 @@
             { name = "LIBRARY_PATH"; prefix = "${lib.getLib sndio}/lib"; }
             { name = "LIBRARY_PATH"; prefix = "${lib.getLib zlib}/lib"; }
             { name = "LIBRARY_PATH"; prefix = "${lib.getLib howard-hinnant-date}/lib"; }
-            { name = "LD_LIBRARY_PATH"; prefix = "${lib.getLib pulseaudio}/lib/pulseaudio"; }
           ];
         };
     });

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
           ] ++ (map lib.getDev [
             # from buildInputs
             wayland wlroots gtkmm3 libsigcxx jsoncpp spdlog gtk-layer-shell howard-hinnant-date libxkbcommon
-            # opttional dependencies
+            # optional dependencies
             gobject-introspection glib playerctl python3.pkgs.pygobject3
             libevdev libinput libjack2 libmpdclient playerctl libnl
             libpulseaudio sndio sway libdbusmenu-gtk3 udev upower wireplumber

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,60 +1,11 @@
 { lib
-, stdenv
-, fetchFromGitHub
-, meson
-, pkg-config
-, ninja
-, wrapGAppsHook
-, wayland
-, wlroots
-, gtkmm3
-, libsigcxx
-, jsoncpp
-, scdoc
-, spdlog
-, gtk-layer-shell
-, howard-hinnant-date
-, libinotify-kqueue
-, libxkbcommon
-, evdevSupport ? true
-, libevdev
-, inputSupport ? true
-, libinput
-, jackSupport ? true
-, libjack2
-, mpdSupport ? true
-, libmpdclient
-, nlSupport ? true
-, libnl
-, pulseSupport ? true
-, libpulseaudio
-, rfkillSupport ? true
-, runTests ? true
-, catch2_3
-, sndioSupport ? true
-, sndio
-, swaySupport ? true
-, sway
-, traySupport ? true
-, libdbusmenu-gtk3
-, udevSupport ? true
-, udev
-, upowerSupport ? true
-, upower
-, wireplumberSupport ? true
-, wireplumber
-, withMediaPlayer ? false
-, glib
-, gobject-introspection
-, python3
-, playerctl
+, waybar
 , version
 }:
 
-stdenv.mkDerivation rec {
-  pname = "waybar";
+waybar.overrideAttrs (prev: {
   inherit version;
-  # version = "0.9.16";
+  # version = "0.9.17";
 
   src = lib.cleanSourceWith {
     filter = name: type:
@@ -66,74 +17,4 @@ stdenv.mkDerivation rec {
         );
     src = lib.cleanSource ../.;
   };
-
-  nativeBuildInputs = [
-    meson
-    ninja
-    pkg-config
-    scdoc
-    wrapGAppsHook
-  ] ++ lib.optional withMediaPlayer gobject-introspection;
-
-  propagatedBuildInputs = lib.optionals withMediaPlayer [
-    glib
-    playerctl
-    python3.pkgs.pygobject3
-  ];
-  strictDeps = false;
-
-  buildInputs = with lib;
-    [ wayland wlroots gtkmm3 libsigcxx jsoncpp spdlog gtk-layer-shell howard-hinnant-date libxkbcommon ]
-    ++ optional (!stdenv.isLinux) libinotify-kqueue
-    ++ optional evdevSupport libevdev
-    ++ optional inputSupport libinput
-    ++ optional jackSupport libjack2
-    ++ optional mpdSupport libmpdclient
-    ++ optional nlSupport libnl
-    ++ optional pulseSupport libpulseaudio
-    ++ optional sndioSupport sndio
-    ++ optional swaySupport sway
-    ++ optional traySupport libdbusmenu-gtk3
-    ++ optional udevSupport udev
-    ++ optional upowerSupport upower
-    ++ optional wireplumberSupport wireplumber;
-
-  checkInputs = [ catch2_3 ];
-  doCheck = runTests;
-
-  mesonFlags = (lib.mapAttrsToList
-    (option: enable: "-D${option}=${if enable then "enabled" else "disabled"}")
-    {
-      dbusmenu-gtk = traySupport;
-      jack = jackSupport;
-      libinput = inputSupport;
-      libnl = nlSupport;
-      libudev = udevSupport;
-      mpd = mpdSupport;
-      pulseaudio = pulseSupport;
-      rfkill = rfkillSupport;
-      sndio = sndioSupport;
-      tests = runTests;
-      upower_glib = upowerSupport;
-      wireplumber = wireplumberSupport;
-    }
-  ) ++ [
-    "-Dsystemd=disabled"
-    "-Dgtk-layer-shell=enabled"
-    "-Dman-pages=enabled"
-  ];
-
-  preFixup = lib.optionalString withMediaPlayer ''
-    cp $src/resources/custom_modules/mediaplayer.py $out/bin/waybar-mediaplayer.py
-    wrapProgram $out/bin/waybar-mediaplayer.py \
-      --prefix PYTHONPATH : "$PYTHONPATH:$out/${python3.sitePackages}"
-  '';
-
-  meta = with lib; {
-    description = "Highly customizable Wayland bar for Sway and Wlroots based compositors";
-    license = licenses.mit;
-    maintainers = with maintainers; [ FlorianFranzen minijackson synthetica lovesegfault ];
-    platforms = platforms.unix;
-    homepage = "https://github.com/alexays/waybar";
-  };
-}
+})


### PR DESCRIPTION
Reason for overriding instead of keeping the full default.nix in-tree: for example, the update from 0.9.16 to 0.9.17 broke this flake because of the changed dependencies/build options, after this change the derivation will be the same as the nixpkgs one (provided the user sets `inputs.waybar.inputs.nixpkgs.follows = "nixpkgs"`). This is the better option since the flake is unmaintained in this repo (although it may still break between releases). If someone decides to start maintaining it, this can be easily reverted.

And the dev shell now allows traditional `make` workflow, as well as clangd integration, allowing nix users to easily setup a dev environment.