### PR TITLE
deprecate persistent_workspaces in favor of persistent-workspaces

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -69,7 +69,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"active": "",
 		"default": ""
 	},
-	"persistent_workspaces": {
+	"persistent-workspaces": {
 		"*": 5, // 5 workspaces by default on every monitor
 		"HDMI-A-1": 3 // but only three on HDMI-A-1
 	}
@@ -88,7 +88,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"active": "",
 		"default": ""
 	},
-	"persistent_workspaces": {
+	"persistent-workspaces": {
 		"*": [ 2,3,4,5 ], // 2-5 on every monitor
 		"HDMI-A-1": [ 1 ] // but only workspace 1 on HDMI-A-1
 	}

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -60,7 +60,7 @@ Addressed by *sway/workspaces*
 	default: false ++
 	If set to true. Only focused workspaces will be shown.
 
-*persistent_workspaces*: ++
+*persistent-workspaces*: ++
 	typeof: json (see below) ++
 	default: empty ++
 	Lists workspaces that should always be shown, even when non existent
@@ -112,7 +112,7 @@ an empty list denoting all outputs.
 
 ```
 "sway/workspaces": {
-	"persistent_workspaces": {
+	"persistent-workspaces": {
 		"3": [], // Always show a workspace with name '3', on all outputs if it does not exists
 		"4": ["eDP-1"], // Always show a workspace with name '4', on output 'eDP-1' if it does not exists
 		"5": ["eDP-1", "DP-2"] // Always show a workspace with name '5', on outputs 'eDP-1' and 'DP-2' if it does not exists

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -231,8 +231,15 @@ void Workspaces::remove_workspace(std::string name) {
 }
 
 void Workspaces::fill_persistent_workspaces() {
-  if (config_["persistent-workspaces"].isObject()) {
-    const Json::Value persistent_workspaces = config_["persistent-workspaces"];
+  if (config_["persistent_workspaces"].isObject()) {
+    spdlog::warn(
+        "persistent_workspaces is deprecated. Please change config to use persistent-workspaces.");
+  }
+
+  if (config_["persistent-workspaces"].isObject() || config_["persistent_workspaces"].isObject()) {
+    const Json::Value persistent_workspaces = config_["persistent-workspaces"].isObject()
+                                                  ? config_["persistent-workspaces"]
+                                                  : config_["persistent_workspaces"];
     const std::vector<std::string> keys = persistent_workspaces.getMemberNames();
 
     for (const std::string &key : keys) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -231,8 +231,8 @@ void Workspaces::remove_workspace(std::string name) {
 }
 
 void Workspaces::fill_persistent_workspaces() {
-  if (config_["persistent_workspaces"].isObject()) {
-    const Json::Value persistent_workspaces = config_["persistent_workspaces"];
+  if (config_["persistent-workspaces"].isObject()) {
+    const Json::Value persistent_workspaces = config_["persistent-workspaces"];
     const std::vector<std::string> keys = persistent_workspaces.getMemberNames();
 
     for (const std::string &key : keys) {

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -80,8 +80,8 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
                      });
 
         // adding persistent workspaces (as per the config file)
-        if (config_["persistent_workspaces"].isObject()) {
-          const Json::Value &p_workspaces = config_["persistent_workspaces"];
+        if (config_["persistent-workspaces"].isObject()) {
+          const Json::Value &p_workspaces = config_["persistent-workspaces"];
           const std::vector<std::string> p_workspaces_names = p_workspaces.getMemberNames();
 
           for (const std::string &p_w_name : p_workspaces_names) {

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -79,9 +79,18 @@ void Workspaces::onCmd(const struct Ipc::ipc_response &res) {
                                   : true;
                      });
 
+        if (config_["persistent_workspaces"].isObject()) {
+          spdlog::warn(
+              "persistent_workspaces is deprecated. Please change config to use "
+              "persistent-workspaces.");
+        }
+
         // adding persistent workspaces (as per the config file)
-        if (config_["persistent-workspaces"].isObject()) {
-          const Json::Value &p_workspaces = config_["persistent-workspaces"];
+        if (config_["persistent-workspaces"].isObject() ||
+            config_["persistent_workspaces"].isObject()) {
+          const Json::Value &p_workspaces = config_["persistent-workspaces"].isObject()
+                                                ? config_["persistent-workspaces"]
+                                                : config_["persistent_workspaces"];
           const std::vector<std::string> p_workspaces_names = p_workspaces.getMemberNames();
 
           for (const std::string &p_w_name : p_workspaces_names) {

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -209,8 +209,17 @@ WorkspaceGroup::WorkspaceGroup(const Bar &bar, Gtk::Box &box, const Json::Value 
 }
 
 auto WorkspaceGroup::fill_persistent_workspaces() -> void {
-  if (config_["persistent-workspaces"].isObject() && !workspace_manager_.all_outputs()) {
-    const Json::Value &p_workspaces = config_["persistent-workspaces"];
+  if (config_["persistent_workspaces"].isObject()) {
+    spdlog::warn(
+        "persistent_workspaces is deprecated. Please change config to use persistent-workspaces.");
+  }
+
+  if ((config_["persistent-workspaces"].isObject() ||
+       config_["persistent_workspaces"].isObject()) &&
+      !workspace_manager_.all_outputs()) {
+    const Json::Value &p_workspaces = config_["persistent-workspaces"].isObject()
+                                          ? config_["persistent-workspaces"]
+                                          : config_["persistent_workspaces"];
     const std::vector<std::string> p_workspaces_names = p_workspaces.getMemberNames();
 
     for (const std::string &p_w_name : p_workspaces_names) {

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -209,8 +209,8 @@ WorkspaceGroup::WorkspaceGroup(const Bar &bar, Gtk::Box &box, const Json::Value 
 }
 
 auto WorkspaceGroup::fill_persistent_workspaces() -> void {
-  if (config_["persistent_workspaces"].isObject() && !workspace_manager_.all_outputs()) {
-    const Json::Value &p_workspaces = config_["persistent_workspaces"];
+  if (config_["persistent-workspaces"].isObject() && !workspace_manager_.all_outputs()) {
+    const Json::Value &p_workspaces = config_["persistent-workspaces"];
     const std::vector<std::string> p_workspaces_names = p_workspaces.getMemberNames();
 
     for (const std::string &p_w_name : p_workspaces_names) {


### PR DESCRIPTION
Closes: https://github.com/Alexays/Waybar/issues/2443 

Persistent workspaces currently is the only option using this naming style, changing to match all other options. 

Prompt updating config from `persistent_workspaces` to `persistent-workspaces` but keep current implementation support until after next release to remove. 

Follow up: Update wiki entries to match new name. 