### PR TITLE
Happy clang

### DIFF
--- a/include/AIconLabel.hpp
+++ b/include/AIconLabel.hpp
@@ -13,7 +13,7 @@ class AIconLabel : public ALabel {
              const std::string &format, uint16_t interval = 0, bool ellipsize = false,
              bool enable_click = false, bool enable_scroll = false);
   virtual ~AIconLabel() = default;
-  virtual auto update() -> void;
+  auto update() -> void override;
 
  protected:
   Gtk::Image image_;

--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -14,7 +14,7 @@ class ALabel : public AModule {
          uint16_t interval = 0, bool ellipsize = false, bool enable_click = false,
          bool enable_scroll = false);
   virtual ~ALabel() = default;
-  virtual auto update() -> void;
+  auto update() -> void override;
   virtual std::string getIcon(uint16_t, const std::string &alt = "", uint16_t max = 0);
   virtual std::string getIcon(uint16_t, const std::vector<std::string> &alts, uint16_t max = 0);
 
@@ -25,7 +25,7 @@ class ALabel : public AModule {
   bool alt_ = false;
   std::string default_format_;
 
-  virtual bool handleToggle(GdkEventButton *const &e);
+  bool handleToggle(GdkEventButton *const &e) override;
   virtual std::string getState(uint8_t value, bool lesser = false);
 };
 

