### PR TITLE
Fix: Hyprland/Workspaces' windows disappearing when moving around

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -162,7 +162,7 @@ class Workspaces : public AModule, public EventHandler {
                                                   {"DEFAULT", SORT_METHOD::DEFAULT}};
 
   void fill_persistent_workspaces();
-  void create_persistent_workspaces();
+  void create_persistent_workspaces(const Json::Value& clients_data);
   std::vector<std::string> persistent_workspaces_to_create_;
   bool persistent_created_ = false;
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -161,7 +161,7 @@ class Workspaces : public AModule, public EventHandler {
                                                   {"DEFAULT", SORT_METHOD::DEFAULT}};
 
   void fill_persistent_workspaces();
-  void create_persistent_workspaces(const Json::Value& clients_data);
+  void create_persistent_workspaces();
   std::vector<std::string> persistent_workspaces_to_create_;
   bool persistent_created_ = false;
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -134,7 +134,6 @@ class Workspaces : public AModule, public EventHandler {
  private:
   void onEvent(const std::string&) override;
   void update_window_count();
-  void initialize_window_maps();
   void sort_workspaces();
   void create_workspace(Json::Value& workspace_data,
                         const Json::Value& clients_data = Json::Value::nullRef);

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -43,6 +43,7 @@ class CreateWindow {
 
  private:
   void clear_addr();
+  void clear_workspace_name();
 
   using Repr = std::string;
   using ClassAndTitle = std::pair<std::string, std::string>;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -29,7 +29,8 @@ class Workspaces;
 class CreateWindow {
  public:
   CreateWindow(std::string workspace_name, WindowAddress window_address, std::string window_repr);
-  CreateWindow(std::string workspace_name, WindowAddress window_address, std::string window_class, std::string window_title);
+  CreateWindow(std::string workspace_name, WindowAddress window_address, std::string window_class,
+               std::string window_title);
   CreateWindow(Json::Value& client_data);
 
   int increment_time_spent_uncreated();
@@ -41,7 +42,6 @@ class CreateWindow {
   WindowAddress addr() const { return window_address_; }
 
  private:
-
   void clear_addr();
 
   using Repr = std::string;
@@ -52,7 +52,6 @@ class CreateWindow {
   WindowAddress window_address_;
   std::string workspace_name_;
   int time_spent_uncreated_ = 0;
-
 };
 
 class Workspace {

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -41,6 +41,8 @@ class CreateWindow {
   std::string workspace_name() const { return workspace_name_; }
   WindowAddress addr() const { return window_address_; }
 
+  void move_to_worksace(std::string& new_workspace_name);
+
  private:
   void clear_addr();
   void clear_workspace_name();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -367,6 +367,15 @@ void Workspaces::on_window_moved(std::string payload) {
 
   std::string window_repr;
 
+  // If the window was still queued to be created, just change its destination
+  // and exit
+  for (auto &window : windows_to_create_) {
+    if (window.addr() == window_address) {
+      window.move_to_worksace(workspace_name);
+      return;
+    }
+  }
+
   // Take the window's representation from the old workspace...
   for (auto &workspace : workspaces_) {
     try {
@@ -379,7 +388,9 @@ void Workspaces::on_window_moved(std::string payload) {
   }
 
   // ...and add it to the new workspace
-  windows_to_create_.emplace_back(CreateWindow(workspace_name, window_address, window_repr));
+  if (!window_repr.empty()) {
+    windows_to_create_.emplace_back(CreateWindow(workspace_name, window_address, window_repr));
+  }
 }
 
 void Workspaces::update_window_count() {
@@ -932,6 +943,10 @@ void CreateWindow::clear_workspace_name() {
     workspace_name_ = workspace_name_.substr(
         SPECIAL_QUALIFIER_PREFIX_LEN, workspace_name_.length() - SPECIAL_QUALIFIER_PREFIX_LEN);
   }
+}
+
+void CreateWindow::move_to_worksace(std::string &new_workspace_name) {
+  workspace_name_ = new_workspace_name;
 }
 
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -417,13 +417,6 @@ void Workspaces::update_window_count() {
   }
 }
 
-void Workspaces::initialize_window_maps() {
-  Json::Value clients_data = gIPC->getSocket1JsonReply("clients");
-  for (auto &workspace : workspaces_) {
-    workspace->initialize_window_map(clients_data);
-  }
-}
-
 void Workspace::initialize_window_map(const Json::Value &clients_data) {
   window_map_.clear();
   for (auto client : clients_data) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -458,17 +458,16 @@ std::optional<std::string> Workspace::on_window_closed(WindowAddress &addr) {
 }
 
 void Workspaces::create_workspace(Json::Value &workspace_data, const Json::Value &clients_data) {
-  // replace the existing persistent workspace if it exists
+  // avoid recreating existing workspaces
   auto workspace = std::find_if(
       workspaces_.begin(), workspaces_.end(), [&](std::unique_ptr<Workspace> const &x) {
         auto name = workspace_data["name"].asString();
         return x->is_persistent() &&
                ((name.starts_with("special:") && name.substr(8) == x->name()) || name == x->name());
       });
+
   if (workspace != workspaces_.end()) {
-    // replace workspace, but keep persistent flag
-    workspaces_.erase(workspace);
-    workspace_data["persistent"] = true;
+    return;
   }
 
   // create new workspace

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -458,11 +458,11 @@ std::optional<std::string> Workspace::on_window_closed(WindowAddress &addr) {
 
 void Workspaces::create_workspace(Json::Value &workspace_data, const Json::Value &clients_data) {
   // avoid recreating existing workspaces
+  auto workspace_name = workspace_data["name"].asString();
   auto workspace = std::find_if(
-      workspaces_.begin(), workspaces_.end(), [&](std::unique_ptr<Workspace> const &x) {
-        auto name = workspace_data["name"].asString();
-        return x->is_persistent() &&
-               ((name.starts_with("special:") && name.substr(8) == x->name()) || name == x->name());
+      workspaces_.begin(), workspaces_.end(), [&](std::unique_ptr<Workspace> const &w) {
+        return (workspace_name.starts_with("special:") && workspace_name.substr(8) == w->name()) ||
+               workspace_name == w->name();
       });
 
   if (workspace != workspaces_.end()) {
@@ -589,9 +589,6 @@ void Workspaces::init() {
     monitor_id_ = (*current_monitor)["id"].asInt();
   }
 
-  fill_persistent_workspaces();
-  create_persistent_workspaces();
-
   const Json::Value workspaces_json = gIPC->getSocket1JsonReply("workspaces");
   const Json::Value clients_json = gIPC->getSocket1JsonReply("clients");
 
@@ -603,6 +600,9 @@ void Workspaces::init() {
       create_workspace(workspace_json, clients_json);
     }
   }
+
+  fill_persistent_workspaces();
+  create_persistent_workspaces();
 
   update_window_count();
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -562,7 +562,7 @@ void Workspaces::fill_persistent_workspaces() {
   }
 }
 
-void Workspaces::create_persistent_workspaces() {
+void Workspaces::create_persistent_workspaces(const Json::Value &clients_data) {
   for (const std::string &workspace_name : persistent_workspaces_to_create_) {
     Json::Value new_workspace;
     try {
@@ -577,7 +577,7 @@ void Workspaces::create_persistent_workspaces() {
     new_workspace["windows"] = 0;
     new_workspace["persistent"] = true;
 
-    create_workspace(new_workspace);
+    create_workspace(new_workspace, clients_data);
   }
 }
 
@@ -596,11 +596,11 @@ void Workspaces::init() {
     monitor_id_ = (*current_monitor)["id"].asInt();
   }
 
-  fill_persistent_workspaces();
-  create_persistent_workspaces();
-
   const Json::Value workspaces_json = gIPC->getSocket1JsonReply("workspaces");
   const Json::Value clients_json = gIPC->getSocket1JsonReply("clients");
+
+  fill_persistent_workspaces();
+  create_persistent_workspaces(clients_json);
 
   for (Json::Value workspace_json : workspaces_json) {
     std::string workspace_name = workspace_json["name"].asString();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -194,6 +194,7 @@ auto Workspaces::update() -> void {
     workspace->update(format_, workspace_icon);
   }
 
+  bool any_window_created = false;
   std::vector<CreateWindow> not_created;
 
   for (auto &window_payload : windows_to_create_) {
@@ -201,6 +202,7 @@ auto Workspaces::update() -> void {
     for (auto &workspace : workspaces_) {
       if (workspace->on_window_opened(window_payload)) {
         created = true;
+        any_window_created = true;
         break;
       }
     }
@@ -210,6 +212,10 @@ auto Workspaces::update() -> void {
         not_created.push_back(window_payload);
       }
     }
+  }
+
+  if (any_window_created) {
+    dp.emit();
   }
 
   windows_to_create_.clear();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -555,7 +555,7 @@ void Workspaces::fill_persistent_workspaces() {
   }
 }
 
-void Workspaces::create_persistent_workspaces(const Json::Value &clients_data) {
+void Workspaces::create_persistent_workspaces() {
   for (const std::string &workspace_name : persistent_workspaces_to_create_) {
     Json::Value new_workspace;
     try {
@@ -570,7 +570,7 @@ void Workspaces::create_persistent_workspaces(const Json::Value &clients_data) {
     new_workspace["windows"] = 0;
     new_workspace["persistent"] = true;
 
-    create_workspace(new_workspace, clients_data);
+    create_workspace(new_workspace);
   }
 }
 
@@ -589,11 +589,11 @@ void Workspaces::init() {
     monitor_id_ = (*current_monitor)["id"].asInt();
   }
 
+  fill_persistent_workspaces();
+  create_persistent_workspaces();
+
   const Json::Value workspaces_json = gIPC->getSocket1JsonReply("workspaces");
   const Json::Value clients_json = gIPC->getSocket1JsonReply("clients");
-
-  fill_persistent_workspaces();
-  create_persistent_workspaces(clients_json);
 
   for (Json::Value workspace_json : workspaces_json) {
     std::string workspace_name = workspace_json["name"].asString();


### PR DESCRIPTION
Fixes #2557

## About this PR

This PR fixes an issue that caused windows to disappear. This was caused because, sometimes, Hyprland's IPC decides to report the window-related event (`openwindow`, `movewindow`) before the `createworkspace` event. This, in turn, caused Waybar to have nowhere to put the moved/opened window, causing it to be discarted.

![grim_2023-10-16T16:27:06-03:00](https://github.com/Alexays/Waybar/assets/25804378/6bae086b-3359-48f7-9afc-c9b459bc8804)

## About the solution

In order to solve this problem, the window creation has been delayed, much akin to how workspaces are created; they are pushed into a vector and are processed during `Workspaces::update()`. There will be 3 attempts to create each window, accounting for the possibility that the `createworkspace` message got *just* late enough that it wasn't processed in the same `update()` call.
