### PR TITLE
Fix hyprland language initialization problem

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -145,9 +145,8 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
   memset(&ai_hints, 0, sizeof(struct addrinfo));
   ai_hints.ai_family = AF_UNSPEC;
   ai_hints.ai_socktype = SOCK_STREAM;
-  const auto SERVER = getaddrinfo("localhost", NULL, &ai_hints, &ai_res);
 
-  if (!SERVER) {
+  if (getaddrinfo("localhost", NULL, &ai_hints, &ai_res) != 0) {
     spdlog::error("Hyprland IPC: Couldn't get host (2)");
     return "";
   }


### PR DESCRIPTION
The return value check of `getaddrinfo` call was incorrect since it returns `0` on success as mentioned here: https://www.man7.org/linux/man-pages/man3/getaddrinfo.3.html#RETURN_VALUE. This fixes the initialization problem of Hyprland language module.

Also, I removed caching the result into the variable `SERVER` since it's not used anywhere down below.