### PR TITLE
Lift reverse-scrolling option into AModule

### DIFF
--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -91,6 +91,10 @@ Additionally you can control the volume by scrolling *up* or *down* while the cu
 	typeof: double ++
 	Threshold to be used when scrolling.
 
+*reverse-scrolling*: ++
+	typeof: bool ++
+	Option to reverse the scroll direction.
+
 *tooltip*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -97,11 +97,14 @@ bool AModule::handleToggle(GdkEventButton* const& e) {
 }
 
 AModule::SCROLL_DIR AModule::getScrollDir(GdkEventScroll* e) {
+  // only affects up/down
+  bool reverse = config_["reverse-scrolling"].asBool();
+
   switch (e->direction) {
     case GDK_SCROLL_UP:
-      return SCROLL_DIR::UP;
+      return reverse ? SCROLL_DIR::DOWN : SCROLL_DIR::UP;
     case GDK_SCROLL_DOWN:
-      return SCROLL_DIR::DOWN;
+      return reverse ? SCROLL_DIR::UP : SCROLL_DIR::DOWN;
     case GDK_SCROLL_LEFT:
       return SCROLL_DIR::LEFT;
     case GDK_SCROLL_RIGHT:

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -305,14 +305,6 @@ bool waybar::modules::Backlight::handleScroll(GdkEventScroll *e) {
     return true;
   }
 
-  if (config_["reverse-scrolling"].asBool()) {
-    if (dir == SCROLL_DIR::UP) {
-      dir = SCROLL_DIR::DOWN;
-    } else if (dir == SCROLL_DIR::DOWN) {
-      dir = SCROLL_DIR::UP;
-    }
-  }
-
   // Get scroll step
   double step = 1;
 

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -81,13 +81,6 @@ bool waybar::modules::Pulseaudio::handleScroll(GdkEventScroll *e) {
   if (dir == SCROLL_DIR::NONE) {
     return true;
   }
-  if (config_["reverse-scrolling"].asInt() == 1) {
-    if (dir == SCROLL_DIR::UP) {
-      dir = SCROLL_DIR::DOWN;
-    } else if (dir == SCROLL_DIR::DOWN) {
-      dir = SCROLL_DIR::UP;
-    }
-  }
   double volume_tick = static_cast<double>(PA_VOLUME_NORM) / 100;
   pa_volume_t change = volume_tick;
   pa_cvolume pa_volume = pa_volume_;


### PR DESCRIPTION
The option is generally useful when scrolling is used, when configuring
input devices to use "natural scroll direction".
Both backlight and pulseaudio were using different implementations, this
unifies and documents them.

Signed-off-by: Robert Günzler <r@gnzler.io>
