### PR TITLE
hyprland/window: Add .hidden CSS class, account for hidden & fullscreen windows

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -40,6 +40,7 @@ class Window : public waybar::ALabel, public EventHandler {
   std::string last_solo_class_;
   bool solo_;
   bool all_floating_;
+  bool hidden_;
   bool fullscreen_;
 };
 

--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -21,6 +21,10 @@ Addressed by *hyprland/window*
 	typeof: object ++
 	Rules to rewrite window title. See *rewrite rules*.
 
+*separate-outputs*: ++
+	typeof: bool ++
+	Show the active window of the monitor the bar belongs to, instead of the focused window.
+
 # REWRITE RULES
 
 *rewrite* is an object where keys are regular expressions and values are
@@ -48,3 +52,18 @@ Invalid expressions (e.g., mismatched parentheses) are skipped.
 # STYLE
 
 - *#window*
+- *#window.empty* When no windows are in the workspace
+
+The following classes are applied to the entire Waybar rather than just the
+window widget:
+
+- *window#waybar.empty* When no windows are in the workspace
+- *window#waybar.solo* When one tiled window is visible in the workspace
+  (floating windows may be present)
+- *window#waybar.<app_id>* Where *<app_id>* is the *class* (e.g. *chromium*) of
+  the solo tiled window in the workspace (use *hyprctl clients* to see classes)
+- *window#waybar.floating* When there are only floating windows in the workspace
+- *window#waybar.fullscreen* When there is a fullscreen window in the workspace;
+  useful with Hyprland's *fullscreen, 1* mode
+- *window#waybar.hidden* When there are hidden windows in the workspace; usually
+  occurs due to window swallowing

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -84,7 +84,7 @@ Addressed by *sway/window*
 	typeof: bool ++
 	default: false ++
 	If the workspace itself is focused and the workspace contains nodes or floating_nodes, show the workspace name. If not set, text remains empty but styles according to nodes in the workspace are still applied.
-	
+
 *rewrite*: ++
 	typeof: object ++
 	Rules to rewrite the module format output. See *rewrite rules*.
@@ -136,6 +136,10 @@ Invalid expressions (e.g., mismatched parentheses) are skipped.
 # STYLE
 
 - *#window*
+
+The following classes are applied to the entire Waybar rather than just the
+window widget:
+
 - *window#waybar.empty* When no windows are in the workspace, or screen is not focused and offscreen-css option is not set
 - *window#waybar.solo* When one tiled window is in the workspace
 - *window#waybar.floating* When there are only floating windows in the workspace

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -141,12 +141,16 @@ void Window::queryActiveWorkspace() {
                  [&](Json::Value window) {
                    return window["workspace"]["id"] == workspace_.id && window["mapped"].asBool();
                  });
-    solo_ = 1 == std::count_if(workspace_windows.begin(), workspace_windows.end(),
-                               [&](Json::Value window) { return !window["floating"].asBool() && !window["hidden"].asBool(); });
-    all_floating_ = std::all_of(workspace_windows.begin(), workspace_windows.end(),
-                                [&](Json::Value window) { return window["floating"].asBool() && !window["hidden"].asBool(); });
     hidden_ = std::any_of(workspace_windows.begin(), workspace_windows.end(),
-                                [&](Json::Value window) { return window["hidden"].asBool(); });
+                          [&](Json::Value window) { return window["hidden"].asBool(); });
+    std::vector<Json::Value> visible_windows;
+    std::copy_if(workspace_windows.begin(), workspace_windows.end(),
+                 std::back_inserter(visible_windows),
+                 [&](Json::Value window) { return !window["hidden"].asBool(); });
+    solo_ = 1 == std::count_if(visible_windows.begin(), visible_windows.end(),
+                               [&](Json::Value window) { return !window["floating"].asBool(); });
+    all_floating_ = std::all_of(visible_windows.begin(), visible_windows.end(),
+                                [&](Json::Value window) { return window["floating"].asBool(); });
     fullscreen_ = (*active_window)["fullscreen"].asBool();
 
     if (fullscreen_) {


### PR DESCRIPTION
* The `.solo` and `.<app_id>` classes now account for `hidden` (aka swallowed) windows, and also fullscreen windows in `"fullscreenMode": 1` (where a window is fullscreen but the bar is visible).
* Add `.hidden` CSS class for when a hidden/swallowed window is present on the workspace.