### PR TITLE
Add output-fallback as a configuration option

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -39,6 +39,7 @@ class Client {
   auto setupCss(const std::string &css_file) -> void;
   struct waybar_output &getOutput(void *);
   std::vector<Json::Value> getOutputConfigs(struct waybar_output &output);
+  std::vector<Json::Value> getOutputFallbackConfigs(struct waybar_output &output);
 
   static void handleGlobal(void *data, struct wl_registry *registry, uint32_t name,
                            const char *interface, uint32_t version);

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -28,6 +28,8 @@ class Config {
 
   std::vector<Json::Value> getOutputConfigs(const std::string &name, const std::string &identifier);
 
+  std::vector<Json::Value> getOutputFallbackConfigs(const std::string &name, const std::string &identifier);
+
  private:
   void setupConfig(Json::Value &dst, const std::string &config_file, int depth);
   void resolveConfigIncludes(Json::Value &config, int depth);

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -32,6 +32,10 @@ Also a minimal example configuration can be found on the at the bottom of this m
 	Specifies on which screen this bar will be displayed. Exclamation mark(*!*) can be used to exclude specific output.
 	In an array, star '*\**' can be used at the end to accept all outputs, in case all previous entries are exclusions.
 
+*output-fallback* ++
+	typeof: string ++
+	Defines the output to be used when the specified output is not available.
+
 *position* ++
 	typeof: string ++
 	default: top ++

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -64,6 +64,10 @@ std::vector<Json::Value> waybar::Client::getOutputConfigs(struct waybar_output &
   return config.getOutputConfigs(output.name, output.identifier);
 }
 
+std::vector<Json::Value> waybar::Client::getOutputFallbackConfigs(struct waybar_output &output) {
+  return config.getOutputFallbackConfigs(output.name, output.identifier);
+}
+
 void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_output*/) {
   auto client = waybar::Client::inst();
   try {
@@ -85,6 +89,15 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
       if (!configs.empty()) {
         for (const auto &config : configs) {
           client->bars.emplace_back(std::make_unique<Bar>(&output, config));
+        }
+      } else {
+        auto configs = client->getOutputFallbackConfigs(output);
+        if (!configs.empty()) {
+          for (const auto &config : configs) {
+            client->bars.emplace_back(std::make_unique<Bar>(&output, config));
+            spdlog::debug("Using output fallback: {} ({})", output.name,
+                         output.identifier);
+          }
         }
       }
     }


### PR DESCRIPTION
The output-fallback configuration option allows you to specify a fallback output if the output specified in the configuration file is not connected. This is useful for laptops that are sometimes connected to an external monitor and sometimes not. This is inspired by Polybar's monitor fallback feature. Closes #2146