### PR TITLE
man: Fix several whitespace formatting issues

### DIFF
--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -25,12 +25,12 @@ The *backlight* module displays the current backlight level.
 	The maximum length in characters the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *rotate*: ++
 	typeof: integer ++
@@ -81,9 +81,9 @@ The *backlight* module displays the current backlight level.
 
 ```
 "backlight": {
-    "device": "intel_backlight",
-    "format": "{percent}% {icon}",
-    "format-icons": ["", ""]
+	"device": "intel_backlight",
+	"format": "{percent}% {icon}",
+	"format-icons": ["", ""]
 }
 ```
 

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -23,9 +23,9 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	Define the max percentage of the battery, for when you've set the battery to stop charging at a lower level to save it. For example, if you've set the battery to stop at 80% that will become the new 100%.
 
 *design-capacity*: ++
-    typeof: bool ++
-    default: false ++
-    Option to use the battery design capacity instead of it's current maximal capacity.
+	typeof: bool ++
+	default: false ++
+	Option to use the battery design capacity instead of it's current maximal capacity.
 
 *interval*: ++
 	typeof: integer ++
@@ -56,12 +56,12 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *rotate*: ++
 	typeof: integer++
@@ -132,8 +132,8 @@ The *battery* module allows one to define custom formats based on up to two fact
 # STATES
 
 - Every entry (*state*) consists of a *<name>* (typeof: *string*) and a *<value>* (typeof: *integer*).
-	- The state can be addressed as a CSS class in the *style.css*. The name of the CSS class is the *<name>* of the state.	Each class gets activated when the current capacity is equal or below the configured *<value>*.
-	- Also each state can have its own *format*. Those con be configured via *format-<name>*. Or if you want to differentiate a bit more even as *format-<status>-<state>*. For more information see *custom-formats*.
+- The state can be addressed as a CSS class in the *style.css*. The name of the CSS class is the *<name>* of the state.	Each class gets activated when the current capacity is equal or below the configured *<value>*.
+- Also each state can have its own *format*. Those con be configured via *format-<name>*. Or if you want to differentiate a bit more even as *format-<status>-<state>*. For more information see *custom-formats*.
 
 
 
@@ -141,15 +141,15 @@ The *battery* module allows one to define custom formats based on up to two fact
 
 ```
 "battery": {
-    "bat": "BAT2",
-    "interval": 60,
-    "states": {
-        "warning": 30,
-        "critical": 15
-    },
-    "format": "{capacity}% {icon}",
-    "format-icons": ["", "", "", "", ""],
-    "max-length": 25
+	"bat": "BAT2",
+	"interval": 60,
+	"states": {
+		"warning": 30,
+		"critical": 15
+	},
+	"format": "{capacity}% {icon}",
+	"format-icons": ["", "", "", "", ""],
+	"max-length": 25
 }
 ```
 

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -57,12 +57,12 @@ Addressed by *bluetooth*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++

--- a/man/waybar-cava.5.scd
+++ b/man/waybar-cava.5.scd
@@ -12,7 +12,7 @@ waybar - cava module
 # FILES
 
 $XDG_CONFIG_HOME/waybar/config ++
-    Per user configuration file
+	Per user configuration file
 
 # ADDITIONAL FILES
 
@@ -139,10 +139,10 @@ Configuration can be provided as:
 . On start Waybar throws an exception "error while loading shared libraries: libcava.so: cannot open shared object file: No such file or directory".
   It might happen when libcava for some reason hasn't been registered in the system. sudo ldconfig should help
 . Waybar is starting but cava module doesn't react on the music
-    1. In such case for at first need to make sure usual cava application is working as well
-    2. If so, need to comment all configuration options. Uncomment cava_config and provide the path to the working cava config
-    3. You might set too huge or too small input_delay. Try to setup to 4 seconds, restart waybar and check again 4 seconds past. Usual even on weak machines it should be enough
-    4. You might accidentally switched action mode to pause mode
+	1. In such case for at first need to make sure usual cava application is working as well
+	2. If so, need to comment all configuration options. Uncomment cava_config and provide the path to the working cava config
+	3. You might set too huge or too small input_delay. Try to setup to 4 seconds, restart waybar and check again 4 seconds past. Usual even on weak machines it should be enough
+	4. You might accidentally switched action mode to pause mode
 
 # RISING ISSUES
 
@@ -158,25 +158,25 @@ In case when cava releases new version and you're wanna get it, it should be rai
 
 ```
 "cava": {
-//        "cava_config": "$XDG_CONFIG_HOME/cava/cava.conf",
-        "framerate": 30,
-        "autosens": 1,
-//        "sensitivity": 100,
-        "bars": 14,
-        "lower_cutoff_freq": 50,
-        "higher_cutoff_freq": 10000,
-        "method": "pulse",
-        "source": "auto",
-        "stereo": true,
-        "reverse": false,
-        "bar_delimiter": 0,
-        "monstercat": false,
-        "waves": false,
-        "noise_reduction": 0.77,
-        "input_delay": 2,
-        "format-icons" : ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" ],
-        "actions": {
-                   "on-click-right": "mode"
-                   }
-    },
+	//"cava_config": "$XDG_CONFIG_HOME/cava/cava.conf",
+	"framerate": 30,
+	"autosens": 1,
+	//"sensitivity": 100,
+	"bars": 14,
+	"lower_cutoff_freq": 50,
+	"higher_cutoff_freq": 10000,
+	"method": "pulse",
+	"source": "auto",
+	"stereo": true,
+	"reverse": false,
+	"bar_delimiter": 0,
+	"monstercat": false,
+	"waves": false,
+	"noise_reduction": 0.77,
+	"input_delay": 2,
+	"format-icons" : ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" ],
+	"actions": {
+		"on-click-right": "mode"
+	}
+},
 ```

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -11,7 +11,7 @@ waybar - clock module
 # FILES
 
 $XDG_CONFIG_HOME/waybar/config ++
