### PR TITLE
feat: hyprland workspaces add sort-by

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -86,6 +86,7 @@ class Workspaces : public AModule, public EventHandler {
   bool all_outputs_ = false;
   bool show_special_ = false;
   bool active_only_ = false;
+  std::string sort_by = "default";
 
   void fill_persistent_workspaces();
   void create_persistent_workspaces();

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -11,6 +11,7 @@
 #include "AModule.hpp"
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
+#include "util/enum.hpp"
 
 namespace waybar::modules::hyprland {
 
@@ -86,7 +87,8 @@ class Workspaces : public AModule, public EventHandler {
   bool all_outputs_ = false;
   bool show_special_ = false;
   bool active_only_ = false;
-  std::string sort_by = "default";
+  util::EnumParser enum_parser_;
+  util::EnumParser::SORT_METHOD sort_by_ = util::EnumParser::SORT_METHOD::DEFAULT;
 
   void fill_persistent_workspaces();
   void create_persistent_workspaces();

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -80,6 +80,8 @@ class Workspaces : public AModule, public EventHandler {
   void create_workspace(Json::Value& value);
   void remove_workspace(std::string name);
   void set_urgent_workspace(std::string windowaddress);
+  void parse_config(const Json::Value& config);
+  void register_ipc();
 
   bool all_outputs_ = false;
   bool show_special_ = false;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -87,8 +87,14 @@ class Workspaces : public AModule, public EventHandler {
   bool all_outputs_ = false;
   bool show_special_ = false;
   bool active_only_ = false;
-  util::EnumParser enum_parser_;
-  util::EnumParser::SORT_METHOD sort_by_ = util::EnumParser::SORT_METHOD::DEFAULT;
+
+  enum SORT_METHOD { ID, NAME, NUMBER, DEFAULT };
+  util::EnumParser<SORT_METHOD> enum_parser_;
+  SORT_METHOD sort_by_ = SORT_METHOD::DEFAULT;
+  std::map<std::string, SORT_METHOD> sort_map_ = {{"ID", SORT_METHOD::ID},
+                                                  {"NAME", SORT_METHOD::NAME},
+                                                  {"NUMBER", SORT_METHOD::NUMBER},
+                                                  {"DEFAULT", SORT_METHOD::DEFAULT}};
 
   void fill_persistent_workspaces();
   void create_persistent_workspaces();

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -88,7 +88,7 @@ class Workspaces : public AModule, public EventHandler {
   bool show_special_ = false;
   bool active_only_ = false;
 
-  enum SORT_METHOD { ID, NAME, NUMBER, DEFAULT };
+  enum class SORT_METHOD { ID, NAME, NUMBER, DEFAULT };
   util::EnumParser<SORT_METHOD> enum_parser_;
   SORT_METHOD sort_by_ = SORT_METHOD::DEFAULT;
   std::map<std::string, SORT_METHOD> sort_map_ = {{"ID", SORT_METHOD::ID},

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -6,32 +6,24 @@
 #include <stdexcept>
 #include <string>
 
+#include "util/string.hpp"
+
 namespace waybar::util {
 
 template <typename EnumType>
 struct EnumParser {
   EnumParser() {}
 
-  // Helper function to capitalize a string
-  std::string capitalizeString(const std::string& str) {
-    std::string result = str;
-    std::transform(result.begin(), result.end(), result.begin(),
-                   [](unsigned char c) { return std::toupper(c); });
-    return result;
-  }
-
   EnumType parseStringToEnum(const std::string& str,
                              const std::map<std::string, EnumType>& enumMap) {
     // Convert the input string to uppercase
-    std::string uppercaseStr = capitalizeString(str);
+    std::string uppercaseStr = capitalize(str);
 
     // Capitalize the map keys before searching
     std::map<std::string, EnumType> capitalizedEnumMap;
-    std::transform(enumMap.begin(), enumMap.end(),
-                   std::inserter(capitalizedEnumMap, capitalizedEnumMap.end()),
-                   [this](const auto& pair) {
-                     return std::make_pair(capitalizeString(pair.first), pair.second);
-                   });
+    std::transform(
+        enumMap.begin(), enumMap.end(), std::inserter(capitalizedEnumMap, capitalizedEnumMap.end()),
+        [this](const auto& pair) { return std::make_pair(capitalize(pair.first), pair.second); });
 
     // Return enum match of string
     auto it = enumMap.find(uppercaseStr);

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -1,25 +1,24 @@
 #pragma once
 
+#include <cctype>
 #include <iostream>
 #include <map>
+#include <stdexcept>
 #include <string>
 
 namespace waybar::util {
 
+template <typename EnumType>
 struct EnumParser {
   EnumParser() {}
 
-  enum SORT_METHOD { ID, NAME, NUMBER, DEFAULT };
-
-  SORT_METHOD sortStringToEnum(const std::string& str) {
-    // Convert the input string to uppercase (make it lenient on config input)
+  EnumType sortStringToEnum(const std::string& str,
+                            const std::map<std::string, EnumType>& enumMap) {
+    // Convert the input string to uppercase
     std::string uppercaseStr;
     for (char c : str) {
-        uppercaseStr += std::toupper(c);
+      uppercaseStr += std::toupper(c);
     }
-
-    static const std::map<std::string, SORT_METHOD> enumMap = {
-        {"ID", ID}, {"NAME", NAME}, {"NUMBER", NUMBER}, {"DEFAULT", DEFAULT}};
 
     auto it = enumMap.find(uppercaseStr);
     if (it != enumMap.end()) {

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -12,20 +12,19 @@ template <typename EnumType>
 struct EnumParser {
   EnumParser() {}
 
-  EnumType sortStringToEnum(const std::string& str,
-                            const std::map<std::string, EnumType>& enumMap) {
+  EnumType parseStringToEnum(const std::string& str,
+                             const std::map<std::string, EnumType>& enumMap) {
     // Convert the input string to uppercase
-    std::string uppercaseStr;
-    for (char c : str) {
-      uppercaseStr += std::toupper(c);
-    }
+    std::string uppercaseStr = str;
+    std::transform(uppercaseStr.begin(), uppercaseStr.end(), uppercaseStr.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
 
+    // Return enum match of string
     auto it = enumMap.find(uppercaseStr);
-    if (it != enumMap.end()) {
-      return it->second;
-    } else {
-      throw std::invalid_argument("Invalid string representation for enum");
-    }
+    if (it != enumMap.end()) return it->second;
+
+    // Throw error if it doesnt return
+    throw std::invalid_argument("Invalid string representation for enum");
   }
 
   ~EnumParser() = default;

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -12,12 +12,26 @@ template <typename EnumType>
 struct EnumParser {
   EnumParser() {}
 
+  // Helper function to capitalize a string
+  std::string capitalizeString(const std::string& str) {
+    std::string result = str;
+    std::transform(result.begin(), result.end(), result.begin(),
+                   [](unsigned char c) { return std::toupper(c); });
+    return result;
+  }
+
   EnumType parseStringToEnum(const std::string& str,
                              const std::map<std::string, EnumType>& enumMap) {
     // Convert the input string to uppercase
-    std::string uppercaseStr = str;
-    std::transform(uppercaseStr.begin(), uppercaseStr.end(), uppercaseStr.begin(),
-                   [](unsigned char c) { return std::toupper(c); });
+    std::string uppercaseStr = capitalizeString(str);
+
+    // Capitalize the map keys before searching
+    std::map<std::string, EnumType> capitalizedEnumMap;
+    std::transform(enumMap.begin(), enumMap.end(),
+                   std::inserter(capitalizedEnumMap, capitalizedEnumMap.end()),
+                   [this](const auto& pair) {
+                     return std::make_pair(capitalizeString(pair.first), pair.second);
+                   });
 
     // Return enum match of string
     auto it = enumMap.find(uppercaseStr);

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <iostream>
+#include <map>
+#include <string>
+
+namespace waybar::util {
+
+struct EnumParser {
+  EnumParser() {}
+
+  enum SORT_METHOD { ID, NAME, NUMBER, DEFAULT };
+
+  SORT_METHOD sortStringToEnum(const std::string& str) {
+    static const std::map<std::string, SORT_METHOD> enumMap = {
+        {"ID", ID}, {"NAME", NAME}, {"NUMBER", NUMBER}, {"DEFAULT", DEFAULT}};
+
+    auto it = enumMap.find(str);
+    if (it != enumMap.end()) {
+      return it->second;
+    } else {
+      throw std::invalid_argument("Invalid string representation for enum");
+    }
+  }
+
+  ~EnumParser() = default;
+};
+}  // namespace waybar::util

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -1,38 +1,19 @@
 #pragma once
 
-#include <cctype>
-#include <iostream>
 #include <map>
 #include <stdexcept>
 #include <string>
-
-#include "util/string.hpp"
 
 namespace waybar::util {
 
 template <typename EnumType>
 struct EnumParser {
-  EnumParser() {}
+ public:
+  EnumParser();
+  ~EnumParser();
 
   EnumType parseStringToEnum(const std::string& str,
-                             const std::map<std::string, EnumType>& enumMap) {
-    // Convert the input string to uppercase
-    std::string uppercaseStr = capitalize(str);
-
-    // Capitalize the map keys before searching
-    std::map<std::string, EnumType> capitalizedEnumMap;
-    std::transform(
-        enumMap.begin(), enumMap.end(), std::inserter(capitalizedEnumMap, capitalizedEnumMap.end()),
-        [this](const auto& pair) { return std::make_pair(capitalize(pair.first), pair.second); });
-
-    // Return enum match of string
-    auto it = enumMap.find(uppercaseStr);
-    if (it != enumMap.end()) return it->second;
-
-    // Throw error if it doesnt return
-    throw std::invalid_argument("Invalid string representation for enum");
-  }
-
-  ~EnumParser() = default;
+                             const std::map<std::string, EnumType>& enumMap);
 };
+
 }  // namespace waybar::util

--- a/include/util/enum.hpp
+++ b/include/util/enum.hpp
@@ -12,10 +12,16 @@ struct EnumParser {
   enum SORT_METHOD { ID, NAME, NUMBER, DEFAULT };
 
   SORT_METHOD sortStringToEnum(const std::string& str) {
+    // Convert the input string to uppercase (make it lenient on config input)
+    std::string uppercaseStr;
+    for (char c : str) {
+        uppercaseStr += std::toupper(c);
+    }
+
     static const std::map<std::string, SORT_METHOD> enumMap = {
         {"ID", ID}, {"NAME", NAME}, {"NUMBER", NUMBER}, {"DEFAULT", DEFAULT}};
 
-    auto it = enumMap.find(str);
+    auto it = enumMap.find(uppercaseStr);
     if (it != enumMap.end()) {
       return it->second;
     } else {

--- a/include/util/string.hpp
+++ b/include/util/string.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <string>
 
 const std::string WHITESPACE = " \n\r\t\f\v";
@@ -15,3 +16,10 @@ inline std::string rtrim(const std::string& s) {
 }
 
 inline std::string trim(const std::string& s) { return rtrim(ltrim(s)); }
+
+inline std::string capitalize(const std::string& str) {
+  std::string result = str;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return std::toupper(c); });
+  return result;
+}

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -36,6 +36,14 @@ Addressed by *hyprland/workspaces*
 	default: false ++
 	If set to true, only the active workspace will be shown.
 
+*sort-by*: ++
+	typeof: string ++
+	default: "default" ++
+	If set to number, workspaces will sort by number.
+	If set to name, workspaces will sort by name.
+	If set to id, workspaces will sort by id.
+	If none of those, workspaces will sort with default behavior.
+
 # FORMAT REPLACEMENTS
 
 *{id}*: id of workspace assigned by compositor

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -273,28 +273,39 @@ Valid options for the (optional) "orientation" property are: "horizontal", "vert
 - *waybar-cpu(5)*
 - *waybar-custom(5)*
 - *waybar-disk(5)*
+- *waybar-dwl-tags(5)*
+- *waybar-gamemode(5)*
+- *waybar-hyprland-language(5)*
+- *waybar-hyprland-submap(5)*
+- *waybar-hyprland-window(5)*
+- *waybar-hyprland-workspaces(5)*
 - *waybar-idle-inhibitor(5)*
 - *waybar-image(5)*
+- *waybar-inhibitor(5)*
+- *waybar-jack(5)*
 - *waybar-keyboard-state(5)*
 - *waybar-memory(5)*
 - *waybar-mpd(5)*
 - *waybar-mpris(5)*
 - *waybar-network(5)*
 - *waybar-pulseaudio(5)*
+- *waybar-river-layout(5)*
 - *waybar-river-mode(5)*
 - *waybar-river-tags(5)*
 - *waybar-river-window(5)*
-- *waybar-river-layout(5)*
+- *waybar-sndio(5)*
 - *waybar-states(5)*
+- *waybar-sway-language(5)*
 - *waybar-sway-mode(5)*
 - *waybar-sway-scratchpad(5)*
 - *waybar-sway-window(5)*
 - *waybar-sway-workspaces(5)*
+- *waybar-temperature(5)*
+- *waybar-tray(5)*
+- *waybar-upower(5)*
 - *waybar-wireplumber(5)*
 - *waybar-wlr-taskbar(5)*
 - *waybar-wlr-workspaces(5)*
-- *waybar-temperature(5)*
-- *waybar-tray(5)*
 
 # SEE ALSO
 

--- a/meson.build
+++ b/meson.build
@@ -171,6 +171,7 @@ src_files = files(
     'src/client.cpp',
     'src/config.cpp',
     'src/group.cpp',
+    'src/util/enum.cpp',
     'src/util/prepare_for_sleep.cpp',
     'src/util/ustring_clen.cpp',
     'src/util/sanitize_str.cpp',

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -61,10 +61,10 @@ auto Workspaces::parse_config(const Json::Value &config) -> void {
   if (config_sort_by.isString()) {
     auto sort_by_str = config_sort_by.asString();
     try {
-      sort_by_ = enum_parser_.sortStringToEnum(sort_by_str);
+      sort_by_ = enum_parser_.sortStringToEnum(sort_by_str, sort_map_);
     } catch (const std::invalid_argument &e) {
       // Handle the case where the string is not a valid enum representation.
-      sort_by_ = util::EnumParser::SORT_METHOD::DEFAULT;
+      sort_by_ = SORT_METHOD::DEFAULT;
       g_warning("Invalid string representation for sort-by. Falling back to default sort method.");
     }
   }
@@ -435,18 +435,18 @@ void Workspaces::sort_workspaces() {
               auto is_number_less = std::stoi(a->name()) < std::stoi(b->name());
 
               switch (sort_by_) {
-                case util::EnumParser::SORT_METHOD::ID:
+                case SORT_METHOD::ID:
                   return is_id_less;
-                case util::EnumParser::SORT_METHOD::NAME:
+                case SORT_METHOD::NAME:
                   return is_name_less;
-                case util::EnumParser::SORT_METHOD::NUMBER:
+                case SORT_METHOD::NUMBER:
                   try {
                     return is_number_less;
                   } catch (const std::invalid_argument &) {
                     // Handle the exception if necessary.
                     break;
                   }
-                case util::EnumParser::SORT_METHOD::DEFAULT:
+                case SORT_METHOD::DEFAULT:
                 default:
                   // Handle the default case here.
                   // normal -> named persistent -> named -> special -> named special

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -61,7 +61,7 @@ auto Workspaces::parse_config(const Json::Value &config) -> void {
   if (config_sort_by.isString()) {
     auto sort_by_str = config_sort_by.asString();
     try {
-      sort_by_ = enum_parser_.sortStringToEnum(sort_by_str, sort_map_);
+      sort_by_ = enum_parser_.parseStringToEnum(sort_by_str, sort_map_);
     } catch (const std::invalid_argument &e) {
       // Handle the case where the string is not a valid enum representation.
       sort_by_ = SORT_METHOD::DEFAULT;

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -14,6 +14,20 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
     : AModule(config, "workspaces", id, false, false),
       bar_(bar),
       box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+  parse_config(config);
+
+  box_.set_name("workspaces");
+  if (!id.empty()) {
+    box_.get_style_context()->add_class(id);
+  }
+  event_box_.add(box_);
+
+  register_ipc();
+
+  init();
+}
+
+auto Workspaces::parse_config(const Json::Value &config) -> void {
   Json::Value config_format = config["format"];
 
   format_ = config_format.isString() ? config_format.asString() : "{name}";
@@ -43,17 +57,18 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
     active_only_ = config_active_only.asBool();
   }
 
-  box_.set_name("workspaces");
-  if (!id.empty()) {
-    box_.get_style_context()->add_class(id);
+  auto config_sort_by = config_["sort-by"];
+  if (config_sort_by.isString()) {
+    sort_by = config_sort_by.asString();
   }
-  event_box_.add(box_);
+}
+
+auto Workspaces::register_ipc() -> void {
   modulesReady = true;
+
   if (!gIPC) {
     gIPC = std::make_unique<IPC>();
   }
-
-  init();
 
   gIPC->registerForIPC("workspace", this);
   gIPC->registerForIPC("createworkspace", this);

--- a/src/util/enum.cpp
+++ b/src/util/enum.cpp
@@ -1,0 +1,45 @@
+#include "util/enum.hpp"
+
+#include <algorithm>  // for std::transform
+#include <cctype>     // for std::toupper
+#include <iostream>
+#include <map>
+#include <stdexcept>
+#include <string>
+
+#include "modules/hyprland/workspaces.hpp"
+#include "util/string.hpp"
+
+namespace waybar::util {
+
+template <typename EnumType>
+EnumParser<EnumType>::EnumParser() = default;
+
+template <typename EnumType>
+EnumParser<EnumType>::~EnumParser() = default;
+
+template <typename EnumType>
+EnumType EnumParser<EnumType>::parseStringToEnum(const std::string& str,
+                                                 const std::map<std::string, EnumType>& enumMap) {
+  // Convert the input string to uppercase
+  std::string uppercaseStr = capitalize(str);
+
+  // Capitalize the map keys before searching
+  std::map<std::string, EnumType> capitalizedEnumMap;
+  std::transform(
+      enumMap.begin(), enumMap.end(), std::inserter(capitalizedEnumMap, capitalizedEnumMap.end()),
+      [this](const auto& pair) { return std::make_pair(capitalize(pair.first), pair.second); });
+
+  // Return enum match of string
+  auto it = capitalizedEnumMap.find(uppercaseStr);
+  if (it != capitalizedEnumMap.end()) return it->second;
+
+  // Throw error if it doesn't return
+  throw std::invalid_argument("Invalid string representation for enum");
+}
+
+// Explicit instantiations for specific EnumType types you intend to use
+// Add explicit instantiations for all relevant EnumType types
+template struct EnumParser<modules::hyprland::Workspaces::SORT_METHOD>;
+
+}  // namespace waybar::util


### PR DESCRIPTION
Closes: https://github.com/Alexays/Waybar/issues/2474

Adds a `sort-by` option that takes in a string to choose how to sort workspaces. This allows you to manually specify the sorting method and future sorting methods can just utilize the same config option. Fallsback to the original sorting. 