### PR TITLE
Fix random segfault on GTK icon functions

### DIFF
--- a/include/util/gtk_icon.hpp
+++ b/include/util/gtk_icon.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include <string>
+#include <mutex>
+#include <gtkmm/icontheme.h>
+
+class DefaultGtkIconThemeWrapper {
+  private:
+    static std::mutex default_theme_mutex;
+  public:
+    static bool has_icon(const std::string&);
+    static Glib::RefPtr<Gdk::Pixbuf> load_icon(const char*, int, Gtk::IconLookupFlags);
+};

--- a/meson.build
+++ b/meson.build
@@ -173,7 +173,8 @@ src_files = files(
     'src/util/prepare_for_sleep.cpp',
     'src/util/ustring_clen.cpp',
     'src/util/sanitize_str.cpp',
-    'src/util/rewrite_string.cpp'
+    'src/util/rewrite_string.cpp',
+    'src/util/gtk_icon.cpp'
 )
 
 inc_dirs = ['include']

--- a/src/modules/gamemode.cpp
+++ b/src/modules/gamemode.cpp
@@ -16,9 +16,10 @@
 #include "glibmm/ustring.h"
 #include "glibmm/variant.h"
 #include "glibmm/varianttype.h"
-#include "gtkmm/icontheme.h"
 #include "gtkmm/label.h"
 #include "gtkmm/tooltip.h"
