### PR TITLE
Fix: Hyprland's special workspaces aren't cleared

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -238,8 +238,10 @@ void Workspaces::create_workspace(Json::Value &value) {
 }
 
 void Workspaces::remove_workspace(std::string name) {
-  auto workspace = std::find_if(workspaces_.begin(), workspaces_.end(),
-                                [&](std::unique_ptr<Workspace> &x) { return x->name() == name; });
+  auto workspace =
+      std::find_if(workspaces_.begin(), workspaces_.end(), [&](std::unique_ptr<Workspace> &x) {
+        return (name.starts_with("special:") && name.substr(8) == x->name()) || name == x->name();
+      });
 
   if (workspace == workspaces_.end()) {
     // happens when a workspace on another monitor is destroyed


### PR DESCRIPTION
Fixes #2505

## About this PR

This PR makes sure special workspaces can be removed. Before this, the code for `Workspaces::remove_workspace()` didn't account for the workspaces starting with `special:` in their names, which resulted in the workspace not being found and, thus, not being removed.

## Additional changes

During the investigation of this bug, I also stumbled upon Hyprland creating special workspaces twice. The second workspace always seems to be called `special:` + the name of the first special workspace, resulting in "doubled specials" (`special:special:<some_name>`). This PR also prevents the creation (and deletion) of workspaces named `special:special:`, which served no purpose and would linger a few seconds in the user's bar. See hyprwm/Hyprland#3424 for more info.

## Related PR
- Introduction of Special Workspace support in Hyprland: #2316 