### PR TITLE
Fix battery not showing for some devices

### DIFF
--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -100,6 +100,11 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	default: true ++
 	Option to disable tooltip on hover.
 
+*bat-compatibility*: ++
+	typeof: bool ++
+	default: false ++
+	Option to enable battery compatibility if not detected.
+
 # FORMAT REPLACEMENTS
 
 *{capacity}*: Capacity in percentage

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -100,9 +100,11 @@ void waybar::modules::Battery::refreshBatteries() {
       }
       auto dir_name = node.path().filename();
       auto bat_defined = config_["bat"].isString();
+      bool bat_compatibility = config_["bat-compatibility"].asBool();
       if (((bat_defined && dir_name == config_["bat"].asString()) || !bat_defined) &&
           (fs::exists(node.path() / "capacity") || fs::exists(node.path() / "charge_now")) &&
-          fs::exists(node.path() / "uevent") && fs::exists(node.path() / "status") &&
+          fs::exists(node.path() / "uevent") &&
+          (fs::exists(node.path() / "status") || bat_compatibility) &&
           fs::exists(node.path() / "type")) {
         std::string type;
         std::ifstream(node.path() / "type") >> type;

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -254,7 +254,13 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
     for (auto const& item : batteries_) {
       auto bat = item.first;
       std::string _status;
-      std::getline(std::ifstream(bat / "status"), _status);
+
+      /* Check for adapter status if battery is not available */
+      if(!std::ifstream(bat / "status")) {
+        std::getline(std::ifstream(adapter_ / "status"), _status);
+      } else {
+        std::getline(std::ifstream(bat / "status"), _status);
+      }
 
       // Some battery will report current and charge in μA/μAh.
       // Scale these by the voltage to get μW/μWh.


### PR DESCRIPTION
Adds `bat-compatibility` boolean checking from configuration file.
Fixes: https://github.com/Alexays/Waybar/issues/2459