### PR TITLE
config:output:Allow multiple exclusions & wildcard

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,4 +29,4 @@ jobs:
       - name: build
         run: ninja -C build
       - name: test
-        run: meson test -C build --no-rebuild --verbose --suite waybar
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,9 @@ run: build
 debug-run: build-debug
 	./build/waybar --log-level debug
 
+test:
+	meson test -C build --no-rebuild --verbose --suite waybar
+.PHONY: test
+
 clean:
 	rm -rf build

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -30,6 +30,7 @@ Also a minimal example configuration can be found on the at the bottom of this m
 *output* ++
 	typeof: string|array ++
 	Specifies on which screen this bar will be displayed. Exclamation mark(*!*) can be used to exclude specific output.
+	In an array, star '*\**' can be used at the end to accept all outputs, in case all previous entries are exclusions.
 
 *position* ++
 	typeof: string ++

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -124,9 +124,21 @@ bool isValidOutput(const Json::Value &config, const std::string &name,
                    const std::string &identifier) {
   if (config["output"].isArray()) {
     for (auto const &output_conf : config["output"]) {
-      if (output_conf.isString() &&
-          (output_conf.asString() == name || output_conf.asString() == identifier)) {
-        return true;
+      if (output_conf.isString()) {
+        auto config_output = output_conf.asString();
+        if (config_output.substr(0, 1) == "!") {
+          if (config_output.substr(1) == name || config_output.substr(1) == identifier) {
+            return false;
+          } else {
+            continue;
+          }
+        }
+        if (config_output == name || config_output == identifier) {
+          return true;
+        }
+        if (config_output.substr(0, 1) == "*") {
+          return true;
+        }
       }
     }
     return false;

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -31,7 +31,7 @@ TEST_CASE("Load config with multiple bars", "[config]") {
 
   SECTION("select multiple configs #1") {
     auto data = conf.getOutputConfigs("DP-0", "Fake DisplayPort output #0");
-    REQUIRE(data.size() == 3);
+    REQUIRE(data.size() == 4);
     REQUIRE(data[0]["layer"].asString() == "bottom");
     REQUIRE(data[0]["height"].asInt() == 20);
     REQUIRE(data[1]["layer"].asString() == "top");
@@ -40,6 +40,7 @@ TEST_CASE("Load config with multiple bars", "[config]") {
     REQUIRE(data[2]["layer"].asString() == "overlay");
     REQUIRE(data[2]["position"].asString() == "right");
     REQUIRE(data[2]["height"].asInt() == 23);
+    REQUIRE(data[3]["height"].asInt() == 24);
   }
   SECTION("select multiple configs #2") {
     auto data = conf.getOutputConfigs("HDMI-0", "Fake HDMI output #0");

--- a/test/config/multi.json
+++ b/test/config/multi.json
@@ -21,5 +21,9 @@
     "layer": "overlay",
     "height": 23,
     "output": "!HDMI-1"
+  },
+  {
+    "height": 24,
+    "output": ["!HDMI-0", "!HDMI-1", "*"]
   }
 ]


### PR DESCRIPTION
As described in 90206f55be01c12be9c1b239b54bc3b346821742:

Covers the use case where needing to exclude more than 1 output but still include all other displays.

e.g. I have 3 monitors: laptop + HD + 4K; and 3 bar types:
- The main bar is on the laptop. `output: "laptop-monitor-id"`
- The 4K has a specific waybar bar-1 configuration. `output: "4K-monitor-id"`
- I want all other displays (3rd HD monitor / any HDMI output when presenting) to have a plain bar: `output: ["!laptop-monitor-id", "!4k-monitor-id", "*"]`

### Testing done
Added tests in the code and tried with an updated CSS:

```css
/* 4K screen */
.4k * {
    font-size: initial;
    background: pink;
}
```
The laptop on the right has the extra modules, the 4K screen in the middle is pink, the HD screen (and hopefully any other screen) displays the workspaces & date

![image](https://user-images.githubusercontent.com/54000402/224585860-282cb4d9-185d-4c7f-adfa-c0c873890110.png)

### Note

If the star `'*'` is added anywhere before the end in the array, all other outputs will be ignored