### PR TITLE
ISSUE#1977. AModule implements module actions call

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -11,16 +11,20 @@ namespace waybar {
 
 class AModule : public IModule {
  public:
-  AModule(const Json::Value &, const std::string &, const std::string &, bool enable_click = false,
-          bool enable_scroll = false);
   virtual ~AModule();
   virtual auto update() -> void;
   virtual auto refresh(int) -> void{};
   virtual operator Gtk::Widget &();
+  virtual auto doAction(const std::string& name) -> void;
 
   Glib::Dispatcher dp;
 
  protected:
+  // Don't need to make an object directly
+  // Derived classes are able to use it
+  AModule(const Json::Value &, const std::string &, const std::string &, bool enable_click = false,
+          bool enable_scroll = false);
+
   enum SCROLL_DIR { NONE, UP, DOWN, LEFT, RIGHT };
 
   SCROLL_DIR getScrollDir(GdkEventScroll *e);
@@ -37,6 +41,7 @@ class AModule : public IModule {
   std::vector<int> pid_;
   gdouble distance_scrolled_y_;
   gdouble distance_scrolled_x_;
+  std::map<std::string, std::string> eventActionMap_;
   static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{
       {std::make_pair(1, GdkEventType::GDK_BUTTON_PRESS), "on-click"},
       {std::make_pair(1, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click"},

--- a/include/IModule.hpp
+++ b/include/IModule.hpp
@@ -9,6 +9,7 @@ class IModule {
   virtual ~IModule() = default;
   virtual auto update() -> void = 0;
   virtual operator Gtk::Widget&() = 0;
+  virtual auto doAction(const std::string& name) -> void = 0;
 };
 
 }  // namespace waybar

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -15,25 +15,25 @@ enum class WeeksSide {
   HIDDEN,
 };
 
-enum class CldMode { MONTH, YEAR };
+enum class CldMode {
+  MONTH,
+  YEAR
+};
 
-class Clock : public ALabel {
+class Clock final : public ALabel {
  public:
   Clock(const std::string&, const Json::Value&);
   ~Clock() = default;
   auto update() -> void;
+  auto doAction(const std::string& name) -> void override;
 
  private:
   util::SleeperThread thread_;
-  std::map<std::pair<uint, GdkEventType>, void (waybar::modules::Clock::*)()> eventMap_;
   std::locale locale_;
   std::vector<const date::time_zone*> time_zones_;
   int current_time_zone_idx_;
   bool is_calendar_in_tooltip_;
   bool is_timezoned_list_in_tooltip_;
-
-  bool handleScroll(GdkEventScroll* e);
-  bool handleToggle(GdkEventButton* const& e);
 
   auto first_day_of_week() -> date::weekday;
   const date::time_zone* current_timezone();
@@ -56,6 +56,20 @@ class Clock : public ALabel {
   /*Calendar functions*/
   auto get_calendar(const date::zoned_seconds& now, const date::zoned_seconds& wtime)
       -> std::string;
+  /*Clock actions*/
   void cldModeSwitch();
+  void cldShift_up();
+  void cldShift_down();
+  void tz_up();
+  void tz_down();
+
+  // ModuleActionMap
+  static inline std::map<const std::string, void(waybar::modules::Clock::* const)()> actionMap_{
+    {"mode", &waybar::modules::Clock::cldModeSwitch},
+    {"shift_up", &waybar::modules::Clock::cldShift_up},
+    {"shift_down", &waybar::modules::Clock::cldShift_down},
+    {"tz_up", &waybar::modules::Clock::tz_up},
+    {"tz_down", &waybar::modules::Clock::tz_down}
+  };
 };
 }  // namespace waybar::modules


### PR DESCRIPTION
Hi @Alexays 
This PR is based on the https://github.com/Alexays/Waybar/issues/1977
The main idea - to stop of the code duplication in every modules when the module has to extend it's functionality via internal module member-functions.
So
1. IModule interface is extended by the doAction method
2. AModule has got it's own base doAction:  1. defines internal mapping between event name and module action name. 2. Calls override doAction.
3. Each module can provide it's own doAction which actually calls internal module functionality. Module action name is provided through function parameter
4. If Module overrides doAction and implements all necessary functionality via member-functions and has got internal mapping ... it could drop override handleToggle and handleScroll methods.
---

Es an example... module Clock now provides all necessary functionality and implement doAction which provide to user an ability to redefine events for intenral actions.(If PR is OK, all actions will be described in WIKI)
```json
 "clock": {
        "format": "{:%H:%M}  ",
        "format-alt": "{:%A, %B %d, %Y (%R)}  ",
        "tooltip-format": "\n<small><tt>{calendar}</tt></small>",
        "calendar": {
                    "mode"          : "year",
                    "mode-mon-col"  : 3,
                    "weeks-pos"     : "right",
                    "on-scroll"     : 1,
                    "format": {
                              "months":     "<span color='#ffead3'><b>{}</b></span>",
                              "days":       "<span color='#ecc6d9'><b>{}</b></span>",
                              "weeks":      "<span color='#99ffdd'><b>W{}</b></span>",
                              "weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
                              "today":      "<span color='#ff6699'><b><u>{}</u></b></span>"
                              }
                    },
        "actions": {
                   "on-click-right": "mode",
                   "on-click-forward": "tz_up",
                   "on-click-backward": "tz_down",
                   "on-scroll-up": "shift_up",
                   "on-scroll-down": "shift_down"
                    }
```
So for now:

1. AModule is responsible for config parsing ("actions" section)
2. AModule handles users events (press buttons, wheel)
3. AModule when it needs calls module doAction in order to call module action
4. Clock got from the AModule which action should be executed
5. Clock defines internal function through function pointer and executes necessary functionality
---
This PR provides an opportunity to any module to focus on internal action implementation. And don't care about event functionality implementation via overriding of the handleToggle, handleScroll functions