### PR TITLE
Lighter Weight Signal-Based Custom Modules

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -22,6 +22,7 @@ class Custom : public ALabel {
  private:
   void delayWorker();
   void continuousWorker();
+  void waitingWorker();
   void parseOutputRaw();
   void parseOutputJson();
   void handleEvent();

--- a/include/util/sleeper_thread.hpp
+++ b/include/util/sleeper_thread.hpp
@@ -58,6 +58,12 @@ class SleeperThread {
 
   bool isRunning() const { return do_run_; }
 
+  auto sleep() {
+    std::unique_lock lk(mutex_);
+    CancellationGuard cancel_lock;
+    return condvar_.wait(lk);
+  }
+
   auto sleep_for(std::chrono::system_clock::duration dur) {
     std::unique_lock lk(mutex_);
     CancellationGuard cancel_lock;

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -34,7 +34,8 @@ Addressed by *custom/<name>*
 	typeof: integer ++
 	The interval (in seconds) in which the information gets polled. ++
 	Use *once* if you want to execute the module only on startup. ++
-	You can update it manually with a signal. If no *interval* is defined, it is assumed that the out script loops it self.
+	You can update it manually with a signal. If no *interval* or *signal* is defined, it is assumed that the out script loops it self. ++
+	If a *signal* is defined then the script will run once on startup and will will only update with a signal.
 
 *restart-interval*: ++
 	typeof: integer ++
@@ -45,7 +46,8 @@ Addressed by *custom/<name>*
 *signal*: ++
 	typeof: integer ++
 	The signal number used to update the module. ++
-	The number is valid between 1 and N, where *SIGRTMIN+N* = *SIGRTMAX*.
+	The number is valid between 1 and N, where *SIGRTMIN+N* = *SIGRTMAX*. ++
+	If no interval is defined then a signal will be the only way to update the module.
 
 *format*: ++
 	typeof: string ++

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -11,11 +11,13 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
       fp_(nullptr),
       pid_(-1) {
   dp.emit();
-  if (interval_.count() > 0) {
+  if (!config_["signal"].empty() && config_["interval"].empty()) {
+    waitingWorker();
+  } else if (interval_.count() > 0) {
     delayWorker();
   } else if (config_["exec"].isString()) {
     continuousWorker();
-  }
+  } 
 }
 
 waybar::modules::Custom::~Custom() {
@@ -89,6 +91,26 @@ void waybar::modules::Custom::continuousWorker() {
       dp.emit();
     }
     free(buff);
+  };
+}
+
+void waybar::modules::Custom::waitingWorker() {
+  thread_ = [this] {
+    bool can_update = true;
+    if (config_["exec-if"].isString()) {
+      output_ = util::command::execNoRead(config_["exec-if"].asString());
+      if (output_.exit_code != 0) {
+        can_update = false;
+        dp.emit();
+      }
+    }
+    if (can_update) {
+      if (config_["exec"].isString()) {
+        output_ = util::command::exec(config_["exec"].asString());
+      }
+      dp.emit();
+    }
+    thread_.sleep();
   };
 }
 


### PR DESCRIPTION
These changes are intended to fix a performance problem I had on my laptop where using signals on my custom modules would cause excess CPU usage and battery drainage.

This PR makes it so that any custom module with an undefined `interval` but a defined `signal` will start up a thread with the new `Custom::waitingWorker()` function. This is identical to an `interval` based update with signals but will instead sleep indefinitely using a new `SleeperThread::sleep()` function.

Aside from making this a usable combination of config options this is higher performance than both the `"once"` option and any given integer interval. Full disclaimer, I am not an optimizations expert but waybar's CPU usage went from between 0.4% and 0.6% (sometimes getting much higher but I haven't recorded that and it might not actually be waybar's fault) to between 0.0% and 0.1% with these additions (CPU usage recorded with btop++).

Please tell me if anything should be changed, thanks! :D