### PR TITLE
mpris: dynamic tag ordering and separator customization

### DIFF
--- a/include/modules/mpris/mpris.hpp
+++ b/include/modules/mpris/mpris.hpp
@@ -66,6 +66,8 @@ class Mpris : public ALabel {
   int album_len_;
   int title_len_;
   int dynamic_len_;
+  std::string dynamic_separator_;
+  std::vector<std::string> dynamic_order_;
   std::vector<std::string> dynamic_prio_;
   bool truncate_hours_;
   bool tooltip_len_limits_;

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -71,11 +71,26 @@ The *mpris* module displays currently playing media via libplayerctl.
 	something less than or equal to this value, so the title will always be ++
 	displayed.
 
+*dynamic-order*: ++
+	typeof: []string ++
+	default: ["title", "artist", "album", "position", "length"] ++
+	Order of the tags shown by Dynamic tag. The position and length tags ++
+	will always be combined in the format [{position}/{length}]. The order ++
+	of these tags in relation to other tags will be determined based on the ++
+	declaration of the first among the two tags. Absence in this list means ++
+	force exclusion.
+
 *dynamic-priority*: ++
 	typeof: []string ++
 	default: ["title", "length", "position", "artist", "album"] ++
 	Priority of the tags when truncating the Dynamic tag (absence in this
 	list means force inclusion).
+
+*dynamic-separator*: ++
+	typeof: string ++
+	default: " - " ++
+	These characters will be used to separate two different tags, except ++
+	when one of these tags is position and length.
 
 *truncate-hours*: ++
 	typeof: bool ++

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -80,11 +80,12 @@ The *mpris* module displays currently playing media via libplayerctl.
 	declaration of the first among the two tags. Absence in this list means ++
 	force exclusion.
 
-*dynamic-priority*: ++
+*dynamic-importance-order*: ++
 	typeof: []string ++
-	default: ["title", "length", "position", "artist", "album"] ++
-	Priority of the tags when truncating the Dynamic tag (absence in this
-	list means force inclusion).
+	default: ["title", "artist", "album", "position", "length"] ++
+	Priority of the tags when truncating the Dynamic tag. The final ones ++
+	will be the first to be truncated. Absence in this list means force ++
+	inclusion.
 
 *dynamic-separator*: ++
 	typeof: string ++

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -79,12 +79,13 @@ Mpris::Mpris(const std::string& id, const Json::Value& config)
   if (config["dynamic-len"].isUInt()) {
     dynamic_len_ = config["dynamic-len"].asUInt();
   }
-  if (config_["dynamic-priority"].isArray()) {
+  // "dynamic-priority" has been kept for backward compatibility
+  if (config_["dynamic-importance-order"].isArray() || config_["dynamic-priority"].isArray()) {
     dynamic_prio_.clear();
-    for (auto it = config_["dynamic-priority"].begin(); it != config_["dynamic-priority"].end();
-         ++it) {
-      if (it->isString()) {
-        dynamic_prio_.push_back(it->asString());
+    const auto& dynamic_priority = config_["dynamic-importance-order"].isArray() ? config_["dynamic-importance-order"] : config_["dynamic-priority"];
+    for (const auto& value : dynamic_priority) {
+      if (value.isString()) {
+        dynamic_prio_.push_back(value.asString());
       }
     }
   }


### PR DESCRIPTION
This PR makes it possible:
 - the choice of tag orders in dynamic mode;
 - the choice of the separator;
 - the non-inclusion of the tag if not declared in "dynamic-order".
 
It is observed that "dynamic-priority" was renamed to "dynamic-importance-order" to be more intuitive and not confused with "dynamic-order".