### PR TITLE
fix, default to true, sway/workspaces: warp-on-scroll

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -327,7 +327,7 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
       return true;
     }
   }
-  if (!config_["warp-on-scroll"].asBool()) {
+  if (!config_["warp-on-scroll"].isNull() && !config_["warp-on-scroll"].asBool()) {
     ipc_.sendCmd(IPC_COMMAND, fmt::format("mouse_warping none"));
   }
   try {
@@ -335,7 +335,7 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
   } catch (const std::exception &e) {
     spdlog::error("Workspaces: {}", e.what());
   }
-  if (!config_["warp-on-scroll"].asBool()) {
+  if (!config_["warp-on-scroll"].isNull() && !config_["warp-on-scroll"].asBool()) {
     ipc_.sendCmd(IPC_COMMAND, fmt::format("mouse_warping container"));
   }
   return true;


### PR DESCRIPTION
Sorry about that, @q234rty correctly pointed out that my previous already merged pull request for a new feature did not default to the old behavior. 

While I don't understand why anyone wouldn't use this feature if they already are using mouse_warp, since I can't read out the current status of the mouse_warp option, having this default to being enable disturbs people who don't use mouse_warp also, which I totally see is a preferential subject. So until there is a way to read the current status of mouse_warp, this has to default to the old behavior.