### PR TITLE
Feature: Hyprland dynamic window names on workspaces

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -2,6 +2,7 @@
 
 #include <gtkmm/button.h>
 #include <gtkmm/label.h>
+#include <json/value.h>
 
 #include <cstddef>
 #include <cstdint>
@@ -17,7 +18,6 @@
 #include "util/enum.hpp"
 
 using WindowAddress = std::string;
-using mywindowtype = std::string;
 namespace waybar::modules::hyprland {
 
 class Workspaces;
@@ -47,9 +47,7 @@ class Workspace {
   void set_windows(uint value) { windows_ = value; };
   void set_name(std::string value) { name_ = value; };
   bool contains_window(WindowAddress addr) { return window_map_.contains(addr); }
-  void insert_window(WindowAddress addr, mywindowtype window_repr) {
-    window_map_.emplace(addr, window_repr);
-  };
+  void insert_window(WindowAddress addr, std::string window_repr);
   void remove_window(WindowAddress addr) { window_map_.erase(addr); }
   void initialize_window_map(const Json::Value& clients_data);
 
@@ -77,7 +75,7 @@ class Workspace {
   bool is_urgent_ = false;
   bool is_visible_ = false;
 
-  std::map<WindowAddress, mywindowtype> window_map_;
+  std::map<WindowAddress, std::string> window_map_;
 
   Gtk::Button button_;
   Gtk::Box content_;
@@ -96,6 +94,9 @@ class Workspaces : public AModule, public EventHandler {
   auto active_only() const -> bool { return active_only_; }
 
   auto get_bar_output() const -> std::string { return bar_.output->name; }
+
+  std::string get_rewrite(std::string window_class);
+  std::string& get_window_separator() { return format_window_separator_; }
 
  private:
   void onEvent(const std::string&) override;
@@ -132,7 +133,8 @@ class Workspaces : public AModule, public EventHandler {
 
   std::string format_;
   std::map<std::string, std::string> icons_map_;
-  std::map<std::string, std::string> window_rewrite_rules_;
+  Json::Value window_rewrite_rules_;
+  std::map<std::string, std::string> regex_cache_;
   std::string format_window_separator_;
   bool with_icon_;
   uint64_t monitor_id_;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -136,6 +136,7 @@ class Workspaces : public AModule, public EventHandler {
   Json::Value window_rewrite_rules_;
   std::map<std::string, std::string> regex_cache_;
   std::string format_window_separator_;
+  std::string window_rewrite_default_;
   bool with_icon_;
   uint64_t monitor_id_;
   std::string active_workspace_name_;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -48,17 +48,14 @@ class Workspace {
   void set_name(std::string value) { name_ = value; };
   bool contains_window(WindowAddress addr) { return window_map_.contains(addr); }
   void insert_window(WindowAddress addr, std::string window_repr);
-  void remove_window(WindowAddress addr) { window_map_.erase(addr); }
+  std::string remove_window(WindowAddress addr);
   void initialize_window_map(const Json::Value& clients_data);
 
-  bool on_window_opened(WindowAddress& addr, std::string& workspace_name,
-                        const Json::Value& clients_data);
+  bool on_window_opened(WindowAddress& addr, std::string& workspace_name, std::string window_repr);
   bool on_window_opened(WindowAddress& addr, std::string& workspace_name, std::string& window_class,
                         std::string& window_title);
 
-  bool on_window_closed(WindowAddress& addr);
-  bool on_window_moved(WindowAddress& addr, std::string& workspace_name,
-                       const Json::Value& clients_data);
+  std::optional<std::string> on_window_closed(WindowAddress& addr);
 
   void update(const std::string& format, const std::string& icon);
 

--- a/include/util/rewrite_string.hpp
+++ b/include/util/rewrite_string.hpp
@@ -5,4 +5,6 @@
 
 namespace waybar::util {
 std::string rewriteString(const std::string&, const Json::Value&);
-}
+std::string rewriteStringOnce(const std::string& value, const Json::Value& rules,
+                              bool& matched_any);
+}  // namespace waybar::util

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -21,6 +21,21 @@ Addressed by *hyprland/workspaces*
 	typeof: array ++
 	Based on the workspace id and state, the corresponding icon gets selected. See *icons*.
 
+*window-rewrite*: ++
+	typeof: object ++
+	Regex rules to map window class to an icon or preferred method of representation for a workspace's window.
+	Keys are the rules, while the values are the methods of representation.
+
+*window-rewrite-default*:
+	typeof: string ++
+	default: "?" ++
+	The default method of representation for a workspace's window. This will be used for windows whose classes do not match any of the rules in *window-rewrite*.
+
+*format-window-separator*: ++
+	typeof: string ++
+	default: " " ++
+	The separator to be used between windows in a workspace.
+
 *show-special*: ++
 	typeof: bool ++
 	default: false ++
@@ -99,6 +114,19 @@ Additional to workspace name matching, the following *format-icons* can be set.
 	"persistent-workspaces": {
 		"*": [ 2,3,4,5 ], // 2-5 on every monitor
 		"HDMI-A-1": [ 1 ] // but only workspace 1 on HDMI-A-1
+	}
+}
+```
+
+```
+"hyprland/workspaces": {
+	"format": "{name}\n{windows}",
+	"format-window-separator": "\n",
+	"window-rewrite-default": "",
+	"window-rewrite": {
+		"firefox": "",
+		"foot": "",
+		"code": "󰨞",
 	}
 }
 ```

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -244,7 +244,9 @@ void waybar::modules::Backlight::upsert_device(ForwardIt first, ForwardIt last, 
   check_nn(name);
 
   const char *actual_brightness_attr =
-      strncmp(name, "amdgpu_bl", 9) == 0 || strcmp(name, "apple-panel-bl") == 0  ? "brightness" : "actual_brightness";
+      strncmp(name, "amdgpu_bl", 9) == 0 || strcmp(name, "apple-panel-bl") == 0
+          ? "brightness"
+          : "actual_brightness";
 
   const char *actual = udev_device_get_sysattr_value(dev, actual_brightness_attr);
   const char *max = udev_device_get_sysattr_value(dev, "max_brightness");

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -256,7 +256,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
       std::string _status;
 
       /* Check for adapter status if battery is not available */
-      if(!std::ifstream(bat / "status")) {
+      if (!std::ifstream(bat / "status")) {
         std::getline(std::ifstream(adapter_ / "status"), _status);
       } else {
         std::getline(std::ifstream(bat / "status"), _status);

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -17,7 +17,7 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
     delayWorker();
   } else if (config_["exec"].isString()) {
     continuousWorker();
-  } 
+  }
 }
 
 waybar::modules::Custom::~Custom() {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -77,6 +77,10 @@ auto Workspaces::parse_config(const Json::Value &config) -> void {
       format_window_separator.isString() ? format_window_separator.asString() : " ";
 
   window_rewrite_rules_ = config["window-rewrite"];
+
+  Json::Value window_rewrite_default = config["window-rewrite-default"];
+  window_rewrite_default_ =
+      window_rewrite_default.isString() ? window_rewrite_default.asString() : "?";
 }
 
 auto Workspaces::register_ipc() -> void {
@@ -757,8 +761,14 @@ std::string Workspaces::get_rewrite(std::string window_class) {
     return regex_cache_[window_class];
   }
 
+  bool matched_any;
+
   std::string window_class_rewrite =
-      waybar::util::rewriteString(window_class, window_rewrite_rules_);
+      waybar::util::rewriteStringOnce(window_class, window_rewrite_rules_, matched_any);
+
+  if (!matched_any) {
+    window_class_rewrite = window_rewrite_default_;
+  }
 
   regex_cache_.emplace(window_class, window_class_rewrite);
 

--- a/src/util/rewrite_string.cpp
+++ b/src/util/rewrite_string.cpp
@@ -30,4 +30,31 @@ std::string rewriteString(const std::string& value, const Json::Value& rules) {
 
   return res;
 }
+
+std::string rewriteStringOnce(const std::string& value, const Json::Value& rules,
+                              bool& matched_any) {
+  if (!rules.isObject()) {
+    return value;
+  }
+
+  matched_any = false;
+
+  std::string res = value;
+
+  for (auto it = rules.begin(); it != rules.end(); ++it) {
+    if (it.key().isString() && it->isString()) {
+      try {
+        const std::regex rule{it.key().asString(), std::regex_constants::icase};
+        if (std::regex_match(value, rule)) {
+          matched_any = true;
+          return std::regex_replace(res, rule, it->asString());
+        }
+      } catch (const std::regex_error& e) {
+        spdlog::error("Invalid rule {}: {}", it.key().asString(), e.what());
+      }
+    }
+  }
+
+  return value;
+}
 }  // namespace waybar::util

--- a/src/util/rewrite_string.cpp
+++ b/src/util/rewrite_string.cpp
@@ -1,5 +1,6 @@
 #include "util/rewrite_string.hpp"
 
+#include <fmt/core.h>
 #include <spdlog/spdlog.h>
 
 #include <regex>
@@ -17,7 +18,7 @@ std::string rewriteString(const std::string& value, const Json::Value& rules) {
       try {
         // malformated regexes will cause an exception.
         // in this case, log error and try the next rule.
-        const std::regex rule{it.key().asString()};
+        const std::regex rule{it.key().asString(), std::regex_constants::icase};
         if (std::regex_match(value, rule)) {
           res = std::regex_replace(res, rule, it->asString());
         }


### PR DESCRIPTION
## About this PR

This PR introduces 3 new configurations for `hyprland/workspaces`, as well as a new formatter for `format`. These can be used to display all of a workspace's currently opened windows.

## Motivation

Unlike actual disciplined people, I can't seem to "assign responsabilities" to my workspaces, and tend to use them chaotically. This means that I frequently forget where I've left my browser or my VS Code windows and have to search for them.

As I'm aware I'm not alone in this, I ported over a functionality I had in my [Eww](https://github.com/elkowar/eww) setup that allows you to display a workspace's content dynamically.

## About the implementation

We've added the `windows_map_` attribute to the `Workspace` class, mapping a window's address (currently represented by a string) to its user-facing representation. The representation is computed by matching the window's class to any of the rules in `window-rewrite`, and defaults to `window-rewrite-default` if there are no matches. Once a given class has had its representation computed once, it will be stored in `Workspaces::regex_cache_`, meaning that new windows of the same class won't need to go through all of the rules again.

Windows are inserted and removed from `Workspace::windows_map_` depending on the event received in `Workspaces::onEvent`. The following events can trigger changes in this mapping (as per [Hyprland's IPC documentation](https://wiki.hyprland.org/hyprland-wiki/pages/IPC/)):

- `openwindow`: This event signals that a new windows has been opened, and accompanies data detailing the window's address, workspace, class and title;
- `closewindow`: This event signals that a window has been closed, and accompanies the window's address;
- `movewindow`: This event signals that a window has been moved to another workspace, and accompanies the window's address and its new workspace;

Additionally, on startup, a call to Hyprland's `clients` JSON is made to populate the initial state of windows.

## Examples 

<details>

<summary><b>Check out an example</b></summary>

![image](https://github.com/Alexays/Waybar/assets/25804378/acef7b73-e528-4648-82c1-ba70ea9f7804)

</details>

<details>

<summary><b>Config options</b></summary>

```json
"hyprland/workspaces": {
  "format": "<sub>{icon}</sub>\n{windows}",
  "format-window-separator": "\n",
  "window-rewrite-default": "",
  "window-rewrite": {
    "firefox": "",
    "foot": "",
    "code": "󰨞",
    ...
  },
  ...
}
```

</details>
