### PR TITLE
[hyprland/window] Add css class for empty window name

### DIFF
--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -92,7 +92,8 @@ void Window::onEvent(const std::string& ev) {
   if (windowName == lastView) return;
 
   lastView = windowName;
-  if (windowName[0] == '\0') {
+
+  if (windowName.empty()) {
     label_.get_style_context()->add_class("empty");
   } else {
     label_.get_style_context()->remove_class("empty");

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -92,6 +92,11 @@ void Window::onEvent(const std::string& ev) {
   if (windowName == lastView) return;
 
   lastView = windowName;
+  if (windowName[0] == '\0') {
+    label_.get_style_context()->add_class("empty");
+  } else {
+    label_.get_style_context()->remove_class("empty");
+  }
 
   spdlog::debug("hyprland window onevent with {}", windowName);
 


### PR DESCRIPTION
Adds an `empty` css class when window name is empty.

Select with `#window.empty`.

Related #2186, #1995, #1934
### Notes
- Assumes `windowName` is not null.
- Matches window with an empty name.