### PR TITLE
File descriptor handling bugs

### DIFF
--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -82,6 +82,8 @@ inline FILE* open(const std::string& cmd, int& pid) {
 
   if (child_pid < 0) {
     spdlog::error("Unable to exec cmd {}, error {}", cmd.c_str(), strerror(errno));
+    ::close(fd[0]);
+    ::close(fd[1]);
     return nullptr;
   }
 

--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -4,6 +4,7 @@
 #include <spdlog/spdlog.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <fcntl.h>
 
 #ifdef __linux__
 #include <sys/prctl.h>
@@ -68,7 +69,11 @@ inline int close(FILE* fp, pid_t pid) {
 inline FILE* open(const std::string& cmd, int& pid) {
   if (cmd == "") return nullptr;
   int fd[2];
-  if (pipe(fd) != 0) {
+  // Open the pipe with the close-on-exec flag set, so it will not be inherited
+  // by any other subprocesses launched by other threads (which could result in
+  // the pipe staying open after this child dies, causing us to hang when trying
+  // to read from it)
+  if (pipe2(fd, O_CLOEXEC) != 0) {
     spdlog::error("Unable to pipe fd");
     return nullptr;
   }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -188,7 +188,7 @@ void waybar::modules::Network::createEventSocket() {
     throw std::runtime_error("Can't create epoll");
   }
   {
-    ev_fd_ = eventfd(0, EFD_NONBLOCK);
+    ev_fd_ = eventfd(0, EFD_NONBLOCK|EFD_CLOEXEC);
     struct epoll_event event;
     memset(&event, 0, sizeof(event));
     event.events = EPOLLIN | EPOLLET;


### PR DESCRIPTION
- Pipes opened to run commands did not have the close-on-exec flag set, creating a brief window where a long-running process spawned by another thread might inherit the write end of the pipe. This would cause whatever was trying to read from the process to hang; in particular this could lead to certain custom modules not appearing properly under certain configurations. Fix this by using `pipe2` with the `O_CLOEXEC` flag (supported on Linux and all the BSDs) to atomically set the close-on-exec flag at startup.
- Set the close-on-exec flag on the eventfd created by the network module. (Allowing children to inherit this file descriptor is less problematic than it is for the pipes, but still best avoided.)
- If `fork()` fails, close both ends of the pipe (previously they would be leaked).