### PR TITLE
Hyprland hyprctl dispatch workspace compatibility

### DIFF
--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -523,7 +523,8 @@ auto Workspace::handle_clicked(GdkEventButton *bt) -> bool {
   if (action.empty())
     return true;
   else if (action == "activate") {
-    zext_workspace_handle_v1_activate(workspace_handle_);
+    const std::string command = "hyprctl dispatch workspace " + name_;
+	system(command.c_str());
   } else if (action == "close") {
     zext_workspace_handle_v1_remove(workspace_handle_);
   } else {


### PR DESCRIPTION
This line of code enables better compatibility with the Hyprland window manager, specifically, when clicking on workspaces shown in Waybar.

I have verified that this does not break the activate-workspace-on-click function on sway for example. 
I didn't test other wlroots-based compositors though.

At https://wiki.hyprland.org/Useful-Utilities/Status-Bars/
see: `sed -i -e 's/zext_workspace_handle_v1_activate(workspace_handle_);/const std::string command = "hyprctl dispatch workspace " + name_;\n\tsystem(command.c_str());/g' src/modules/wlr/workspace_manager.cpp`


Thanks a lot!