### PR TITLE
App Icons for `hyprland/window`

### DIFF
--- a/include/AAppIconLabel.hpp
+++ b/include/AAppIconLabel.hpp
@@ -16,7 +16,8 @@ class AAppIconLabel : public AIconLabel {
   auto update() -> void override;
 
  protected:
-  void updateAppIconName(const std::string &app_identifier);
+  void updateAppIconName(const std::string &app_identifier,
+                         const std::string &alternative_app_identifier);
   void updateAppIcon();
   unsigned app_icon_size_{24};
   bool update_app_icon_{true};

--- a/include/AAppIconLabel.hpp
+++ b/include/AAppIconLabel.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <gtkmm/box.h>
+#include <gtkmm/image.h>
+
+#include "AIconLabel.hpp"
+
+namespace waybar {
+
+class AAppIconLabel : public AIconLabel {
+ public:
+  AAppIconLabel(const Json::Value &config, const std::string &name, const std::string &id,
+                const std::string &format, uint16_t interval = 0, bool ellipsize = false,
+                bool enable_click = false, bool enable_scroll = false);
+  virtual ~AAppIconLabel() = default;
+  auto update() -> void override;
+
+ protected:
+  void updateAppIconName(const std::string &app_identifier);
+  void updateAppIcon();
+  unsigned app_icon_size_{24};
+  bool update_app_icon_{true};
+  std::string app_icon_name_;
+};
+
+}  // namespace waybar

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -1,13 +1,13 @@
 #include <fmt/format.h>
 
-#include "AIconLabel.hpp"
+#include "AAppIconLabel.hpp"
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
 #include "util/json.hpp"
 
 namespace waybar::modules::hyprland {
 
-class Window : public waybar::AIconLabel, public EventHandler {
+class Window : public waybar::AAppIconLabel, public EventHandler {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
   virtual ~Window();
@@ -40,8 +40,6 @@ class Window : public waybar::AIconLabel, public EventHandler {
   void onEvent(const std::string&) override;
   void queryActiveWorkspace();
   void setClass(const std::string&, bool enable);
-  void updateAppIconName();
-  void updateAppIcon();
 
   bool separate_outputs;
   std::mutex mutex_;
@@ -55,9 +53,6 @@ class Window : public waybar::AIconLabel, public EventHandler {
   bool all_floating_;
   bool hidden_;
   bool fullscreen_;
-  unsigned app_icon_size_{24};
-  bool update_app_icon_{true};
-  std::string app_icon_name_;
 };
 
 }  // namespace waybar::modules::hyprland

--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -1,13 +1,13 @@
 #include <fmt/format.h>
 
-#include "ALabel.hpp"
+#include "AIconLabel.hpp"
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
 #include "util/json.hpp"
 
 namespace waybar::modules::hyprland {
 
-class Window : public waybar::ALabel, public EventHandler {
+class Window : public waybar::AIconLabel, public EventHandler {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
   virtual ~Window();
@@ -40,6 +40,8 @@ class Window : public waybar::ALabel, public EventHandler {
   void onEvent(const std::string&) override;
   void queryActiveWorkspace();
   void setClass(const std::string&, bool enable);
+  void updateAppIconName();
+  void updateAppIcon();
 
   bool separate_outputs;
   std::mutex mutex_;
@@ -53,6 +55,9 @@ class Window : public waybar::ALabel, public EventHandler {
   bool all_floating_;
   bool hidden_;
   bool fullscreen_;
+  unsigned app_icon_size_{24};
+  bool update_app_icon_{true};
+  std::string app_icon_name_;
 };
 
 }  // namespace waybar::modules::hyprland

--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -4,7 +4,7 @@
 
 #include <tuple>
 
-#include "AIconLabel.hpp"
+#include "AAppIconLabel.hpp"
 #include "bar.hpp"
 #include "client.hpp"
 #include "modules/sway/ipc/client.hpp"
@@ -12,7 +12,7 @@
 
 namespace waybar::modules::sway {
 
-class Window : public AIconLabel, public sigc::trackable {
+class Window : public AAppIconLabel, public sigc::trackable {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
   virtual ~Window() = default;
@@ -25,8 +25,6 @@ class Window : public AIconLabel, public sigc::trackable {
   std::tuple<std::size_t, int, int, std::string, std::string, std::string, std::string, std::string>
   getFocusedNode(const Json::Value& nodes, std::string& output);
   void getTree();
-  void updateAppIconName();
-  void updateAppIcon();
 
   const Bar& bar_;
   std::string window_;
@@ -37,9 +35,6 @@ class Window : public AIconLabel, public sigc::trackable {
   std::string old_app_id_;
   std::size_t app_nb_;
   std::string shell_;
-  unsigned app_icon_size_{24};
-  bool update_app_icon_{true};
-  std::string app_icon_name_;
   int floating_count_;
   util::JsonParser parser_;
   std::mutex mutex_;

--- a/meson.build
+++ b/meson.build
@@ -159,6 +159,7 @@ src_files = files(
     'src/AModule.cpp',
     'src/ALabel.cpp',
     'src/AIconLabel.cpp',
+    'src/AAppIconLabel.cpp',
     'src/modules/custom.cpp',
     'src/modules/disk.cpp',
     'src/modules/idle_inhibitor.cpp',

--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -1,0 +1,124 @@
+#include "AAppIconLabel.hpp"
+
+#include <gdkmm/pixbuf.h>
+#include <glibmm/fileutils.h>
+#include <glibmm/keyfile.h>
+#include <glibmm/miscutils.h>
+#include <spdlog/spdlog.h>
+
+#include <filesystem>
+#include <optional>
+
+#include "util/gtk_icon.hpp"
+
+namespace waybar {
+
+AAppIconLabel::AAppIconLabel(const Json::Value& config, const std::string& name,
+                             const std::string& id, const std::string& format, uint16_t interval,
+                             bool ellipsize, bool enable_click, bool enable_scroll)
+    : AIconLabel(config, name, id, format, interval, ellipsize, enable_click, enable_scroll) {
+  // Icon size
+  if (config["icon-size"].isUInt()) {
+    app_icon_size_ = config["icon-size"].asUInt();
+  }
+  image_.set_pixel_size(app_icon_size_);
+}
+
+std::optional<std::string> getDesktopFilePath(const std::string& app_identifier) {
+  const auto data_dirs = Glib::get_system_data_dirs();
+  for (const auto& data_dir : data_dirs) {
+    const auto data_app_dir = data_dir + "applications/";
+    auto desktop_file_path = data_app_dir + app_identifier + ".desktop";
+    if (std::filesystem::exists(desktop_file_path)) {
+      return desktop_file_path;
+    }
+  }
+  return {};
+}
+
+std::optional<Glib::ustring> getIconName(const std::string& app_identifier) {
+  const auto desktop_file_path = getDesktopFilePath(app_identifier);
+  if (!desktop_file_path.has_value()) {
+    // Try some heuristics to find a matching icon
+
+    if (DefaultGtkIconThemeWrapper::has_icon(app_identifier)) {
+      return app_identifier;
+    }
+
+    const auto app_identifier_desktop = app_identifier + "-desktop";
+    if (DefaultGtkIconThemeWrapper::has_icon(app_identifier_desktop)) {
+      return app_identifier_desktop;
+    }
+
+    const auto to_lower = [](const std::string& str) {
+      auto str_cpy = str;
+      std::transform(str_cpy.begin(), str_cpy.end(), str_cpy.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      return str;
+    };
+
+    const auto first_space = app_identifier.find_first_of(' ');
+    if (first_space != std::string::npos) {
+      const auto first_word = to_lower(app_identifier.substr(0, first_space));
+      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
+        return first_word;
+      }
+    }
+
+    const auto first_dash = app_identifier.find_first_of('-');
+    if (first_dash != std::string::npos) {
+      const auto first_word = to_lower(app_identifier.substr(0, first_dash));
+      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
+        return first_word;
+      }
+    }
+
+    return {};
+  }
+
+  try {
+    Glib::KeyFile desktop_file;
+    desktop_file.load_from_file(desktop_file_path.value());
+    return desktop_file.get_string("Desktop Entry", "Icon");
+  } catch (Glib::FileError& error) {
+    spdlog::warn("Error while loading desktop file {}: {}", desktop_file_path.value(),
+                 error.what().c_str());
+  } catch (Glib::KeyFileError& error) {
+    spdlog::warn("Error while loading desktop file {}: {}", desktop_file_path.value(),
+                 error.what().c_str());
+  }
+  return {};
+}
+
+void AAppIconLabel::updateAppIconName(const std::string& app_identifier) {
+  if (!iconEnabled()) {
+    return;
+  }
+
+  const auto icon_name = getIconName(app_identifier);
+  if (icon_name.has_value()) {
+    app_icon_name_ = icon_name.value();
+  } else {
+    app_icon_name_ = "";
+  }
+  update_app_icon_ = true;
+}
+
+void AAppIconLabel::updateAppIcon() {
+  if (update_app_icon_) {
+    update_app_icon_ = false;
+    if (app_icon_name_.empty()) {
+      image_.set_visible(false);
+    } else {
+      image_.set_from_icon_name(app_icon_name_, Gtk::ICON_SIZE_INVALID);
+      image_.set_visible(true);
+    }
+  }
+}
+
+auto AAppIconLabel::update() -> void {
+  updateAppIcon();
+  AIconLabel::update();
+}
+
+}  // namespace waybar

--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -24,7 +24,8 @@ AAppIconLabel::AAppIconLabel(const Json::Value& config, const std::string& name,
   image_.set_pixel_size(app_icon_size_);
 }
 
-std::optional<std::string> getDesktopFilePath(const std::string& app_identifier) {
+std::optional<std::string> getDesktopFilePath(const std::string& app_identifier,
+                                              const std::string& alternative_app_identifier) {
   const auto data_dirs = Glib::get_system_data_dirs();
   for (const auto& data_dir : data_dirs) {
     const auto data_app_dir = data_dir + "applications/";
@@ -32,12 +33,19 @@ std::optional<std::string> getDesktopFilePath(const std::string& app_identifier)
     if (std::filesystem::exists(desktop_file_path)) {
       return desktop_file_path;
     }
+    if (!alternative_app_identifier.empty()) {
+      desktop_file_path = data_app_dir + alternative_app_identifier + ".desktop";
+      if (std::filesystem::exists(desktop_file_path)) {
+        return desktop_file_path;
+      }
+    }
   }
   return {};
 }
 
-std::optional<Glib::ustring> getIconName(const std::string& app_identifier) {
-  const auto desktop_file_path = getDesktopFilePath(app_identifier);
+std::optional<Glib::ustring> getIconName(const std::string& app_identifier,
+                                         const std::string& alternative_app_identifier) {
+  const auto desktop_file_path = getDesktopFilePath(app_identifier, alternative_app_identifier);
   if (!desktop_file_path.has_value()) {
     // Try some heuristics to find a matching icon
 
@@ -90,12 +98,13 @@ std::optional<Glib::ustring> getIconName(const std::string& app_identifier) {
   return {};
 }
 
-void AAppIconLabel::updateAppIconName(const std::string& app_identifier) {
+void AAppIconLabel::updateAppIconName(const std::string& app_identifier,
+                                      const std::string& alternative_app_identifier) {
   if (!iconEnabled()) {
     return;
   }
 
-  const auto icon_name = getIconName(app_identifier);
+  const auto icon_name = getIconName(app_identifier, alternative_app_identifier);
   if (icon_name.has_value()) {
     app_icon_name_ = icon_name.value();
   } else {

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -192,7 +192,7 @@ auto Window::update() -> void {
 
   updateAppIcon();
 
-  ALabel::update();
+  AIconLabel::update();
 }
 
 auto Window::getActiveWorkspace() -> Workspace {

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -152,7 +152,7 @@ void Window::queryActiveWorkspace() {
     }
 
     window_data_ = WindowData::parse(*active_window);
-    updateAppIconName(window_data_.class_name);
+    updateAppIconName(window_data_.class_name, window_data_.initial_class_name);
     std::vector<Json::Value> workspace_windows;
     std::copy_if(clients.begin(), clients.end(), std::back_inserter(workspace_windows),
                  [&](Json::Value window) {

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -1,22 +1,34 @@
 #include "modules/hyprland/window.hpp"
 
+#include <glibmm/fileutils.h>
+#include <glibmm/keyfile.h>
+#include <glibmm/miscutils.h>
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <filesystem>
+#include <optional>
 #include <regex>
 #include <util/sanitize_str.hpp>
 #include <vector>
 
 #include "modules/hyprland/backend.hpp"
+#include "util/gtk_icon.hpp"
 #include "util/json.hpp"
 #include "util/rewrite_string.hpp"
 
 namespace waybar::modules::hyprland {
 
 Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
-    : ALabel(config, "window", id, "{title}", 0, true), bar_(bar) {
+    : AIconLabel(config, "window", id, "{title}", 0, true), bar_(bar) {
   modulesReady = true;
   separate_outputs = config["separate-outputs"].asBool();
+
+  // Icon size
+  if (config["icon-size"].isUInt()) {
+    app_icon_size_ = config["icon-size"].asUInt();
+  }
+  image_.set_pixel_size(app_icon_size_);
 
   if (!gIPC.get()) {
     gIPC = std::make_unique<IPC>();
@@ -37,6 +49,98 @@ Window::~Window() {
   gIPC->unregisterForIPC(this);
   // wait for possible event handler to finish
   std::lock_guard<std::mutex> lg(mutex_);
+}
+
+std::optional<std::string> getDesktopFilePath(const std::string& app_class) {
+  const auto data_dirs = Glib::get_system_data_dirs();
+  for (const auto& data_dir : data_dirs) {
+    const auto data_app_dir = data_dir + "applications/";
+    auto desktop_file_path = data_app_dir + app_class + ".desktop";
+    if (std::filesystem::exists(desktop_file_path)) {
+      return desktop_file_path;
+    }
+  }
+  return {};
+}
+
+std::optional<Glib::ustring> getIconName(const std::string& app_class) {
+  const auto desktop_file_path = getDesktopFilePath(app_class);
+  if (!desktop_file_path.has_value()) {
+    // Try some heuristics to find a matching icon
+
+    if (DefaultGtkIconThemeWrapper::has_icon(app_class)) {
+      return app_class;
+    }
+
+    const auto app_identifier_desktop = app_class + "-desktop";
+    if (DefaultGtkIconThemeWrapper::has_icon(app_identifier_desktop)) {
+      return app_identifier_desktop;
+    }
+
+    const auto to_lower = [](const std::string& str) {
+      auto str_cpy = str;
+      std::transform(str_cpy.begin(), str_cpy.end(), str_cpy.begin(),
+                     [](unsigned char c) { return std::tolower(c); });
+      return str;
+    };
+
+    const auto first_space = app_class.find_first_of(' ');
+    if (first_space != std::string::npos) {
+      const auto first_word = to_lower(app_class.substr(0, first_space));
+      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
+        return first_word;
+      }
+    }
+
+    const auto first_dash = app_class.find_first_of('-');
+    if (first_dash != std::string::npos) {
+      const auto first_word = to_lower(app_class.substr(0, first_dash));
+      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
+        return first_word;
+      }
+    }
+
+    return {};
+  }
+
+  try {
+    Glib::KeyFile desktop_file;
+    desktop_file.load_from_file(desktop_file_path.value());
+    return desktop_file.get_string("Desktop Entry", "Icon");
+  } catch (Glib::FileError& error) {
+    spdlog::warn("Error while loading desktop file {}: {}", desktop_file_path.value(),
+                 error.what().c_str());
+  } catch (Glib::KeyFileError& error) {
+    spdlog::warn("Error while loading desktop file {}: {}", desktop_file_path.value(),
+                 error.what().c_str());
+  }
+  return {};
+}
+
+void Window::updateAppIconName() {
+  if (!iconEnabled()) {
+    return;
+  }
+
+  const auto icon_name = getIconName(window_data_.class_name);
+  if (icon_name.has_value()) {
+    app_icon_name_ = icon_name.value();
+  } else {
+    app_icon_name_ = "";
+  }
+  update_app_icon_ = true;
+}
+
+void Window::updateAppIcon() {
+  if (update_app_icon_) {
+    update_app_icon_ = false;
+    if (app_icon_name_.empty()) {
+      image_.set_visible(false);
+    } else {
+      image_.set_from_icon_name(app_icon_name_, Gtk::ICON_SIZE_INVALID);
+      image_.set_visible(true);
+    }
+  }
 }
 
 auto Window::update() -> void {
@@ -85,6 +189,8 @@ auto Window::update() -> void {
     spdlog::trace("Adding solo class: {}", solo_class_);
   }
   last_solo_class_ = solo_class_;
+
+  updateAppIcon();
 
   ALabel::update();
 }
@@ -148,6 +254,7 @@ void Window::queryActiveWorkspace() {
     }
 
     window_data_ = WindowData::parse(*active_window);
+    updateAppIconName();
     std::vector<Json::Value> workspace_windows;
     std::copy_if(clients.begin(), clients.end(), std::back_inserter(workspace_windows),
                  [&](Json::Value window) {

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -43,7 +43,7 @@ void Window::onCmd(const struct Ipc::ipc_response& res) {
     auto output = payload["output"].isString() ? payload["output"].asString() : "";
     std::tie(app_nb_, floating_count_, windowId_, window_, app_id_, app_class_, shell_, layout_) =
         getFocusedNode(payload["nodes"], output);
-    updateAppIconName(app_id_);
+    updateAppIconName(app_id_, app_class_);
     dp.emit();
   } catch (const std::exception& e) {
     spdlog::error("Window: {}", e.what());

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -17,13 +17,7 @@
 namespace waybar::modules::sway {
 
 Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
-    : AIconLabel(config, "window", id, "{}", 0, true), bar_(bar), windowId_(-1) {
-  // Icon size
-  if (config_["icon-size"].isUInt()) {
-    app_icon_size_ = config["icon-size"].asUInt();
-  }
-  image_.set_pixel_size(app_icon_size_);
-
+    : AAppIconLabel(config, "window", id, "{}", 0, true), bar_(bar), windowId_(-1) {
   ipc_.subscribe(R"(["window","workspace"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &Window::onEvent));
   ipc_.signal_cmd.connect(sigc::mem_fun(*this, &Window::onCmd));
@@ -49,110 +43,11 @@ void Window::onCmd(const struct Ipc::ipc_response& res) {
     auto output = payload["output"].isString() ? payload["output"].asString() : "";
     std::tie(app_nb_, floating_count_, windowId_, window_, app_id_, app_class_, shell_, layout_) =
         getFocusedNode(payload["nodes"], output);
-    updateAppIconName();
+    updateAppIconName(app_id_);
     dp.emit();
   } catch (const std::exception& e) {
     spdlog::error("Window: {}", e.what());
     spdlog::trace("Window::onCmd exception");
-  }
-}
-
-std::optional<std::string> getDesktopFilePath(const std::string& app_id,
-                                              const std::string& app_class) {
-  const auto data_dirs = Glib::get_system_data_dirs();
-  for (const auto& data_dir : data_dirs) {
-    const auto data_app_dir = data_dir + "applications/";
-    auto desktop_file_path = data_app_dir + app_id + ".desktop";
-    if (std::filesystem::exists(desktop_file_path)) {
-      return desktop_file_path;
-    }
-    if (!app_class.empty()) {
-      desktop_file_path = data_app_dir + app_class + ".desktop";
-      if (std::filesystem::exists(desktop_file_path)) {
-        return desktop_file_path;
-      }
-    }
-  }
-  return {};
-}
-
-std::optional<Glib::ustring> getIconName(const std::string& app_id, const std::string& app_class) {
-  const auto desktop_file_path = getDesktopFilePath(app_id, app_class);
-  if (!desktop_file_path.has_value()) {
-    // Try some heuristics to find a matching icon
-
-    if (DefaultGtkIconThemeWrapper::has_icon(app_id)) {
-      return app_id;
-    }
-
-    const auto app_id_desktop = app_id + "-desktop";
-    if (DefaultGtkIconThemeWrapper::has_icon(app_id_desktop)) {
-      return app_id_desktop;
-    }
-
-    const auto to_lower = [](const std::string& str) {
-      auto str_cpy = str;
-      std::transform(str_cpy.begin(), str_cpy.end(), str_cpy.begin(),
-                     [](unsigned char c) { return std::tolower(c); });
-      return str;
-    };
-
-    const auto first_space = app_id.find_first_of(' ');
-    if (first_space != std::string::npos) {
-      const auto first_word = to_lower(app_id.substr(0, first_space));
-      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
-        return first_word;
-      }
-    }
-
-    const auto first_dash = app_id.find_first_of('-');
-    if (first_dash != std::string::npos) {
-      const auto first_word = to_lower(app_id.substr(0, first_dash));
-      if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
-        return first_word;
-      }
-    }
-
-    return {};
-  }
-
-  try {
-    Glib::KeyFile desktop_file;
-    desktop_file.load_from_file(desktop_file_path.value());
-    return desktop_file.get_string("Desktop Entry", "Icon");
-  } catch (Glib::FileError& error) {
-    spdlog::warn("Error while loading desktop file {}: {}", desktop_file_path.value(),
-                 error.what().c_str());
-  } catch (Glib::KeyFileError& error) {
-    spdlog::warn("Error while loading desktop file {}: {}", desktop_file_path.value(),
-                 error.what().c_str());
-  }
-  return {};
-}
-
-void Window::updateAppIconName() {
-  if (!iconEnabled()) {
-    return;
-  }
-
-  const auto icon_name = getIconName(app_id_, app_class_);
-  if (icon_name.has_value()) {
-    app_icon_name_ = icon_name.value();
-  } else {
-    app_icon_name_ = "";
-  }
-  update_app_icon_ = true;
-}
-
-void Window::updateAppIcon() {
-  if (update_app_icon_) {
-    update_app_icon_ = false;
-    if (app_icon_name_.empty()) {
-      image_.set_visible(false);
-    } else {
-      image_.set_from_icon_name(app_icon_name_, Gtk::ICON_SIZE_INVALID);
-      image_.set_visible(true);
-    }
   }
 }
 
@@ -210,7 +105,7 @@ auto Window::update() -> void {
   updateAppIcon();
 
   // Call parent update
-  AIconLabel::update();
+  AAppIconLabel::update();
 }
 
 void Window::setClass(std::string classname, bool enable) {


### PR DESCRIPTION
This PR introduces App Icons for the `hyprland/window` module (as requested in #1925)

Since this required almost no changes from the code for `sway/window` and I didn't want to duplicate the code, I introduces a new `AAppIconLabel` class which now both `hyprland/window` and `sway/window` inherit from. The sway implementation uses `app_class` if `app_id` is not set (appears to be the case if the window is running under xwayland) but I wasn't really able to find a suitable replacement for that with hyprland (`app_id` seems to correspond to hyprlands `class` though). 
Tested on both hyprland and sway