### PR TITLE
hyprland/window: Fix overlap with .hidden class from default style

### DIFF
--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -76,5 +76,5 @@ window widget:
 - *window#waybar.floating* When there are only floating windows in the workspace
 - *window#waybar.fullscreen* When there is a fullscreen window in the workspace;
   useful with Hyprland's *fullscreen, 1* mode
-- *window#waybar.hidden* When there are hidden windows in the workspace; usually
-  occurs due to window swallowing
+- *window#waybar.hidden-window* When there are hidden windows in the workspace;
+  can occur due to window swallowing, *fullscreen, 1* mode, or grouped windows

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -11,8 +11,6 @@
 #include <vector>
 
 #include "modules/hyprland/backend.hpp"
-#include "util/gtk_icon.hpp"
-#include "util/json.hpp"
 #include "util/rewrite_string.hpp"
 
 namespace waybar::modules::hyprland {
@@ -74,7 +72,7 @@ auto Window::update() -> void {
   setClass("empty", workspace_.windows == 0);
   setClass("solo", solo_);
   setClass("floating", all_floating_);
-  setClass("hidden", hidden_);
+  setClass("hidden-window", hidden_);
   setClass("fullscreen", fullscreen_);
 
   if (!last_solo_class_.empty() && solo_class_ != last_solo_class_) {


### PR DESCRIPTION
I made a mistake in #2270, apparently the .hidden class is already used for something else, and the default style.css has a rule for it (I did not realize this because I use a custom style.css).

https://github.com/Alexays/Waybar/blob/c2f98d07efc23bbe7d7dc91d06f6685abf2e625d/resources/style.css#L15

This led to #2301, where the waybar became transparent when there are hidden windows. This was not intended behvior.

I honestly don't know what the `opacity: 0.2` rule is used for. But if it really is used for something, then this PR should fix any issues, by renaming `hyprland/window`'s style to `.hidden-window`.