### PR TITLE
hyprland/window remove duplicate empty css

### DIFF
--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -63,7 +63,7 @@ Invalid expressions (e.g., mismatched parentheses) are skipped.
 # STYLE
 
 - *#window*
-- *#window.empty* When no windows are in the workspace
+- *window#waybar.empty #window* When no windows are in the workspace
 
 The following classes are applied to the entire Waybar rather than just the
 window widget:

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -48,14 +48,7 @@ auto Window::update() -> void {
   std::string window_name = waybar::util::sanitize_string(workspace_.last_window_title);
   std::string window_address = workspace_.last_window;
 
-  if (window_name != window_data_.title) {
-    if (window_name.empty()) {
-      label_.get_style_context()->add_class("empty");
-    } else {
-      label_.get_style_context()->remove_class("empty");
-    }
-    window_data_.title = window_name;
-  }
+  window_data_.title = window_name;
 
   if (!format_.empty()) {
     label_.show();


### PR DESCRIPTION
There's no need to keep `#window.empty` since `window#waybar.empty #window` achieves the same effect. Also, `#window.empty` doesn't seem to be working anymore