-    Per user configuration file
+	Per user configuration file
 
 # CONFIGURATION
 
@@ -164,9 +164,9 @@ View all valid format options in *strftime(3)* or have a look <https://fmt.dev/l
 
 ```
 "clock": {
-    "interval": 60,
-    "format": "{:%H:%M}",
-    "max-length": 25
+	"interval": 60,
+	"format": "{:%H:%M}",
+	"max-length": 25
 }
 ```
 
@@ -174,30 +174,30 @@ View all valid format options in *strftime(3)* or have a look <https://fmt.dev/l
 
 ```
 "clock": {
-    "format": "{:%H:%M}  ",
-    "format-alt": "{:%A, %B %d, %Y (%R)}  ",
-    "tooltip-format": "<tt><small>{calendar}</small></tt>",
-    "calendar": {
-                "mode"          : "year",
-                "mode-mon-col"  : 3,
-                "weeks-pos"     : "right",
-                "on-scroll"     : 1,
-                "on-click-right": "mode",
-                "format": {
-                            "months":     "<span color='#ffead3'><b>{}</b></span>",
-                            "days":       "<span color='#ecc6d9'><b>{}</b></span>",
-                            "weeks":      "<span color='#99ffdd'><b>W{}</b></span>",
-                            "weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
-                            "today":      "<span color='#ff6699'><b><u>{}</u></b></span>"
-                            }
-                },
-    "actions":  {
-                "on-click-right": "mode",
-                "on-click-forward": "tz_up",
-                "on-click-backward": "tz_down",
-                "on-scroll-up": "shift_up",
-                "on-scroll-down": "shift_down"
-                }
+	"format": "{:%H:%M}  ",
+	"format-alt": "{:%A, %B %d, %Y (%R)}  ",
+	"tooltip-format": "<tt><small>{calendar}</small></tt>",
+	"calendar": {
+		"mode"          : "year",
+		"mode-mon-col"  : 3,
+		"weeks-pos"     : "right",
+		"on-scroll"     : 1,
+		"on-click-right": "mode",
+		"format": {
+			"months":     "<span color='#ffead3'><b>{}</b></span>",
+			"days":       "<span color='#ecc6d9'><b>{}</b></span>",
+			"weeks":      "<span color='#99ffdd'><b>W{}</b></span>",
+			"weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
+			"today":      "<span color='#ff6699'><b><u>{}</u></b></span>"
+		}
+	},
+	"actions": {
+		"on-click-right": "mode",
+		"on-click-forward": "tz_up",
+		"on-click-backward": "tz_down",
+		"on-scroll-up": "shift_up",
+		"on-scroll-down": "shift_down"
+	}
 },
 ```
 
@@ -205,10 +205,10 @@ View all valid format options in *strftime(3)* or have a look <https://fmt.dev/l
 
 ```
 "clock": {
-    "interval": 60,
-    "tooltip": true,
-    "format": "{:%H.%M}",
-    "tooltip-format": "{:%Y-%m-%d}",
+	"interval": 60,
+	"tooltip": true,
+	"format": "{:%H.%M}",
+	"tooltip-format": "{:%Y-%m-%d}",
 }
 ```
 
@@ -238,31 +238,31 @@ Example of working config
 
 ```
 "clock": {
-        "format": "{:%H:%M}  ",
-        "format-alt": "{:%A, %B %d, %Y (%R)}  ",
-        "tooltip-format": "\n<span size='9pt' font='WenQuanYi Zen Hei Mono'>{calendar}</span>",
-        "calendar": {
-                    "mode"          : "year",
-                    "mode-mon-col"  : 3,
-                    "weeks-pos"     : "right",
-                    "on-scroll"     : 1,
-                    "on-click-right": "mode",
-                    "format": {
-                              "months":     "<span color='#ffead3'><b>{}</b></span>",
-                              "days":       "<span color='#ecc6d9'><b>{}</b></span>",
-                              "weeks":      "<span color='#99ffdd'><b>W{}</b></span>",
-                              "weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
-                              "today":      "<span color='#ff6699'><b><u>{}</u></b></span>"
-                              }
-                    },
-        "actions":  {
-                    "on-click-right": "mode",
-                    "on-click-forward": "tz_up",
-                    "on-click-backward": "tz_down",
-                    "on-scroll-up": "shift_up",
-                    "on-scroll-down": "shift_down"
-                    }
-    },
+	"format": "{:%H:%M}  ",
+	"format-alt": "{:%A, %B %d, %Y (%R)}  ",
+	"tooltip-format": "\n<span size='9pt' font='WenQuanYi Zen Hei Mono'>{calendar}</span>",
+	"calendar": {
+		"mode"          : "year",
+		"mode-mon-col"  : 3,
+		"weeks-pos"     : "right",
+		"on-scroll"     : 1,
+		"on-click-right": "mode",
+		"format": {
+			"months":     "<span color='#ffead3'><b>{}</b></span>",
+			"days":       "<span color='#ecc6d9'><b>{}</b></span>",
+			"weeks":      "<span color='#99ffdd'><b>W{}</b></span>",
+			"weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
+			"today":      "<span color='#ff6699'><b><u>{}</u></b></span>"
+		}
+	},
+	"actions": {
+		"on-click-right": "mode",
+		"on-click-forward": "tz_up",
+		"on-click-backward": "tz_down",
+		"on-scroll-up": "shift_up",
+		"on-scroll-down": "shift_down"
+	}
+},
 ```
 
 # AUTHOR

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -30,12 +30,12 @@ The *cpu* module displays the current cpu utilization.
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *rotate*: ++
 	typeof: integer ++

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -1,5 +1,4 @@
 waybar-custom(5)
