### PR TITLE
hyprland/window: rename .hidden to .swallowing (and fix grouped windows)

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -31,6 +31,8 @@ class Window : public waybar::AAppIconLabel, public EventHandler {
     std::string initial_class_name;
     std::string title;
     std::string initial_title;
+    bool fullscreen;
+    bool grouped;
 
     static auto parse(const Json::Value&) -> WindowData;
   };
@@ -51,7 +53,7 @@ class Window : public waybar::AAppIconLabel, public EventHandler {
   std::string last_solo_class_;
   bool solo_;
   bool all_floating_;
-  bool hidden_;
+  bool swallowing_;
   bool fullscreen_;
 };
 

--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -76,5 +76,4 @@ window widget:
 - *window#waybar.floating* When there are only floating windows in the workspace
 - *window#waybar.fullscreen* When there is a fullscreen window in the workspace;
   useful with Hyprland's *fullscreen, 1* mode
-- *window#waybar.hidden-window* When there are hidden windows in the workspace;
-  can occur due to window swallowing, *fullscreen, 1* mode, or grouped windows
+- *window#waybar.swallowing* When there is a swallowed window in the workspace


### PR DESCRIPTION
Sorry, I know I submitted #2307 just half an hour ago, but I changed my mind. Rather than renaming `.hidden` to some other class name, I have renamed it to `.swallowing`. After some more discussion in the comments to https://github.com/Alexays/Waybar/commit/cdece498c1e3849ea6e8ff7795ddce1ca8265803#commitcomment-121410267 I realized that instead of excluding so many edge cases for it, it's easier to check specifically for window swallowing, as that's the only use case that makes sense and is not covered by other means.