### PR TITLE
Fixed some build warnings

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -91,10 +91,11 @@ waybar::modules::Network::Network(const std::string &id, const Json::Value &conf
       cidr_(0),
       signal_strength_dbm_(0),
       signal_strength_(0),
+      frequency_(0.0),
 #ifdef WANT_RFKILL
-      rfkill_{RFKILL_TYPE_WLAN},
+      rfkill_{RFKILL_TYPE_WLAN}
 #endif
-      frequency_(0.0) {
+{
 
   // Start with some "text" in the module's label_. update() will then
   // update it. Since the text should be different, update() will be able

--- a/src/util/rfkill.cpp
+++ b/src/util/rfkill.cpp
@@ -63,7 +63,7 @@ bool waybar::util::Rfkill::on_event(Glib::IOCondition cond) {
       return false;
     }
 
-    if (len < RFKILL_EVENT_SIZE_V1) {
+    if (static_cast<size_t>(len) < RFKILL_EVENT_SIZE_V1) {
       spdlog::error("Wrong size of RFKILL event: {} < {}", len, RFKILL_EVENT_SIZE_V1);
       return true;
     }
@@ -73,10 +73,9 @@ bool waybar::util::Rfkill::on_event(Glib::IOCondition cond) {
       on_update.emit(event);
     }
     return true;
-  } else {
-    spdlog::error("Failed to poll RFKILL control device");
-    return false;
   }
+  spdlog::error("Failed to poll RFKILL control device");
+  return false;
 }
 
 bool waybar::util::Rfkill::getState() const { return state_; }


### PR DESCRIPTION
While compiling Waybar, I had these warnings:

```
In file included from ../src/modules/network.cpp:1:
../include/modules/network.hpp: In constructor ‘waybar::modules::Network::Network(const std::string&, const Json::Value&)’:
../include/modules/network.hpp:87:16: warning: ‘waybar::modules::Network::rfkill_’ will be initialized after [-Wreorder]
   87 |   util::Rfkill rfkill_;
      |                ^~~~~~~
../include/modules/network.hpp:81:9: warning:   ‘float waybar::modules::Network::frequency_’ [-Wreorder]
   81 |   float frequency_;
      |         ^~~~~~~~~~
../src/modules/network.cpp:80:1: warning:   when initialized here [-Wreorder]
   80 | waybar::modules::Network::Network(const std::string &id, const Json::Value &config)
      | ^~~~~~
[141/150] Compiling C++ object waybar.p/src_util_rfkill.cpp.o
../src/util/rfkill.cpp: In member function ‘bool waybar::util::Rfkill::on_event(Glib::IOCondition)’:
../src/util/rfkill.cpp:66:13: warning: comparison of integer expressions of different signedness: ‘ssize_t’ {aka ‘long int’} and ‘long unsigned int’ [-Wsign-compare]
   66 |     if (len < RFKILL_EVENT_SIZE_V1) {
      |             ^
```

This PR fixes these warnings.