-
 # NAME
 
 waybar - custom module
@@ -19,14 +18,13 @@ Addressed by *custom/<name>*
 
 *exec-if*: ++
 	typeof: string ++
-	The path to a script, which determines if the script in *exec* should be executed.
+	The path to a script, which determines if the script in *exec* should be executed. ++
 	*exec* will be executed if the exit code of *exec-if* equals 0.
 
 *exec-on-event*: ++
 	typeof: bool ++
 	default: true ++
-	If an event command is set (e.g. *on-click* or *on-scroll-up*) then re-execute the script after
-	executing the event command.
+	If an event command is set (e.g. *on-click* or *on-scroll-up*) then re-execute the script after executing the event command.
 
 *return-type*: ++
 	typeof: string ++
@@ -34,20 +32,19 @@ Addressed by *custom/<name>*
 
 *interval*: ++
 	typeof: integer ++
-	The interval (in seconds) in which the information gets polled.
-	Use *once* if you want to execute the module only on startup.
-	You can update it manually with a signal. If no *interval* is defined,
-	it is assumed that the out script loops it self.
+	The interval (in seconds) in which the information gets polled. ++
+	Use *once* if you want to execute the module only on startup. ++
+	You can update it manually with a signal. If no *interval* is defined, it is assumed that the out script loops it self.
 
 *restart-interval*: ++
 	typeof: integer ++
-	The restart interval (in seconds).
-	Can't be used with the *interval* option, so only with continuous scripts.
+	The restart interval (in seconds). ++
+	Can't be used with the *interval* option, so only with continuous scripts. ++
 	Once the script exit, it'll be re-executed after the *restart-interval*.
 
 *signal*: ++
 	typeof: integer ++
-	The signal number used to update the module.
+	The signal number used to update the module. ++
 	The number is valid between 1 and N, where *SIGRTMIN+N* = *SIGRTMAX*.
 
 *format*: ++
@@ -68,12 +65,12 @@ Addressed by *custom/<name>*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -40,12 +40,12 @@ Addressed by *disk*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++

--- a/man/waybar-dwl-tags.5.scd
+++ b/man/waybar-dwl-tags.5.scd
@@ -13,24 +13,24 @@ The *tags* module displays the current state of tags in dwl.
 Addressed by *dwl/tags*
 
 *num-tags*: ++
-    typeof: uint ++
-    default: 9 ++
-    The number of tags that should be displayed. Max 32.
+	typeof: uint ++
+	default: 9 ++
+	The number of tags that should be displayed. Max 32.
 
 *tag-labels*: ++
-    typeof: array ++
-    The label to display for each tag.
+	typeof: array ++
+	The label to display for each tag.
 
 *disable-click*: ++
-   typeof: bool ++
-   default: false ++
-   If set to false, you can left click to set focused tag. Right click to toggle tag focus. If set to true this behaviour is disabled.
+	typeof: bool ++
+	default: false ++
+	If set to false, you can left click to set focused tag. Right click to toggle tag focus. If set to true this behaviour is disabled.
 
 # EXAMPLE
 
 ```
 "dwl/tags": {
-    "num-tags": 5
+	"num-tags": 5
 }
 ```
 

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -18,12 +18,12 @@ Addressed by *hyprland/language*
 	The format, how information should be displayed.
 
 *format-<lang>* ++
-    typeof: string++
-    Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
+	typeof: string++
+	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
 
 *keyboard-name*: ++
-    typeof: string ++
-    Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
+	typeof: string ++
+	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
 
 # FORMAT REPLACEMENTS
@@ -41,10 +41,10 @@ Addressed by *hyprland/language*
 
 ```
 "hyprland/language": {
-    "format": "Lang: {long}"
-    "format-en": "AMERICA, HELL YEAH!"
-    "format-tr": "As bayrakları"
-    "keyboard-name": "at-translated-set-2-keyboard"
+	"format": "Lang: {long}"
+	"format-en": "AMERICA, HELL YEAH!"
+	"format-tr": "As bayrakları"
+	"keyboard-name": "at-translated-set-2-keyboard"
 }
 ```
 

--- a/man/waybar-hyprland-submap.5.scd
+++ b/man/waybar-hyprland-submap.5.scd
@@ -26,12 +26,12 @@ Addressed by *hyprland/submap*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++
@@ -71,9 +71,9 @@ Addressed by *hyprland/submap*
 
 ```
 "hyprland/submap": {
-    "format": "✌️ {}",
-    "max-length": 8,
-    "tooltip": false
+	"format": "✌️ {}",
+	"max-length": 8,
+	"tooltip": false
 }
 ```
 

--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -62,11 +62,11 @@ Invalid expressions (e.g., mismatched parentheses) are skipped.
 
 ```
 "hyprland/window": {
-    "format": "{}",
-    "rewrite": {
-      "(.*) - Mozilla Firefox": "🌎 $1",
-      "(.*) - zsh": "> [$1]"
-    }
+	"format": "{}",
+	"rewrite": {
+		"(.*) - Mozilla Firefox": "🌎 $1",
+		"(.*) - zsh": "> [$1]"
+	}
 }
 ```
 

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -61,7 +61,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"default": ""
 	},
 	"all-outputs": false,
