### PR TITLE
Manpage fixes

### DIFF
--- a/man/waybar-cava.5.scd
+++ b/man/waybar-cava.5.scd
@@ -2,7 +2,7 @@ waybar-cava(5) "waybar-cava" "User Manual"
 
 # NAME
 
-cava
+waybar - cava module
 
 # DESCRIPTION
 

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -37,13 +37,13 @@ $XDG_CONFIG_HOME/waybar/config ++
 :[ list of strings
 :[
 :[ A list of timezones (as in *timezone*) to use for time display, changed using
-  the scroll wheel. Do not specify *timezone* option when *timezones* is specified.
+   the scroll wheel. Do not specify *timezone* option when *timezones* is specified.
    "" represents the system's local timezone
 |[ *locale*
 :[ string
 :[
 :[ A locale to be used to display the time. Intended to render times in custom
-  timezones with the proper language and format
+   timezones with the proper language and format
 |[ *max-length*
 :[ integer
 :[
@@ -104,14 +104,14 @@ View all valid format options in *strftime(3)* or have a look <https://fmt.dev/l
 :[ integer
 :[
 :[ The position where week numbers should be displayed. Disabled when is empty.
-  Possible values: left|right
+   Possible values: left|right
 |[ *on-scroll*
 :[ integer
 :[ 1
 :[ Value to scroll months/years forward/backward. Can be negative. Is
-  configured under *on-scroll* option
+   configured under *on-scroll* option
 
-3. Adressed by *clock: calendar: format*
+3. Addressed by *clock: calendar: format*
 [- *Option*
 :- *Typeof*
 :- *Default*

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -2,7 +2,7 @@ waybar-clock(5) "waybar-clock" "User Manual"
 
 # NAME
 
-clock
+waybar - clock module
 
 # DESCRIPTION
 

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -1,4 +1,4 @@
-waybar-wlr-workspaces(5)
+waybar-hyprland-workspaces(5)
 
 # NAME
 

--- a/man/waybar-states.5.scd
+++ b/man/waybar-states.5.scd
@@ -1,5 +1,9 @@
 waybar-states(5)
 
+# NAME
+
+waybar - states property
+
 # OVERVIEW
 
 Some modules support 'states' which allows percentage values to be used as styling triggers to

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -2,7 +2,7 @@ waybar-wlr-taskbar(5)
 
 # NAME
 
-wlroots - Taskbar module
+waybar - wlr taskbar module
 
 # DESCRIPTION
 


### PR DESCRIPTION
This PR consists of the following 2 changes/commits:

man/waybar-clock: Fix typo and formatting
    
    typo: Adressed -> Addressed
    formatting: Add missing spaces


man: Make NAME-ing consistent
    
    Tools like `apropos` and `whatis` use the NAME section to generate their
    database, so make sure every manpage has it.
    Also make sure they all have a brief description and make it consistent
    across the manpages.
