### PR TITLE
cava bump

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -346,7 +346,7 @@ if get_option('experimental')
 endif
 
 cava = dependency('cava',
-                  version : '>=0.8.4',
+                  version : '>=0.8.5',
                   required: get_option('cava'),
                   fallback : ['cava', 'cava_dep'],
                   not_found_message: 'cava is not found. Building waybar without cava')

--- a/subprojects/cava.wrap
+++ b/subprojects/cava.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = cava-0.8.4
-source_url = https://github.com/LukashonakV/cava/archive/0.8.4.tar.gz
-source_filename = cava-0.8.4.tar.gz
-source_hash = 523353f446570277d40b8e1efb84468d70fdec53e1356a555c14bf466557a3ed
+directory = cava-0.8.5
+source_url = https://github.com/LukashonakV/cava/archive/0.8.5.tar.gz
+source_filename = cava-0.8.5.tar.gz
+source_hash = 9ce3df7d374dc83ed0704fe3caef5e00600ce061d85608aad4142d2c59aa4647
 [provide]
 cava = cava_dep


### PR DESCRIPTION
Hi @Alexays , this PR should fix #2281 . 
I've rebuilt cava library. The problem here was: cava lib was providing sndio.h header. The name totaly the same as a standard sndio.h library. So it seems during waybar with cava build process the builder is not able to identify exact header is needed by waybar sndio module. 

----
In order to remove libcava properly users should do: 

1. `sudo rm -rfv /usr/lib/libcava.so`
2. `sudo rm -rfv /usr/lib64/libcava.so`
3. `sudo rm -rfv /usr/lib/pkgconfig/cava.pc`
4. `sudo rm -rfv /usr/lib64/pkgconfig/cava.pc`
5. `sudo rm -rfv /usr/include/cava`