### PR TITLE
Match rewrite rules iteratively, using array structure

### DIFF
--- a/src/util/rewrite_string.cpp
+++ b/src/util/rewrite_string.cpp
@@ -6,23 +6,27 @@
 
 namespace waybar::util {
 std::string rewriteString(const std::string& value, const Json::Value& rules) {
-  if (!rules.isObject()) {
+  if (rules.isObject()) {
+    // TODO: convert objects to the array structure to accept existing configs.
+  }
+
+  if (!rules.isArray()) {
     return value;
   }
 
   std::string res = value;
 
-  for (auto it = rules.begin(); it != rules.end(); ++it) {
-    if (it.key().isString() && it->isString()) {
+  for (Json::Value::ArrayIndex i = 0; i != rules.size(); i++) {
+    if (rules[i].isArray() && rules[i][0].isString() && rules[i][1].isString()) {
       try {
-        // malformated regexes will cause an exception.
+        // malformed regexes will cause an exception.
         // in this case, log error and try the next rule.
-        const std::regex rule{it.key().asString()};
-        if (std::regex_match(value, rule)) {
-          res = std::regex_replace(res, rule, it->asString());
+        const std::regex rule{rules[i][0].asString()};
+        if (std::regex_match(res, rule)) {
+          res = std::regex_replace(res, rule, rules[i][1].asString());
         }
       } catch (const std::regex_error& e) {
-        spdlog::error("Invalid rule {}: {}", it.key().asString(), e.what());
+        spdlog::error("Invalid rule {}: {}", rules[i][0].asString(), e.what());
       }
     }
   }


### PR DESCRIPTION
**Disclaimer:** I don't know C++, so this is the result of trial and error!

This is not ready to be merged (although it works for me), I just wanted to check if this was something that might be desirable? Basically, I wanted to guarantee the order of rewrite rules (which is possible when rewrite rules are specified as an array, but not an object), and to allow successive rules to match against and replace the results of previous rules.

Here is an example config:

```
{
  "wlr/taskbar": {
    "format": "{name}%%%{title}",
    "on-click": "activate",
    "sort-by-app-id": true,
    "rewrite": [
      [".*(Alacritty).*?%%%(.*)", "\uf120  $2"],
      [".*(Audacious).*", "\uf001  $1"],
      [".*(Chromium).*", "\uf268  $1"],
      [".*(Firefox).*", "\ue007  $1"],
      [".*(Lutris|RetroArch|Steam).*", "\uf11b  $1"],
      ["^.*?%%%(.*)", "$1"],
      ["^(.{16}).+", "$1…"]
    ]
  }
}
```

The motivation was to have both the `{name}` and the `{title}` available in the format string so I can match against either on a case by case basis (falling back to one of the two if nothing earlier matches).

The array structure should be an alternative to the existing object structure although I didn't get that far as I'm just not comfortable with C++. If an object is passed to the function it should probably just restructure it into an array.

The other change, which could potentially alter the behaviour of existing configs (so probably more of a concern) is that it matches against the current value of `res` rather than the original `value` in the conditional which decides whether or not to apply the rule.