### PR TITLE
Reduce freebsd ci timeout

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,6 +12,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Test in FreeBSD VM
       uses: vmactions/freebsd-vm@v0
+      timeout-minutes: 30
       with:
         mem: 2048
         usesh: true


### PR DESCRIPTION
Since the freebsd job is pretty unreliable, I reduced the timeout to 30min instead of the default of 6h.

The issue is known: https://github.com/vmactions/freebsd-vm/issues/74

Alternatively, if there are no fixes for this github action, it could be considered to switch to a different action.
One project already moved away from the one that is currently used in waybar:
https://github.com/mpv-player/mpv/commit/71a497deee8f5cb47a9ea37bc14038ecdf238e21