-        "show-special": false
+	"show-special": false
 }
 ```
 

--- a/man/waybar-idle-inhibitor.5.scd
+++ b/man/waybar-idle-inhibitor.5.scd
@@ -28,12 +28,12 @@ screensaving, also known as "presentation mode".
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++
@@ -64,9 +64,9 @@ screensaving, also known as "presentation mode".
 	Threshold to be used when scrolling.
 
 *start-activated*: ++
-  typeof: bool ++
-  default: *false* ++
-  Whether the inhibit should be activated when starting waybar.
+	typeof: bool ++
+	default: *false* ++
+	Whether the inhibit should be activated when starting waybar.
 
 *timeout*: ++
 	typeof: double ++
@@ -97,8 +97,8 @@ screensaving, also known as "presentation mode".
 "idle_inhibitor": {
 	"format": "{icon}",
 	"format-icons": {
-	    "activated": "",
-	    "deactivated": ""
+		"activated": "",
+		"deactivated": ""
 	},
 	"timeout": 30.5
 }

--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -13,24 +13,26 @@ The *image* module displays an image from a path.
 *path*: ++
 	typeof: string ++
 	The path to the image.
+
 *exec*: ++
 	typeof: string ++
-	The path to the script, which should return image path file
-	it will only execute if the path is not set
+	The path to the script, which should return image path file. ++
+	It will only execute if the path is not set
+
 *size*: ++
 	typeof: integer ++
 	The width/height to render the image.
 
 *interval*: ++
 	typeof: integer ++
-	The interval (in seconds) to re-render the image.
-	This is useful if the contents of *path* changes.
+	The interval (in seconds) to re-render the image. ++
+	This is useful if the contents of *path* changes. ++
 	If no *interval* is defined, the image will only be rendered once.
 
 *signal*: ++
 	typeof: integer ++
-	The signal number used to update the module.
-	This can be used instead of *interval* if the file changes irregularly.
+	The signal number used to update the module. ++
+	This can be used instead of *interval* if the file changes irregularly. ++
 	The number is valid between 1 and N, where *SIGRTMIN+N* = *SIGRTMAX*.
 
 *on-click*: ++

--- a/man/waybar-inhibitor.5.scd
+++ b/man/waybar-inhibitor.5.scd
@@ -85,8 +85,8 @@ See *systemd-inhibit*(1) for more information.
 	"what": "handle-lid-switch",
 	"format": "{icon}",
 	"format-icons": {
-	    "activated": "",
-	    "deactivated": ""
+		"activated": "",
+		"deactivated": ""
 	}
 }
 ```

--- a/man/waybar-jack.5.scd
+++ b/man/waybar-jack.5.scd
@@ -13,73 +13,73 @@ The *jack* module displays the current state of the JACK server.
 Addressed by *jack*
 
 *format*: ++
-    typeof: string ++
-    default: *{load}%* ++
-    The format, how information should be displayed. This format is used when other formats aren't specified.
+	typeof: string ++
+	default: *{load}%* ++
+	The format, how information should be displayed. This format is used when other formats aren't specified.
 
 *format-connected*: ++
-    typeof: string ++
-    This format is used when the module is connected to the JACK server.
+	typeof: string ++
+	This format is used when the module is connected to the JACK server.
 
 *format-disconnected*: ++
-    typeof: string ++
-    This format is used when the module is not connected to the JACK server.
+	typeof: string ++
+	This format is used when the module is not connected to the JACK server.
 
 *format-xrun*: ++
-    typeof: string ++
-    This format is used for one polling interval, when the JACK server reports an xrun.
+	typeof: string ++
+	This format is used for one polling interval, when the JACK server reports an xrun.
 
 *realtime*: ++
-    typeof: bool ++
-    default: *true* ++
-    Option to drop real-time privileges for the JACK client opened by Waybar.
+	typeof: bool ++
+	default: *true* ++
+	Option to drop real-time privileges for the JACK client opened by Waybar.
 
 *tooltip*: ++
-    typeof: bool ++
-    default: *true* ++
-    Option to disable tooltip on hover.
+	typeof: bool ++
+	default: *true* ++
+	Option to disable tooltip on hover.
 
 *tooltip-format*: ++
-    typeof: string ++
-    default: *{bufsize}/{samplerate} {latency}ms* ++
-    The format of information displayed in the tooltip.
+	typeof: string ++
+	default: *{bufsize}/{samplerate} {latency}ms* ++
+	The format of information displayed in the tooltip.
 
 *interval*: ++
-    typeof: integer ++
-    default: 1 ++
-    The interval in which the information gets polled.
+	typeof: integer ++
+	default: 1 ++
+	The interval in which the information gets polled.
 
 *rotate*: ++
-    typeof: integer ++
-    Positive value to rotate the text label.
+	typeof: integer ++
+	Positive value to rotate the text label.
 
 *max-length*: ++
-    typeof: integer ++
-    The maximum length in character the module should display.
+	typeof: integer ++
+	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
-    typeof: string ++
-    Command to execute when clicked on the module.
+	typeof: string ++
+	Command to execute when clicked on the module.
 
 *on-click-middle*: ++
-    typeof: string ++
-    Command to execute when middle-clicked on the module using mousewheel.
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
 
 *on-click-right*: ++
-    typeof: string ++
-    Command to execute when you right clicked on the module.
+	typeof: string ++
+	Command to execute when you right clicked on the module.
 
 *on-update*: ++
-    typeof: string ++
-    Command to execute when the module is updated.
+	typeof: string ++
+	Command to execute when the module is updated.
 
 # FORMAT REPLACEMENTS
 
@@ -97,10 +97,10 @@ Addressed by *jack*
 
 ```
 "jack": {
-    "format": "DSP {}%",
-    "format-xrun": "{xruns} xruns",
-    "format-disconnected": "DSP off",
-    "realtime": true
+	"format": "DSP {}%",
+	"format-xrun": "{xruns} xruns",
+	"format-disconnected": "DSP off",
+	"realtime": true
 }
 ```
 

