### PR TITLE
sway/workspaces: setting to not warp to window when scrolling

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -77,6 +77,11 @@ Addressed by *sway/workspaces*
     typeof: bool ++
     Whether to sort workspaces alphabetically. Please note this can make "swaymsg workspace prev/next" move to workspaces inconsistent with the ordering shown in Waybar.
 
+warp-on-scroll: ++
+    typeof: bool ++
+    default: true ++
+    If set to false, you can scroll to cycle through workspaces without mouse warping being enabled. If set to true this behaviour is disabled.
+
 # FORMAT REPLACEMENTS
 
 *{value}*: Name of the workspace, as defined by sway.

--- a/resources/config
+++ b/resources/config
@@ -12,6 +12,7 @@
     // "sway/workspaces": {
     //     "disable-scroll": true,
     //     "all-outputs": true,
+    //     "warp-on-scroll": false,
     //     "format": "{name}: {icon}",
     //     "format-icons": {
     //         "1": "",

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -326,10 +326,16 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
       return true;
     }
   }
+  if (!config_["warp-on-scroll"].asBool()) {
+      ipc_.sendCmd(IPC_COMMAND, fmt::format("mouse_warping none"));
+  }
   try {
     ipc_.sendCmd(IPC_COMMAND, fmt::format(workspace_switch_cmd_, "--no-auto-back-and-forth", name));
   } catch (const std::exception &e) {
     spdlog::error("Workspaces: {}", e.what());
+  }
+  if (!config_["warp-on-scroll"].asBool()) {
+      ipc_.sendCmd(IPC_COMMAND, fmt::format("mouse_warping container"));
   }
   return true;
 }


### PR DESCRIPTION
## Tl;dr
This adds an option, it defaults to true which is the old behavior, when switching workspaces in the sway plugin using the mouse wheel, it uses sway ipc calls to disable mouse warp, and enable it again. 

## Why?:
When using the mouse to switch workspaces I don't want my mouse to move programmatically.

## Issues: 

1. I haven't found a way to read the in memory currently active setting for mouse warp, to only do this if mouse warp ins enabled currently. I don't know if it is possible via sway ipc. I don't think reading the setting file is the way to go, as you can edit settings in situ using ipc calls. The effect this has is that if this setting is set away from the default in waybar it will enable mouse warp ephemerally if you use the mouse scroll wheel to switch workspaces. I don't know if this is a big issue, since this is not the default behavior.
2. I haven't done the same for switching workspaces using left click. If upstream is open to merging this, this might be something that should be added before merging. It's the same chain of though, if my hand is on the mouse, the mouse should not be moved other than by me, as that is a jarring experience.

## Why did I add Request for comment to the title?:
Because I this is my first time opening a merge request to a C++ project

## Background:
Why do I have mouse warping on at all? Well when I was using i3wm I was doing some typing, example passwords, etc. using shell scripts, dmenu and xdotool. I had issues with this, like the text not being typed into the text field, just weird issues where the workaround was to just use xdotool to move the mouse again to make sure the window had focus. This didn't work like exactly the same in sway. So I was looking for a way to just make it work in my workflow. Then I discovered that if I enabled mouse warping I never had this issue. But it is very jarring for the mouse to move to a window when I use the mouse to switch workspaces using the sway module in waybar. 

## Have I tested this code?:
I've ran with these changes for 3 months,  when [0.9.18](https://github.com/Alexays/Waybar/releases/tag/0.9.18) was released in the repos of my distro was reminded to open this merge request since it overwrote the binary I had on my disk. I used git apply to check if the changes worked on 0.9.18, and I have been using that since 4 days. 