### PR TITLE
fix(backlight): wrong percentage numbers for device apple-panel-bl

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
       inherit (nixpkgs) lib;
       genSystems = lib.genAttrs [
         "x86_64-linux"
+        "aarch64-linux"
       ];
 
       pkgsFor = genSystems (system:

--- a/result
+++ b/result
@@ -1,0 +1,1 @@
+/nix/store/0pz53p83i16kv8ff5pwxhpp7zvmxapm9-waybar-0.9.22+date=2023-09-13_dirty

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/0pz53p83i16kv8ff5pwxhpp7zvmxapm9-waybar-0.9.22+date=2023-09-13_dirty

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -244,7 +244,7 @@ void waybar::modules::Backlight::upsert_device(ForwardIt first, ForwardIt last, 
   check_nn(name);
 
   const char *actual_brightness_attr =
-      strncmp(name, "amdgpu_bl", 9) == 0 ? "brightness" : strcmp(name, "apple-panel-bl") == 0 ? "brightness" : "actual_brightness";
+      strncmp(name, "amdgpu_bl", 9) == 0 || strcmp(name, "apple-panel-bl") == 0  ? "brightness" : "actual_brightness";
 
   const char *actual = udev_device_get_sysattr_value(dev, actual_brightness_attr);
   const char *max = udev_device_get_sysattr_value(dev, "max_brightness");

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -244,7 +244,7 @@ void waybar::modules::Backlight::upsert_device(ForwardIt first, ForwardIt last, 
   check_nn(name);
 
   const char *actual_brightness_attr =
-      strncmp(name, "amdgpu_bl", 9) == 0 ? "brightness" : "actual_brightness";
+      strncmp(name, "amdgpu_bl", 9) == 0 ? "brightness" : strcmp(name, "apple-panel-bl") == 0 ? "brightness" : "actual_brightness";
 
   const char *actual = udev_device_get_sysattr_value(dev, actual_brightness_attr);
   const char *max = udev_device_get_sysattr_value(dev, "max_brightness");


### PR DESCRIPTION
fixes backlight module showings incorrect percentage(eg 101% instead of 100% or 47% instead of 45%) on asahi linux
we need use `brightness` not `actual_brightness`