### PR TITLE
Show the network interface with highest priority (aka lower metric)

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -656,7 +656,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
         checking route id
         **/
         if (!is_del_event &&
-            ((net->ifid_ == -1) || (priority < net->route_priority) || (net->ifid_ != temp_idx))) {
+            ((net->ifid_ == -1) || (priority < net->route_priority))) {
           // Clear if's state for the case were there is a higher priority
           // route on a different interface.
           net->clearIface();


### PR DESCRIPTION
On new interface discovery a new index is (may be) assigned to the `temp_idx`.

The new interface should be assigned to `net` if is the first one (`net->ifid_ == -1`) or if has higher priority (`priority < net->route_priority`... lower is higher according to metric).

This PR removes the additional condition `net->ifid_ != temp_idx` which is always be true and incorrectly ends up showing the last found route instead of the one with higher priority

Closes https://github.com/Alexays/Waybar/issues/2167