### PR TITLE
wlr/taskbar: add support for rewrite rules

### DIFF
--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -142,9 +142,9 @@ Invalid expressions (e.g., mismatched parentheses) are skipped.
 		"firefoxdeveloperedition": "firefox-developer-edition"
 	},
 	"rewrite": {
-      "Firefox Web Browser": "Firefox",
-      "Foot Server": "Terminal"
-    }
+		"Firefox Web Browser": "Firefox",
+		"Foot Server": "Terminal"
+	}
 }
 ```
 

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -81,6 +81,10 @@ Addressed by *wlr/taskbar*
 	typeof: object ++
 	Dictionary of app_id to be replaced with
 
+*rewrite*: ++
+	typeof: object ++
+	Rules to rewrite the module format output. See *rewrite rules*.
+
 # FORMAT REPLACEMENTS
 
 *{icon}*: The icon of the application.
@@ -109,6 +113,18 @@ Addressed by *wlr/taskbar*
 
 *close*: Close the application.
 
+# REWRITE RULES
+
+*rewrite* is an object where keys are regular expressions and values are
+rewrite rules if the expression matches. Rules may contain references to
+captures of the expression.
+
+Regular expression and replacement follow ECMA-script rules.
+
+If no expression matches, the format output is left unchanged.
+
+Invalid expressions (e.g., mismatched parentheses) are skipped.
+
 # EXAMPLES
 
 ```
@@ -124,7 +140,11 @@ Addressed by *wlr/taskbar*
 	],
 	"app_ids-mapping": {
 		"firefoxdeveloperedition": "firefox-developer-edition"
-	}
+	},
+	"rewrite": {
+      "Firefox Web Browser": "Firefox",
+      "Foot Server": "Terminal"
+    }
 }
 ```
 

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -22,6 +22,8 @@
 #include "util/format.hpp"
 #include "util/string.hpp"
 
+#include "util/rewrite_string.hpp"
+
 namespace waybar::modules::wlr {
 
 /* Icon loading functions */
@@ -622,6 +624,9 @@ void Task::update() {
         fmt::format(fmt::runtime(format_before_), fmt::arg("title", title), fmt::arg("name", name),
                     fmt::arg("app_id", app_id), fmt::arg("state", state_string()),
                     fmt::arg("short_state", state_string(true)));
+
+    txt = waybar::util::rewriteString(txt, config_["rewrite"]);
+
     if (markup)
       text_before_.set_markup(txt);
     else
@@ -633,6 +638,9 @@ void Task::update() {
         fmt::format(fmt::runtime(format_after_), fmt::arg("title", title), fmt::arg("name", name),
                     fmt::arg("app_id", app_id), fmt::arg("state", state_string()),
                     fmt::arg("short_state", state_string(true)));
+
+    txt = waybar::util::rewriteString(txt, config_["rewrite"]);
+
     if (markup)
       text_after_.set_markup(txt);
     else


### PR DESCRIPTION
Hello,

I'm using the _wlr/taskbar_ and I was annoyed by some long application names like "Firefox Web Browser". I would prefer to just read "Firefox", so the button doesn't take so much space. 

I simply implemented the rewrite logic from sway/window and _hyprland/window_ for _wlr/taskbar_. A simple `waybar::util::rewriteString` was added and the man page was updated.

**Here is an example:**
![grafik](https://github.com/Alexays/Waybar/assets/6116717/73fac785-58af-41a6-9762-27b2dc93d010)
The top waybar is using the rewrite rules. The bottom waybar is the old version with the full names.

You see, that the taskbar is way shorter by removing unnecessary parts from the application name.

```
        "wlr/taskbar": {
            "format": "{icon} {name}",
            "icon-size": 20,
            "tooltip": false,
            "on-click": "activate",
            "on-click-middle": "close",
            "on-click-right": "minimize-raise",
            "rewrite": {
                "(\\s*)Firefox Web Browser": "$1Firefox",
                "(\\s*)Foot Server": "$1Terminal",
                "(\\s*)CLion.*": "$1CLion",
                "(\\s*)IntelliJ IDEA.*": "$1IDEA"
            }
        },
```
*I had to include the whitespace between the {icon} and {name}.*

Sure, you could simply change the `.desktop` file for these application, but they may reset after an update. I hope this change is useful for some of you.