### PR TITLE
Adding options to allow disk outputs to always be in a specific unit.

### DIFF
--- a/include/modules/disk.hpp
+++ b/include/modules/disk.hpp
@@ -20,6 +20,9 @@ class Disk : public ALabel {
  private:
   util::SleeperThread thread_;
   std::string path_;
+  std::string unit_;
+
+  float calc_specific_divisor(const std::string divisor);
 };
 
 }  // namespace waybar::modules

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -85,19 +85,29 @@ Addressed by *disk*
 	default: "{used} out of {total} used ({percentage_used}%)" ++
 	The format of the information displayed in the tooltip.
 
+*unit*: ++
+	typeof: string ++
+	Use with specific_free, specific_used, and speciifc_total to force calculation to always be in a certain unit. Accepts kB, kiB, MB, Mib, GB, GiB, TB, TiB.
+
 # FORMAT REPLACEMENTS
 
 *{percentage_used}*: Percentage of disk in use.
 
 *{percentage_free}*: Percentage of free disk space
 
-*{total}*: Total amount of space on the disk, partition or mountpoint.
+*{total}*: Total amount of space on the disk, partition or mountpoint. Automatically selects unit based on size remaining.
 
-*{used}*: Amount of used disk space.
+*{used}*: Amount of used disk space. Automatically selects unit based on size remaining.
 
-*{free}*: Amount of available disk space for normal users.
+*{free}*: Amount of available disk space for normal users. Automatically selects unit based on size remaining.
 
 *{path}*: The path specified in the configuration.
+
+*{specific_total}*: Total amount of space on the disk, partition or mountpoint in a specific unit. Deaults to bytes.
+
+*{specific_used}*: Amount of used disk space in a specific unit. Deaults to bytes.
+
+*{specific_free}*: Amount of available disk space for normal users in a specific unit. Deaults to bytes.
 
 # EXAMPLES
 
@@ -107,6 +117,14 @@ Addressed by *disk*
 	"format": "{percentage_free}% free on {path}",
 }
 ```
+
+```
+"disk": {
+	"interval": 30,
+	"format": "{specific_free:0.2f} GB out of {specific_total:0.2f} GB available. Alternatively {free} out of {total} available",
+	"unit": "GB"
+	// 1434.25 GB out of 2000.00 GB available. Alternatively 1.4TiB out of 1.9TiB available.
+}
 
 # STYLE
 

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -125,6 +125,7 @@ Addressed by *disk*
 	"unit": "GB"
 	// 1434.25 GB out of 2000.00 GB available. Alternatively 1.4TiB out of 1.9TiB available.
 }
+```
 
 # STYLE
 

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -11,6 +11,9 @@ waybar::modules::Disk::Disk(const std::string& id, const Json::Value& config)
   if (config["path"].isString()) {
     path_ = config["path"].asString();
   }
+  if (config["unit"].isString()) {
+    unit_ = config["unit"].asString();
+  }
 }
 
 auto waybar::modules::Disk::update() -> void {
@@ -43,6 +46,13 @@ auto waybar::modules::Disk::update() -> void {
     return;
   }
 
+  float specific_free, specific_used, specific_total, divisor;
+
+  divisor = calc_specific_divisor(unit_);
+  specific_free = (stats.f_bavail * stats.f_frsize)/divisor;
+  specific_used = ((stats.f_blocks - stats.f_bfree) * stats.f_frsize)/divisor;
+  specific_total = (stats.f_blocks * stats.f_frsize)/divisor;
+
   auto free = pow_format(stats.f_bavail * stats.f_frsize, "B", true);
   auto used = pow_format((stats.f_blocks - stats.f_bfree) * stats.f_frsize, "B", true);
   auto total = pow_format(stats.f_blocks * stats.f_frsize, "B", true);
@@ -62,7 +72,8 @@ auto waybar::modules::Disk::update() -> void {
         fmt::runtime(format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
         fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
         fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),
-        fmt::arg("path", path_)));
+        fmt::arg("path", path_), fmt::arg("specific_free", specific_free), 
+        fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total)));
   }
 
   if (tooltipEnabled()) {
@@ -74,8 +85,31 @@ auto waybar::modules::Disk::update() -> void {
         fmt::runtime(tooltip_format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
         fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
         fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),
-        fmt::arg("path", path_)));
+        fmt::arg("path", path_), fmt::arg("specific_free", specific_free), 
+        fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total)));
   }
   // Call parent update
   ALabel::update();
+}
+
+float waybar::modules::Disk::calc_specific_divisor(std::string divisor) {
+  if (divisor == "kB") {
+    return 1000.0;
+  } else if (divisor == "kiB") {
+    return 1024.0;
+  } else if (divisor == "MB") {
+    return 1000.0 * 1000.0;
+  } else if (divisor == "MiB") {
+    return 1024.0 * 1024.0;
+  } else if (divisor == "GB") {
+    return 1000.0 * 1000.0 * 1000.0;
+  } else if (divisor == "GiB") {
+    return 1024.0 * 1024.0 * 1024.0;
+  } else if (divisor == "TB") {
+    return 1000.0 * 1000.0 * 1000.0 * 1000.0;
+  } else if (divisor == "TiB") {
+    return 1024.0 * 1024.0 * 1024.0 * 1024.0;
+  } else { //default to Bytes if it is anything that we don't recongnise
+    return 1.0;
+  }
 }


### PR DESCRIPTION
This PR allows the user to force the disk output to always be in a specific unit, and not automatically change unit as the size in question changes. See below for a few example configs, which should demonstrate this change.
```
"disk": {
	"interval": 30,
	"format": "{specific_free:0.2f} GB out of {specific_total:0.2f} GB available. Alternatively {free} out of {total} available",
	"unit": "GB"
	// 1434.25 GB out of 2000.00 GB available. Alternatively 1.4TiB out of 1.9TiB available.
}
```
```
"disk": {
	"interval": 30,
	"format": "{specific_free:0.2f} GB out of {specific_total:0.2f} GB available. Alternatively {free} out of {total} available",
	"unit": "GB"
	// 0.25 GB out of 2000.00 GB available. Alternatively 241.3MiB out of 1.9TiB available.
}
```
I have added new options instead of updating existing ones to ensure I don't change anyone's existing config. 
Supported specific units are: B, kB, kiB, MB, MiB, GB, GiB, TB, TiB