### PR TITLE
Feat/Hyprland: Allow matching against Window Titles for Rewrite

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -48,7 +48,7 @@ class Workspace {
   void set_visible(bool value = true) { is_visible_ = value; };
   void set_windows(uint value) { windows_ = value; };
   void set_name(std::string value) { name_ = value; };
-  bool contains_window(WindowAddress addr) { return window_map_.contains(addr); }
+  bool contains_window(WindowAddress addr) const { return window_map_.contains(addr); }
   void insert_window(WindowAddress addr, std::string window_class, std::string window_title);
   std::string remove_window(WindowAddress addr);
   void initialize_window_map(const Json::Value& clients_data);
@@ -112,6 +112,8 @@ class Workspaces : public AModule, public EventHandler {
   void on_window_opened(std::string payload);
   void on_window_closed(std::string payload);
   void on_window_moved(std::string payload);
+
+  int window_rewrite_priority_function(std::string& window_rule);
 
   bool all_outputs_ = false;
   bool show_special_ = false;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -16,8 +16,10 @@
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
 #include "util/enum.hpp"
+#include "util/regex_collection.hpp"
 
 using WindowAddress = std::string;
+
 namespace waybar::modules::hyprland {
 
 class Workspaces;
@@ -47,7 +49,7 @@ class Workspace {
   void set_windows(uint value) { windows_ = value; };
   void set_name(std::string value) { name_ = value; };
   bool contains_window(WindowAddress addr) { return window_map_.contains(addr); }
-  void insert_window(WindowAddress addr, std::string window_repr);
+  void insert_window(WindowAddress addr, std::string window_class, std::string window_title);
   std::string remove_window(WindowAddress addr);
   void initialize_window_map(const Json::Value& clients_data);
 
@@ -92,7 +94,7 @@ class Workspaces : public AModule, public EventHandler {
 
   auto get_bar_output() const -> std::string { return bar_.output->name; }
 
-  std::string get_rewrite(std::string window_class);
+  std::string get_rewrite(std::string window_class, std::string window_title);
   std::string& get_window_separator() { return format_window_separator_; }
 
  private:
@@ -129,11 +131,12 @@ class Workspaces : public AModule, public EventHandler {
   bool persistent_created_ = false;
 
   std::string format_;
+
   std::map<std::string, std::string> icons_map_;
-  Json::Value window_rewrite_rules_;
-  std::map<std::string, std::string> regex_cache_;
+  util::RegexCollection window_rewrite_rules_;
+  bool any_window_rewrite_rule_uses_title_ = false;
   std::string format_window_separator_;
-  std::string window_rewrite_default_;
+
   bool with_icon_;
   uint64_t monitor_id_;
   std::string active_workspace_name_;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -97,6 +97,8 @@ class Workspaces : public AModule, public EventHandler {
   std::string get_rewrite(std::string window_class, std::string window_title);
   std::string& get_window_separator() { return format_window_separator_; }
 
+  bool window_rewrite_config_uses_title() const { return any_window_rewrite_rule_uses_title_; }
+
  private:
   void onEvent(const std::string&) override;
   void update_window_count();

--- a/include/util/regex_collection.hpp
+++ b/include/util/regex_collection.hpp
@@ -16,6 +16,14 @@ struct Rule {
 
 int default_priority_function(std::string& key);
 
+/* A collection of regexes and strings, with a default string to return if no regexes.
+ * When a regex is matched, the corresponding string is returned.
+ * All regexes that are matched are cached, so that the regexes are only
+ * evaluated once against a given string.
+ * Regexes may be given a higher priority than others, so that they are matched
+ * first. The priority function is given the regex string, and should return a
+ * higher number for higher priority regexes.
+ */
 class RegexCollection {
  private:
   std::vector<Rule> rules;

--- a/include/util/regex_collection.hpp
+++ b/include/util/regex_collection.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <json/json.h>
+
+#include <functional>
+#include <regex>
+#include <string>
+
+namespace waybar::util {
+
+struct Rule {
+  std::regex rule;
+  std::string repr;
+  int priority;
+};
+
+int default_priority_function(std::string& key);
+
+class RegexCollection {
+ private:
+  std::vector<Rule> rules;
+  std::map<std::string, std::string> regex_cache;
+  std::string default_repr;
+
+  std::string& find_match(std::string& value, bool& matched_any);
+
+ public:
+  RegexCollection() = default;
+  RegexCollection(const Json::Value& map, std::string default_repr = "",
+                  std::function<int(std::string&)> priority_function = default_priority_function);
+  ~RegexCollection() = default;
+
+  std::string& get(std::string& value, bool& matched_any);
+  std::string& get(std::string& value);
+};
+
+}  // namespace waybar::util

--- a/include/util/regex_collection.hpp
+++ b/include/util/regex_collection.hpp
@@ -12,6 +12,12 @@ struct Rule {
   std::regex rule;
   std::string repr;
   int priority;
+
+  // Fix for Clang < 16
+  // See https://en.cppreference.com/w/cpp/compiler_support/20 "Parenthesized initialization of
+  // aggregates"
+  Rule(std::regex rule, std::string repr, int priority)
+      : rule(rule), repr(repr), priority(priority) {}
 };
 
 int default_priority_function(std::string& key);

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -25,6 +25,7 @@ Addressed by *hyprland/workspaces*
 	typeof: object ++
 	Regex rules to map window class to an icon or preferred method of representation for a workspace's window.
 	Keys are the rules, while the values are the methods of representation.
+	Rules may specify `class<...>`, `title<...>` or both in order to fine-tune the matching.
 
 *window-rewrite-default*:
 	typeof: string ++
@@ -124,8 +125,10 @@ Additional to workspace name matching, the following *format-icons* can be set.
 	"format-window-separator": "\n",
 	"window-rewrite-default": "",
 	"window-rewrite": {
-		"firefox": "",
-		"foot": "",
+		"title<.*youtube.*>": "", // Windows whose titles contain "youtube"
+		"class<firefox>": "", // Windows whose classes are "firefox"
+		"class<firefox> title<.*github.*>": "", // Windows whose class is "firefox" and title contains "github". Note that "class" always comes first.
+		"foot": "", // Windows that contain "foot" in either class or title. For optimization reasons, it will only match against a title if at least one other window explicitly matches against a title.
 		"code": "󰨞",
 	}
 }

--- a/meson.build
+++ b/meson.build
@@ -177,7 +177,8 @@ src_files = files(
     'src/util/ustring_clen.cpp',
     'src/util/sanitize_str.cpp',
     'src/util/rewrite_string.cpp',
-    'src/util/gtk_icon.cpp'
+    'src/util/gtk_icon.cpp',
+    'src/util/regex_collection.cpp'
 )
 
 inc_dirs = ['include']

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -49,9 +49,9 @@ auto waybar::modules::Disk::update() -> void {
   float specific_free, specific_used, specific_total, divisor;
 
   divisor = calc_specific_divisor(unit_);
-  specific_free = (stats.f_bavail * stats.f_frsize)/divisor;
-  specific_used = ((stats.f_blocks - stats.f_bfree) * stats.f_frsize)/divisor;
-  specific_total = (stats.f_blocks * stats.f_frsize)/divisor;
+  specific_free = (stats.f_bavail * stats.f_frsize) / divisor;
+  specific_used = ((stats.f_blocks - stats.f_bfree) * stats.f_frsize) / divisor;
+  specific_total = (stats.f_blocks * stats.f_frsize) / divisor;
 
   auto free = pow_format(stats.f_bavail * stats.f_frsize, "B", true);
   auto used = pow_format((stats.f_blocks - stats.f_bfree) * stats.f_frsize, "B", true);
@@ -72,7 +72,7 @@ auto waybar::modules::Disk::update() -> void {
         fmt::runtime(format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
         fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
         fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),
-        fmt::arg("path", path_), fmt::arg("specific_free", specific_free), 
+        fmt::arg("path", path_), fmt::arg("specific_free", specific_free),
         fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total)));
   }
 
@@ -85,7 +85,7 @@ auto waybar::modules::Disk::update() -> void {
         fmt::runtime(tooltip_format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
         fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
         fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),
-        fmt::arg("path", path_), fmt::arg("specific_free", specific_free), 
+        fmt::arg("path", path_), fmt::arg("specific_free", specific_free),
         fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total)));
   }
   // Call parent update
@@ -109,7 +109,7 @@ float waybar::modules::Disk::calc_specific_divisor(std::string divisor) {
     return 1000.0 * 1000.0 * 1000.0 * 1000.0;
   } else if (divisor == "TiB") {
     return 1024.0 * 1024.0 * 1024.0 * 1024.0;
-  } else { //default to Bytes if it is anything that we don't recongnise
+  } else {  // default to Bytes if it is anything that we don't recongnise
     return 1.0;
   }
 }

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -12,15 +12,17 @@
 
 namespace waybar::modules::hyprland {
 
-int window_rewrite_priority_function(std::string &window_rule) {
+int Workspaces::window_rewrite_priority_function(std::string &window_rule) {
   // Rules that match against title are prioritized
   // Rules that don't specify if they're matching against either title or class are deprioritized
   bool has_title = window_rule.find("title") != std::string::npos;
   bool has_class = window_rule.find("class") != std::string::npos;
 
   if (has_title && has_class) {
+    any_window_rewrite_rule_uses_title_ = true;
     return 3;
   } else if (has_title) {
+    any_window_rewrite_rule_uses_title_ = true;
     return 2;
   } else if (has_class) {
     return 1;
@@ -98,8 +100,10 @@ auto Workspaces::parse_config(const Json::Value &config) -> void {
   std::string window_rewrite_default =
       window_rewrite_default_config.isString() ? window_rewrite_default_config.asString() : "?";
 
-  window_rewrite_rules_ = util::RegexCollection(window_rewrite, window_rewrite_default,
-                                                window_rewrite_priority_function);
+  window_rewrite_rules_ = util::RegexCollection(
+      window_rewrite, window_rewrite_default, [this](std::string &window_rule) {
+        return this->window_rewrite_priority_function(window_rule);
+      });
 }
 
 auto Workspaces::register_ipc() -> void {
@@ -119,6 +123,13 @@ auto Workspaces::register_ipc() -> void {
   gIPC->registerForIPC("closewindow", this);
   gIPC->registerForIPC("movewindow", this);
   gIPC->registerForIPC("urgent", this);
+
+  if (any_window_rewrite_rule_uses_title_) {
+    spdlog::info(
+        "Registering for Hyprland's 'windowtitle' events because a user-defined window "
+        "rewrite rule uses the 'title' field.");
+    gIPC->registerForIPC("windowtitle", this);
+  }
 }
 
 auto Workspaces::update() -> void {
@@ -240,6 +251,25 @@ void Workspaces::onEvent(const std::string &ev) {
         break;
       }
     }
+  } else if (eventName == "windowtitle") {
+    auto window_workspace =
+        std::find_if(workspaces_.begin(), workspaces_.end(),
+                     [payload](auto &workspace) { return workspace->contains_window(payload); });
+
+    if (window_workspace != workspaces_.end()) {
+      Json::Value clients_data = gIPC->getSocket1JsonReply("clients");
+      std::string json_window_address = fmt::format("0x{}", payload);
+
+      auto client = std::find_if(clients_data.begin(), clients_data.end(),
+                                 [json_window_address](auto &client) {
+                                   return client["address"].asString() == json_window_address;
+                                 });
+
+      if (!client->empty()) {
+        (*window_workspace)
+            ->insert_window(payload, (*client)["class"].asString(), (*client)["title"].asString());
+      }
+    }
   }
 
   dp.emit();
@@ -350,7 +380,7 @@ void Workspace::insert_window(WindowAddress addr, std::string window_class,
                               std::string window_title) {
   auto window_repr = workspace_manager_.get_rewrite(window_class, window_title);
   if (!window_repr.empty()) {
-    window_map_.emplace(addr, window_repr);
+    window_map_[addr] = window_repr;
   }
 };
 
@@ -364,7 +394,7 @@ std::string Workspace::remove_window(WindowAddress addr) {
 bool Workspace::on_window_opened(WindowAddress &addr, std::string &workspace_name,
                                  std::string window_repr) {
   if (workspace_name == name()) {
-    window_map_.emplace(addr, window_repr);
+    window_map_[addr] = window_repr;
     return true;
   } else {
     return false;

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -816,7 +816,12 @@ void Workspaces::set_urgent_workspace(std::string windowaddress) {
 }
 
 std::string Workspaces::get_rewrite(std::string window_class, std::string window_title) {
-  std::string window_repr_key = fmt::format("class<{}> title<{}>", window_class, window_title);
+  std::string window_repr_key;
+  if (any_window_rewrite_rule_uses_title_) {
+    window_repr_key = fmt::format("class<{}> title<{}>", window_class, window_title);
+  } else {
+    window_repr_key = fmt::format("class<{}>", window_class);
+  }
   return window_rewrite_rules_.get(window_repr_key);
 }
 

--- a/src/util/regex_collection.cpp
+++ b/src/util/regex_collection.cpp
@@ -1,0 +1,69 @@
+#include "util/regex_collection.hpp"
+
+#include <json/value.h>
+#include <spdlog/spdlog.h>
+
+namespace waybar::util {
+
+int default_priority_function(std::string& key) { return 0; }
+
+RegexCollection::RegexCollection(const Json::Value& map, std::string default_repr,
+                                 std::function<int(std::string&)> priority_function)
+    : default_repr(default_repr) {
+  if (!map.isObject()) {
+    spdlog::warn("Mapping is not an object");
+    return;
+  }
+
+  for (auto it = map.begin(); it != map.end(); ++it) {
+    if (it.key().isString() && it->isString()) {
+      std::string key = it.key().asString();
+      int priority = priority_function(key);
+      try {
+        const std::regex rule{key, std::regex_constants::icase};
+        rules.emplace_back(rule, it->asString(), priority);
+      } catch (const std::regex_error& e) {
+        spdlog::error("Invalid rule '{}': {}", key, e.what());
+      }
+    }
+  }
+
+  std::sort(rules.begin(), rules.end(), [](Rule& a, Rule& b) { return a.priority > b.priority; });
+}
+
+std::string& RegexCollection::find_match(std::string& value, bool& matched_any) {
+  for (auto& rule : rules) {
+    if (std::regex_search(value, rule.rule)) {
+      matched_any = true;
+      return rule.repr;
+    }
+  }
+
+  return value;
+}
+
+std::string& RegexCollection::get(std::string& value, bool& matched_any) {
+  if (regex_cache.contains(value)) {
+    return regex_cache[value];
+  }
+
+  // std::string repr =
+  // waybar::util::find_match(value, window_rewrite_rules_, matched_any);
+
+  std::string repr = find_match(value, matched_any);
+
+  if (!matched_any) {
+    repr = default_repr;
+  }
+
+  regex_cache.emplace(value, repr);
+
+  return regex_cache[value];  // Necessary in order to return a reference to the heap
+}
+
+std::string& RegexCollection::get(std::string& value) {
+  bool matched_any = false;
+  return get(value, matched_any);
+}
+
+}  // namespace waybar::util

--- a/src/util/rewrite_string.cpp
+++ b/src/util/rewrite_string.cpp
@@ -1,6 +1,5 @@
 #include "util/rewrite_string.hpp"
 
-#include <fmt/core.h>
 #include <spdlog/spdlog.h>
 
 #include <regex>
@@ -29,32 +28,5 @@ std::string rewriteString(const std::string& value, const Json::Value& rules) {
   }
 
   return res;
-}
-
-std::string rewriteStringOnce(const std::string& value, const Json::Value& rules,
-                              bool& matched_any) {
-  if (!rules.isObject()) {
-    return value;
-  }
-
-  matched_any = false;
-
-  std::string res = value;
-
-  for (auto it = rules.begin(); it != rules.end(); ++it) {
-    if (it.key().isString() && it->isString()) {
-      try {
-        const std::regex rule{it.key().asString(), std::regex_constants::icase};
-        if (std::regex_match(value, rule)) {
-          matched_any = true;
-          return std::regex_replace(res, rule, it->asString());
-        }
-      } catch (const std::regex_error& e) {
-        spdlog::error("Invalid rule {}: {}", it.key().asString(), e.what());
-      }
-    }
-  }
-
-  return value;
 }
 }  // namespace waybar::util


### PR DESCRIPTION
Resolves #2561 

## About this PR

This PR builds upon #2529 to introduce matching against a window's title in order to get its icon. In order to do that, the function that matches against regexes will now be supplied a string in this format: `"class<WINDOW_CLASS> title<WINDOW_TITLE>"`, as opposed to just the class. This way, users may provide rules in the following forms:

```json
"window-rewrite": {
  "title<.*youtube.*>": "", // Windows whose titles contain "youtube"
  "class<firefox>": "", // Windows whose classes are "firefox"
  "class<firefox> title<.*github.*>": "", // Windows whose class is "firefox" and title contains "github". Note that "class" always comes first.
  "foot": "", // Windows that contain "foot" in either class or title. For optimization reasons, it will only match against a title if at least one other window explicitly matches against a title.
}
```

Rules are now also prioritized, from more specilized to least. In the previous example, the priority order would be:
1. GitHub — Contains both class and title matching;
2. YouTube — Matches against a title, which is preferred over simply a class;
3. FireFox — Explicitly matches against a class;
4. Foot — Doesn't explicitly match against anything and, thus, is considered low priority. This prevents having your browser be displayed as a terminal if you search for "foot" in FireFox, for example.

## Backwards Compatibility

Because of the possible problem pointed out in **4.**, matching against titles is disabled **unless** at least one rule explicitly matches against titles. If no rules do so, titles are not sent to the aforementioned function, and, instead, the string `"class<WINDOW_CLASS>"` is used.

This does mean, however, that rules written as `"^something_here$"` will not work anymore, and should be replace by either `"somethind_here"`, `"class<something_here>"` or `"^class<something_here>$"`. While I don't believe anyone might've written such a specific rule, I'm open to hear the reasoning for that and work out something that doesn't break this niche use case.

## Implementation Details

A refactor has been made to separate the logic behind the regex map, its cache and default values. This whole logic is now available as the `waybar::util::RegexCollection` class, which can be constructed from a `Json::Value`. This class also provides a way to sort rules, giving priority to whichever rule scores higher in the parameter function.

When titles are used in any rules, the workspace module will be subscribed to an additional event called `windowtitle`, which, [according to Hyprland's IPC documentation](https://wiki.hyprland.org/IPC/), only features the window's address as a parameter. This means that an additional call to Hyprland's `"clients"` socket1 must be made in order to retrieve the window's latest name.

The module is not subscribed to this event when titles aren't explicitly used simply because it would be of no use and could break compatibility as mentioned above.