### PR TITLE
General cleanup in hyprland/workspaces

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -14,7 +14,7 @@ namespace waybar::modules::hyprland {
 class Window : public waybar::AAppIconLabel, public EventHandler {
  public:
   Window(const std::string&, const waybar::Bar&, const Json::Value&);
-  virtual ~Window();
+  ~Window() override;
 
   auto update() -> void override;
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -88,7 +88,7 @@ class Workspace {
   void initialize_window_map(const Json::Value& clients_data);
 
   bool on_window_opened(WindowCreationPayload const& create_window_paylod);
-  std::optional<std::string> on_window_closed(WindowAddress const& addr);
+  std::optional<std::string> close_window(WindowAddress const& addr);
 
   void update(const std::string& format, const std::string& icon);
 
@@ -127,7 +127,7 @@ class Workspaces : public AModule, public EventHandler {
 
   std::string get_rewrite(std::string window_class, std::string window_title);
   std::string& get_window_separator() { return format_window_separator_; }
-  bool is_workspace_ignored(std::string& workspace_name);
+  bool is_workspace_ignored(std::string const& workspace_name);
 
   bool window_rewrite_config_uses_title() const { return any_window_rewrite_rule_uses_title_; }
 
@@ -142,9 +142,22 @@ class Workspaces : public AModule, public EventHandler {
   void parse_config(const Json::Value& config);
   void register_ipc();
 
+  // workspace events
+  void on_workspace_activated(std::string const& payload);
+  void on_workspace_destroyed(std::string const& payload);
+  void on_workspace_created(std::string const& payload);
+  void on_workspace_moved(std::string const& payload);
+  void on_workspace_renamed(std::string const& payload);
+
+  // monitor events
+  void on_monitor_focused(std::string const& payload);
+
+  // window events
   void on_window_opened(std::string const& payload);
   void on_window_closed(std::string const& payload);
   void on_window_moved(std::string const& payload);
+
+  void on_window_title_event(std::string const& payload);
 
   int window_rewrite_priority_function(std::string const& window_rule);
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -26,13 +26,13 @@ namespace waybar::modules::hyprland {
 
 class Workspaces;
 
-class WorkspaceWindow {
+class WindowCreationPayload {
  public:
-  WorkspaceWindow(std::string workspace_name, WindowAddress window_address,
-                  std::string window_repr);
-  WorkspaceWindow(std::string workspace_name, WindowAddress window_address,
-                  std::string window_class, std::string window_title);
-  WorkspaceWindow(Json::Value const& client_data);
+  WindowCreationPayload(std::string workspace_name, WindowAddress window_address,
+                        std::string window_repr);
+  WindowCreationPayload(std::string workspace_name, WindowAddress window_address,
+                        std::string window_class, std::string window_title);
+  WindowCreationPayload(Json::Value const& client_data);
 
   int increment_time_spent_uncreated();
   bool is_empty(Workspaces& workspace_manager);
@@ -83,11 +83,11 @@ class Workspace {
   void set_windows(uint value) { windows_ = value; };
   void set_name(std::string const& value) { name_ = value; };
   bool contains_window(WindowAddress const& addr) const { return window_map_.contains(addr); }
-  void insert_window(WorkspaceWindow create_window_paylod);
+  void insert_window(WindowCreationPayload create_window_paylod);
   std::string remove_window(WindowAddress const& addr);
   void initialize_window_map(const Json::Value& clients_data);
 
-  bool on_window_opened(WorkspaceWindow const& create_window_paylod);
+  bool on_window_opened(WindowCreationPayload const& create_window_paylod);
   std::optional<std::string> on_window_closed(WindowAddress const& addr);
 
   void update(const std::string& format, const std::string& icon);
@@ -178,7 +178,7 @@ class Workspaces : public AModule, public EventHandler {
   std::vector<std::unique_ptr<Workspace>> workspaces_;
   std::vector<Json::Value> workspaces_to_create_;
   std::vector<std::string> workspaces_to_remove_;
-  std::vector<WorkspaceWindow> windows_to_create_;
+  std::vector<WindowCreationPayload> windows_to_create_;
 
   std::vector<std::regex> ignore_workspaces_;
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -26,12 +26,13 @@ namespace waybar::modules::hyprland {
 
 class Workspaces;
 
-class CreateWindow {
+class WorkspaceWindow {
  public:
-  CreateWindow(std::string workspace_name, WindowAddress window_address, std::string window_repr);
-  CreateWindow(std::string workspace_name, WindowAddress window_address, std::string window_class,
-               std::string window_title);
-  CreateWindow(Json::Value& client_data);
+  WorkspaceWindow(std::string workspace_name, WindowAddress window_address,
+                  std::string window_repr);
+  WorkspaceWindow(std::string workspace_name, WindowAddress window_address,
+                  std::string window_class, std::string window_title);
+  WorkspaceWindow(Json::Value const& client_data);
 
   int increment_time_spent_uncreated();
   bool is_empty(Workspaces& workspace_manager);
@@ -49,18 +50,18 @@ class CreateWindow {
 
   using Repr = std::string;
   using ClassAndTitle = std::pair<std::string, std::string>;
-
   std::variant<Repr, ClassAndTitle> window_;
 
   WindowAddress window_address_;
   std::string workspace_name_;
+
   int time_spent_uncreated_ = 0;
 };
 
 class Workspace {
  public:
   explicit Workspace(const Json::Value& workspace_data, Workspaces& workspace_manager,
-                     const Json::Value& clients_json = Json::Value::nullRef);
+                     const Json::Value& clients_data = Json::Value::nullRef);
   std::string& select_icon(std::map<std::string, std::string>& icons_map);
   Gtk::Button& button() { return button_; };
 
@@ -74,21 +75,20 @@ class Workspace {
   bool is_empty() const { return windows_ == 0; };
   bool is_urgent() const { return is_urgent_; };
 
-  auto handle_clicked(GdkEventButton* bt) -> bool;
+  bool handle_clicked(GdkEventButton* bt) const;
   void set_active(bool value = true) { active_ = value; };
   void set_persistent(bool value = true) { is_persistent_ = value; };
   void set_urgent(bool value = true) { is_urgent_ = value; };
   void set_visible(bool value = true) { is_visible_ = value; };
   void set_windows(uint value) { windows_ = value; };
-  void set_name(std::string value) { name_ = value; };
-  bool contains_window(WindowAddress addr) const { return window_map_.contains(addr); }
-  void insert_window(CreateWindow create_window_paylod);
-  std::string remove_window(WindowAddress addr);
+  void set_name(std::string const& value) { name_ = value; };
+  bool contains_window(WindowAddress const& addr) const { return window_map_.contains(addr); }
+  void insert_window(WorkspaceWindow create_window_paylod);
+  std::string remove_window(WindowAddress const& addr);
   void initialize_window_map(const Json::Value& clients_data);
 
-  bool on_window_opened(CreateWindow create_window_paylod);
-
-  std::optional<std::string> on_window_closed(WindowAddress& addr);
+  bool on_window_opened(WorkspaceWindow const& create_window_paylod);
+  std::optional<std::string> on_window_closed(WindowAddress const& addr);
 
   void update(const std::string& format, const std::string& icon);
 
@@ -132,21 +132,21 @@ class Workspaces : public AModule, public EventHandler {
   bool window_rewrite_config_uses_title() const { return any_window_rewrite_rule_uses_title_; }
 
  private:
-  void onEvent(const std::string&) override;
+  void onEvent(const std::string& e) override;
   void update_window_count();
   void sort_workspaces();
-  void create_workspace(Json::Value& workspace_data,
-                        const Json::Value& clients_data = Json::Value::nullRef);
-  void remove_workspace(std::string name);
-  void set_urgent_workspace(std::string windowaddress);
+  void create_workspace(Json::Value const& workspace_data,
+                        Json::Value const& clients_data = Json::Value::nullRef);
+  void remove_workspace(std::string const& name);
+  void set_urgent_workspace(std::string const& windowaddress);
   void parse_config(const Json::Value& config);
   void register_ipc();
 
-  void on_window_opened(std::string payload);
-  void on_window_closed(std::string payload);
-  void on_window_moved(std::string payload);
+  void on_window_opened(std::string const& payload);
+  void on_window_closed(std::string const& payload);
+  void on_window_moved(std::string const& payload);
 
-  int window_rewrite_priority_function(std::string& window_rule);
+  int window_rewrite_priority_function(std::string const& window_rule);
 
   bool all_outputs_ = false;
   bool show_special_ = false;
@@ -178,7 +178,7 @@ class Workspaces : public AModule, public EventHandler {
   std::vector<std::unique_ptr<Workspace>> workspaces_;
   std::vector<Json::Value> workspaces_to_create_;
   std::vector<std::string> workspaces_to_remove_;
-  std::vector<CreateWindow> windows_to_create_;
+  std::vector<WorkspaceWindow> windows_to_create_;
 
   std::vector<std::regex> ignore_workspaces_;
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -289,13 +289,10 @@ void Workspaces::onEvent(const std::string &ev) {
       workspaces_to_remove_.push_back(workspace);
     }
   } else if (eventName == "openwindow") {
-    update_window_count();
     on_window_opened(payload);
   } else if (eventName == "closewindow") {
-    update_window_count();
     on_window_closed(payload);
   } else if (eventName == "movewindow") {
-    update_window_count();
     on_window_moved(payload);
   } else if (eventName == "urgent") {
     set_urgent_workspace(payload);
@@ -336,6 +333,7 @@ void Workspaces::onEvent(const std::string &ev) {
 }
 
 void Workspaces::on_window_opened(std::string const &payload) {
+  update_window_count();
   size_t last_comma_idx = 0;
   size_t next_comma_idx = payload.find(',');
   std::string window_address = payload.substr(last_comma_idx, next_comma_idx - last_comma_idx);
@@ -356,6 +354,7 @@ void Workspaces::on_window_opened(std::string const &payload) {
 }
 
 void Workspaces::on_window_closed(std::string const &addr) {
+  update_window_count();
   for (auto &workspace : workspaces_) {
     if (workspace->on_window_closed(addr)) {
       break;
@@ -364,6 +363,7 @@ void Workspaces::on_window_closed(std::string const &addr) {
 }
 
 void Workspaces::on_window_moved(std::string const &payload) {
+  update_window_count();
   size_t last_comma_idx = 0;
   size_t next_comma_idx = payload.find(',');
   std::string window_address = payload.substr(last_comma_idx, next_comma_idx - last_comma_idx);

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -655,8 +655,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
         higher priority. Disable router -> RTA_GATEWAY -> up new router -> set higher priority added
         checking route id
         **/
-        if (!is_del_event &&
-            ((net->ifid_ == -1) || (priority < net->route_priority))) {
+        if (!is_del_event && ((net->ifid_ == -1) || (priority < net->route_priority))) {
           // Clear if's state for the case were there is a higher priority
           // route on a different interface.
           net->clearIface();


### PR DESCRIPTION
Did some cleanup in hyprland/workspaces:

* Renamed the CreateWindow class to WindowCreationPayload, to make it clearer it isn't a function but a class.
* Added const qualifiers and references to functions 
* Added std::move in initializer lists to avoid making copies
* ~~Put the WINDOW_CREATION_TIMEOUT variable in an anonymous namespace (it used to be statically defined inside the function it was used in, I don't understand why?)~~

On a related note, I also started a discussion here about adding a clang-tidy file to the repo: https://github.com/Alexays/Waybar/discussions/2591. I'd love to hear your thoughts on this. 

CC: @Syndelis @khaneliman @Anakael @MightyPlaza 