--- a/man/waybar-keyboard-state.5.scd
+++ b/man/waybar-keyboard-state.5.scd
@@ -65,13 +65,13 @@ The following *format-icons* can be set.
 
 ```
 "keyboard-state": {
-    "numlock": true,
-    "capslock": true,
-    "format": "{name} {icon}",
-    "format-icons": {
-        "locked": "",
-        "unlocked": ""
-    }
+	"numlock": true,
+	"capslock": true,
+	"format": "{name} {icon}",
+	"format-icons": {
+		"locked": "",
+		"unlocked": ""
+	}
 }
 ```
 

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -40,12 +40,12 @@ Addressed by *memory*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -13,8 +13,7 @@ The *mpris* module displays currently playing media via libplayerctl.
 *player*: ++
 	typeof: string ++
 	default: playerctld ++
-	Name of the MPRIS player to attach to. Using the default value always
-	follows the currenly active player.
+	Name of the MPRIS player to attach to. Using the default value always follows the currenly active player.
 
 *ignored-players*: ++
 	typeof: []string ++
@@ -49,18 +48,15 @@ The *mpris* module displays currently playing media via libplayerctl.
 
 *artist-len*: ++
 	typeof: integer ++
-	Maximum length of the Artist tag (Wide/Fullwidth Unicode characters
-	count as two). Set to zero to hide the artist in `{dynamic}` tag.
+	Maximum length of the Artist tag (Wide/Fullwidth Unicode characters count as two). Set to zero to hide the artist in `{dynamic}` tag.
 
 *album-len*: ++
 	typeof: integer ++
-	Maximum length of the Album tag (Wide/Fullwidth Unicode characters count
-	as two). Set to zero to hide the album in `{dynamic}` tag.
+	Maximum length of the Album tag (Wide/Fullwidth Unicode characters count as two). Set to zero to hide the album in `{dynamic}` tag.
 
 *title-len*: ++
 	typeof: integer ++
-	Maximum length of the Title tag (Wide/Fullwidth Unicode characters count
-	as two). Set to zero to hide the title in `{dynamic}` tag.
+	Maximum length of the Title tag (Wide/Fullwidth Unicode characters count as two). Set to zero to hide the title in `{dynamic}` tag.
 
 *dynamic-len*: ++
 	typeof: integer ++
@@ -101,14 +97,12 @@ The *mpris* module displays currently playing media via libplayerctl.
 *enable-tooltip-len-limits*: ++
 	typeof: bool ++
 	default: false ++
-	Option to enable the length limits for the tooltip as well. By default
-	the tooltip ignores all length limits.
+	Option to enable the length limits for the tooltip as well. By default the tooltip ignores all length limits.
 
 *ellipsis*: ++
 	typeof: string ++
 	default: "…" ++
-	This character will be used when any of the tags exceed their maximum
-	length. If you don't want to use an ellipsis, set this to empty string.
+	This character will be used when any of the tags exceed their maximum length. If you don't want to use an ellipsis, set this to empty string.
 
 *rotate*: ++
 	typeof: integer ++
@@ -124,7 +118,7 @@ The *mpris* module displays currently playing media via libplayerctl.
 
 *align*: ++
 	typeof: float ++
-	The alignment of the text, where 0 is left-aligned and 1 is right-aligned.
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. ++
 	If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
@@ -148,8 +142,7 @@ The *mpris* module displays currently playing media via libplayerctl.
 
 *status-icons*: ++
 	typeof: map[string]string ++
-	Allows setting _{status-icon}_ based on player status (playing, paused,
-	stopped).
+	Allows setting _{status-icon}_ based on player status (playing, paused, stopped).
 
 
 # FORMAT REPLACEMENTS
@@ -167,7 +160,7 @@ The *mpris* module displays currently playing media via libplayerctl.
 *{length}*: Length of the track, formatted as HH:MM:SS
 
 *{dynamic}*: Use _{artist}_, _{album}_, _{title}_ and _{length}_, automatically omit++
-           empty values
+	empty values
 
 *{player_icon}*: Chooses an icon from _player-icons_ based on _{player}_
 

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -65,12 +65,12 @@ Addressed by *network*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++

--- a/man/waybar-river-layout.5.scd
+++ b/man/waybar-river-layout.5.scd
@@ -15,45 +15,45 @@ It may not be set until a layout is first applied.
 Addressed by *river/layout*
 
 *format*: ++
-    typeof: string ++
-    default: {} ++
-    The format, how information should be displayed. On {} data gets inserted.
+	typeof: string ++
+	default: {} ++
+	The format, how information should be displayed. On {} data gets inserted.
 
 *rotate*: ++
-    typeof: integer ++
-    Positive value to rotate the text label.
+	typeof: integer ++
+	Positive value to rotate the text label.
 
 *max-length*: ++
-    typeof: integer ++
-    The maximum length in character the module should display.
+	typeof: integer ++
+	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
-    typeof: string ++
-    Command to execute when clicked on the module.
+	typeof: string ++
+	Command to execute when clicked on the module.
 
 *on-click-middle*: ++
-    typeof: string ++
-    Command to execute when middle-clicked on the module using mousewheel.
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
 
 *on-click-right*: ++
-    typeof: string ++
-    Command to execute when you right clicked on the module.
+	typeof: string ++
+	Command to execute when you right clicked on the module.
 
 # EXAMPLE
 
 ```
 "river/layout": {
-    "format": "{}",
-    "min-length": 4,
-    "align": "right"
+	"format": "{}",
+	"min-length": 4,
+	"align": "right"
 }
 ```
 

--- a/man/waybar-river-mode.5.scd
+++ b/man/waybar-river-mode.5.scd
@@ -13,59 +13,59 @@ The *mode* module displays the current mapping mode of river.
 Addressed by *river/mode*
 
 *format*: ++
-    typeof: string  ++
-    default: {} ++
-    The format, how information should be displayed. On {} data gets inserted.
+	typeof: string  ++
+	default: {} ++
+	The format, how information should be displayed. On {} data gets inserted.
 
 *rotate*: ++
