### PR TITLE
fix: mpd bug paused with no song.

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -122,7 +122,10 @@ void waybar::modules::MPD::setLabel() {
   std::chrono::seconds elapsedTime, totalTime;
 
   std::string stateIcon = "";
-  if (stopped()) {
+  bool no_song = song_.get() == nullptr;
+  if (stopped() || no_song ) {
+    if (no_song)
+      spdlog::warn("Bug in mpd: no current song but state is not stopped.");
     format =
         config_["format-stopped"].isString() ? config_["format-stopped"].asString() : "stopped";
     label_.get_style_context()->add_class("stopped");


### PR DESCRIPTION
Mpd can report a status of playing when no song is playing.

Env:
- mopidy 3.4.1/ mopidy-mpd 3.3.0

`mpc` shows
```shell
warning: MPD 0.21 required
[paused]  #0/0   0:00/0:00 (0%)
volume:100%   repeat: off   random: off   single: off   consume: off
```

This is almost certainly a bug in `mopidy-mpd` or `libmpdclient`.  But it's trivial to work around here, and might be affecting other users.

Unfortunately I can't reproduce it reliably, but if it happens at all it happens when I've never played anything from mopidy.

Closes #2045