### PR TITLE
fix(mpris): omit empty values in dynamic format

### DIFF
--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -338,10 +338,10 @@ auto Mpris::update() -> void {
   // dynamic is the auto-formatted string containing a nice out-of-the-box
   // format text
   std::stringstream dynamic;
-  if (info.artist) dynamic << *info.artist << " - ";
-  if (info.album) dynamic << *info.album << " - ";
-  if (info.title) dynamic << *info.title;
-  if (info.length)
+  if (info.artist && !info.artist.value().empty()) dynamic << *info.artist << " - ";
+  if (info.album && !info.album.value().empty()) dynamic << *info.album << " - ";
+  if (info.title && !info.title.value().empty()) dynamic << *info.title;
+  if (info.length && !info.length.value().empty())
     dynamic << " "
             << "<small>"
             << "[" << *info.length << "]"


### PR DESCRIPTION
Add emptiness check to the concatenation of the `dynamic` format replacement. 

Before:

![image](https://user-images.githubusercontent.com/32458727/225706050-0d2f7b8c-3943-49b4-87f9-2793c3fdd9bf.png)

After:

![image](https://user-images.githubusercontent.com/32458727/225706298-20246a34-9d81-46f7-9035-52dda51d929e.png)

In `playerctl`:

```console
$ playerctl metadata
firefox mpris:trackid             '/org/mpris/MediaPlayer2/firefox'
firefox xesam:title               Susumu Hirasawa - The Girl In Byakkoya
firefox xesam:album
firefox xesam:artist              Crizz Boi
```

I am not a C++ developer, please let me know if it is not the idiomatic approach. :slightly_smiling_face:

Fixes #1953