### PR TITLE
[wlr/workspaces] Separate CSS class for empty persistent workspaces

### DIFF
--- a/include/modules/wlr/workspace_manager.hpp
+++ b/include/modules/wlr/workspace_manager.hpp
@@ -30,6 +30,7 @@ class Workspace {
   auto is_active() const -> bool { return state_ & static_cast<uint32_t>(State::ACTIVE); }
   auto is_urgent() const -> bool { return state_ & static_cast<uint32_t>(State::URGENT); }
   auto is_hidden() const -> bool { return state_ & static_cast<uint32_t>(State::HIDDEN); }
+  auto is_empty() const -> bool { return state_ & static_cast<uint32_t>(State::EMPTY); }
   auto is_persistent() const -> bool { return persistent_; }
   // wlr stuff
   auto handle_name(const std::string &name) -> void;
@@ -51,6 +52,7 @@ class Workspace {
     ACTIVE = (1 << 0),
     URGENT = (1 << 1),
     HIDDEN = (1 << 2),
+    EMPTY = (1 << 3),
   };
 
  private:

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -374,6 +374,8 @@ Workspace::Workspace(const Bar &bar, const Json::Value &config, WorkspaceGroup &
       name_(name) {
   if (workspace) {
     add_workspace_listener(workspace, this);
+  } else {
+    state_ = (uint32_t)State::EMPTY;
   }
 
   auto config_format = config["format"];
@@ -447,6 +449,8 @@ auto Workspace::handle_remove() -> void {
   }
   if (!persistent_) {
     workspace_group_.remove_workspace(id_);
+  } else {
+    state_ = (uint32_t)State::EMPTY;
   }
 }
 
@@ -465,6 +469,7 @@ auto Workspace::handle_done() -> void {
   add_or_remove_class(style_context, is_active(), "active");
   add_or_remove_class(style_context, is_urgent(), "urgent");
   add_or_remove_class(style_context, is_hidden(), "hidden");
+  add_or_remove_class(style_context, is_empty(), "persistent");
 
   if (workspace_group_.creation_delayed()) {
     return;


### PR DESCRIPTION
Persistent workspaces without any windows now get their own CSS class