### PR TITLE
fix(modules/mpris): fix on-*-click typos

### DIFF
--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -126,12 +126,12 @@ The *mpris* module displays currently playing media via libplayerctl.
 	default: play-pause ++
 	Overwrite default action toggles.
 
-*on-middle-click*: ++
+*on-click-middle*: ++
 	typeof: string ++
 	default: previous track ++
 	Overwrite default action toggles.
 
-*on-right-click*: ++
+*on-click-right*: ++
 	typeof: string ++
 	default: next track ++
 	Overwrite default action toggles.

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -587,13 +587,13 @@ bool Mpris::handleToggle(GdkEventButton* const& e) {
         playerctl_player_play_pause(player, &error);
         break;
       case 2:  // middle-click
-        if (config_["on-middle-click"].isString()) {
+        if (config_["on-click-middle"].isString()) {
           return ALabel::handleToggle(e);
         }
         playerctl_player_previous(player, &error);
         break;
       case 3:  // right-click
-        if (config_["on-right-click"].isString()) {
+        if (config_["on-click-right"].isString()) {
           return ALabel::handleToggle(e);
         }
         playerctl_player_next(player, &error);


### PR DESCRIPTION
In all other places, the norm is to use `on-click-(middle|right)` but in the mpris module, `on-(middle|right)-click` was being used which caused clicks to malfunction if set to some custom commands