### PR TITLE
fix: rename workspace active fix

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -163,6 +163,9 @@ void Workspaces::onEvent(const std::string &ev) {
     std::string new_name = payload.substr(payload.find(',') + 1);
     for (auto &workspace : workspaces_) {
       if (workspace->id() == workspace_id) {
+        if (workspace->name() == active_workspace_name_) {
+          active_workspace_name_ = new_name;
+        }
         workspace->set_name(new_name);
         break;
       }


### PR DESCRIPTION
Closes: https://github.com/Alexays/Waybar/issues/2481

Verified locally. With a `hyprctl dispatch renameworkspace 3 "4"` and saw old behavior (top) and new behavior (bottom) of it keeping the active state. My config visible = blue and active = green. 

![image](https://github.com/Alexays/Waybar/assets/1778670/227dd5d9-5204-459f-885a-071347830a8b)

