### PR TITLE
docs: fix Arch repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Waybar [![Licence](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Paypal Donate](https://img.shields.io/badge/Donate-Paypal-2244dd.svg)](https://paypal.me/ARouillard)<br>![Waybar](https://raw.githubusercontent.com/alexays/waybar/master/preview-2.png)
 
 > Highly customizable Wayland bar for Sway and Wlroots based compositors.<br>
-> Available in Arch [community](https://www.archlinux.org/packages/extra/x86_64/waybar/) or
+> Available in Arch [extra](https://www.archlinux.org/packages/extra/x86_64/waybar/) or
 [AUR](https://aur.archlinux.org/packages/waybar-git/), [Gentoo](https://packages.gentoo.org/packages/gui-apps/waybar), [openSUSE](https://build.opensuse.org/package/show/X11:Wayland/waybar), and [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=waybar).<br>
 > *Waybar [examples](https://github.com/Alexays/Waybar/wiki/Examples)*
 


### PR DESCRIPTION
As mentioned in #2200 the Arch repository name was renamed from `community` to `extra` ([official announcement](https://archlinux.org/news/git-migration-announcement/)). The URL was fixed, but not the text.