### PR TITLE
hyprland/window: Add CSS customization similar to sway/window

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -1,7 +1,5 @@
 #include <fmt/format.h>
 
-#include <tuple>
-
 #include "ALabel.hpp"
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
@@ -17,15 +15,29 @@ class Window : public waybar::ALabel, public EventHandler {
   auto update() -> void override;
 
  private:
-  int getActiveWorkspaceID(std::string);
-  std::string getLastWindowTitle(int);
+  struct Workspace {
+    int windows;
+    std::string last_window;
+    std::string last_window_title;
+
+    static auto parse(const Json::Value&) -> Workspace;
+  };
+
+  auto getActiveWorkspace(const std::string&) -> Workspace;
+  auto getActiveWorkspace() -> Workspace;
+  auto getWindowClass(const std::string&) -> std::string;
   void onEvent(const std::string&) override;
+  void queryActiveWorkspace();
+  void setClass(const std::string&, bool enable);
 
   bool separate_outputs;
   std::mutex mutex_;
   const Bar& bar_;
   util::JsonParser parser_;
-  std::string lastView;
+  std::string last_title_;
+  Workspace workspace_;
+  std::string solo_class_;
+  std::string last_solo_class_;
 };
 
 }  // namespace waybar::modules::hyprland

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -38,8 +38,9 @@ class Window : public waybar::ALabel, public EventHandler {
   Workspace workspace_;
   std::string solo_class_;
   std::string last_solo_class_;
-  bool fullscreen_;
+  bool solo_;
   bool all_floating_;
+  bool fullscreen_;
 };
 
 }  // namespace waybar::modules::hyprland

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -16,6 +16,7 @@ class Window : public waybar::ALabel, public EventHandler {
 
  private:
   struct Workspace {
+    int id;
     int windows;
     std::string last_window;
     std::string last_window_title;
@@ -25,7 +26,6 @@ class Window : public waybar::ALabel, public EventHandler {
 
   auto getActiveWorkspace(const std::string&) -> Workspace;
   auto getActiveWorkspace() -> Workspace;
-  auto getWindowClass(const std::string&) -> std::string;
   void onEvent(const std::string&) override;
   void queryActiveWorkspace();
   void setClass(const std::string&, bool enable);
@@ -38,6 +38,8 @@ class Window : public waybar::ALabel, public EventHandler {
   Workspace workspace_;
   std::string solo_class_;
   std::string last_solo_class_;
+  bool fullscreen_;
+  bool all_floating_;
 };
 
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -22,7 +22,7 @@ Language::Language(const std::string& id, const Bar& bar, const Json::Value& con
   initLanguage();
 
   label_.hide();
-  ALabel::update();
+  update();
 
   // register for hyprland ipc
   gIPC->registerForIPC("activelayout", this);


### PR DESCRIPTION
This PR reworks the `hyprland/window` module a bit, to allow the following CSS classes:

- `window#waybar.empty` When no windows are in the active workspace (or monitor's workspace if `separate-outputs` is enabled)
- `window#waybar.solo` When one tiled window is in the workspace
- `window#waybar.<app_id>` Where `<app_id>` is the class name (e.g. `chromium`) of the only window in the workspace

These are similar to the Sway module, except without the layout modes, because Hyprland's layout modes are different (and afaik it doesn't expose them to IPC anyway)

The "rework" was done because Hyprland IPC doesn't have one clear event for when the amount of windows on a workspace changes, so we just listen to `activewindow`, `closewindow` and `movewindow` and query the current workspace every time. I did not extensively test this but this seems like it should cover most use cases.

Also I migrated to using IPC for everything instead of executing `hyprctl`.