### PR TITLE
Hyprland urgent class support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,15 +2,15 @@
   "nodes": {
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
       },
       "locked": {
-        "lastModified": 1676293499,
-        "narHash": "sha256-uIOTlTxvrXxpKeTvwBI1JGDGtCxMXE3BI0LFwoQMhiQ=",
+        "lastModified": 1692523566,
+        "narHash": "sha256-VDJDihK6jNebVw9y3qKCVD6+6QaC/x8kxZzL4MaIPPY=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "71e3022e3ab20bbf1342640547ef5bc14fb43bf4",
+        "rev": "d208c58e2f7afef838add5f18a9936b12a71d695",
         "type": "github"
       },
       "original": {
@@ -36,27 +36,15 @@
       }
     },
     "flake-utils": {
-      "locked": {
-        "lastModified": 1642700792,
-        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
-        "type": "github"
+      "inputs": {
+        "systems": "systems_2"
       },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1689068808,
+        "narHash": "sha256-6ixXo3wt24N/melDWjq70UuHQLxGV8jZvooRanIHXw0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "919d646de7be200f3bf08cb76ae1f09402b6f9b4",
         "type": "github"
       },
       "original": {
@@ -67,11 +55,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1643381941,
-        "narHash": "sha256-pHTwvnN4tTsEKkWlXQ8JMY423epos8wUOhthpwJjtpc=",
+        "lastModified": 1677383253,
+        "narHash": "sha256-UfpzWfSxkfXHnb4boXZNaKsAcUrZT9Hw+tao1oZxd08=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5efc8ca954272c4376ac929f4c5ffefcc20551d5",
+        "rev": "9952d6bc395f5841262b006fbace8dd7e143b634",
         "type": "github"
       },
       "original": {
@@ -83,11 +71,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1676300157,
-        "narHash": "sha256-1HjRzfp6LOLfcj/HJHdVKWAkX9QRAouoh6AjzJiIerU=",
+        "lastModified": 1692638711,
+        "narHash": "sha256-J0LgSFgJVGCC1+j5R2QndadWI1oumusg6hCtYAzLID4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "545c7a31e5dedea4a6d372712a18e00ce097d462",
+        "rev": "91a22f76cd1716f9d0149e8a5c68424bb691de15",
         "type": "github"
       },
       "original": {
@@ -101,8 +89,38 @@
       "inputs": {
         "devshell": "devshell",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -47,17 +47,12 @@
         let pkgs = import nixpkgs {
           inherit system;
 
-          overlays = [ devshell.overlay ];
+          overlays = [ devshell.overlays.default ];
         };
         in
         pkgs.devshell.mkShell {
           imports = [ "${pkgs.devshell.extraModulesDir}/language/c.nix" ];
-          commands = [
-            {
-              package = pkgs.devshell.cli;
-              help = "Per project developer environments";
-            }
-          ];
+
           devshell.packages = with pkgs; [
             clang-tools
             gdb
@@ -79,6 +74,7 @@
             at-spi2-atk atkmm cairo cairomm catch2 fmt_8 fontconfig
             gdk-pixbuf glibmm gtk3 harfbuzz pango pangomm wayland-protocols
           ]);
+
           env = with pkgs; [
             { name = "CPLUS_INCLUDE_PATH"; prefix = "$DEVSHELL_DIR/include"; }
             { name = "PKG_CONFIG_PATH"; prefix = "$DEVSHELL_DIR/lib/pkgconfig"; }

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -22,10 +22,12 @@ class Workspace {
   bool is_special() const { return is_special_; };
   bool is_persistent() const { return is_persistent_; };
   bool is_empty() const { return windows_ == 0; };
+  bool is_urgent() const { return is_urgent_; };
 
   auto handle_clicked(GdkEventButton* bt) -> bool;
   void set_active(bool value = true) { active_ = value; };
   void set_persistent(bool value = true) { is_persistent_ = value; };
+  void set_urgent(bool value = true) { is_urgent_ = value; };
   void set_windows(uint value) { windows_ = value; };
 
   void update(const std::string& format, const std::string& icon);
@@ -38,6 +40,7 @@ class Workspace {
   bool active_ = false;
   bool is_special_ = false;
   bool is_persistent_ = false;
+  bool is_urgent_ = false;
 
   Gtk::Button button_;
   Gtk::Box content_;
@@ -62,6 +65,7 @@ class Workspaces : public AModule, public EventHandler {
   void sort_workspaces();
   void create_workspace(Json::Value& value);
   void remove_workspace(std::string name);
+  void set_urgent_workspace(std::string windowaddress);
 
   bool all_outputs_ = false;
   bool show_special_ = false;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -76,3 +76,4 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces button.active*
 - *#workspaces button.persistent*
 - *#workspaces button.special*
+- *#workspaces button.urgent*


### PR DESCRIPTION
Adding urgent class support to the hyprland workspaces module.

- Subscribe to urgent IPC
- Set is_urgent on workspace that is in the payload from the IPC call.
- Clear is_urgent when you activate a workspace that has is_urgent set.

related issue: https://github.com/Alexays/Waybar/issues/2271