### PR TITLE
More robust Hyprland backend

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -181,17 +181,21 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
   }
 
   char buffer[8192] = {0};
+  std::string response;
 
-  sizeWritten = read(SERVERSOCKET, buffer, 8192);
+  do {
+    sizeWritten = read(SERVERSOCKET, buffer, 8192);
 
-  if (sizeWritten < 0) {
-    spdlog::error("Hyprland IPC: Couldn't read (5)");
-    return "";
-  }
+    if (sizeWritten < 0) {
+      spdlog::error("Hyprland IPC: Couldn't read (5)");
+      close(SERVERSOCKET);
+      return "";
+    }
+    response.append(buffer, sizeWritten);
+  } while (sizeWritten == 8192);
 
   close(SERVERSOCKET);
-
-  return std::string(buffer);
+  return response;
 }
 
 }  // namespace waybar::modules::hyprland


### PR DESCRIPTION
Basically I was testing #2245 and noticed that Waybar would randomly crash when there are too many windows in a workspace. Turns out the current IPC implementation only reads 8192 bytes of response and discards the rest. This PR is a quick fix.