### PR TITLE
Fix FreeBSD build error and increase freebsd ci timeout

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Test in FreeBSD VM
         uses: cross-platform-actions/action@v0.19.1
-        timeout-minutes: 30
+        timeout-minutes: 120
         with:
           operating_system: freebsd
           version: "13.2"

--- a/src/modules/cpu_usage/bsd.cpp
+++ b/src/modules/cpu_usage/bsd.cpp
@@ -34,7 +34,7 @@ std::vector<std::tuple<size_t, size_t>> waybar::modules::CpuUsage::parseCpuinfo(
   int ncpu = sysconf(_SC_NPROCESSORS_CONF);
   size_t sz = CPUSTATES * (ncpu + 1) * sizeof(pcp_time_t);
   pcp_time_t *cp_time = static_cast<pcp_time_t *>(malloc(sz)), *pcp_time = cp_time;
-  waybar::util::scope_guard cp_time_deleter([cp_time]() {
+  waybar::util::ScopeGuard cp_time_deleter([cp_time]() {
     if (cp_time) {
       free(cp_time);
     }


### PR DESCRIPTION
Since the new CI Action for FreeBSD seems to take more than 30min, I increased the limit to 2h.

Additionally, due to the defective CI a build error is in the master due to the renaming of `scope_guard` to `ScopeGuard` (I missed that one unfortunately).