### PR TITLE
Fix simpleclock module compilation with recent fmt

### DIFF
--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -18,13 +18,13 @@ auto waybar::modules::Clock::update() -> void {
   tzset();  // Update timezone information
   auto now = std::chrono::system_clock::now();
   auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
-  auto text = fmt::format(format_, localtime);
+  auto text = fmt::format(fmt::runtime(format_), localtime);
   label_.set_markup(text);
 
   if (tooltipEnabled()) {
     if (config_["tooltip-format"].isString()) {
       auto tooltip_format = config_["tooltip-format"].asString();
-      auto tooltip_text = fmt::format(tooltip_format, localtime);
+      auto tooltip_text = fmt::format(fmt::runtime(tooltip_format), localtime);
       label_.set_tooltip_text(tooltip_text);
     } else {
       label_.set_tooltip_text(text);


### PR DESCRIPTION
both `format_` and `tooltip_format` are dynamically provided formats so wrap them in `fmt::runtime()`