### PR TITLE
Don't apply reverse scrolling to mice wheels

### DIFF
--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -99,11 +99,12 @@ bool AModule::handleToggle(GdkEventButton* const& e) {
 AModule::SCROLL_DIR AModule::getScrollDir(GdkEventScroll* e) {
   // only affects up/down
   bool reverse = config_["reverse-scrolling"].asBool();
+  bool reverse_mouse = config_["reverse-mouse-scrolling"].asBool();
 
   // ignore reverse-scrolling if event comes from a mouse wheel
   GdkDevice* device = gdk_event_get_source_device((GdkEvent *)e);
   if (device != NULL && gdk_device_get_source(device) == GDK_SOURCE_MOUSE) {
-    reverse = false;
+    reverse = reverse_mouse;
   }
 
   switch (e->direction) {

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -100,6 +100,12 @@ AModule::SCROLL_DIR AModule::getScrollDir(GdkEventScroll* e) {
   // only affects up/down
   bool reverse = config_["reverse-scrolling"].asBool();
 
+  // ignore reverse-scrolling if event comes from a mouse wheel
+  GdkDevice* device = gdk_event_get_source_device((GdkEvent *)e);
+  if (device != NULL && gdk_device_get_source(device) == GDK_SOURCE_MOUSE) {
+    reverse = false;
+  }
+
   switch (e->direction) {
     case GDK_SCROLL_UP:
       return reverse ? SCROLL_DIR::DOWN : SCROLL_DIR::UP;

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -121,9 +121,9 @@ AModule::SCROLL_DIR AModule::getScrollDir(GdkEventScroll* e) {
       }
 
       if (distance_scrolled_y_ < -threshold) {
-        dir = SCROLL_DIR::UP;
+        dir = reverse ? SCROLL_DIR::DOWN : SCROLL_DIR::UP;
       } else if (distance_scrolled_y_ > threshold) {
-        dir = SCROLL_DIR::DOWN;
+        dir = reverse ? SCROLL_DIR::UP : SCROLL_DIR::DOWN;
       } else if (distance_scrolled_x_ > threshold) {
         dir = SCROLL_DIR::RIGHT;
       } else if (distance_scrolled_x_ < -threshold) {


### PR DESCRIPTION
This is a fix for #1140.

Currently reverse-scrolling is applied globally. This can be annoying for those who use both a mouse and touchpad with "natural scrolling". In the case of scrolling to adjust volume, brightness, etc, scrolling up on a touchpad feels "natural" to adjust those things up.

However, this is the opposite of what "natural scrolling" does because it was designed for scrolling documents, which _does_ feel natural to reverse up/down.

So what this means for Waybar is that if we leave reverse-scrolling = false, the mouse wheel feels natural, but the touchpad feels backwards. If we set reverse-scrolling = true, the touchpad feels natural, but the mouse wheel feels backwards.

This PR does two things to address this issue:

- Fixes a regression introduced in #2232 that prevents reverse-scrolling from being applied on smooth scroll events (e.g. most touchpad events)
- Disables reverse-scrolling on mouse wheel scroll events, even if reverse-scrolling = true

I can't see any good reason someone would want to apply "natural scrolling" to a mouse wheel. If you are concerned that [someone might](https://xkcd.com/1172/), I could refactor this to have independent `reverse-mouse-scrolling` and `reverse-touchpad-scrolling` config options, keeping the existing `reverse-scrolling` as a global option.