### PR TITLE
river/window: Add tooltip.

### DIFF
--- a/src/modules/river/window.cpp
+++ b/src/modules/river/window.cpp
@@ -106,7 +106,11 @@ void Window::handle_focused_view(const char *title) {
     label_.hide();  // hide empty labels or labels with empty format
   } else {
     label_.show();
-    label_.set_markup(fmt::format(fmt::runtime(format_), Glib::Markup::escape_text(title).raw()));
+    auto text = fmt::format(fmt::runtime(format_), Glib::Markup::escape_text(title).raw());
+    label_.set_markup(text);
+    if (tooltipEnabled()) {
+      label_.set_tooltip_markup(text);
+    }
   }
 
   ALabel::update();


### PR DESCRIPTION
The wiki mentions the river/window module has a tooltip, but it does not. This merge adds a tooltip with the same content as the label itself.