### PR TITLE
Add output port (display) of workspace to template function of sway/workspace

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -87,6 +87,8 @@ Addressed by *sway/workspaces*
 
 *{index}*: Index of the workspace.
 
+*{output}*: Output where the workspace is located.
+
 # ICONS
 
 Additional to workspace name matching, the following *format-icons* can be set.

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -235,7 +235,8 @@ auto Workspaces::update() -> void {
       auto format = config_["format"].asString();
       output = fmt::format(fmt::runtime(format), fmt::arg("icon", getIcon(output, *it)),
                            fmt::arg("value", output), fmt::arg("name", trimWorkspaceName(output)),
-                           fmt::arg("index", (*it)["num"].asString()));
+                           fmt::arg("index", (*it)["num"].asString()),
+                           fmt::arg("output", (*it)["output"].asString()));
     }
     if (!config_["disable-markup"].asBool()) {
       static_cast<Gtk::Label *>(button.get_children()[0])->set_markup(output);


### PR DESCRIPTION
Wanted to have the output displayed in the workspace switcher, this is just a simple one-line edit to achieve that.