### PR TITLE
fix clock to work with fmt 10.x

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -175,7 +175,7 @@ auto waybar::modules::Clock::update() -> void {
       tz, date::local_days(shiftedDay) +
               (now.get_local_time() - date::floor<date::days>(now.get_local_time())))};
 
-  label_.set_markup(fmt::format(locale_, fmt::runtime(format_), now));
+  label_.set_markup(fmt::format(locale_, fmt::runtime(format_), now.get_local_time().time_since_epoch()));
 
   if (tooltipEnabled()) {
     const std::string tz_text{(is_timezoned_list_in_tooltip_) ? timezones_text(now.get_sys_time())


### PR DESCRIPTION
Fix allows for 12 hour clock format "{:%-I:%0M %p}" resulting in no leading zero on the hour.