### PR TITLE
hyprland/backend: Fix JSON parser runtime error

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -192,7 +192,7 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
       return "";
     }
     response.append(buffer, sizeWritten);
-  } while (sizeWritten == 8192);
+  } while (sizeWritten > 0);
 
   close(SERVERSOCKET);
   return response;


### PR DESCRIPTION
`getSocket1Reply` can get an incomplete response. When `getSocket1JsonReply` parses this response with the JSON parser, it throws the runtime error.

The socket read ends early when it doesn't completely fill the socket buffer when it has more data. The socket read now stops when the socket returns nothing instead of stopping when it has returned less than the size of the buffer.

Closes #2313 