### PR TITLE
Implement 'active_only' option and 'visible' class in hyprland/workspaces

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -14,9 +14,11 @@
 
 namespace waybar::modules::hyprland {
 
+class Workspaces;
+
 class Workspace {
  public:
-  explicit Workspace(const Json::Value& workspace_data);
+  explicit Workspace(const Json::Value& workspace_data, Workspaces& workspace_manager);
   std::string& select_icon(std::map<std::string, std::string>& icons_map);
   Gtk::Button& button() { return button_; };
 
@@ -26,6 +28,7 @@ class Workspace {
   bool active() const { return active_; };
   bool is_special() const { return is_special_; };
   bool is_persistent() const { return is_persistent_; };
+  bool is_visible() const { return is_visible_; };
   bool is_empty() const { return windows_ == 0; };
   bool is_urgent() const { return is_urgent_; };
 
@@ -33,12 +36,15 @@ class Workspace {
   void set_active(bool value = true) { active_ = value; };
   void set_persistent(bool value = true) { is_persistent_ = value; };
   void set_urgent(bool value = true) { is_urgent_ = value; };
+  void set_visible(bool value = true) { is_visible_ = value; };
   void set_windows(uint value) { windows_ = value; };
   void set_name(std::string value) { name_ = value; };
 
   void update(const std::string& format, const std::string& icon);
 
  private:
+  Workspaces& workspace_manager_;
+
   int id_;
   std::string name_;
   std::string output_;
@@ -47,6 +53,7 @@ class Workspace {
   bool is_special_ = false;
   bool is_persistent_ = false;
   bool is_urgent_ = false;
+  bool is_visible_ = false;
 
   Gtk::Button button_;
   Gtk::Box content_;
@@ -62,6 +69,7 @@ class Workspaces : public AModule, public EventHandler {
 
   auto all_outputs() const -> bool { return all_outputs_; }
   auto show_special() const -> bool { return show_special_; }
+  auto active_only() const -> bool { return active_only_; }
 
   auto get_bar_output() const -> std::string { return bar_.output->name; }
 
@@ -75,6 +83,7 @@ class Workspaces : public AModule, public EventHandler {
 
   bool all_outputs_ = false;
   bool show_special_ = false;
+  bool active_only_ = false;
 
   void fill_persistent_workspaces();
   void create_persistent_workspaces();

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -24,12 +24,17 @@ Addressed by *hyprland/workspaces*
 *show-special*: ++
 	typeof: bool ++
 	default: false ++
-	If set to true special workspaces will be shown.
+	If set to true, special workspaces will be shown.
 
 *all-outputs*: ++
 	typeof: bool ++
 	default: false ++
 	If set to false workspaces group will be shown only in assigned output. Otherwise all workspace groups are shown.
+
+*active-only*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, only the active workspace will be shown.
 
 # FORMAT REPLACEMENTS
 
@@ -43,10 +48,11 @@ Addressed by *hyprland/workspaces*
 
 Additional to workspace name matching, the following *format-icons* can be set.
 
-- *default*: Will be shown, when no string match is found.
+- *default*: Will be shown, when no string match is found and none of the below conditions have defined icons.
 - *active*: Will be shown, when workspace is active
 - *special*: Will be shown on non-active special workspaces
-- *empty*: Will be shown on empty persistent workspaces
+- *empty*: Will be shown on non-active, non-special empty persistent workspaces
+- *visible*: Will be shown on workspaces that are visible but not active. For example: this is useful if you want your visible workspaces on other monitors to have the same look as active.
 - *persistent*: Will be shown on non-empty persistent workspaces
 
 # EXAMPLES
@@ -95,6 +101,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces button*
 - *#workspaces button.active*
 - *#workspaces button.empty*
+- *#workspaces button.visible*
 - *#workspaces button.persistent*
 - *#workspaces button.special*
 - *#workspaces button.urgent*


### PR DESCRIPTION
With this PR, `active_only` can be set to true, which will only show the active workspace. 

If I understand the feature request correctly, each monitor should show the currently visible workspace, right? This PR currently only shows the active one as reported by Hyprland, so if a monitor is not focused, it will not show any workspaces. Is this supposed to happen? I would expect it to be better if each monitor shows one "active" workspace, i.e. the one currently visible.

Let me know if this can be improved.

CC @Anakael @MightyPlaza 