### PR TITLE
custom module: free memory returned by libc's getline

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -88,6 +88,7 @@ void waybar::modules::Custom::continuousWorker() {
       output_ = {0, output};
       dp.emit();
     }
+    free(buff);
   };
 }
 


### PR DESCRIPTION
This fixes a memory leak I've been experiencing for quite some time.