### PR TITLE
Display battery percentage as weighted average of battery levels

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -533,6 +533,13 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       }
     }
 
+    // Handle weighted-average
+    if ((config_["weighted-average"].isBool() ? config_["weighted-average"].asBool() : false) &&
+        total_energy_exists && total_energy_full_exists) {
+      if (total_energy_full > 0.0f)
+        calculated_capacity = ((float)total_energy * 100.0f / (float)total_energy_full);
+    }
+
     // Handle design-capacity
     if ((config_["design-capacity"].isBool() ? config_["design-capacity"].asBool() : false) &&
         total_energy_exists && total_energy_full_design_exists) {


### PR DESCRIPTION
A few days ago, I opened issue #2126 requesting this feature. I had some free time recently and decided to try making a pull request. I determined that weighted average of percentages with capacities as weights was a little complex, and that a better way to calculate the percentage that I wanted would be to just compute total_energy * 100 / total_energy_full. No change is required for the condition where the user sets design-capacity to true, as that is already total_energy * 100 / total_energy_full_design.

Right now, the option to enable this is called weighted-average. Is that an appropriate name, or should I call it something else?

Additionally, I discovered that it total_capacity is not greater than zero, Waybar already falls back to doing this calculation. (And still would, even if weighted-average is set to false.) However, it does not fall back if total_capacity could not be calculated at all. Is this the intended behavior? I have a feeling that the following code a few lines before my changes:
```
if (total_capacity_exists) {
  if (total_capacity > 0.0f)
    calculated_capacity = (float)total_capacity / batteries_.size();
  else if (total_energy_full_exists && total_energy_exists) {
    if (total_energy_full > 0.0f)
      calculated_capacity = ((float)total_energy * 100.0f / (float)total_energy_full);
  }
}
```
should have been this:
```
if (total_capacity_exists && total_capacity > 0.0f) {
  calculated_capacity = (float)total_capacity / batteries_.size();
} else if (total_energy_full_exists && total_energy_exists) {
  if (total_energy_full > 0.0f)
    calculated_capacity = ((float)total_energy * 100.0f / (float)total_energy_full);
}
```
but I wasn't quite confident enough to make the change myself. Is that correct?