### PR TITLE
deprecated: implicit capture of 'this' via '[=]'

### DIFF
--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -64,7 +64,7 @@ WorkspaceManager::WorkspaceManager(const std::string &id, const waybar::Bar &bar
 
 auto WorkspaceManager::workspace_comparator() const
     -> std::function<bool(std::unique_ptr<Workspace> &, std::unique_ptr<Workspace> &)> {
-  return [=](std::unique_ptr<Workspace> &lhs, std::unique_ptr<Workspace> &rhs) {
+  return [=, this](std::unique_ptr<Workspace> &lhs, std::unique_ptr<Workspace> &rhs) {
     auto is_name_less = lhs->get_name() < rhs->get_name();
     auto is_name_eq = lhs->get_name() == rhs->get_name();
     auto is_coords_less = lhs->get_coords() < rhs->get_coords();


### PR DESCRIPTION
Just to turn off annoying C++20 compiler about [../src/modules/wlr/workspace_manager.cpp:67:10: warning: implicit capture of 'this' via '[=]' is deprecated in C++20 [-Wdeprecated]](https://github.com/LukashonakV/Waybar/actions/runs/5192869066/jobs/9362634710#step:5:160)