### PR TITLE
Add on-button release actions

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -44,18 +44,23 @@ class AModule : public IModule {
   std::map<std::string, std::string> eventActionMap_;
   static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{
       {std::make_pair(1, GdkEventType::GDK_BUTTON_PRESS), "on-click"},
+      {std::make_pair(1, GdkEventType::GDK_BUTTON_RELEASE), "on-click-release"},
       {std::make_pair(1, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click"},
       {std::make_pair(1, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click"},
       {std::make_pair(2, GdkEventType::GDK_BUTTON_PRESS), "on-click-middle"},
+      {std::make_pair(2, GdkEventType::GDK_BUTTON_RELEASE), "on-click-middle-release"},
       {std::make_pair(2, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-middle"},
       {std::make_pair(2, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-middle"},
       {std::make_pair(3, GdkEventType::GDK_BUTTON_PRESS), "on-click-right"},
+      {std::make_pair(3, GdkEventType::GDK_BUTTON_RELEASE), "on-click-right-release"},
       {std::make_pair(3, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-right"},
       {std::make_pair(3, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-right"},
       {std::make_pair(8, GdkEventType::GDK_BUTTON_PRESS), "on-click-backward"},
+      {std::make_pair(8, GdkEventType::GDK_BUTTON_RELEASE), "on-click-backward-release"},
       {std::make_pair(8, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-backward"},
       {std::make_pair(8, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-backward"},
       {std::make_pair(9, GdkEventType::GDK_BUTTON_PRESS), "on-click-forward"},
+      {std::make_pair(9, GdkEventType::GDK_BUTTON_RELEASE), "on-click-forward-release"},
       {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-forward"},
       {std::make_pair(9, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-forward"}};
 };

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -34,9 +34,15 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
     std::map<std::pair<uint, GdkEventType>, std::string>::const_iterator it{eventMap_.cbegin()};
     while (it != eventMap_.cend()) {
       if (config_[it->second].isString()) {
-        event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
-        event_box_.signal_button_press_event().connect(
+        if (it->first.second == GdkEventType::GDK_BUTTON_RELEASE) {
+          event_box_.add_events(Gdk::BUTTON_RELEASE_MASK);
+          event_box_.signal_button_release_event().connect(
             sigc::mem_fun(*this, &AModule::handleToggle));
+        } else {
+          event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
+          event_box_.signal_button_press_event().connect(
+            sigc::mem_fun(*this, &AModule::handleToggle));
+        }
         break;
       }
       ++it;


### PR DESCRIPTION
Allow `on-click-release` actions for most buttons, this will exec the action when the button is released.  

This is a workaround for #1968 (I believe the bug is caused by an unexpected focus lost while holding the button)  
> at least, it works for me.

By doing `"on-click-release": "swaync-client -t -sw",` I could fix the wrong location click bug without a sleep longer than the click.


But I think, on-release will have other uses too!