-    typeof: integer ++
-    Positive value to rotate the text label.
+	typeof: integer ++
+	Positive value to rotate the text label.
 
 *max-length*: ++
-    typeof: integer ++
-    The maximum length in character the module should display.
+	typeof: integer ++
+	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
-    typeof: string ++
-    Command to execute when clicked on the module.
+	typeof: string ++
+	Command to execute when clicked on the module.
 
 *on-click-middle*: ++
-    typeof: string ++
-    Command to execute when middle-clicked on the module using mousewheel.
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mousewheel.
 
 *on-click-right*: ++
-    typeof: string ++
-    Command to execute when you right clicked on the module.
+	typeof: string ++
+	Command to execute when you right clicked on the module.
 
 *on-update*: ++
-    typeof: string ++
-    Command to execute when the module is updated.
+	typeof: string ++
+	Command to execute when the module is updated.
 
 *on-scroll-up*: ++
-    typeof: string ++
-    Command to execute when scrolling up on the module.
+	typeof: string ++
+	Command to execute when scrolling up on the module.
 
 *on-scroll-down*: ++
-    typeof: string ++
-    Command to execute when scrolling down on the module.
+	typeof: string ++
+	Command to execute when scrolling down on the module.
 
 *smooth-scrolling-threshold*: ++
-    typeof: double ++
-    Threshold to be used when scrolling.
+	typeof: double ++
+	Threshold to be used when scrolling.
 
 # EXAMPLES
 
 ```
 "river/mode": {
-    "format": " {}"
+	"format": " {}"
 }
 ```
 

--- a/man/waybar-river-tags.5.scd
+++ b/man/waybar-river-tags.5.scd
@@ -13,24 +13,24 @@ The *tags* module displays the current state of tags in river.
 Addressed by *river/tags*
 
 *num-tags*: ++
-    typeof: uint ++
-    default: 9 ++
-    The number of tags that should be displayed. Max 32.
+	typeof: uint ++
+	default: 9 ++
+	The number of tags that should be displayed. Max 32.
 
 *tag-labels*: ++
-    typeof: array ++
-    The label to display for each tag.
+	typeof: array ++
+	The label to display for each tag.
 
 *disable-click*: ++
-   typeof: bool ++
-   default: false ++
-   If set to false, you can left click to set focused tag. Right click to toggle tag focus. If set to true this behaviour is disabled.
+	typeof: bool ++
+	default: false ++
+	If set to false, you can left click to set focused tag. Right click to toggle tag focus. If set to true this behaviour is disabled.
 
 # EXAMPLE
 
 ```
 "river/tags": {
-    "num-tags": 5
+	"num-tags": 5
 }
 ```
 

--- a/man/waybar-river-window.5.scd
+++ b/man/waybar-river-window.5.scd
@@ -26,12 +26,12 @@ Addressed by *river/window*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++
@@ -49,7 +49,7 @@ Addressed by *river/window*
 
 ```
 "river/window": {
-    "format": "{}"
+	"format": "{}"
 }
 ```
 

--- a/man/waybar-sndio.5.scd
+++ b/man/waybar-sndio.5.scd
@@ -27,12 +27,12 @@ cursor is over the module, and clicking on the module toggles mute.
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *scroll-step*: ++
 	typeof: int ++
@@ -58,12 +58,12 @@ cursor is over the module, and clicking on the module toggles mute.
 
 *on-scroll-up*: ++
 	typeof: string ++
-	Command to execute when scrolling up on the module.
+	Command to execute when scrolling up on the module. ++
 	This replaces the default behaviour of volume control.
 
 *on-scroll-down*: ++
 	typeof: string ++
-	Command to execute when scrolling down on the module.
+	Command to execute when scrolling down on the module. ++
 	This replaces the default behaviour of volume control.
 
 *smooth-scrolling-threshold*: ++
@@ -80,8 +80,8 @@ cursor is over the module, and clicking on the module toggles mute.
 
 ```
 "sndio": {
-    "format": "{raw_value} 🎜",
-    "scroll-step": 3
+	"format": "{raw_value} 🎜",
+	"scroll-step": 3
 }
 ```
 

--- a/man/waybar-sway-language.5.scd
+++ b/man/waybar-sway-language.5.scd
@@ -43,11 +43,11 @@ Addressed by *sway/language*
 
 ```
 "sway/language": {
-    "format": "{}",
+	"format": "{}",
 },
 
 "sway/language": {
-    "format": "{short} {variant}",
+	"format": "{short} {variant}",
 }
 ```
 

--- a/man/waybar-sway-mode.5.scd
+++ b/man/waybar-sway-mode.5.scd
@@ -26,12 +26,12 @@ Addressed by *sway/mode*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++
@@ -70,8 +70,8 @@ Addressed by *sway/mode*
 
 ```
 "sway/mode": {
-    "format": " {}",
-    "max-length": 50
+	"format": " {}",
+	"max-length": 50
 }
 ```
 

--- a/man/waybar-sway-scratchpad.5.scd
+++ b/man/waybar-sway-scratchpad.5.scd
@@ -50,11 +50,11 @@ Addressed by *sway/scratchpad*
 
 ```
 "sway/scratchpad": {
-    "format": "{icon} {count}",
-    "show-empty": false,
-    "format-icons": ["", ""],
-    "tooltip": true,
-    "tooltip-format": "{app}: {title}"
+	"format": "{icon} {count}",
+	"show-empty": false,
+	"format-icons": ["", ""],
+	"tooltip": true,
+	"tooltip-format": "{app}: {title}"
 }
 ```
 

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -26,12 +26,12 @@ Addressed by *sway/window*
 	The maximum length in character the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++
