### PR TITLE
[wlr/workspaces] Improve persistent_workspaces by allowing fixed nr of workspaces per monitor

### DIFF
--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -216,7 +216,7 @@ auto WorkspaceGroup::fill_persistent_workspaces() -> void {
     for (const std::string &key : keys) {
       const Json::Value &value = pWorkspaces[key];
 
-      if (value.isNumeric()) {
+      if (value.isNumeric() && value.asInt() > 0) {
         // value == amount of workspaces this workspace should have
         uint32_t monitorId = 0;  // TEMP: how to get monitor ID from output name, that matches Hyprland's ID?
         if ((key == "*" && std::find(keys.begin(), keys.end(), bar_.output->name) == keys.end()) ||


### PR DESCRIPTION
WIP, attempts to fix #2243.

This PR improves the `persistent_workspaces` option in `wlr/workspaces`. Currently, for every workspace you want to add, you have to specify an array of monitors where that workspace should show up.

With this PR, you can now also specify an amount of workspaces a monitor should have. It will automatically calculate what the workspace names should be.

Example that will add 3 workspaces for every monitor, but add 5 for the monitor with name "eDP-1":
```json
"persistent_workspaces": {
  "*": 3,
  "eDP-1": 5
}
```

**TODO:**
- [ ] Find a way to get the monitor ID. In Hyprland, every monitor gets a name (string) and an ID (integer).
  -  I'm using [this plugin](https://github.com/Duckonaut/split-monitor-workspaces) to automatically assign workspaces based on the monitor ID
  - Say the amount of workspaces is 5, and the ID is 0, that monitor should have workspaces 1-5. If the ID is 2, that monitor should have workspaces 11-15. 
  - I could get this using hyprctl, but I'm looking for a more general wlroots solution.
- [x] Test with more monitors. I wrote this on a single monitor, will test more when I have access to a 2nd monitor.
- [ ] Add documentation
