### PR TITLE
hyprland/window: Fix no info with separate-outputs=true

### DIFF
--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -103,9 +103,9 @@ auto Window::getActiveWorkspace(const std::string& monitorName) -> Workspace {
 
   const auto workspaces = gIPC->getSocket1JsonReply("workspaces");
   assert(workspaces.isArray());
-  auto workspace = std::find_if(monitors.begin(), monitors.end(),
+  auto workspace = std::find_if(workspaces.begin(), workspaces.end(),
                                 [&](Json::Value workspace) { return workspace["id"] == id; });
-  if (workspace == std::end(monitors)) {
+  if (workspace == std::end(workspaces)) {
     spdlog::warn("No workspace with id {}", id);
     return Workspace{-1, 0, "", ""};
   }


### PR DESCRIPTION
It was trying to find a workspace from the wrong array. The array of workspaces is there but it was not used.

Closes #2285