+
+#include "util/gtk_icon.hpp"
 
 namespace waybar::modules {
 Gamemode::Gamemode(const std::string& id, const Json::Value& config)
@@ -224,7 +225,7 @@ auto Gamemode::update() -> void {
   label_.set_markup(str);
 
   if (useIcon) {
-    if (!Gtk::IconTheme::get_default()->has_icon(iconName)) {
+    if (!DefaultGtkIconThemeWrapper::has_icon(iconName)) {
       iconName = DEFAULT_ICON_NAME;
     }
     icon_.set_from_icon_name(iconName, Gtk::ICON_SIZE_INVALID);

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "util/format.hpp"
+#include "util/gtk_icon.hpp"
 
 template <>
 struct fmt::formatter<Glib::VariantBase> : formatter<std::string> {
@@ -379,10 +380,8 @@ Glib::RefPtr<Gdk::Pixbuf> Item::getIconByName(const std::string& name, int reque
     return icon_theme->load_icon(name.c_str(), tmp_size,
                                  Gtk::IconLookupFlags::ICON_LOOKUP_FORCE_SIZE);
   }
-  Glib::RefPtr<Gtk::IconTheme> default_theme = Gtk::IconTheme::get_default();
-  default_theme->rescan_if_needed();
-  return default_theme->load_icon(name.c_str(), tmp_size,
-                                  Gtk::IconLookupFlags::ICON_LOOKUP_FORCE_SIZE);
+  return DefaultGtkIconThemeWrapper::load_icon(name.c_str(), tmp_size,
+                                               Gtk::IconLookupFlags::ICON_LOOKUP_FORCE_SIZE);
 }
 
 double Item::getScaledIconSize() {

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -5,7 +5,6 @@
 #include <glibmm/keyfile.h>
 #include <glibmm/miscutils.h>
 #include <gtkmm/enums.h>
-#include <gtkmm/icontheme.h>
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
@@ -13,6 +12,7 @@
 #include <string>
 
 #include "util/rewrite_string.hpp"
+#include "util/gtk_icon.hpp"
 
 namespace waybar::modules::sway {
 
@@ -81,13 +81,12 @@ std::optional<Glib::ustring> getIconName(const std::string& app_id, const std::s
   if (!desktop_file_path.has_value()) {
     // Try some heuristics to find a matching icon
 
-    const auto default_icon_theme = Gtk::IconTheme::get_default();
-    if (default_icon_theme->has_icon(app_id)) {
+    if (DefaultGtkIconThemeWrapper::has_icon(app_id)) {
       return app_id;
     }
 
     const auto app_id_desktop = app_id + "-desktop";
-    if (default_icon_theme->has_icon(app_id_desktop)) {
+    if (DefaultGtkIconThemeWrapper::has_icon(app_id_desktop)) {
       return app_id_desktop;
     }
 
@@ -101,7 +100,7 @@ std::optional<Glib::ustring> getIconName(const std::string& app_id, const std::s
     const auto first_space = app_id.find_first_of(' ');
     if (first_space != std::string::npos) {
       const auto first_word = to_lower(app_id.substr(0, first_space));
-      if (default_icon_theme->has_icon(first_word)) {
+      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
         return first_word;
       }
     }
@@ -109,7 +108,7 @@ std::optional<Glib::ustring> getIconName(const std::string& app_id, const std::s
     const auto first_dash = app_id.find_first_of('-');
     if (first_dash != std::string::npos) {
       const auto first_word = to_lower(app_id.substr(0, first_dash));
-      if (default_icon_theme->has_icon(first_word)) {
+      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
         return first_word;
       }
     }

--- a/src/modules/upower/upower.cpp
+++ b/src/modules/upower/upower.cpp
@@ -5,8 +5,9 @@
 #include <cstring>
 #include <string>
 
-#include "gtkmm/icontheme.h"
 #include "gtkmm/tooltip.h"
+
+#include "util/gtk_icon.hpp"
 
 namespace waybar::modules::upower {
 UPower::UPower(const std::string& id, const Json::Value& config)
@@ -372,7 +373,7 @@ auto UPower::update() -> void {
   label_.set_markup(onlySpaces ? "" : label_format);
 
   // Set icon
-  if (icon_name == NULL || !Gtk::IconTheme::get_default()->has_icon(icon_name)) {
+  if (icon_name == NULL || !DefaultGtkIconThemeWrapper::has_icon(icon_name)) {
     icon_name = (char*)"battery-missing-symbolic";
   }
   icon_.set_from_icon_name(icon_name, Gtk::ICON_SIZE_INVALID);

--- a/src/modules/upower/upower_tooltip.cpp
+++ b/src/modules/upower/upower_tooltip.cpp
@@ -2,9 +2,10 @@
 
 #include "gtkmm/box.h"
 #include "gtkmm/enums.h"
-#include "gtkmm/icontheme.h"
 #include "gtkmm/image.h"
 #include "gtkmm/label.h"
+
+#include "util/gtk_icon.hpp"
 
 namespace waybar::modules::upower {
 UPowerTooltip::UPowerTooltip(uint iconSize_, uint tooltipSpacing_, uint tooltipPadding_)
@@ -62,7 +63,7 @@ uint UPowerTooltip::updateTooltip(Devices& devices) {
     std::string deviceIconName = getDeviceIcon(kind);
     Gtk::Image* deviceIcon = new Gtk::Image();
     deviceIcon->set_pixel_size(iconSize);
-    if (!Gtk::IconTheme::get_default()->has_icon(deviceIconName)) {
+    if (!DefaultGtkIconThemeWrapper::has_icon(deviceIconName)) {
       deviceIconName = "battery-missing-symbolic";
     }
     deviceIcon->set_from_icon_name(deviceIconName, Gtk::ICON_SIZE_INVALID);
@@ -79,7 +80,7 @@ uint UPowerTooltip::updateTooltip(Devices& devices) {
     // Set icon
     Gtk::Image* icon = new Gtk::Image();
     icon->set_pixel_size(iconSize);
-    if (icon_name == NULL || !Gtk::IconTheme::get_default()->has_icon(icon_name)) {
+    if (icon_name == NULL || !DefaultGtkIconThemeWrapper::has_icon(icon_name)) {
       icon_name = (char*)"battery-missing-symbolic";
     }
     icon->set_from_icon_name(icon_name, Gtk::ICON_SIZE_INVALID);

--- a/src/util/gtk_icon.cpp
+++ b/src/util/gtk_icon.cpp
@@ -1,0 +1,26 @@
+#include "util/gtk_icon.hpp"
+
+/* We need a global mutex for accessing the object returned by Gtk::IconTheme::get_default()
+ * because it always returns the same object across different threads, and concurrent
+ * access can cause data corruption and lead to invalid memory access and crashes.
+ * Even concurrent calls that seem read only such as has_icon can cause issues because
+ * the GTK lib may update the internal icon cache on this calls.
+*/
+
+std::mutex DefaultGtkIconThemeWrapper::default_theme_mutex;
+
+bool DefaultGtkIconThemeWrapper::has_icon(const std::string& value) {
+
+  const std::lock_guard<std::mutex> lock(default_theme_mutex);
+
+  return Gtk::IconTheme::get_default()->has_icon(value);
+}
+
+Glib::RefPtr<Gdk::Pixbuf> DefaultGtkIconThemeWrapper::load_icon(const char *name, int tmp_size, Gtk::IconLookupFlags flags) {
+
+  const std::lock_guard<std::mutex> lock(default_theme_mutex);
+
+  auto default_theme = Gtk::IconTheme::get_default();
+  default_theme->rescan_if_needed();
+  return default_theme->load_icon(name, tmp_size, flags);
+}


### PR DESCRIPTION
The segfaults were happening on GTK icon theme functions, which are called via the C++ interface functions such as Gtk::IconTheme::has_icon.

There are multiple modules and threads using this functions on the default icon theme by calling Gtk::IconTheme::get_default(), which returns the same object for all callers, and was causing concurrent access to the same internal data structures on the GTK lib. Even a seemingly read-only function such as has_icon can cause writes due to the internal icon cache being updated.

To avoid this issues, a program wide global mutex must be used to ensure a single thread is accessing the default icon theme instance.

This commit implements wrappers for the existing IconTheme function calls, ensuring the global lock is held while calling the underling GTK functions.

 **Additional details**

I could only reproduce this consistently with icon=true for the sway/window module and on closing/opening the Telegram app (wayland native and does not have a tasbar icon), but from the root cause I was able determine, the issue may happen with other apps and also in other modules that uses the object returned by Gtk::IconTheme::get_default().

I've used the following command to reproduce the issue reliably:
`while pidof waybar>/dev/null; do swaymsg '[title="Telegram"] kill'; sleep 0.2; Telegram; sleep 0.2; done`

On the master branch, it normally takes just between 5 and 12 iterations to crash waybar.
With this fix it I ran up to thousands of iterations without ever crashing.

Attached the gdb backtrace for one of this segfaults: [gdb_backtrace.txt](https://github.com/Alexays/Waybar/files/11941480/gdb_backtrace.txt)

After some debugging it seemed to be a concurrency issue, which was feasible when verified that the get_default() object was the same across all the code base, and it was being used on different threads.

Using the valgrind tool hellgrind I was able to validate this data race: [helgrind_has_icon_conflict.txt](https://github.com/Alexays/Waybar/files/11941512/helgrind_has_icon_conflict.txt)

About the solution, it fixes the what I'm confident to be the root cause, but I'm not an everyday C++ programmer and also not familiar with the Gtk lib, so this particular solution may not be best. But I'm happy to refactor it to better fit the project if needed.