### PR TITLE
Fix sleep_for for max duration

### DIFF
--- a/include/modules/upower/upower.hpp
+++ b/include/modules/upower/upower.hpp
@@ -69,7 +69,7 @@ class UPower : public AModule {
   UpDevice *displayDevice;
   guint login1_id;
   GDBusConnection *login1_connection;
-  UPowerTooltip *upower_tooltip;
+  std::unique_ptr<UPowerTooltip> upower_tooltip;
   std::string lastStatus;
   bool showAltText;
   bool upowerRunning;

--- a/include/modules/upower/upower_tooltip.hpp
+++ b/include/modules/upower/upower_tooltip.hpp
@@ -2,6 +2,7 @@
 
 #include <libupower-glib/upower.h>
 
+#include <memory>
 #include <unordered_map>
 
 #include "gtkmm/box.h"
@@ -16,7 +17,7 @@ class UPowerTooltip : public Gtk::Window {
 
   const std::string getDeviceIcon(UpDeviceKind& kind);
 
-  Gtk::Box* contentBox;
+  std::unique_ptr<Gtk::Box> contentBox;
 
   uint iconSize;
   uint tooltipSpacing;

--- a/include/util/scope_guard.hpp
+++ b/include/util/scope_guard.hpp
@@ -5,14 +5,14 @@
 namespace waybar::util {
 
 template <typename Func>
-class scope_guard {
+class ScopeGuard {
  public:
-  explicit scope_guard(Func&& exit_function) : f{std::forward<Func>(exit_function)} {}
-  scope_guard(const scope_guard&) = delete;
-  scope_guard(scope_guard&&) = default;
-  scope_guard& operator=(const scope_guard&) = delete;
-  scope_guard& operator=(scope_guard&&) = default;
-  ~scope_guard() { f(); }
+  explicit ScopeGuard(Func&& exit_function) : f{std::forward<Func>(exit_function)} {}
+  ScopeGuard(const ScopeGuard&) = delete;
+  ScopeGuard(ScopeGuard&&) = default;
+  ScopeGuard& operator=(const ScopeGuard&) = delete;
+  ScopeGuard& operator=(ScopeGuard&&) = default;
+  ~ScopeGuard() { f(); }
 
  private:
   Func f;

--- a/include/util/scope_guard.hpp
+++ b/include/util/scope_guard.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <utility>
+
+namespace waybar::util {
+
+template <typename Func>
+class scope_guard {
+ public:
+  explicit scope_guard(Func&& exit_function) : f{std::forward<Func>(exit_function)} {}
+  scope_guard(const scope_guard&) = delete;
+  scope_guard(scope_guard&&) = default;
+  scope_guard& operator=(const scope_guard&) = delete;
+  scope_guard& operator=(scope_guard&&) = default;
+  ~scope_guard() { f(); }
+
+ private:
+  Func f;
+};
+
+}  // namespace waybar::util

--- a/include/util/sleeper_thread.hpp
+++ b/include/util/sleeper_thread.hpp
@@ -67,6 +67,12 @@ class SleeperThread {
   auto sleep_for(std::chrono::system_clock::duration dur) {
     std::unique_lock lk(mutex_);
     CancellationGuard cancel_lock;
+    using timepoint = std::chrono::system_clock::time_point;
+    static_assert(std::numeric_limits<timepoint::rep>::max() >=
+                  std::numeric_limits<decltype(dur)::rep>::max());
+    if (std::chrono::system_clock::now() >= timepoint::max() - dur) {
+      dur = timepoint::max() - std::chrono::system_clock::now() - std::chrono::seconds(1);
+    }
     return condvar_.wait_for(lk, dur, [this] { return signal_ || !do_run_; });
   }
 

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -12,7 +12,7 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
     : AModule(config, name, id, config["format-alt"].isString() || enable_click, enable_scroll),
       format_(config_["format"].isString() ? config_["format"].asString() : format),
       interval_(config_["interval"] == "once"
-                    ? std::chrono::seconds(100000000)
+                    ? std::chrono::seconds::max()
                     : std::chrono::seconds(
                           config_["interval"].isUInt() ? config_["interval"].asUInt() : interval)),
       default_format_(format_) {

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -14,7 +14,7 @@ using GDBusManager = std::unique_ptr<GDBusObjectManager, void (*)(GDBusObjectMan
 
 auto generateManager() -> GDBusManager {
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error) {
       g_error_free(error);
     }

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -59,7 +59,7 @@ void waybar::modules::Custom::continuousWorker() {
   }
   thread_ = [this, cmd] {
     char* buff = nullptr;
-    waybar::util::scope_guard buff_deleter([buff]() {
+    waybar::util::ScopeGuard buff_deleter([buff]() {
       if (buff) {
         free(buff);
       }

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -2,6 +2,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include "util/scope_guard.hpp"
+
 waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
                                 const Json::Value& config)
     : ALabel(config, "custom-" + name, id, "{}"),
@@ -57,6 +59,11 @@ void waybar::modules::Custom::continuousWorker() {
   }
   thread_ = [this, cmd] {
     char* buff = nullptr;
+    waybar::util::scope_guard buff_deleter([buff]() {
+      if (buff) {
+        free(buff);
+      }
+    });
     size_t len = 0;
     if (getline(&buff, &len, fp_) == -1) {
       int exit_code = 1;
@@ -90,7 +97,6 @@ void waybar::modules::Custom::continuousWorker() {
       output_ = {0, output};
       dp.emit();
     }
-    free(buff);
   };
 }
 

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -119,7 +119,7 @@ Mpris::Mpris(const std::string& id, const Json::Value& config)
   }
 
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error) {
       g_error_free(error);
     }
@@ -482,7 +482,7 @@ auto Mpris::getPlayerInfo() -> std::optional<PlayerInfo> {
   }
 
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error) {
       g_error_free(error);
     }
@@ -580,7 +580,7 @@ errorexit:
 
 bool Mpris::handleToggle(GdkEventButton* const& e) {
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error) {
       g_error_free(error);
     }

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -59,7 +59,7 @@ void Host::nameVanished(const Glib::RefPtr<Gio::DBus::Connection>& conn, const G
 
 void Host::proxyReady(GObject* src, GAsyncResult* res, gpointer data) {
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error != nullptr) {
       g_error_free(error);
     }
@@ -81,7 +81,7 @@ void Host::proxyReady(GObject* src, GAsyncResult* res, gpointer data) {
 
 void Host::registerHost(GObject* src, GAsyncResult* res, gpointer data) {
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error != nullptr) {
       g_error_free(error);
     }

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -2,6 +2,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include "util/scope_guard.hpp"
+
 namespace waybar::modules::SNI {
 
 Host::Host(const std::size_t id, const Json::Value& config, const Bar& bar,
@@ -57,17 +59,20 @@ void Host::nameVanished(const Glib::RefPtr<Gio::DBus::Connection>& conn, const G
 
 void Host::proxyReady(GObject* src, GAsyncResult* res, gpointer data) {
   GError* error = nullptr;
+  waybar::util::scope_guard error_deleter([error]() {
+    if (error != nullptr) {
+      g_error_free(error);
+    }
+  });
   SnWatcher* watcher = sn_watcher_proxy_new_finish(res, &error);
   if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
     spdlog::error("Host: {}", error->message);
-    g_error_free(error);
     return;
   }
   auto host = static_cast<SNI::Host*>(data);
   host->watcher_ = watcher;
   if (error != nullptr) {
     spdlog::error("Host: {}", error->message);
-    g_error_free(error);
     return;
   }
   sn_watcher_call_register_host(host->watcher_, host->object_path_.c_str(), host->cancellable_,
@@ -76,16 +81,19 @@ void Host::proxyReady(GObject* src, GAsyncResult* res, gpointer data) {
 
 void Host::registerHost(GObject* src, GAsyncResult* res, gpointer data) {
   GError* error = nullptr;
+  waybar::util::scope_guard error_deleter([error]() {
+    if (error != nullptr) {
+      g_error_free(error);
+    }
+  });
   sn_watcher_call_register_host_finish(SN_WATCHER(src), res, &error);
   if (g_error_matches(error, G_IO_ERROR, G_IO_ERROR_CANCELLED)) {
     spdlog::error("Host: {}", error->message);
-    g_error_free(error);
     return;
   }
   auto host = static_cast<SNI::Host*>(data);
   if (error != nullptr) {
     spdlog::error("Host: {}", error->message);
-    g_error_free(error);
     return;
   }
   g_signal_connect(host->watcher_, "item-registered", G_CALLBACK(&Host::itemRegistered), data);

--- a/src/modules/sni/watcher.cpp
+++ b/src/modules/sni/watcher.cpp
@@ -31,7 +31,7 @@ Watcher::~Watcher() {
 
 void Watcher::busAcquired(const Glib::RefPtr<Gio::DBus::Connection>& conn, Glib::ustring name) {
   GError* error = nullptr;
-  waybar::util::scope_guard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([error]() {
     if (error) {
       g_error_free(error);
     }

--- a/src/modules/upower/upower.cpp
+++ b/src/modules/upower/upower.cpp
@@ -63,7 +63,7 @@ UPower::UPower(const std::string& id, const Json::Value& config)
   box_.set_has_tooltip(tooltip_enabled);
   if (tooltip_enabled) {
     // Sets the window to use when showing the tooltip
-    upower_tooltip = new UPowerTooltip(iconSize, tooltip_spacing, tooltip_padding);
+    upower_tooltip = std::make_unique<UPowerTooltip>(iconSize, tooltip_spacing, tooltip_padding);
     box_.set_tooltip_window(*upower_tooltip);
     box_.signal_query_tooltip().connect(sigc::mem_fun(*this, &UPower::show_tooltip_callback));
   }
@@ -72,14 +72,13 @@ UPower::UPower(const std::string& id, const Json::Value& config)
                                       G_BUS_NAME_WATCHER_FLAGS_AUTO_START, upowerAppear,
                                       upowerDisappear, this, NULL);
 
-  GError* error = NULL;
-  client = up_client_new_full(NULL, &error);
+  client = up_client_new_full(NULL, NULL);
   if (client == NULL) {
     throw std::runtime_error("Unable to create UPower client!");
   }
 
   // Connect to Login1 PrepareForSleep signal
-  login1_connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
+  login1_connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, NULL);
   if (!login1_connection) {
     throw std::runtime_error("Unable to connect to the SYSTEM Bus!...");
   } else {
@@ -99,6 +98,7 @@ UPower::UPower(const std::string& id, const Json::Value& config)
 }
 
 UPower::~UPower() {
+  if (displayDevice != NULL) g_object_unref(displayDevice);
   if (client != NULL) g_object_unref(client);
   if (login1_id > 0) {
     g_dbus_connection_signal_unsubscribe(login1_connection, login1_id);

--- a/src/modules/upower/upower_tooltip.cpp
+++ b/src/modules/upower/upower_tooltip.cpp
@@ -9,11 +9,10 @@
 namespace waybar::modules::upower {
 UPowerTooltip::UPowerTooltip(uint iconSize_, uint tooltipSpacing_, uint tooltipPadding_)
     : Gtk::Window(),
+      contentBox(std::make_unique<Gtk::Box>(Gtk::ORIENTATION_VERTICAL)),
       iconSize(iconSize_),
       tooltipSpacing(tooltipSpacing_),
       tooltipPadding(tooltipPadding_) {
-  contentBox = new Gtk::Box(Gtk::ORIENTATION_VERTICAL);
-
   // Sets the Tooltip Padding
   contentBox->set_margin_top(tooltipPadding);
   contentBox->set_margin_bottom(tooltipPadding);

--- a/src/util/prepare_for_sleep.cpp
+++ b/src/util/prepare_for_sleep.cpp
@@ -7,8 +7,7 @@ namespace {
 class PrepareForSleep {
  private:
   PrepareForSleep() {
-    GError *error = NULL;
-    login1_connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
+    login1_connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, NULL);
     if (!login1_connection) {
       spdlog::warn("Unable to connect to the SYSTEM Bus!...");
     } else {


### PR DESCRIPTION
As mentioned in the issue, the bug is caused by the standard library expecting for `std::condition_variable::sleep_for` a duration which does not cause an overflow when added to the current time.

This PR fixes the issue by using `sleep_until` to emulate `sleep_for` since `sleep_for` is defined as identical to adding the current time and then using `sleep_until` by the standard.

Additionally, this PR re-applies #2586 which was reverted in #2599 because of this bug.

I also tried to write a test to catch this kind of error for `SleeperThread`, but I wasn't able to check for this kind of failure.
The standard does not specify the behavior if a too big duration is passed.
I ended up writing a few basic other tests for the class and restructured the build system to allow for easier addition to the tests by providing all sources of `waybar` as a static library which is now simply linked against `main.cpp` for the executable.


Resolves #2598 