### PR TITLE
feat: hyprland/workspaces

### DIFF
--- a/include/factory.hpp
+++ b/include/factory.hpp
@@ -31,6 +31,7 @@
 #include "modules/hyprland/language.hpp"
 #include "modules/hyprland/submap.hpp"
 #include "modules/hyprland/window.hpp"
+#include "modules/hyprland/workspaces.hpp"
 #endif
 #if defined(__FreeBSD__) || (defined(__linux__) && !defined(NO_FILESYSTEM))
 #include "modules/battery.hpp"

--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -5,6 +5,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include "util/json.hpp"
 
 namespace waybar::modules::hyprland {
 
@@ -22,12 +23,14 @@ class IPC {
   void unregisterForIPC(EventHandler*);
 
   std::string getSocket1Reply(const std::string& rq);
+  Json::Value getSocket1JsonReply(const std::string& rq);
 
  private:
   void startIPC();
   void parseIPC(const std::string&);
 
   std::mutex callbackMutex;
+  util::JsonParser parser_;
   std::list<std::pair<std::string, EventHandler*>> callbacks;
 };
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -1,0 +1,44 @@
+#include <gtkmm/button.h>
+#include <gtkmm/label.h>
+
+#include "AModule.hpp"
+#include "bar.hpp"
+#include "modules/hyprland/backend.hpp"
+
+namespace waybar::modules::hyprland {
+
+class Workspace {
+ public:
+  Workspace(int id);
+  int id() { return id_; };
+  Gtk::Button& button() { return button_; };
+
+  static Workspace parse(const Json::Value&);
+  void update();
+
+ private:
+  int id_;
+
+  Gtk::Button button_;
+  Gtk::Box content_;
+  Gtk::Label label_;
+};
+
+class Workspaces : public AModule, public EventHandler {
+ public:
+  Workspaces(const std::string&, const waybar::Bar&, const Json::Value&);
+  virtual ~Workspaces();
+  void update() override;
+  void init();
+
+ private:
+  void onEvent(const std::string&) override;
+
+  std::vector<Workspace> workspaces;
+
+  std::mutex mutex_;
+  const Bar& bar_;
+  Gtk::Box box_;
+};
+
+}  // namespace waybar::modules::hyprland

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -7,17 +7,27 @@
 
 namespace waybar::modules::hyprland {
 
+struct WorkspaceDto {
+  int id;
+
+  static WorkspaceDto parse(const Json::Value& value);
+};
+
 class Workspace {
  public:
   Workspace(int id);
-  int id() { return id_; };
+  Workspace(WorkspaceDto dto);
+  int id() const { return id_; };
+  int active() const { return active_; };
+  std::string& select_icon(std::map<std::string, std::string>& icons_map);
+  void set_active(bool value = true) { active_ = value; };
   Gtk::Button& button() { return button_; };
 
-  static Workspace parse(const Json::Value&);
-  void update();
+  void update(const std::string& format, const std::string& icon);
 
  private:
   int id_;
+  bool active_;
 
   Gtk::Button button_;
   Gtk::Box content_;
@@ -33,9 +43,13 @@ class Workspaces : public AModule, public EventHandler {
 
  private:
   void onEvent(const std::string&) override;
+  void sort_workspaces();
 
-  std::vector<Workspace> workspaces;
-
+  std::string format_;
+  std::map<std::string, std::string> icons_map_;
+  bool with_icon_;
+  int active_workspace_id;
+  std::vector<Workspace> workspaces_;
   std::mutex mutex_;
   const Bar& bar_;
   Gtk::Box box_;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -1,0 +1,59 @@
+waybar-wlr-workspaces(5)
+
+# NAME
+
+waybar - hyprland workspaces module
+
+# DESCRIPTION
+
+The *workspaces* module displays the currently used workspaces in hyprland compositor.
+
+# CONFIGURATION
+
+Addressed by *hyprland/workspaces*
+
+*format*: ++
+	typeof: string ++
+	default: {id} ++
+	The format, how information should be displayed.
+
+*format-icons*: ++
+	typeof: array ++
+	Based on the workspace id and state, the corresponding icon gets selected. See *icons*.
+
+# FORMAT REPLACEMENTS
+
+*{id}*: id of workspace assigned by compositor
+
+*{icon}*: Icon, as defined in *format-icons*.
+
+# ICONS
+
+Additional to workspace name matching, the following *format-icons* can be set.
+
+- *default*: Will be shown, when no string match is found.
+- *active*: Will be shown, when workspace is active
+
+# EXAMPLES
+
+```
+"wlr/workspaces": {
+	"format": "{name}: {icon}",
+	"format-icons": {
+		"1": "",
+		"2": "",
+		"3": "",
+		"4": "",
+		"5": "",
+		"active": "",
+		"default": ""
+	},
+	"sort-by-number": true
+}
+```
+
+# Style
+
+- *#workspaces*
+- *#workspaces button*
+- *#workspaces button.active*

--- a/man/waybar-wlr-workspaces.5.scd
+++ b/man/waybar-wlr-workspaces.5.scd
@@ -65,7 +65,7 @@ Addressed by *wlr/workspaces*
 Additional to workspace name matching, the following *format-icons* can be set.
 
 - *default*: Will be shown, when no string match is found.
-- *focused*: Will be shown, when workspace is focused
+- *active*: Will be shown, when workspace is active
 
 # EXAMPLES
 
@@ -78,7 +78,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"3": "",
 		"4": "",
 		"5": "",
-		"focused": "",
+		"active": "",
 		"default": ""
 	},
 	"sort-by-number": true

--- a/meson.build
+++ b/meson.build
@@ -480,6 +480,15 @@ if scdoc.found()
     endforeach
 endif
 
+catch2 = dependency(
+    'catch2',
+    version: '>=2.0.0',
+    fallback: ['catch2', 'catch2_dep'],
+    required: get_option('tests'),
+)
+if catch2.found()
+    subdir('test')
+endif
 
 clangtidy = find_program('clang-tidy', required: false)
 

--- a/meson.build
+++ b/meson.build
@@ -240,6 +240,7 @@ if true
     src_files += 'src/modules/hyprland/window.cpp'
     src_files += 'src/modules/hyprland/language.cpp'
     src_files += 'src/modules/hyprland/submap.cpp'
+    src_files += 'src/modules/hyprland/workspaces.cpp'
 endif
 
 if libnl.found() and libnlgen.found()
@@ -479,15 +480,6 @@ if scdoc.found()
     endforeach
 endif
 
-catch2 = dependency(
-    'catch2',
-    version: '>=2.0.0',
-    fallback: ['catch2', 'catch2_dep'],
-    required: get_option('tests'),
-)
-if catch2.found()
-    subdir('test')
-endif
 
 clangtidy = find_program('clang-tidy', required: false)
 

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -83,6 +83,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name) const {
     if (ref == "hyprland/submap") {
       return new waybar::modules::hyprland::Submap(id, bar_, config_[name]);
     }
+    if (ref == "hyprland/workspaces") {
+      return new waybar::modules::hyprland::Workspaces(id, bar_, config_[name]);
+    }
 #endif
     if (ref == "idle_inhibitor") {
       return new waybar::modules::IdleInhibitor(id, bar_, config_[name]);

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -198,4 +198,8 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
   return response;
 }
 
+Json::Value IPC::getSocket1JsonReply(const std::string& rq) {
+  return parser_.parse(getSocket1Reply("j/" + rq));
+}
+
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -74,7 +74,7 @@ void Workspaces::onEvent(const std::string &ev) {
     int new_workspace_id;
     std::from_chars(payload.data(), payload.data() + payload.size(), new_workspace_id);
     workspaces_.push_back(new_workspace_id);
-    Gtk::Button& new_workspace_button = workspaces_.back().button();
+    Gtk::Button &new_workspace_button = workspaces_.back().button();
     box_.pack_end(new_workspace_button, false, false);
     sort_workspaces();
     new_workspace_button.show_all();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1,15 +1,32 @@
 #include "modules/hyprland/workspaces.hpp"
 
+#include <json/value.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <charconv>
 #include <string>
 
 namespace waybar::modules::hyprland {
+
 Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value &config)
     : AModule(config, "workspaces", id, false, false),
       bar_(bar),
       box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+  Json::Value config_format = config["format"];
+
+  format_ = config_format.isString() ? config_format.asString() : "{id}";
+  with_icon_ = format_.find("{icon}") != std::string::npos;
+
+  if (with_icon_ && icons_map_.empty()) {
+    Json::Value format_icons = config["format-icons"];
+    for (std::string &name : format_icons.getMemberNames()) {
+      icons_map_.emplace(name, format_icons[name].asString());
+    }
+
+    icons_map_.emplace("", "");
+  }
+
   box_.set_name("workspaces");
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
@@ -22,32 +39,63 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
 
   init();
 
+  gIPC->registerForIPC("workspace", this);
   gIPC->registerForIPC("createworkspace", this);
   gIPC->registerForIPC("destroyworkspace", this);
-  gIPC->registerForIPC("urgent", this);
 }
 
 auto Workspaces::update() -> void {
   std::lock_guard<std::mutex> lock(mutex_);
-  for (Workspace &workspace : workspaces) {
-    workspace.update();
+  for (Workspace &workspace : workspaces_) {
+    workspace.set_active(workspace.id() == active_workspace_id);
+
+    std::string &workspace_icon = icons_map_[""];
+    if (with_icon_) {
+      workspace_icon = workspace.select_icon(icons_map_);
+    }
+
+    workspace.update(format_, workspace_icon);
   }
+
   AModule::update();
 }
 
-void Workspaces::onEvent(const std::string &ev) { dp.emit(); }
+void Workspaces::onEvent(const std::string &ev) {
+  std::string eventName(begin(ev), begin(ev) + ev.find_first_of('>'));
+  std::string payload = ev.substr(eventName.size() + 2);
+  if (eventName == "workspace") {
+    std::from_chars(payload.data(), payload.data() + payload.size(), active_workspace_id);
+  } else if (eventName == "destroyworkspace") {
+    int deleted_workspace_id;
+    std::from_chars(payload.data(), payload.data() + payload.size(), deleted_workspace_id);
+    workspaces_.erase(std::remove_if(workspaces_.begin(), workspaces_.end(),
+                                     [&](Workspace &x) { return x.id() == deleted_workspace_id; }));
+  } else if (eventName == "createworkspace") {
+    int new_workspace_id;
+    std::from_chars(payload.data(), payload.data() + payload.size(), new_workspace_id);
+    workspaces_.push_back(new_workspace_id);
+    Gtk::Button& new_workspace_button = workspaces_.back().button();
+    box_.pack_end(new_workspace_button, false, false);
+    sort_workspaces();
+    new_workspace_button.show_all();
+  }
+
+  dp.emit();
+}
 
 void Workspaces::init() {
-  const auto activeWorkspace = Workspace::parse(gIPC->getSocket1JsonReply("activeworkspace"));
+  const auto activeWorkspace = WorkspaceDto::parse(gIPC->getSocket1JsonReply("activeworkspace"));
+  active_workspace_id = activeWorkspace.id;
   const Json::Value workspaces_json = gIPC->getSocket1JsonReply("workspaces");
   for (const Json::Value &workspace_json : workspaces_json) {
-    workspaces.push_back(Workspace::parse(workspace_json));
+    workspaces_.push_back(Workspace(WorkspaceDto::parse(workspace_json)));
   }
-  std::sort(workspaces.begin(), workspaces.end(),
-            [](Workspace &lhs, Workspace &rhs) { return lhs.id() < rhs.id(); });
-  for (auto &workspace : workspaces) {
+
+  for (auto &workspace : workspaces_) {
     box_.pack_start(workspace.button(), false, false);
   }
+
+  sort_workspaces();
 
   dp.emit();
 }
@@ -58,9 +106,11 @@ Workspaces::~Workspaces() {
   std::lock_guard<std::mutex> lg(mutex_);
 }
 
-Workspace Workspace::Workspace::parse(const Json::Value &value) {
-  return Workspace{value["id"].asInt()};
+WorkspaceDto WorkspaceDto::parse(const Json::Value &value) {
+  return WorkspaceDto{value["id"].asInt()};
 }
+
+Workspace::Workspace(WorkspaceDto dto) : Workspace(dto.id){};
 
 Workspace::Workspace(int id) : id_(id) {
   button_.set_relief(Gtk::RELIEF_NONE);
@@ -68,5 +118,50 @@ Workspace::Workspace(int id) : id_(id) {
   button_.add(content_);
 };
 
-void Workspace::update() { label_.set_text(std::to_string(id_)); }
+void add_or_remove_class(Glib::RefPtr<Gtk::StyleContext> context, bool condition,
+                         const std::string &class_name) {
+  if (condition) {
+    context->add_class(class_name);
+  } else {
+    context->remove_class(class_name);
+  }
+}
+
+void Workspace::update(const std::string &format, const std::string &icon) {
+  Glib::RefPtr<Gtk::StyleContext> style_context = button_.get_style_context();
+  add_or_remove_class(style_context, active(), "active");
+
+  label_.set_markup(
+      fmt::format(fmt::runtime(format), fmt::arg("id", id()), fmt::arg("icon", icon)));
+}
+
+void Workspaces::sort_workspaces() {
+  std::sort(workspaces_.begin(), workspaces_.end(),
+            [](Workspace &lhs, Workspace &rhs) { return lhs.id() < rhs.id(); });
+
+  for (size_t i = 0; i < workspaces_.size(); ++i) {
+    box_.reorder_child(workspaces_[i].button(), i);
+  }
+}
+
+std::string &Workspace::select_icon(std::map<std::string, std::string> &icons_map) {
+  if (active()) {
+    auto active_icon_it = icons_map.find("active");
+    if (active_icon_it != icons_map.end()) {
+      return active_icon_it->second;
+    }
+  }
+
+  auto named_icon_it = icons_map.find(std::to_string(id()));
+  if (named_icon_it != icons_map.end()) {
+    return named_icon_it->second;
+  }
+
+  auto default_icon_it = icons_map.find("default");
+  if (default_icon_it != icons_map.end()) {
+    return default_icon_it->second;
+  }
+
+  return icons_map[""];
+}
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1,0 +1,72 @@
+#include "modules/hyprland/workspaces.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <string>
+
+namespace waybar::modules::hyprland {
+Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value &config)
+    : AModule(config, "workspaces", id, false, false),
+      bar_(bar),
+      box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+  box_.set_name("workspaces");
+  if (!id.empty()) {
+    box_.get_style_context()->add_class(id);
+  }
+  event_box_.add(box_);
+  modulesReady = true;
+  if (!gIPC.get()) {
+    gIPC = std::make_unique<IPC>();
+  }
+
+  init();
+
+  gIPC->registerForIPC("createworkspace", this);
+  gIPC->registerForIPC("destroyworkspace", this);
+  gIPC->registerForIPC("urgent", this);
+}
+
+auto Workspaces::update() -> void {
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (Workspace &workspace : workspaces) {
+    workspace.update();
+  }
+  AModule::update();
+}
+
+void Workspaces::onEvent(const std::string &ev) { dp.emit(); }
+
+void Workspaces::init() {
+  const auto activeWorkspace = Workspace::parse(gIPC->getSocket1JsonReply("activeworkspace"));
+  const Json::Value workspaces_json = gIPC->getSocket1JsonReply("workspaces");
+  for (const Json::Value &workspace_json : workspaces_json) {
+    workspaces.push_back(Workspace::parse(workspace_json));
+  }
+  std::sort(workspaces.begin(), workspaces.end(),
+            [](Workspace &lhs, Workspace &rhs) { return lhs.id() < rhs.id(); });
+  for (auto &workspace : workspaces) {
+    box_.pack_start(workspace.button(), false, false);
+  }
+
+  dp.emit();
+}
+
+Workspaces::~Workspaces() {
+  gIPC->unregisterForIPC(this);
+  // wait for possible event handler to finish
+  std::lock_guard<std::mutex> lg(mutex_);
+}
+
+Workspace Workspace::Workspace::parse(const Json::Value &value) {
+  return Workspace{value["id"].asInt()};
+}
+
+Workspace::Workspace(int id) : id_(id) {
+  button_.set_relief(Gtk::RELIEF_NONE);
+  content_.set_center_widget(label_);
+  button_.add(content_);
+};
+
+void Workspace::update() { label_.set_text(std::to_string(id_)); }
+}  // namespace waybar::modules::hyprland


### PR DESCRIPTION
Resolves: https://github.com/Alexays/Waybar/issues/2194

Just basic functionality for now: show with id and/or icon witch active class.

In next PR I plan to merge some wlr/workspaces features: urgent class, active only workspace, different sorting options. Maybe also all-output and  persistent options (but I can not test it on multiple outputs by myself, so it'll require some help with testing)

test config:
```json
    "modules-left": [ "hyprland/workspaces" ],
    "hyprland/workspaces": {
        "format": "{id}: {icon}",
        "format-icons": {
            "1": "",
            "2": "",
            "3": "",
            "4": "",
            "default": ""
        }
    }
```

![image](https://github.com/Alexays/Waybar/assets/17771546/dd318fa2-7458-4422-87b1-50f87c6e7062)
