### PR TITLE
Button release action

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -44,18 +44,23 @@ class AModule : public IModule {
   std::map<std::string, std::string> eventActionMap_;
   static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{
       {std::make_pair(1, GdkEventType::GDK_BUTTON_PRESS), "on-click"},
+      {std::make_pair(1, GdkEventType::GDK_BUTTON_RELEASE), "on-click-release"},
       {std::make_pair(1, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click"},
       {std::make_pair(1, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click"},
       {std::make_pair(2, GdkEventType::GDK_BUTTON_PRESS), "on-click-middle"},
+      {std::make_pair(2, GdkEventType::GDK_BUTTON_RELEASE), "on-click-middle-release"},
       {std::make_pair(2, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-middle"},
       {std::make_pair(2, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-middle"},
       {std::make_pair(3, GdkEventType::GDK_BUTTON_PRESS), "on-click-right"},
+      {std::make_pair(3, GdkEventType::GDK_BUTTON_RELEASE), "on-click-right-release"},
       {std::make_pair(3, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-right"},
       {std::make_pair(3, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-right"},
       {std::make_pair(8, GdkEventType::GDK_BUTTON_PRESS), "on-click-backward"},
+      {std::make_pair(8, GdkEventType::GDK_BUTTON_RELEASE), "on-click-backward-release"},
       {std::make_pair(8, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-backward"},
       {std::make_pair(8, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-backward"},
       {std::make_pair(9, GdkEventType::GDK_BUTTON_PRESS), "on-click-forward"},
+      {std::make_pair(9, GdkEventType::GDK_BUTTON_RELEASE), "on-click-forward-release"},
       {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-forward"},
       {std::make_pair(9, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-forward"}};
 };

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -27,20 +27,18 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
   }
 
   // configure events' user commands
-  if (enable_click) {
+
+  bool hasEvent = std::find_if(eventMap_.cbegin(), eventMap_.cend(),
+    [&config](const auto& eventEntry) {
+      return config[eventEntry.second].isString();
+    }) != eventMap_.cend();
+  
+  if (enable_click || hasEvent) {
     event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
     event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &AModule::handleToggle));
-  } else {
-    std::map<std::pair<uint, GdkEventType>, std::string>::const_iterator it{eventMap_.cbegin()};
-    while (it != eventMap_.cend()) {
-      if (config_[it->second].isString()) {
-        event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
-        event_box_.signal_button_press_event().connect(
-            sigc::mem_fun(*this, &AModule::handleToggle));
-        break;
-      }
-      ++it;
-    }
+    // register key release
+    event_box_.add_events(Gdk::BUTTON_RELEASE_MASK);
+    event_box_.signal_button_release_event().connect(sigc::mem_fun(*this, &AModule::handleToggle));
   }
   if (config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString() || enable_scroll) {
     event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);


### PR DESCRIPTION
Allow `on-click-release` actions for most buttons, this will execute the action when the button is **released**.  

This is a workaround for #1968 (I believe the bug is caused by an unexpected focus loss while holding the button)  
> at least, it works for me.
By doing `"on-click-release": "swaync-client -t -sw",` I could fix the wrong location click bug without a sleep longer than the click.


And  I think, on-release will have other uses too!