### PR TITLE
Add a new start_hidden flag

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -593,6 +593,10 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     setMode(MODE_DEFAULT);
   }
 
+  if (config["start_hidden"].asBool()) {
+    setVisible(false);
+  }
+
   window.signal_map_event().connect_notify(sigc::mem_fun(*this, &Bar::onMap));
 
 #if HAVE_SWAY


### PR DESCRIPTION
Add a new `start_hidden` flag to set visibility on launch.

I'm using `"mode": "hide"` on Hyprland.

To make the bar hide on launch, I currently have to do `waybar & sleep 1 && killall -SIGUSR1 waybar` to hide waybar on launch.  (I think the sleep is required because it takes a little under a second for the signal handling thread to become available.)

With this change, I can add this to my waybar config and have it hide on launch:
```json    
"mode": "hide",
"start_hidden": true,
```