### PR TITLE
sway/window: app_id on unfocused workspaces

### DIFF
--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -251,6 +251,39 @@ std::pair<int, int> leafNodesInWorkspace(const Json::Value& node) {
   return {sum, floating_sum};
 }
 
+std::optional<std::reference_wrapper<const Json::Value>> getSingleChildNode(const Json::Value& node) {
+  auto const& nodes = node["nodes"];
+  if (nodes.empty()) {
+    if (node["type"].asString() == "workspace")
+      return {};
+    else if (node["type"].asString() == "floating_con") {
+      return {};
+    } else {
+      return {std::cref(node)};
+    }
+  }
+  auto it = std::cbegin(nodes);
+  if (it == std::cend(nodes)) {
+    return {};
+  }
+  auto const& child = *it;
+  ++it;
+  if (it != std::cend(nodes)) {
+    return {};
+  }
+  return {getSingleChildNode(child)};
+}
+
+std::tuple<std::string, std::string, std::string> getWindowInfo(const Json::Value& node) {
+  const auto app_id = node["app_id"].isString() ? node["app_id"].asString()
+                                                : node["window_properties"]["instance"].asString();
+  const auto app_class = node["window_properties"]["class"].isString()
+                             ? node["window_properties"]["class"].asString()
+                             : "";
+  const auto shell = node["shell"].isString() ? node["shell"].asString() : "";
+  return {app_id, app_class, shell};
+}
+
 std::tuple<std::size_t, int, int, std::string, std::string, std::string, std::string, std::string>
 gfnWithWorkspace(const Json::Value& nodes, std::string& output, const Json::Value& config_,
                  const Bar& bar_, Json::Value& parentWorkspace,
@@ -287,12 +320,7 @@ gfnWithWorkspace(const Json::Value& nodes, std::string& output, const Json::Valu
       // found node
       spdlog::trace("actual output {}, output found {}, node (focused) found {}", bar_.output->name,
                     output, node["name"].asString());
-      auto app_id = node["app_id"].isString() ? node["app_id"].asString()
-                                              : node["window_properties"]["instance"].asString();
-      const auto app_class = node["window_properties"]["class"].isString()
-                                 ? node["window_properties"]["class"].asString()
-                                 : "";
-      const auto shell = node["shell"].isString() ? node["shell"].asString() : "";
+      const auto [app_id, app_class, shell] = getWindowInfo(node);
       int nb = node.size();
       int floating_count = 0;
       std::string workspace_layout = "";
@@ -332,15 +360,24 @@ gfnWithWorkspace(const Json::Value& nodes, std::string& output, const Json::Valu
     std::pair all_leaf_nodes = leafNodesInWorkspace(immediateParent);
     // using an empty string as default ensures that no window depending styles are set due to the
     // checks above for !name.empty()
+    std::string app_id = "";
+    std::string app_class = "";
+    std::string workspace_layout = "";
+    if (all_leaf_nodes.first == 1) {
+      const auto single_child = getSingleChildNode(immediateParent);
+      if (single_child.has_value()) {
+        std::tie(app_id, app_class, workspace_layout) = getWindowInfo(single_child.value());
+      }
+    }
     return {all_leaf_nodes.first,
             all_leaf_nodes.second,
             0,
             (all_leaf_nodes.first > 0 || all_leaf_nodes.second > 0)
                 ? config_["offscreen-css-text"].asString()
                 : "",
-            "",
-            "",
-            "",
+            app_id,
+            app_class,
+            workspace_layout,
             immediateParent["layout"].asString()};
   }
 


### PR DESCRIPTION
This patch tries to make `app_id` specific styling from `sway/window` more useful if the `smart_borders` and `smart_gaps` Sway options are used in conjunction with the `offscreen-css` option of the module.

My main use case for this is styles like `window#waybar.solo.kitty`, which can make Waybar blend in with the solo window on the workspace (gapless and borderless thanks to the Sway options). For example, you may set a semi-transparent background for Waybar only if a terminal with semi-transparent background is the only window on the workspace, but use a fully opaque background for any other (opaque) window.

Unfortunately, `app_id`-specific styling is not very useful with multiple monitors. Even if `offscreen-css` is enabled, the CSS class corresponding to `app_id` is only applied for the focused window. Thus, Waybar can only ever blends with focused windows.

This patch also applies the `app_id` for unfocused workspaces when `offscreen-css` is set, but only if there is a single, non-floating window. This should catch situations where `smart_borders` and `smart_gaps` are useful. Technically, gaps and borders are collapsed also when the workspace itself is set to tabbed/stacking with multiple windows, but in that case titlebars (for tabs/stacks) are always present, which would prevent the bar from seamlessly blending in with the visible window anyways.

Since this changes established behavior and might break some configs, a more prudent alternative approach would be to add another configuration option to be used in conjunction with `offscreen-css` to enable this behavior.