### PR TITLE
feat(sway): add workspace css class

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -231,6 +231,7 @@ auto Workspaces::update() -> void {
       box_.reorder_child(button, it - workspaces_.begin());
     }
     std::string output = (*it)["name"].asString();
+    button.get_style_context()->add_class("workspace-" + trimWorkspaceName(output));
     if (config_["format"].isString()) {
       auto format = config_["format"].asString();
       output = fmt::format(fmt::runtime(format), fmt::arg("icon", getIcon(output, *it)),


### PR DESCRIPTION
From what I can see, it is currently not possible to individually and consistently style workspace buttons using css (unless all workspaces are visible at all times such that `:nth-child` can be used). This PR adds a css class to every workspace button using the workspace name. This the allows to use selectors such as `#workspaces button.workspace-2.focused`.

### Notes
 - The css classes are not sanitized, special symbols have to be escaped by the user. For example, if my workspace has the name `"@x$ f"`, the selector is `.workspace-\@x\$\ f`.
 - The wiki would need to be updated.