### PR TITLE
modules/mpris: change default interval value to 0

### DIFF
--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -21,6 +21,7 @@ The *mpris* module displays currently playing media via libplayerctl.
 
 *interval*: ++
 	typeof: integer ++
+	default: 0 ++
 	Refresh MPRIS information on a timer.
 
 *format*: ++

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -20,7 +20,7 @@ namespace waybar::modules::mpris {
 const std::string DEFAULT_FORMAT = "{player} ({status}): {dynamic}";
 
 Mpris::Mpris(const std::string& id, const Json::Value& config)
-    : ALabel(config, "mpris", id, DEFAULT_FORMAT, 5, false, true),
+    : ALabel(config, "mpris", id, DEFAULT_FORMAT, 0, false, true),
       tooltip_(DEFAULT_FORMAT),
       artist_len_(-1),
       album_len_(-1),


### PR DESCRIPTION
This PR sets the interval value to 0. It seems this is what it was meant to be set at, but was changed to '5' in commit ba6faa7.

This closes #2392.