### PR TITLE
cava: shared library is not found

### DIFF
--- a/Dockerfiles/gentoo
+++ b/Dockerfiles/gentoo
@@ -8,4 +8,4 @@ RUN export FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox -sandbox -usersa
 		emerge --verbose --update --deep --with-bdeps=y --backtrack=30 --newuse @world && \
 		USE="wayland gtk3 gtk -doc X" emerge dev-vcs/git dev-libs/wayland dev-libs/wayland-protocols =dev-cpp/gtkmm-3.24.6 x11-libs/libxkbcommon \
 		x11-libs/gtk+:3 dev-libs/libdbusmenu dev-libs/libnl sys-power/upower media-libs/libpulse dev-libs/libevdev media-libs/libmpdclient \
-		media-sound/sndio gui-libs/gtk-layer-shell app-text/scdoc media-sound/playerctl
+		media-sound/sndio gui-libs/gtk-layer-shell app-text/scdoc media-sound/playerctl dev-libs/iniparser

--- a/meson.build
+++ b/meson.build
@@ -341,13 +341,11 @@ if get_option('experimental')
     add_project_arguments('-DUSE_EXPERIMENTAL', language: 'cpp')
 endif
 
-cava = compiler.find_library('cava',
-                             required: get_option('cava'))
-if not cava.found() and not get_option('cava').disabled()
-   cava = dependency('cava',
-                     required: false,
-                     fallback: [ 'cava', 'cava_dep' ])
-endif
+cava = dependency('cava',
+                  version : '>=0.8.4',
+                  required: get_option('cava'),
+                  fallback : ['cava', 'cava_dep'],
+                  not_found_message: 'cava is not found. Building waybar without cava')
 
 if cava.found()
    add_project_arguments('-DHAVE_LIBCAVA', language: 'cpp')

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -497,8 +497,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
 
           net->ifname_ = new_ifname;
           net->ifid_ = ifi->ifi_index;
-          if (ifi->ifi_flags & IFF_POINTOPOINT)
-            net->is_p2p_ = true;
+          if (ifi->ifi_flags & IFF_POINTOPOINT) net->is_p2p_ = true;
           if (carrier.has_value()) {
             net->carrier_ = carrier.value();
           }
@@ -543,8 +542,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
       for (; RTA_OK(ifa_rta, attrlen); ifa_rta = RTA_NEXT(ifa_rta, attrlen)) {
         switch (ifa_rta->rta_type) {
           case IFA_ADDRESS:
-            if (net->is_p2p_)
-              continue;
+            if (net->is_p2p_) continue;
           case IFA_LOCAL:
             char ipaddr[INET6_ADDRSTRLEN];
             if (!is_del_event) {

--- a/subprojects/cava.wrap
+++ b/subprojects/cava.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = cava-0.8.3
-source_url = https://github.com/LukashonakV/cava/archive/0.8.3.tar.gz
-source_filename = cava-0.8.3.tar.gz
-source_hash = 10f9ec910682102c47dc39d684fd3fc90d38a4d1c2e5a310f132f70ad0e00850
+directory = cava-0.8.4
+source_url = https://github.com/LukashonakV/cava/archive/0.8.4.tar.gz
+source_filename = cava-0.8.4.tar.gz
+source_hash = 523353f446570277d40b8e1efb84468d70fdec53e1356a555c14bf466557a3ed
 [provide]
 cava = cava_dep


### PR DESCRIPTION
Hi @Alexays , 
Arch users noticed cava fork compiles both and library and application. So once waybar is installed it overrides existing cava application what is not they want. So in the libcava fork I refreshed building logic and by default provide libcava as a single library. In addition new  libcava release now provides pkg-config manifest. So waybar can use dependency meson method now.
This PR should solve [Arch, ...] users complaining about cava module with the error:  shared library is not found
Relates: #2133, #2130, #2129