### PR TITLE
Lint header files with hpp file ending

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,5 +10,5 @@ jobs:
     - uses: DoozyX/clang-format-lint-action@v0.13
       with:
         source: '.'
-        extensions: 'h,cpp,c'
+        extensions: 'hpp,h,cpp,c'
         clangFormatVersion: 12

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: DoozyX/clang-format-lint-action@v0.13
+    - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: '.'
         extensions: 'hpp,h,cpp,c'
-        clangFormatVersion: 12
+        clangFormatVersion: 16


### PR DESCRIPTION
Currently, only `h`, `cpp` and `c` files are linted using the Linter CI workflow.

Since there are multiple files with the `hpp` file ending, I added this file ending to the workflow config.