### PR TITLE
Fix: Hyprland/Workspaces workspaces not being created as persistent when they already exist at startup

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -487,6 +487,9 @@ void Workspaces::create_workspace(Json::Value const &workspace_data,
       });
 
   if (workspace != workspaces_.end()) {
+    if (workspace_data["persistent"].asBool() and !(*workspace)->is_persistent()) {
+      (*workspace)->set_persistent();
+    }
     return;
   }
 


### PR DESCRIPTION
Fixes #2597

## About this PR

This PR guarantees persistent workspace rules will be applied even if the workspaces already exists at bar startup.

Previously, persistent workspaces would always be created before regular workspaces. #2578 changed that in order to guarantee workspaces were created with their respective windows.

However, this meant that pre-existing would-be-persistent workspaces were being created by another function, one which did not account for the persistent configuration.

The changes in this PR makes it so that the `Workspaces::create_workspace` method checks if a workspace with the same name already exists and, if so, sets the workspace as persistent depending on the payload, rather than attempting to create a new one.