@@ -124,12 +124,12 @@ Invalid expressions (e.g., mismatched parentheses) are skipped.
 
 ```
 "sway/window": {
-    "format": "{}",
-    "max-length": 50,
-    "rewrite": {
-      "(.*) - Mozilla Firefox": "🌎 $1",
-      "(.*) - zsh": "> [$1]"
-    }
+	"format": "{}",
+	"max-length": 50,
+	"rewrite": {
+		"(.*) - Mozilla Firefox": "🌎 $1",
+		"(.*) - zsh": "> [$1]"
+	}
 }
 ```
 

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -13,74 +13,74 @@ The *workspaces* module displays the currently used workspaces in Sway.
 Addressed by *sway/workspaces*
 
 *all-outputs*: ++
-    typeof: bool ++
-    default: false ++
-    If set to false, workspaces will only be shown on the output they are on. If set to true all workspaces will be shown on every output.
+	typeof: bool ++
+	default: false ++
+	If set to false, workspaces will only be shown on the output they are on. If set to true all workspaces will be shown on every output.
 
 *format*: ++
-    typeof: string ++
-    default: {value} ++
-    The format, how information should be displayed.
+	typeof: string ++
+	default: {value} ++
+	The format, how information should be displayed.
 
 *format-icons*: ++
-    typeof: array ++
-    Based on the workspace name and state, the corresponding icon gets selected. See *icons*.
+	typeof: array ++
+	Based on the workspace name and state, the corresponding icon gets selected. See *icons*.
 
 *disable-scroll*: ++
-    typeof: bool ++
-    default: false ++
-    If set to false, you can scroll to cycle through workspaces. If set to true this behaviour is disabled.
+	typeof: bool ++
+	default: false ++
+	If set to false, you can scroll to cycle through workspaces. If set to true this behaviour is disabled.
 
 *disable-click*: ++
-    typeof: bool ++
-    default: false ++
-    If set to false, you can click to change workspace. If set to true this behaviour is disabled.
+	typeof: bool ++
+	default: false ++
+	If set to false, you can click to change workspace. If set to true this behaviour is disabled.
 
 *smooth-scrolling-threshold*: ++
-    typeof: double ++
-    Threshold to be used when scrolling.
+	typeof: double ++
+	Threshold to be used when scrolling.
 
 *disable-scroll-wraparound*: ++
-    typeof: bool ++
-    default: false ++
-    If set to false, scrolling on the workspace indicator will wrap around to the first workspace when reading the end, and vice versa. If set to true this behavior is disabled.
+	typeof: bool ++
+	default: false ++
+	If set to false, scrolling on the workspace indicator will wrap around to the first workspace when reading the end, and vice versa. If set to true this behavior is disabled.
 
 *enable-bar-scroll*: ++
-    typeof: bool ++
-    default: false ++
-    If set to false, you can't scroll to cycle throughout workspaces from the entire bar. If set to true this behaviour is enabled.
+	typeof: bool ++
+	default: false ++
+	If set to false, you can't scroll to cycle throughout workspaces from the entire bar. If set to true this behaviour is enabled.
 
 *disable-markup*: ++
-    typeof: bool ++
-    default: false ++
-    If set to true, button label will escape pango markup.
+	typeof: bool ++
+	default: false ++
+	If set to true, button label will escape pango markup.
 
 *current-only*: ++
-    typeof: bool ++
-    default: false ++
-    If set to true. Only focused workspaces will be shown.
+	typeof: bool ++
+	default: false ++
+	If set to true. Only focused workspaces will be shown.
 
 *persistent_workspaces*: ++
-    typeof: json (see below) ++
-    default: empty ++
-    Lists workspaces that should always be shown, even when non existent
+	typeof: json (see below) ++
+	default: empty ++
+	Lists workspaces that should always be shown, even when non existent
 
 *on-update*: ++
-    typeof: string ++
-    Command to execute when the module is updated.
+	typeof: string ++
+	Command to execute when the module is updated.
 
 *disable-auto-back-and-forth*: ++
-    typeof: bool ++
-    Whether to disable *workspace_auto_back_and_forth* when clicking on workspaces. If this is set to *true*, clicking on a workspace you are already on won't do anything, even if *workspace_auto_back_and_forth* is enabled in the Sway configuration.
+	typeof: bool ++
+	Whether to disable *workspace_auto_back_and_forth* when clicking on workspaces. If this is set to *true*, clicking on a workspace you are already on won't do anything, even if *workspace_auto_back_and_forth* is enabled in the Sway configuration.
 
 *alphabetical_sort*: ++
-    typeof: bool ++
-    Whether to sort workspaces alphabetically. Please note this can make "swaymsg workspace prev/next" move to workspaces inconsistent with the ordering shown in Waybar.
+	typeof: bool ++
+	Whether to sort workspaces alphabetically. Please note this can make "swaymsg workspace prev/next" move to workspaces inconsistent with the ordering shown in Waybar.
 
 warp-on-scroll: ++
-    typeof: bool ++
-    default: true ++
-    If set to false, you can scroll to cycle through workspaces without mouse warping being enabled. If set to true this behaviour is disabled.
+	typeof: bool ++
+	default: true ++
+	If set to false, you can scroll to cycle through workspaces without mouse warping being enabled. If set to true this behaviour is disabled.
 
 # FORMAT REPLACEMENTS
 
@@ -112,11 +112,11 @@ an empty list denoting all outputs.
 
 ```
 "sway/workspaces": {
-    "persistent_workspaces": {
-        "3": [], // Always show a workspace with name '3', on all outputs if it does not exists
-        "4": ["eDP-1"], // Always show a workspace with name '4', on output 'eDP-1' if it does not exists
-        "5": ["eDP-1", "DP-2"] // Always show a workspace with name '5', on outputs 'eDP-1' and 'DP-2' if it does not exists
-    }
+	"persistent_workspaces": {
+		"3": [], // Always show a workspace with name '3', on all outputs if it does not exists
+		"4": ["eDP-1"], // Always show a workspace with name '4', on output 'eDP-1' if it does not exists
+		"5": ["eDP-1", "DP-2"] // Always show a workspace with name '5', on outputs 'eDP-1' and 'DP-2' if it does not exists
+	}
 }
 ```
 
