### PR TITLE
Fixed sway IPC compile warnings

### DIFF
--- a/src/modules/sway/ipc/client.cpp
+++ b/src/modules/sway/ipc/client.cpp
@@ -1,6 +1,7 @@
 #include "modules/sway/ipc/client.hpp"
 
 #include <fcntl.h>
+#include <spdlog/spdlog.h>
 
 #include <stdexcept>
 
@@ -17,12 +18,16 @@ Ipc::~Ipc() {
 
   if (fd_ > 0) {
     // To fail the IPC header
-    write(fd_, "close-sway-ipc", 14);
+    if (write(fd_, "close-sway-ipc", 14) == -1) {
+      spdlog::error("Failed to close sway IPC");
+    }
     close(fd_);
     fd_ = -1;
   }
   if (fd_event_ > 0) {
-    write(fd_event_, "close-sway-ipc", 14);
+    if (write(fd_event_, "close-sway-ipc", 14) == -1) {
+      spdlog::error("Failed to close sway IPC event handler");
+    }
     close(fd_event_);
     fd_event_ = -1;
   }


### PR DESCRIPTION
I havent' tested this because I don't use sway, but it's a pretty small change.

Fixes these warnings:

```
[103/154] Compiling C++ object waybar.p/src_modules_sway_ipc_client.cpp.o
../waybar-hyprland-git/src/modules/sway/ipc/client.cpp: In destructor ‘waybar::modules::sway::Ipc::~Ipc()’:
../waybar-hyprland-git/src/modules/sway/ipc/client.cpp:20:10: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   20 |     write(fd_, "close-sway-ipc", 14);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~
../waybar-hyprland-git/src/modules/sway/ipc/client.cpp:25:10: warning: ignoring return value of ‘ssize_t write(int, const void*, size_t)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
   25 |     write(fd_event_, "close-sway-ipc", 14);
      |     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```