--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -12,10 +12,10 @@ namespace waybar {
 class AModule : public IModule {
  public:
   virtual ~AModule();
-  virtual auto update() -> void;
+  auto update() -> void override;
   virtual auto refresh(int) -> void{};
-  virtual operator Gtk::Widget &();
-  virtual auto doAction(const std::string& name) -> void;
+  operator Gtk::Widget &() override;
+  auto doAction(const std::string& name) -> void override;
 
   Glib::Dispatcher dp;
 

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -14,8 +14,8 @@ class Group : public AModule {
  public:
   Group(const std::string&, const Bar&, const Json::Value&);
   ~Group() = default;
-  auto update() -> void;
-  operator Gtk::Widget&();
+  auto update() -> void override;
+  operator Gtk::Widget&() override;
   Gtk::Box box;
 };
 

--- a/include/modules/backlight.hpp
+++ b/include/modules/backlight.hpp
@@ -40,8 +40,8 @@ class Backlight : public ALabel {
 
  public:
   Backlight(const std::string &, const Json::Value &);
-  ~Backlight();
-  auto update() -> void;
+  virtual ~Backlight();
+  auto update() -> void override;
 
  private:
   template <class ForwardIt>
@@ -51,7 +51,7 @@ class Backlight : public ALabel {
   template <class ForwardIt, class Inserter>
   static void enumerate_devices(ForwardIt first, ForwardIt last, Inserter inserter, udev *udev);
 
-  bool handleScroll(GdkEventScroll *e);
+  bool handleScroll(GdkEventScroll *e) override;
 
   const std::string preferred_device_;
   static constexpr int EPOLL_MAX_EVENTS = 16;

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -29,8 +29,8 @@ namespace fs = std::filesystem;
 class Battery : public ALabel {
  public:
   Battery(const std::string&, const Json::Value&);
-  ~Battery();
-  auto update() -> void;
+  virtual ~Battery();
+  auto update() -> void override;
 
  private:
   static inline const fs::path data_dir_ = "/sys/class/power_supply/";

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -45,8 +45,8 @@ class Bluetooth : public ALabel {
 
  public:
   Bluetooth(const std::string&, const Json::Value&);
-  ~Bluetooth() = default;
-  auto update() -> void;
+  virtual ~Bluetooth() = default;
+  auto update() -> void override;
 
  private:
   static auto onInterfaceAddedOrRemoved(GDBusObjectManager*, GDBusObject*, GDBusInterface*,

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -23,8 +23,8 @@ enum class CldMode {
 class Clock final : public ALabel {
  public:
   Clock(const std::string&, const Json::Value&);
-  ~Clock() = default;
-  auto update() -> void;
+  virtual ~Clock() = default;
+  auto update() -> void override;
   auto doAction(const std::string& name) -> void override;
 
  private:

--- a/include/modules/cpu.hpp
+++ b/include/modules/cpu.hpp
@@ -17,8 +17,8 @@ namespace waybar::modules {
 class Cpu : public ALabel {
  public:
   Cpu(const std::string&, const Json::Value&);
-  ~Cpu() = default;
-  auto update() -> void;
+  virtual ~Cpu() = default;
+  auto update() -> void override;
 
  private:
   double getCpuLoad();

--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -15,9 +15,9 @@ namespace waybar::modules {
 class Custom : public ALabel {
  public:
   Custom(const std::string&, const std::string&, const Json::Value&);
-  ~Custom();
-  auto update() -> void;
-  void refresh(int /*signal*/);
+  virtual ~Custom();
+  auto update() -> void override;
+  void refresh(int /*signal*/) override;
 
  private:
   void delayWorker();
@@ -25,8 +25,8 @@ class Custom : public ALabel {
   void parseOutputRaw();
   void parseOutputJson();
   void handleEvent();
-  bool handleScroll(GdkEventScroll* e);
-  bool handleToggle(GdkEventButton* const& e);
+  bool handleScroll(GdkEventScroll* e) override;
+  bool handleToggle(GdkEventButton* const& e) override;
 
   const std::string name_;
   std::string text_;

--- a/include/modules/disk.hpp
+++ b/include/modules/disk.hpp
@@ -14,8 +14,8 @@ namespace waybar::modules {
 class Disk : public ALabel {
  public:
   Disk(const std::string&, const Json::Value&);
-  ~Disk() = default;
-  auto update() -> void;
+  virtual ~Disk() = default;
+  auto update() -> void override;
 
  private:
   util::SleeperThread thread_;

--- a/include/modules/gamemode.hpp
+++ b/include/modules/gamemode.hpp
@@ -18,8 +18,8 @@ namespace waybar::modules {
 class Gamemode : public AModule {
  public:
   Gamemode(const std::string &, const Json::Value &);
-  ~Gamemode();
-  auto update() -> void;
+  virtual ~Gamemode();
+  auto update() -> void override;
 
  private:
   const std::string DEFAULT_ICON_NAME = "input-gaming-symbolic";
@@ -39,7 +39,7 @@ class Gamemode : public AModule {
                  const Glib::VariantContainerBase &arguments);
 
   void getData();
-  bool handleToggle(GdkEventButton *const &);
+  bool handleToggle(GdkEventButton *const &) override;
 
   // Config
   std::string format = DEFAULT_FORMAT;

--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -10,12 +10,12 @@ namespace waybar::modules::hyprland {
 class Language : public waybar::ALabel, public EventHandler {
  public:
   Language(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Language();
+  virtual ~Language();
 
-  auto update() -> void;
+  auto update() -> void override;
 
  private:
-  void onEvent(const std::string&);
+  void onEvent(const std::string&) override;
 
   void initLanguage();
   std::string getShortFrom(const std::string&);

--- a/include/modules/hyprland/submap.hpp
+++ b/include/modules/hyprland/submap.hpp
@@ -10,12 +10,12 @@ namespace waybar::modules::hyprland {
 class Submap : public waybar::ALabel, public EventHandler {
  public:
   Submap(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Submap();
+  virtual ~Submap();
 
-  auto update() -> void;
+  auto update() -> void override;
 
  private:
-  void onEvent(const std::string&);
+  void onEvent(const std::string&) override;
 
   std::mutex mutex_;
   const Bar& bar_;

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -12,14 +12,14 @@ namespace waybar::modules::hyprland {
 class Window : public waybar::ALabel, public EventHandler {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Window();
+  virtual ~Window();
 
-  auto update() -> void;
+  auto update() -> void override;
 
  private:
   int getActiveWorkspaceID(std::string);
   std::string getLastWindowTitle(int);
-  void onEvent(const std::string&);
+  void onEvent(const std::string&) override;
 
   bool separate_outputs;
   std::mutex mutex_;

--- a/include/modules/idle_inhibitor.hpp
+++ b/include/modules/idle_inhibitor.hpp
@@ -13,13 +13,13 @@ class IdleInhibitor : public ALabel {
 
  public:
   IdleInhibitor(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~IdleInhibitor();
-  auto update() -> void;
+  virtual ~IdleInhibitor();
+  auto update() -> void override;
   static std::list<waybar::AModule*> modules;
   static bool status;
 
  private:
-  bool handleToggle(GdkEventButton* const& e);
+  bool handleToggle(GdkEventButton* const& e) override;
   void toggleStatus();
 
   const Bar& bar_;

--- a/include/modules/image.hpp
+++ b/include/modules/image.hpp
@@ -17,8 +17,9 @@ namespace waybar::modules {
 class Image : public AModule {
  public:
   Image(const std::string&, const Json::Value&);
-  auto update() -> void;
-  void refresh(int /*signal*/);
+  virtual ~Image() = default;
+  auto update() -> void override;
+  void refresh(int /*signal*/) override;
 
  private:
   void delayWorker();

--- a/include/modules/inhibitor.hpp
+++ b/include/modules/inhibitor.hpp
@@ -12,12 +12,12 @@ namespace waybar::modules {
 class Inhibitor : public ALabel {
  public:
   Inhibitor(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Inhibitor() override;
-  auto update() -> void;
+  virtual ~Inhibitor();
+  auto update() -> void override;
   auto activated() -> bool;
 
  private:
-  auto handleToggle(::GdkEventButton* const& e) -> bool;
+  auto handleToggle(::GdkEventButton* const& e) -> bool override;
 
   const std::unique_ptr<::GDBusConnection, void (*)(::GDBusConnection*)> dbus_;
   const std::string inhibitors_;

--- a/include/modules/jack.hpp
+++ b/include/modules/jack.hpp
@@ -14,8 +14,8 @@ namespace waybar::modules {
 class JACK : public ALabel {
  public:
   JACK(const std::string &, const Json::Value &);
-  ~JACK() = default;
-  auto update() -> void;
+  virtual ~JACK() = default;
+  auto update() -> void override;
 
   int bufSize(jack_nframes_t size);
   int sampleRate(jack_nframes_t rate);

--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -19,8 +19,8 @@ namespace waybar::modules {
 class KeyboardState : public AModule {
  public:
   KeyboardState(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~KeyboardState();
-  auto update() -> void;
+  virtual ~KeyboardState();
+  auto update() -> void override;
 
  private:
   auto tryAddDevice(const std::string&) -> void;

--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -13,8 +13,8 @@ namespace waybar::modules {
 class Memory : public ALabel {
  public:
   Memory(const std::string&, const Json::Value&);
-  ~Memory() = default;
-  auto update() -> void;
+  virtual ~Memory() = default;
+  auto update() -> void override;
 
  private:
   void parseMeminfo();

--- a/include/modules/mpd/mpd.hpp
+++ b/include/modules/mpd/mpd.hpp
@@ -37,7 +37,7 @@ class MPD : public ALabel {
  public:
   MPD(const std::string&, const Json::Value&);
   virtual ~MPD() noexcept = default;
-  auto update() -> void;
+  auto update() -> void override;
 
  private:
   std::string getTag(mpd_tag_type type, unsigned idx = 0) const;

--- a/include/modules/mpris/mpris.hpp
+++ b/include/modules/mpris/mpris.hpp
@@ -19,9 +19,9 @@ namespace waybar::modules::mpris {
 class Mpris : public AModule {
  public:
   Mpris(const std::string&, const Json::Value&);
-  ~Mpris();
-  auto update() -> void;
-  bool handleToggle(GdkEventButton* const&);
+  virtual ~Mpris();
+  auto update() -> void override;
+  bool handleToggle(GdkEventButton* const&) override;
 
  private:
   static auto onPlayerNameAppeared(PlayerctlPlayerManager*, PlayerctlPlayerName*, gpointer) -> void;

--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -21,8 +21,8 @@ namespace waybar::modules {
 class Network : public ALabel {
  public:
   Network(const std::string&, const Json::Value&);
-  ~Network();
-  auto update() -> void;
+  virtual ~Network();
+  auto update() -> void override;
 
  private:
   static const uint8_t MAX_RETRY = 5;

--- a/include/modules/pulseaudio.hpp
+++ b/include/modules/pulseaudio.hpp
@@ -14,8 +14,8 @@ namespace waybar::modules {
 class Pulseaudio : public ALabel {
  public:
   Pulseaudio(const std::string&, const Json::Value&);
-  ~Pulseaudio();
-  auto update() -> void;
+  virtual ~Pulseaudio();
+  auto update() -> void override;
 
  private:
   static void subscribeCb(pa_context*, pa_subscription_event_type_t, uint32_t, void*);
@@ -25,7 +25,7 @@ class Pulseaudio : public ALabel {
   static void serverInfoCb(pa_context*, const pa_server_info*, void*);
   static void volumeModifyCb(pa_context*, int, void*);
 
-  bool handleScroll(GdkEventScroll* e);
+  bool handleScroll(GdkEventScroll* e) override;
   const std::vector<std::string> getPulseIcon() const;
 
   pa_threaded_mainloop* mainloop_;

--- a/include/modules/river/layout.hpp
+++ b/include/modules/river/layout.hpp
@@ -11,7 +11,7 @@ namespace waybar::modules::river {
 class Layout : public waybar::ALabel {
  public:
   Layout(const std::string &, const waybar::Bar &, const Json::Value &);
-  ~Layout();
+  virtual ~Layout();
 
   // Handlers for wayland events
   void handle_name(const char *name);

--- a/include/modules/river/mode.hpp
+++ b/include/modules/river/mode.hpp
@@ -11,7 +11,7 @@ namespace waybar::modules::river {
 class Mode : public waybar::ALabel {
  public:
   Mode(const std::string &, const waybar::Bar &, const Json::Value &);
-  ~Mode();
+  virtual ~Mode();
 
   // Handlers for wayland events
   void handle_mode(const char *mode);

--- a/include/modules/river/tags.hpp
+++ b/include/modules/river/tags.hpp
@@ -14,7 +14,7 @@ namespace waybar::modules::river {
 class Tags : public waybar::AModule {
  public:
   Tags(const std::string &, const waybar::Bar &, const Json::Value &);
-  ~Tags();
+  virtual ~Tags();
 
   // Handlers for wayland events
   void handle_focused_tags(uint32_t tags);

--- a/include/modules/river/window.hpp
+++ b/include/modules/river/window.hpp
@@ -13,7 +13,7 @@ namespace waybar::modules::river {
 class Window : public waybar::ALabel {
  public:
   Window(const std::string &, const waybar::Bar &, const Json::Value &);
-  ~Window();
+  virtual ~Window();
 
   // Handlers for wayland events
   void handle_focused_view(const char *title);

--- a/include/modules/simpleclock.hpp
+++ b/include/modules/simpleclock.hpp
@@ -10,8 +10,8 @@ namespace waybar::modules {
 class Clock : public ALabel {
  public:
   Clock(const std::string&, const Json::Value&);
-  ~Clock() = default;
-  auto update() -> void;
+  virtual ~Clock() = default;
+  auto update() -> void override;
 
  private:
   util::SleeperThread thread_;

--- a/include/modules/sndio.hpp
+++ b/include/modules/sndio.hpp
@@ -12,12 +12,12 @@ namespace waybar::modules {
 class Sndio : public ALabel {
  public:
   Sndio(const std::string &, const Json::Value &);
-  ~Sndio();
-  auto update() -> void;
+  virtual ~Sndio();
+  auto update() -> void override;
   auto set_desc(struct sioctl_desc *, unsigned int) -> void;
   auto put_val(unsigned int, unsigned int) -> void;
-  bool handleScroll(GdkEventScroll *);
-  bool handleToggle(GdkEventButton *const &);
+  bool handleScroll(GdkEventScroll *) override;
+  bool handleToggle(GdkEventButton *const &) override;
 
  private:
   auto connect_to_sndio() -> void;

--- a/include/modules/sni/tray.hpp
+++ b/include/modules/sni/tray.hpp
@@ -13,8 +13,8 @@ namespace waybar::modules::SNI {
 class Tray : public AModule {
  public:
   Tray(const std::string&, const Bar&, const Json::Value&);
-  ~Tray() = default;
-  auto update() -> void;
+  virtual ~Tray() = default;
+  auto update() -> void override;
 
  private:
   void onAdd(std::unique_ptr<Item>& item);

--- a/include/modules/sway/language.hpp
+++ b/include/modules/sway/language.hpp
@@ -17,8 +17,8 @@ namespace waybar::modules::sway {
 class Language : public ALabel, public sigc::trackable {
  public:
   Language(const std::string& id, const Json::Value& config);
-  ~Language() = default;
-  auto update() -> void;
+  virtual ~Language() = default;
+  auto update() -> void override;
 
  private:
   enum class DispayedShortFlag { None = 0, ShortName = 1, ShortDescription = 1 << 1 };

--- a/include/modules/sway/mode.hpp
+++ b/include/modules/sway/mode.hpp
@@ -13,8 +13,8 @@ namespace waybar::modules::sway {
 class Mode : public ALabel, public sigc::trackable {
  public:
   Mode(const std::string&, const Json::Value&);
-  ~Mode() = default;
-  auto update() -> void;
+  virtual ~Mode() = default;
+  auto update() -> void override;
 
  private:
   void onEvent(const struct Ipc::ipc_response&);

--- a/include/modules/sway/scratchpad.hpp
+++ b/include/modules/sway/scratchpad.hpp
@@ -15,8 +15,8 @@ namespace waybar::modules::sway {
 class Scratchpad : public ALabel {
  public:
   Scratchpad(const std::string&, const Json::Value&);
-  ~Scratchpad() = default;
-  auto update() -> void;
+  virtual ~Scratchpad() = default;
+  auto update() -> void override;
 
  private:
   auto getTree() -> void;

--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -15,8 +15,8 @@ namespace waybar::modules::sway {
 class Window : public AIconLabel, public sigc::trackable {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Window() = default;
-  auto update() -> void;
+  virtual ~Window() = default;
+  auto update() -> void override;
 
  private:
   void setClass(std::string classname, bool enable);

--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -18,8 +18,8 @@ namespace waybar::modules::sway {
 class Workspaces : public AModule, public sigc::trackable {
  public:
   Workspaces(const std::string&, const waybar::Bar&, const Json::Value&);
-  ~Workspaces() = default;
-  auto update() -> void;
+  virtual ~Workspaces() = default;
+  auto update() -> void override;
 
  private:
   static constexpr std::string_view workspace_switch_cmd_ = "workspace {} \"{}\"";
@@ -37,7 +37,7 @@ class Workspaces : public AModule, public sigc::trackable {
   const std::string getCycleWorkspace(std::vector<Json::Value>::iterator, bool prev) const;
   uint16_t getWorkspaceIndex(const std::string& name) const;
   std::string trimWorkspaceName(std::string);
-  bool handleScroll(GdkEventScroll*);
+  bool handleScroll(GdkEventScroll*) override;
 
   const Bar& bar_;
   std::vector<Json::Value> workspaces_;

--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -12,8 +12,8 @@ namespace waybar::modules {
 class Temperature : public ALabel {
  public:
   Temperature(const std::string&, const Json::Value&);
-  ~Temperature() = default;
-  auto update() -> void;
+  virtual ~Temperature() = default;
+  auto update() -> void override;
 
  private:
   float getTemperature();

--- a/include/modules/upower/upower.hpp
+++ b/include/modules/upower/upower.hpp
@@ -19,8 +19,8 @@ namespace waybar::modules::upower {
 class UPower : public AModule {
  public:
   UPower(const std::string &, const Json::Value &);
-  ~UPower();
-  auto update() -> void;
+  virtual ~UPower();
+  auto update() -> void override;
 
  private:
   typedef std::unordered_map<std::string, UpDevice *> Devices;
@@ -45,7 +45,7 @@ class UPower : public AModule {
   void resetDevices();
   void removeDevices();
   bool show_tooltip_callback(int, int, bool, const Glib::RefPtr<Gtk::Tooltip> &tooltip);
-  bool handleToggle(GdkEventButton *const &);
+  bool handleToggle(GdkEventButton *const &) override;
   std::string timeToString(gint64 time);
 
   const std::string getDeviceStatus(UpDeviceState &state);

--- a/include/modules/upower/upower_tooltip.hpp
+++ b/include/modules/upower/upower_tooltip.hpp
@@ -24,7 +24,7 @@ class UPowerTooltip : public Gtk::Window {
 
  public:
   UPowerTooltip(uint iconSize, uint tooltipSpacing, uint tooltipPadding);
-  ~UPowerTooltip();
+  virtual ~UPowerTooltip();
 
   uint updateTooltip(Devices& devices);
 };

--- a/include/modules/user.hpp
+++ b/include/modules/user.hpp
@@ -11,8 +11,8 @@ namespace waybar::modules {
 class User : public AIconLabel {
  public:
   User(const std::string&, const Json::Value&);
-  ~User() = default;
-  auto update() -> void;
+  virtual ~User() = default;
+  auto update() -> void override;
 
   bool handleToggle(GdkEventButton* const& e) override;
 

--- a/include/modules/wireplumber.hpp
+++ b/include/modules/wireplumber.hpp
@@ -13,8 +13,8 @@ namespace waybar::modules {
 class Wireplumber : public ALabel {
  public:
   Wireplumber(const std::string&, const Json::Value&);
-  ~Wireplumber();
-  auto update() -> void;
+  virtual ~Wireplumber();
+  auto update() -> void override;
 
  private:
   void loadRequiredApiModules();


### PR DESCRIPTION
Hi @Alexays , the goal of this PR is to:
1. Reduce warnings during clang compiling
2. To bring more order into code

Some points here:
1. According general useful recommendations when we have a deal with the inheritance, destructors in derived classes should be marked as virtual
2. Virtual methods on the most base classes should be marked as virtuals
3. Methods of derived classes should me marked as override

This PR quite huge but should impact any functionality. 