### PR TITLE
`hyprland/window` expose more data

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -24,8 +24,20 @@ class Window : public waybar::ALabel, public EventHandler {
     static auto parse(const Json::Value&) -> Workspace;
   };
 
+  struct WindowData {
+    bool floating;
+    int monitor;
+    std::string class_name;
+    std::string initial_class_name;
+    std::string title;
+    std::string initial_title;
+
+    static auto parse(const Json::Value&) -> WindowData;
+  };
+
   auto getActiveWorkspace(const std::string&) -> Workspace;
   auto getActiveWorkspace() -> Workspace;
+  auto getWindowData(const std::string& window_id) -> WindowData;
   void onEvent(const std::string&) override;
   void queryActiveWorkspace();
   void setClass(const std::string&, bool enable);
@@ -34,7 +46,9 @@ class Window : public waybar::ALabel, public EventHandler {
   std::mutex mutex_;
   const Bar& bar_;
   util::JsonParser parser_;
+  std::string last_window_address_;
   std::string last_title_;
+  WindowData window_data_;
   Workspace workspace_;
   std::string solo_class_;
   std::string last_solo_class_;

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -37,7 +37,6 @@ class Window : public waybar::ALabel, public EventHandler {
 
   auto getActiveWorkspace(const std::string&) -> Workspace;
   auto getActiveWorkspace() -> Workspace;
-  auto getWindowData(const std::string& window_id) -> WindowData;
   void onEvent(const std::string&) override;
   void queryActiveWorkspace();
   void setClass(const std::string&, bool enable);

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -26,7 +26,7 @@ class Window : public waybar::ALabel, public EventHandler {
 
   struct WindowData {
     bool floating;
-    int monitor;
+    int monitor = -1;
     std::string class_name;
     std::string initial_class_name;
     std::string title;
@@ -46,8 +46,6 @@ class Window : public waybar::ALabel, public EventHandler {
   std::mutex mutex_;
   const Bar& bar_;
   util::JsonParser parser_;
-  std::string last_window_address_;
-  std::string last_title_;
   WindowData window_data_;
   Workspace workspace_;
   std::string solo_class_;

--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -30,11 +30,11 @@ See the output of "hyprctl clients" for examples
 
 *{title}*: The current title of the focused window.
 
-*{initial-title}*: The initial title of the focused window.
+*{initialTitle}*: The initial title of the focused window.
 
 *{class}*: The current class of the focused window.
 
-*{initial-class}*: The initial class of the focused window.
+*{initialClass}*: The initial class of the focused window.
 
 # REWRITE RULES
 

--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -14,7 +14,7 @@ Addressed by *hyprland/window*
 
 *format*: ++
 	typeof: string ++
-	default: {} ++
+	default: {title} ++
 	The format, how information should be displayed. On {} the current window title is displayed.
 
 *rewrite*: ++
@@ -24,6 +24,17 @@ Addressed by *hyprland/window*
 *separate-outputs*: ++
 	typeof: bool ++
 	Show the active window of the monitor the bar belongs to, instead of the focused window.
+
+# FORMAT REPLACEMENTS
+See the output of "hyprctl clients" for examples
+
+*{title}*: The current title of the focused window.
+
+*{initial-title}*: The initial title of the focused window.
+
+*{class}*: The current class of the focused window.
+
+*{initial-class}*: The initial class of the focused window.
 
 # REWRITE RULES
 

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -122,19 +122,6 @@ auto Window::Workspace::parse(const Json::Value& value) -> Window::Workspace {
                    value["lastwindowtitle"].asString()};
 }
 
-auto Window::getWindowData(const std::string& window_address) -> WindowData {
-  const auto clients = gIPC->getSocket1JsonReply("clients");
-  assert(clients.isArray());
-  auto window = std::find_if(clients.begin(), clients.end(), [&](Json::Value window) {
-    return window["address"] == window_address;
-  });
-  if (window == std::end(clients)) {
-    spdlog::warn("No client with address {}", window_address);
-    return WindowData{false, -1, "", "", "", ""};
-  }
-  return WindowData::parse(*window);
-}
-
 auto Window::WindowData::parse(const Json::Value& value) -> Window::WindowData {
   return WindowData{value["floating"].asBool(), value["monitor"].asInt(),
                     value["class"].asString(),  value["initialClass"].asString(),

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -59,9 +59,9 @@ auto Window::update() -> void {
     label_.show();
     label_.set_markup(waybar::util::rewriteString(
         fmt::format(fmt::runtime(format_), fmt::arg("title", window_name),
-                    fmt::arg("initial-title", window_data_.initial_title),
+                    fmt::arg("initialTitle", window_data_.initial_title),
                     fmt::arg("class", window_data_.class_name),
-                    fmt::arg("initial-class", window_data_.initial_class_name)),
+                    fmt::arg("initialClass", window_data_.initial_class_name)),
         config_["rewrite"]));
   } else {
     label_.hide();

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -46,18 +46,13 @@ auto Window::update() -> void {
   std::string window_name = waybar::util::sanitize_string(workspace_.last_window_title);
   std::string window_address = workspace_.last_window;
 
-  if (window_name != last_title_) {
+  if (window_name != window_data_.title) {
     if (window_name.empty()) {
       label_.get_style_context()->add_class("empty");
     } else {
       label_.get_style_context()->remove_class("empty");
     }
-    last_title_ = window_name;
-  }
-
-  if (window_address != last_window_address_) {
-    last_window_address_ = window_address;
-    window_data_ = getWindowData(window_address);
+    window_data_.title = window_name;
   }
 
   if (!format_.empty()) {
@@ -165,6 +160,7 @@ void Window::queryActiveWorkspace() {
       return;
     }
 
+    window_data_ = WindowData::parse(*active_window);
     std::vector<Json::Value> workspace_windows;
     std::copy_if(clients.begin(), clients.end(), std::back_inserter(workspace_windows),
                  [&](Json::Value window) {
@@ -187,11 +183,12 @@ void Window::queryActiveWorkspace() {
     }
 
     if (solo_) {
-      solo_class_ = (*active_window)["class"].asString();
+      solo_class_ = window_data_.class_name;
     } else {
       solo_class_ = "";
     }
   } else {
+    window_data_ = WindowData{};
     all_floating_ = false;
     hidden_ = false;
     fullscreen_ = false;

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -59,9 +59,9 @@ auto Window::update() -> void {
     label_.show();
     label_.set_markup(waybar::util::rewriteString(
         fmt::format(fmt::runtime(format_), fmt::arg("title", window_name),
-                    fmt::arg("initialTitle", window_data_.initial_title),
+                    fmt::arg("initial-title", window_data_.initial_title),
                     fmt::arg("class", window_data_.class_name),
-                    fmt::arg("initialClass", window_data_.initial_class_name)),
+                    fmt::arg("initial-class", window_data_.initial_class_name)),
         config_["rewrite"]));
   } else {
     label_.hide();


### PR DESCRIPTION
This exposes more data as format arguments in the `hyprland/window` module. Most importantly you can now use `"{initialTitle}"` which often shows a nice String describing the program, other than the current state of the program (i.e. for a Firefox window it is "Mozilla Firefox" not "Comparing Alexays:master...Mr-Pine:hyprland-window-data · Alexays/Waybar — Mozilla Firefox")

Fixes #2289 