### PR TITLE
Feat/Hyprland/Workspaces: Ignore workspaces

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -94,6 +95,7 @@ class Workspaces : public AModule, public EventHandler {
 
   std::string get_rewrite(std::string window_class);
   std::string& get_window_separator() { return format_window_separator_; }
+  bool is_workspace_ignored(std::string& workspace_name);
 
  private:
   void onEvent(const std::string&) override;
@@ -140,6 +142,9 @@ class Workspaces : public AModule, public EventHandler {
   std::vector<std::unique_ptr<Workspace>> workspaces_;
   std::vector<Json::Value> workspaces_to_create_;
   std::vector<std::string> workspaces_to_remove_;
+
+  std::vector<std::regex> ignore_workspaces_;
+
   std::mutex mutex_;
   const Bar& bar_;
   Gtk::Box box_;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -51,6 +51,11 @@ Addressed by *hyprland/workspaces*
 	default: false ++
 	If set to true, only the active workspace will be shown.
 
+*ignore-workspaces*: ++
+	typeof: array ++
+	default: [] ++
+	Regexes to match against workspaces names. If there's a match, the workspace will not be shown. This takes precedence over *show-special*, *all-outputs* and *active-only*.
+
 *sort-by*: ++
 	typeof: string ++
 	default: "default" ++
@@ -128,6 +133,14 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"foot": "",
 		"code": "󰨞",
 	}
+}
+```
+
+"hyprland/workspaces": {
+	// Formatting omitted for brevity
+	"ignore-workspaces": [
+		"(special:)?chrome-sharing-indicator"
+	]
 }
 ```
 


### PR DESCRIPTION
## About this PR

This PR introduces a new option to `hyprland/workspaces` called `ignore-workspaces`. This option is an array of regexes that will be matched against workspace names. If there's a match, the workspace being created will not be shown on the user's bar.

## Motivation

Chrome is notorious for launching a "sharing indicator" when your screen is being shared. This is specially frustrating when using tiling managers, such as Hyprland. 

![image](https://github.com/Alexays/Waybar/assets/25804378/ce37900f-9b6e-415b-a4d1-1a227391c7ee)

My current solution for not having to see it is by forcing it to move to a workspace named `special:hell`. This PR, then, lets me add it to a ignored list of workspaces, with the following rule:

```json
"hyprland/workspaces": {
        "ignore-workspaces": [
            "(special:)?hell"
        ]
}
```

*(note that I'm optionally matching against "special:" because Hyprland is not very consistent when it comes to naming special workspaces)*