### PR TITLE
[WIP] Sway workspaces: Configure output from which workspaces are shown

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -30,6 +30,7 @@ class Workspaces : public AModule, public sigc::trackable {
 
   void onCmd(const struct Ipc::ipc_response&);
   void onEvent(const struct Ipc::ipc_response&);
+  bool isShown(const Json::Value&);
   bool filterButtons();
   Gtk::Button& addButton(const Json::Value&);
   void onButtonReady(const Json::Value&, Gtk::Button&);


### PR DESCRIPTION
This change allows configuring a sway workspaces module that only shows workspaces from one specific output, even if it's not the current output.

## Use Case

My use case is that I have 3 monitors but only one bar on one of the monitors. That bar shows all workspaces, but to have it organized better, I wanted to visually differentiate 3 workspace groups so that it is easily identifiable what workspace is on what output. I have 3 workspace modules configured something like this:

```json
    "sway/workspaces#out1": { 
        "for-output": "DP-2"
    },
    "sway/workspaces#out2": {
        "for-output": "HDMI-A-1"
    },
    "sway/workspaces#out3": {
        "for-output": "DP-1"
    },
```

This style gives each group a different underline color:

```css
#workspaces.out1 button {
    box-shadow: inset 0 -3px #dc0024;
}

#workspaces.out2 button {
    box-shadow: inset 0 -3px #00b41e;
}   

#workspaces.out3 button {
    box-shadow: inset 0 -3px #dcdc00;
}
```
### Screenshot
![workspaces](https://user-images.githubusercontent.com/26202156/222985162-87abf96f-c424-4878-9eb4-b194f8ab4367.png)

## Further comments

If there is a desire to include this feature, then there probably is a bit more to be done before it can be merged:

* Documentation
* Possibly the same in other workspace modules, not just sway (where would that apply?)

Finally, I'm not that experienced with C++, so if you take issue with anything I've written, don't hesitate to say so.