### PR TITLE
Tray module causes: Invalid id passed to g_bus_unwatch_name()

### DIFF
--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -22,10 +22,6 @@ Host::~Host() {
     Gio::DBus::unwatch_name(bus_name_id_);
     bus_name_id_ = 0;
   }
-  if (watcher_id_ > 0) {
-    Gio::DBus::unwatch_name(watcher_id_);
-    watcher_id_ = 0;
-  }
   g_cancellable_cancel(cancellable_);
   g_clear_object(&cancellable_);
   g_clear_object(&watcher_);

--- a/src/modules/sni/watcher.cpp
+++ b/src/modules/sni/watcher.cpp
@@ -14,7 +14,7 @@ Watcher::Watcher()
       watcher_(sn_watcher_skeleton_new()) {}
 
 Watcher::~Watcher() {
-   if (items_ != nullptr) {
+  if (items_ != nullptr) {
     g_slist_free_full(items_, gfWatchFree);
     items_ = nullptr;
   }

--- a/src/modules/sni/watcher.cpp
+++ b/src/modules/sni/watcher.cpp
@@ -14,12 +14,7 @@ Watcher::Watcher()
       watcher_(sn_watcher_skeleton_new()) {}
 
 Watcher::~Watcher() {
-  if (hosts_ != nullptr) {
-    g_slist_free_full(hosts_, gfWatchFree);
-    hosts_ = nullptr;
-  }
-
-  if (items_ != nullptr) {
+   if (items_ != nullptr) {
     g_slist_free_full(items_, gfWatchFree);
     items_ = nullptr;
   }


### PR DESCRIPTION
When Waybar exit in the log I see:
![ps_2023-06-06-23_18_51](https://github.com/Alexays/Waybar/assets/23121044/24703f5b-f102-4a51-af62-32a401743d49)
`(waybar:25493): GLib-GIO-WARNING **: 22:57:40.825: Invalid id 2 passed to g_bus_unwatch_name()`

Investigation shows: Tray module constructor calls :
1. watcher constructor
2. host constructor
In the same time both base classes(watcher and host) keeps information about cross resources. Watcher instance has got information about host and watcher either. The same for host class..
So when time to destruct instances, both watcher and host are trying to destroy cross resources. In such case : watcher may kill host resource earlier then host destruction is called and vise versa for host class.
This PR splits resource destruction between base classes. Host now destruct only host objects, watcher - watchers objects.

Actually I didn't find any other dependencies where these base classes are used separately without each other.