### PR TITLE
Custom module: Allow signal without interrupt

### DIFF
--- a/include/util/sleeper_thread.hpp
+++ b/include/util/sleeper_thread.hpp
@@ -61,7 +61,7 @@ class SleeperThread {
   auto sleep() {
     std::unique_lock lk(mutex_);
     CancellationGuard cancel_lock;
-    return condvar_.wait(lk);
+    return condvar_.wait(lk, [this] { return signal_ || !do_run_; });
   }
 
   auto sleep_for(std::chrono::system_clock::duration dur) {


### PR DESCRIPTION
This PR fixes an issue which prevented `signal` from working without an `interval`.

For some reason, it was not allowed to interrupt the `sleep()` of a `SleeperThread`.
This change keeps the function consistent with sleep_until() and sleep_for() which both can be interrupted.

Resolves #2587 

Edit: `exec-on-event` is probably also affected