### PR TITLE
Fix SEGFAULT in battery module

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -36,7 +36,8 @@ waybar::modules::Battery::~Battery() {
   }
   close(global_watch_fd_);
 
-  for (auto it = batteries_.cbegin(); it != batteries_.cend(); it++) {
+  for (auto it = batteries_.cbegin(), next_it = it; it != batteries_.cend(); it = next_it) {
+    ++next_it;
     auto watch_id = (*it).second;
     if (watch_id >= 0) {
       inotify_rm_watch(battery_watch_fd_, watch_id);


### PR DESCRIPTION
In waybar::modules::Battery::~Battery(), store a copy of the batteries_ iterator before calling erase(), as erase() invalidates the iterator.

Prior to this change, disconnecting outputs resulted in a SEGFAULT when using the battery module; e.g.,

    [debug] Received SIGCHLD in signalThread
    [debug] Cmd exited with code 0
    [debug] Received SIGCHLD in signalThread
    [debug] Cmd exited with code 0
    [debug] Received SIGCHLD in signalThread
    [debug] Cmd exited with code 0
    [debug] Output removed: AU Optronics 0x2336
    [info] Bar configured (width: 1280, height: 25) for output: eDP-1
    [info] Bar configured (width: 1280, height: 25) for output: eDP-1
    zsh: segmentation fault (core dumped)  ./build/waybar -l trace