### PR TITLE
Stop MPRIS module from updating every ~20ms

### DIFF
--- a/include/modules/mpris/mpris.hpp
+++ b/include/modules/mpris/mpris.hpp
@@ -80,6 +80,7 @@ class Mpris : public ALabel {
   std::string lastPlayer;
 
   util::SleeperThread thread_;
+  std::chrono::time_point<std::chrono::system_clock> last_update_;
 };
 
 }  // namespace waybar::modules::mpris

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -31,7 +31,8 @@ Mpris::Mpris(const std::string& id, const Json::Value& config)
       ellipsis_("\u2026"),
       player_("playerctld"),
       manager(),
-      player() {
+      player(),
+      last_update_(std::chrono::system_clock::now() - interval_) {
   if (config_["format-playing"].isString()) {
     format_playing_ = config_["format-playing"].asString();
   }
@@ -559,6 +560,10 @@ bool Mpris::handleToggle(GdkEventButton* const& e) {
 }
 
 auto Mpris::update() -> void {
+  const auto now = std::chrono::system_clock::now();
+  if (now - last_update_ < interval_) return;
+  last_update_ = now;
+
   auto opt = getPlayerInfo();
   if (!opt) {
     event_box_.set_visible(false);


### PR DESCRIPTION
I noticed that while MPRIS module is running and music is playing, all tooltips on other modules stop working.  When music is paused or stopped, they work again.

Upon investigation, MPRIS onPlayerMetadata(), onPlayerPlay() callbacks get triggered every ~20ms and call Mpris::update() without regard for update interval configured.  The Mpris label gets updated every time and interferes with showing tooltips for other modules.

The fix is to ignore any Mpris::update() calls until the configured update interval elapses from the previous non-ignored call.