### PR TITLE
Add Auto-Hide feature

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -106,9 +106,9 @@ class Bar {
   void setupAltFormatKeyForModule(const std::string &module_name);
   void setupAltFormatKeyForModuleList(const char *module_list_name);
   void setMode(const bar_mode &);
-  static void showMainbar(GtkWidget * widget, const gchar* h,  gpointer data);
-  static void hideMainbar(GtkWidget * widget, const gchar* h, gpointer data);
-  static void hideMainbarCallback(gpointer data);
+  void showMainbar(GdkEventCrossing* ev);
+  void hideMainbar(GdkEventCrossing* ev);
+  bool hideMainbarCallback();
 
   /* Copy initial set of modes to allow customization */
   bar_mode_map configured_modes = PRESET_MODES;
@@ -129,9 +129,8 @@ class Bar {
 #endif
   std::vector<std::shared_ptr<waybar::AModule>> modules_all_;
 
-  std::atomic<unsigned int> autohide_delay_ms = 0;
-  std::mutex autohide_mutex;
-  std::atomic<guint> autohide_timeout_handle;
+  unsigned int autohide_delay_ms = 0;
+  sigc::connection autohide_connection;
 };
 
 }  // namespace waybar

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -10,8 +10,6 @@
 
 #include <memory>
 #include <vector>
-#include <atomic>
-#include <mutex>
 
 #include "AModule.hpp"
 #include "xdg-output-unstable-v1-client-protocol.h"

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -118,6 +118,22 @@ modifier-reset ++
 	typeof: string ++
 	*bar_id* for the Sway IPC. Use this if you need to override the value passed with the *-b bar_id* commandline argument for the specific bar instance.
 
+*autohide* ++
+	typeof: bool ++
+	default: false ++
+	Option to specify whether bar must autohide.
+	Use *autohide-delay* and *autohide-starthidden* to customize autohide.
+
+*autohide-delay* ++
+	typeof: integer ++
+	default: 0 ++
+	Time in milliseconds after which the bar must autohide if cursor is no longer over the bar.
+
+*autohide-starthidden* ++
+	typeof: bool ++
+	default: false ++
+	Option to specify whether the bar must start in hidden state if *autohide* option is true.
+	
 *include* ++
 	typeof: string|array ++
 	Paths to additional configuration files.

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -582,10 +582,6 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   {
     surface_impl_ = std::make_unique<RawSurfaceImpl>(window, *output);
     hotspotsurface_impl_ = std::make_unique<RawSurfaceImpl>(hotspotWindow, *output);
-    if(autohide_enabled) {
-      spdlog::info("Autohide can't be enabled because this build isn't compiled with gtk-layer-shell");
-      autohide_enabled = false;
-    }
   }
 
   surface_impl_->setMargins(margins_);
@@ -736,12 +732,11 @@ void waybar::Bar::setupAutohide() {
   this->autohide_connection.disconnect();
   this->autohide_delay_ms = config["autohide-delay"].isUInt() ? config["autohide-delay"].asUInt() : 0;
 
-  gtk_layer_set_layer(hotspotWindow.gobj(), GTK_LAYER_SHELL_LAYER_OVERLAY);
-  gtk_layer_set_exclusive_zone(hotspotWindow.gobj(), 0);
+  hotspotsurface_impl_->setLayer(bar_layer::OVERLAY);
+  hotspotsurface_impl_->setExclusiveZone(true);
 
   hotspotWindow.signal_enter_notify_event().connect_notify(sigc::mem_fun(*this, &waybar::Bar::showMainbar));
   window.signal_leave_notify_event().connect_notify(sigc::mem_fun(*this, &waybar::Bar::hideMainbar));
-
 }
 
 // Converting string to button code rn as to avoid doing it later

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -569,6 +569,9 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     margins_ = {.top = gaps, .right = gaps, .bottom = gaps, .left = gaps};
   }
 
+  auto autohide_enabled = config["autohide"].isBool() ? config["autohide"].asBool() : false;
+  auto autohide_starthidden = autohide_enabled && ( config["autohide-starthidden"].isBool() ? config["autohide-starthidden"].asBool() : false);
+
 #ifdef HAVE_GTK_LAYER_SHELL
   bool use_gls = config["gtk-layer-shell"].isBool() ? config["gtk-layer-shell"].asBool() : true;
   if (use_gls) {
@@ -579,6 +582,10 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   {
     surface_impl_ = std::make_unique<RawSurfaceImpl>(window, *output);
     hotspotsurface_impl_ = std::make_unique<RawSurfaceImpl>(hotspotWindow, *output);
+    if(autohide_enabled) {
+      spdlog::info("Autohide can't be enabled because this build isn't compiled with gtk-layer-shell");
+      autohide_enabled = false;
+    }
   }
 
   surface_impl_->setMargins(margins_);
@@ -600,9 +607,6 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
 
   /* Update "default" mode with the global bar options */
   from_json(config, configured_modes[MODE_DEFAULT]);
-
-  auto autohide_enabled = config["autohide"].isBool() ? config["autohide"].asBool() : false;
-  auto autohide_starthidden = autohide_enabled && ( config["autohide-starthidden"].isBool() ? config["autohide-starthidden"].asBool() : false);
 
   if (auto mode = config.get("mode", {}); mode.isString()) {
     setMode(config["mode"].asString());


### PR DESCRIPTION
@Alexays ,
I implemented Auto-Hide feature in Waybar.  It allows Bar to autohide itself when cursor is no longer over it and makes itself visible when the cursor touches the edge of the screen to which Bar is positioned. It's incredibly useful in Small screen displays.  It's working properly for me. I wish to have this merged. It adds three more configuration options to the config.

```
*autohide* ++
	typeof: bool ++
	default: false ++
	Option to specify whether bar must autohide.
	Use *autohide-delay* and *autohide-starthidden* to customize autohide.

*autohide-delay* ++
	typeof: integer ++
	default: 0 ++
	Time in milliseconds after which the bar must autohide if cursor is no longer over the bar.

*autohide-starthidden* ++
	typeof: bool ++
	default: false ++
	Option to specify whether the bar must start in hidden state if *autohide* option is true.
```