### PR TITLE
Explicitly cast ustring to string when passing to fmt

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -93,7 +93,7 @@ template <>
 struct formatter<Glib::ustring> : formatter<std::string> {
   template <typename FormatContext>
   auto format(const Glib::ustring& value, FormatContext& ctx) {
-    return formatter<std::string>::format(value, ctx);
+    return formatter<std::string>::format(static_cast<std::string>(value), ctx);
   }
 };
 }  // namespace fmt

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -22,7 +22,7 @@ struct fmt::formatter<Glib::VariantBase> : formatter<std::string> {
   template <typename FormatContext>
   auto format(const Glib::VariantBase& value, FormatContext& ctx) {
     if (is_printable(value)) {
-      return formatter<std::string>::format(value.print(), ctx);
+      return formatter<std::string>::format(static_cast<std::string>(value.print()), ctx);
     } else {
       return formatter<std::string>::format(value.get_type_string(), ctx);
     }


### PR DESCRIPTION
don't rely on implicit conversion which is no longer present in fmt 10.1.0

Fixes #2403