### PR TITLE
Arch CI cava

### DIFF
--- a/Dockerfiles/archlinux
+++ b/Dockerfiles/archlinux
@@ -3,5 +3,5 @@
 FROM archlinux:base-devel
 
 RUN pacman -Syu --noconfirm && \
-    pacman -S --noconfirm git meson base-devel libinput wayland wayland-protocols pixman libxkbcommon mesa gtkmm3 jsoncpp pugixml scdoc libpulse libdbusmenu-gtk3 libmpdclient gobject-introspection libxkbcommon playerctl && \
+    pacman -S --noconfirm git meson base-devel libinput wayland wayland-protocols pixman libxkbcommon mesa gtkmm3 jsoncpp pugixml scdoc libpulse libdbusmenu-gtk3 libmpdclient gobject-introspection libxkbcommon playerctl iniparser fftw && \
     sed -Ei 's/#(en_(US|GB)\.UTF)/\1/' /etc/locale.gen && locale-gen


### PR DESCRIPTION
Hi @Alexays , I've rebuilt arch docker image. Can you retake it [vilu1209/waybar:archlinux](https://hub.docker.com/layers/vilu1209/waybar/archlinux/images/sha256-1492530202dbc7352fa866b079616b25d7ae3c8ce9e23e5e8ab00db13f2de704?context=repo)
This PR is raised in order to prevent any further questions about cava from arch community about build failures. As for example: #2281 