### PR TITLE
modules/clock: fix calendar shift in months with 31 days

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -162,6 +162,9 @@ auto waybar::modules::Clock::update() -> void {
   auto ztime = date::zoned_time{time_zone, date::floor<std::chrono::seconds>(now)};
 
   auto shifted_date = date::year_month_day{date::floor<date::days>(now)} + cldCurrShift_;
+  if (cldCurrShift_.count()) {
+    shifted_date = date::year_month_day(shifted_date.year(), shifted_date.month(), date::day(1));
+  }
   auto now_shifted = date::sys_days{shifted_date} + (now - date::floor<date::days>(now));
   auto shifted_ztime = date::zoned_time{time_zone, date::floor<std::chrono::seconds>(now_shifted)};
 


### PR DESCRIPTION
**Reproducer:** set the date to 31 March 2023, try scrolling the calendar (`"on-scroll-up": "shift_down"`, ...)
**Expected:** All months
**Actual:** Months with 31 days only

Debug print shows `2023-02-31 is not a valid year_month_day`

In this MR I set day to 1 if shit is not zero to fix this.