@@ -126,20 +126,20 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
 
 ```
 "sway/workspaces": {
-    "disable-scroll": true,
-    "all-outputs": true,
-    "format": "{name}: {icon}",
-    "format-icons": {
-        "1": "",
-        "2": "",
-        "3": "",
-        "4": "",
-        "5": "",
+	"disable-scroll": true,
+	"all-outputs": true,
+	"format": "{name}: {icon}",
+	"format-icons": {
+		"1": "",
+		"2": "",
+		"3": "",
+		"4": "",
+		"5": "",
 		"high-priority-named": [ "1", "2" ],
-        "urgent": "",
-        "focused": "",
-        "default": ""
-    }
+		"urgent": "",
+		"focused": "",
+		"default": ""
+	}
 }
 ```
 

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -66,12 +66,12 @@ Addressed by *temperature*
 	The maximum length in characters the module should display.
 
 *min-length*: ++
-    typeof: integer ++
-    The minimum length in characters the module should take up.
+	typeof: integer ++
+	The minimum length in characters the module should take up.
 
 *align*: ++
-    typeof: float ++
-    The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
+	typeof: float ++
+	The alignment of the text, where 0 is left-aligned and 1 is right-aligned. If the module is rotated, it will follow the flow of the text.
 
 *on-click*: ++
 	typeof: string ++

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -6,32 +6,32 @@ waybar - tray module
 
 # DESCRIPTION
 
-_WARNING_ *tray* is still in beta. There may me bugs. Breaking changes may occur.
+_WARNING_ *tray* is still in beta. There may be bugs. Breaking changes may occur.
 
 # CONFIGURATION
 
 Addressed by *tray*
 
 *icon-size*: ++
-    typeof: integer ++
-    Defines the size of the tray icons.
+	typeof: integer ++
+	Defines the size of the tray icons.
 
 *show-passive-items*: ++
-    typeof: bool ++
-    default: false ++
-    Defines visibility of the tray icons with *Passive* status.
+	typeof: bool ++
+	default: false ++
+	Defines visibility of the tray icons with *Passive* status.
 
 *smooth-scrolling-threshold*: ++
 	typeof: double ++
 	Threshold to be used when scrolling.
 
 *spacing*: ++
-    typeof: integer ++
-    Defines the spacing between the tray icons.
+	typeof: integer ++
+	Defines the spacing between the tray icons.
 
 *reverse-direction*: ++
-    typeof: bool ++
-    Defines if new app icons should be added in a reverse order
+	typeof: bool ++
+	Defines if new app icons should be added in a reverse order
 
 *on-update*: ++
 	typeof: string ++
@@ -41,8 +41,8 @@ Addressed by *tray*
 
 ```
 "tray": {
-    "icon-size": 21,
-    "spacing": 10
+	"icon-size": 21,
+	"spacing": 10
 }
 
 ```

--- a/man/waybar-upower.5.scd
+++ b/man/waybar-upower.5.scd
@@ -12,10 +12,10 @@ compatible devices in the tooltip.
 # CONFIGURATION
 
 *native-path*: ++
-    typeof: string ++
-    default: ++
-    The battery to monitor. Refer to the https://upower.freedesktop.org/docs/UpDevice.html#UpDevice--native-path ++
-    Can be obtained using `upower --dump`
+	typeof: string ++
+	default: ++
+	The battery to monitor. Refer to the https://upower.freedesktop.org/docs/UpDevice.html#UpDevice--native-path ++
+	Can be obtained using `upower --dump`
 
 *icon-size*: ++
 	typeof: integer ++

--- a/man/waybar-wireplumber.5.scd
+++ b/man/waybar-wireplumber.5.scd
@@ -93,9 +93,9 @@ The *wireplumber* module displays the current volume reported by WirePlumber.
 
 ```
 "wireplumber": {
-    "format": "{volume}%",
-    "format-muted": "",
-    "on-click": "helvum"
+	"format": "{volume}%",
+	"format-muted": "",
+	"on-click": "helvum"
 }
 ```
 

--- a/man/waybar-wlr-workspaces.5.scd
+++ b/man/waybar-wlr-workspaces.5.scd
@@ -29,9 +29,8 @@ Addressed by *wlr/workspaces*
 *sort-by-coordinates*: ++
 	typeof: bool ++
 	default: true ++
-	Should workspaces be sorted by coordinates.
-	Note that if both  *sort-by-name* and *sort-by-coordinates* are true sort by name will be first.
-	If both are false - sort by id will be performed.
+	Should workspaces be sorted by coordinates. ++
+	Note that if both  *sort-by-name* and *sort-by-coordinates* are true sort by name will be first. If both are false - sort by id will be performed.
 
 *sort-by-number*: ++
 	typeof: bool ++


### PR DESCRIPTION
Fix the following whitespace formatting issues:
- Indentation in scdoc source files should be done with tabs.
- Lines where there (clearly) should be a line break, need to have '++' at the end, but several were missing them.
- The scdoc manual (clearly) states that lines should be hard wrapped at 80 columns, but when line(s) are indented, that causes rendering issues. So lines where a line break was not clearly intended or clearly not intended, have been put onto 1 line to circumvent the rendering issue.

Link: https://lists.sr.ht/~sircmpwn/public-inbox/%3C8251560.T7Z3S40VBb%40bagend%3E