### PR TITLE
hyprland/workspaces: use `name` as fallback icon

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -549,7 +549,8 @@ std::string &Workspace::select_icon(std::map<std::string, std::string> &icons_ma
   if (default_icon_it != icons_map.end()) {
     return default_icon_it->second;
   }
-  return icons_map[""];
+
+  return name_;
 }
 
 auto Workspace::handle_clicked(GdkEventButton *bt) -> bool {


### PR DESCRIPTION
Wlr and Sway modules use the workspace `name` as the default icon if no icon is provided. This adds the same behavior for the `hyprland/workspace` module. 

Closes https://github.com/Alexays/Waybar/issues/2533

Before this fix, it defaulted to the last defined icon, which is silly (see above issue).