### PR TITLE
`hyprland/window` start behavior fix

### DIFF
--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -25,6 +25,16 @@ Addressed by *hyprland/window*
 	typeof: bool ++
 	Show the active window of the monitor the bar belongs to, instead of the focused window.
 
+*icon*: ++
+	typeof: bool ++
+	default: false ++
+	Option to hide the application icon.
+
+*icon-size*: ++
+	typeof: integer ++
+	default: 24 ++
+	Option to change the size of the application icon.
+
 # FORMAT REPLACEMENTS
 See the output of "hyprctl clients" for examples
 

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -26,6 +26,7 @@ Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
 
   queryActiveWorkspace();
   update();
+  dp.emit();
 
   // register for hyprland ipc
   gIPC->registerForIPC("activewindow", this);


### PR DESCRIPTION
Fix for #2343 
Adds an emit call to the dispatcher. This is basically what the sway version does, too (not directly but via an ipc call)

As a bonus this documents the icon options for `hyprland/window`