### PR TITLE
sni: fix passing relative coordinates to dbus methods

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -91,6 +91,9 @@ class Bar {
   bool vertical = false;
   Gtk::Window window;
 
+  int x_global;
+  int y_global;
+
 #ifdef HAVE_SWAY
   std::string bar_id;
 #endif
@@ -102,10 +105,15 @@ class Bar {
   void setupAltFormatKeyForModule(const std::string &module_name);
   void setupAltFormatKeyForModuleList(const char *module_list_name);
   void setMode(const bar_mode &);
+  void onConfigure(GdkEventConfigure *ev);
+  void configureGlobalOffset(int width, int height);
+  void onOutputGeometryChanged();
 
   /* Copy initial set of modes to allow customization */
   bar_mode_map configured_modes = PRESET_MODES;
   std::string last_mode_{MODE_DEFAULT};
+
+  struct bar_margins margins_;
 
   std::unique_ptr<BarSurface> surface_impl_;
   Gtk::Box left_;

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -84,6 +84,8 @@ class Item : public sigc::trackable {
   // visibility of items with Status == Passive
   bool show_passive_ = false;
 
+  const Bar& bar_;
+
   Glib::RefPtr<Gio::DBus::Proxy> proxy_;
   Glib::RefPtr<Gio::Cancellable> cancellable_;
   std::set<std::string_view> update_pending_;

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -39,7 +39,8 @@ Item::Item(const std::string& bn, const std::string& op, const Json::Value& conf
       object_path(op),
       icon_size(16),
       effective_icon_size(0),
-      icon_theme(Gtk::IconTheme::create()) {
+      icon_theme(Gtk::IconTheme::create()),
+      bar_(bar) {
   if (config["icon-size"].isUInt()) {
     icon_size = config["icon-size"].asUInt();
   }
@@ -410,7 +411,8 @@ void Item::makeMenu() {
 
 bool Item::handleClick(GdkEventButton* const& ev) {
   auto parameters = Glib::VariantContainerBase::create_tuple(
-      {Glib::Variant<int>::create(ev->x), Glib::Variant<int>::create(ev->y)});
+      {Glib::Variant<int>::create(ev->x_root + bar_.x_global),
+       Glib::Variant<int>::create(ev->y_root + bar_.y_global)});
   if ((ev->button == 1 && item_is_menu) || ev->button == 3) {
     makeMenu();
     if (gtk_menu != nullptr) {


### PR DESCRIPTION
Fixes passing relative coordinates to `ContextMenu`, `Activate`, `SecondaryActivate` DBus methods, while handling mouse click events. Resolves #2165.