### PR TITLE
Fixing 'incomplete type error' during building

### DIFF
--- a/include/modules/sway/ipc/client.hpp
+++ b/include/modules/sway/ipc/client.hpp
@@ -7,6 +7,7 @@
 
 #include <cstring>
 #include <memory>
+#include <stdexcept>
 #include <mutex>
 #include <string>
 


### PR DESCRIPTION
Fixing errors during the building due to missing library after latest GCC updates.

This PR will fix the following issues: https://github.com/Alexays/Waybar/issues/2159 https://github.com/Alexays/Waybar/issues/2177