### PR TITLE
backlight: do not convert percent to string in fmt

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -191,7 +191,7 @@ auto waybar::modules::Backlight::update() -> void {
       const uint8_t percent =
           best->get_max() == 0 ? 100 : round(best->get_actual() * 100.0f / best->get_max());
       std::string desc =
-          fmt::format(fmt::runtime(format_), fmt::arg("percent", std::to_string(percent)),
+          fmt::format(fmt::runtime(format_), fmt::arg("percent", percent),
                       fmt::arg("icon", getIcon(percent)));
       label_.set_markup(desc);
       getState(percent);
@@ -202,7 +202,7 @@ auto waybar::modules::Backlight::update() -> void {
         }
         if (!tooltip_format.empty()) {
           label_.set_tooltip_text(fmt::format(fmt::runtime(tooltip_format),
-                                              fmt::arg("percent", std::to_string(percent)),
+                                              fmt::arg("percent", percent),
                                               fmt::arg("icon", getIcon(percent))));
         } else {
           label_.set_tooltip_text(desc);


### PR DESCRIPTION
fix #2311 

this removes the `std::to_string` conversions from `percent` in the `backlight.cpp` when passing to `fmt::format`. i don't think this should break anything, as `percent` is defined as a `uint8_t`.

i aḿ not exactly certain why this was added in the first place, as this was originally added in 331b28393aa65354e8a7bdff5a35a61f8d2479cc and has been unchanged since, and i can not see any specific reason given in either the commit or the corresponding pr.