### PR TITLE
hyprland/language: Differentiating keyboard layout variants

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -38,7 +38,10 @@ auto Language::update() -> void {
   std::lock_guard<std::mutex> lg(mutex_);
 
   std::string layoutName = std::string{};
-  if (config_.isMember("format-" + layout_.short_description)) {
+  if (config_.isMember("format-" + layout_.short_description + "-" + layout_.variant)) {
+    const auto propName = "format-" + layout_.short_description + "-" + layout_.variant;
+    layoutName = fmt::format(fmt::runtime(format_), config_[propName].asString());
+  } else if (config_.isMember("format-" + layout_.short_description)) {
     const auto propName = "format-" + layout_.short_description;
     layoutName = fmt::format(fmt::runtime(format_), config_[propName].asString());
   } else {


### PR DESCRIPTION
This improves hyprland/language module, so you can specify keyboard variant for formatting.
So you are able to have multiple keyboard variants of same language and differentiate between them, for example, you can define "format-cs-qwerty" and "format-cs-coder".