### PR TITLE
sway/window: fix appid style not cleared

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -178,10 +178,6 @@ auto Window::update() -> void {
     } else {
       mode += 32;
     }
-    if (!app_id_.empty() && !bar_.window.get_style_context()->has_class(app_id_)) {
-      bar_.window.get_style_context()->add_class(app_id_);
-      old_app_id_ = app_id_;
-    }
   }
 
   if (!old_app_id_.empty() && ((mode & 2) == 0 || old_app_id_ != app_id_) &&


### PR DESCRIPTION
Should fix #2227.

Probably a rebase error during development of #1419. The code block now removed was not supposed to be there anymore.

It also slipped from the `elseif (app_nb==1)` branch into the `else` (more than 1 node) branch and erroneously set app_id style and `old_app_id_=app_id_`.
