### PR TITLE
Clock tz try catch

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -22,11 +22,10 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
       is_timezoned_list_in_tooltip_(false) {
   if (config_["timezones"].isArray() && !config_["timezones"].empty()) {
     for (const auto& zone_name : config_["timezones"]) {
-      if (!zone_name.isString() || zone_name.asString().empty())
-        continue;
+      if (!zone_name.isString() || zone_name.asString().empty()) continue;
       try {
         time_zones_.push_back(date::locate_zone(zone_name.asString()));
-      } catch(const std::exception& e) {
+      } catch (const std::exception& e) {
         spdlog::warn("Timezone: {0}. {1}", zone_name.asString(), e.what());
       }
     }

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -22,14 +22,20 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
       is_timezoned_list_in_tooltip_(false) {
   if (config_["timezones"].isArray() && !config_["timezones"].empty()) {
     for (const auto& zone_name : config_["timezones"]) {
-      if (!zone_name.isString() || zone_name.asString().empty()) {
-        time_zones_.push_back(nullptr);
+      if (!zone_name.isString() || zone_name.asString().empty())
         continue;
+      try {
+        time_zones_.push_back(date::locate_zone(zone_name.asString()));
+      } catch(const std::exception& e) {
+        spdlog::warn("Timezone: {0}. {1}", zone_name.asString(), e.what());
       }
-      time_zones_.push_back(date::locate_zone(zone_name.asString()));
     }
   } else if (config_["timezone"].isString() && !config_["timezone"].asString().empty()) {
-    time_zones_.push_back(date::locate_zone(config_["timezone"].asString()));
+    try {
+      time_zones_.push_back(date::locate_zone(config_["timezone"].asString()));
+    } catch (const std::exception& e) {
+      spdlog::warn("Timezone: {0}. {1}", config_["timezone"].asString(), e.what());
+    }
   }
 
   // If all timezones are parsed and no one is good, add current time zone. nullptr in timezones


### PR DESCRIPTION
Hi @Alexays , this PR should (but not sure 😄  ) solve #878 . At least there's a potential issue: 
1. User defines timezones as an array
2. User defines timezone as a single value

In both cases there no any check to ensure timezone can be initialize properly. 

This PR does:
1. TZ initialization is wrapped into try catch. If there is an exception waybar prints it as a warning,
2. If array of necessary timezones is empty waybar tries to use default system timezone