### PR TITLE
Show workspaces on all outputs if persistent_workspaces value is empty

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -227,6 +227,9 @@ void Workspaces::fill_persistent_workspaces() {
             break;
           }
         }
+      } else {
+        // this workspace should be displayed on all monitors
+        persistent_workspaces_to_create_.emplace_back(key);
       }
     }
   }


### PR DESCRIPTION
This would make the behavior consistent with sway/workspaces and wlr/workspaces. A config like this:
```json
"hyprland/workspaces": {
    "disable-scroll": true,
    "active-only": false,
    "all-outputs": false,
    "on-click": "activate",
    "sort-by-number": true,
    "persistent_workspaces": {
      "1": [],
      "2": [],
      "3": [],
      "4": [],
      "5": []
    }
  }
```

Would show workspaces 1 - 5 on all outputs.