### PR TITLE
Revise cava module to hide on silence

### DIFF
--- a/include/modules/cava.hpp
+++ b/include/modules/cava.hpp
@@ -36,6 +36,7 @@ class Cava final : public ALabel {
   std::chrono::seconds fetch_input_delay_{4};
   std::chrono::seconds suspend_silence_delay_{0};
   bool silence_{false};
+  bool hide_on_silence_{false};
   int sleep_counter_{0};
   // Cava method
   void pause_resume();

--- a/man/waybar-cava.5.scd
+++ b/man/waybar-cava.5.scd
@@ -35,7 +35,7 @@ libcava lives in:
 |[ *framerate*
 :[ integer
 :[ 30
-:[ rames per second. Is used as a replacement for *interval*
+:[ Frames per second. Is used as a replacement for *interval*
 |[ *autosens*
 :[ integer
 :[ 1
@@ -60,6 +60,10 @@ libcava lives in:
 :[ integer
 :[ 5
 :[ Seconds with no input before cava main thread goes to sleep mode
+|[ *hide_on_silence*
+:[ bool
+:[ false
+:[ Hides the widget if no input (after sleep_timer elapsed)
 |[ *method*
 :[ string
 :[ pulse

--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -64,6 +64,7 @@ waybar::modules::Cava::Cava(const std::string& id, const Json::Value& config)
     prm_.noise_reduction = config_["noise_reduction"].asDouble();
   if (config_["input_delay"].isInt())
     fetch_input_delay_ = std::chrono::seconds(config_["input_delay"].asInt());
+  if (config_["hide_on_silence"].isBool()) hide_on_silence_ = config_["hide_on_silence"].asBool();
   // Make cava parameters configuration
   plan_ = new cava_plan{};
 
@@ -174,10 +175,13 @@ auto waybar::modules::Cava::update() -> void {
       }
 
       label_.set_markup(text_);
+      label_.show();
       ALabel::update();
     }
-  } else
+  } else {
     upThreadDelay(frame_time_milsec_, suspend_silence_delay_);
+    if (hide_on_silence_) label_.hide();
+  }
 }
 
 auto waybar::modules::Cava::doAction(const std::string& name) -> void {


### PR DESCRIPTION
Hi everyone, this is a great project, thank you! It urged me to contribute....

I added to the cava module a configuration option `hide_on_silence`. If it is set to `true` the cava label is hidden if no sound is played after `sleep_timer` seconds.
If the option is not specified or set to `false` the bahaviour is unchanged (current behaviour, no hiding).