### PR TITLE
Partially revert 3af1853260 to fix use-after-free

### DIFF
--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -19,8 +19,12 @@ Host::Host(const std::size_t id, const Json::Value& config, const Bar& bar,
 
 Host::~Host() {
   if (bus_name_id_ > 0) {
-    Gio::DBus::unwatch_name(bus_name_id_);
+    Gio::DBus::unown_name(bus_name_id_);
     bus_name_id_ = 0;
+  }
+  if (watcher_id_ > 0) {
+    Gio::DBus::unwatch_name(watcher_id_);
+    watcher_id_ = 0;
   }
   g_cancellable_cancel(cancellable_);
   g_clear_object(&cancellable_);

--- a/src/modules/sni/watcher.cpp
+++ b/src/modules/sni/watcher.cpp
@@ -14,6 +14,10 @@ Watcher::Watcher()
       watcher_(sn_watcher_skeleton_new()) {}
 
 Watcher::~Watcher() {
+  if (hosts_ != nullptr) {
+    g_slist_free_full(hosts_, gfWatchFree);
+    hosts_ = nullptr;
+  }
   if (items_ != nullptr) {
     g_slist_free_full(items_, gfWatchFree);
     items_ = nullptr;


### PR DESCRIPTION
After upgrading to the latest release of Waybar the bar will crash whenever I close the laptop lid. After some debugging I believe it is because the watching added by `watch_name` in `Host` is not being correctly canceled using `unwatch_name`. After the Tray object and Host object are destroyed, additional callbacks will become use-after-free.

Apparently commit 3af1853260dafc43c992fc2357a3f3bace3bccaa removed the `unwatch_name`. I'm not sure why it did that, but it seems dangerous.

Additionally, bus_name_id_ is created by own_name. According to that function's documentation, the correct inverse operation is unown_name.