### PR TITLE
Revert "feat(sway): add workspace css class"

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -231,7 +231,6 @@ auto Workspaces::update() -> void {
       box_.reorder_child(button, it - workspaces_.begin());
     }
     std::string output = (*it)["name"].asString();
-    button.get_style_context()->add_class("workspace-" + trimWorkspaceName(output));
     if (config_["format"].isString()) {
       auto format = config_["format"].asString();
       output = fmt::format(fmt::runtime(format), fmt::arg("icon", getIcon(output, *it)),


### PR DESCRIPTION
This reverts commit a10464d9bb67ba75d3c9159bd027b67a565318e1.

Reverts https://github.com/Alexays/Waybar/pull/2017

Well this is awkward. Turns out there was already an `id` called `sway-workspace-{name}`. My changes were not necessary. Sorry about that.