### PR TITLE
Skips logging NoActivePlayer error msgs

### DIFF
--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -574,7 +574,13 @@ auto Mpris::getPlayerInfo() -> std::optional<PlayerInfo> {
   return info;
 
 errorexit:
-  spdlog::error("mpris[{}]: {}", info.name, error->message);
+  std::string errorMsg = error->message;
+  //  When mpris checks for  active player sessions periodically(5 secs), NoActivePlayer error message is
+  // thrown when there are no active sessions. This error message is spamming logs without having any value
+  // addition. Log the error only if the error we recceived is not NoActivePlayer.
+  if(errorMsg.rfind("GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer") == std::string::npos){
+    spdlog::error("mpris[{}]: {}", info.name, error->message);
+  }
   return std::nullopt;
 }
 


### PR DESCRIPTION
NoActivePlayer messages is being logged everytime mpris polls for players when there are no active players. This message is spamming my hyprland error logs. Attached the log



```
[2023-10-31 11:00:18.444] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:18.557] [info] Bar configured (width: 1440, height: 34) for output: eDP-1
[2023-10-31 11:00:28.408] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:33.407] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:38.407] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:43.407] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:48.409] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:53.405] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:00:58.410] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:03.408] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:08.407] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:13.409] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:18.407] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:23.406] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:28.409] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:33.406] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:38.408] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:43.406] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:48.413] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:01:58.417] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:02:08.416] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:02:18.415] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:02:28.419] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:02:38.416] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:02:48.416] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:02:58.412] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:03:03.412] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:03:08.415] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:03:18.417] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:03:28.419] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:03:38.418] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctld
[2023-10-31 11:03:48.414] [error] mpris[playerctld]: GDBus.Error:com.github.altdesktop.playerctld.NoActivePlayer: No player is being controlled by playerctl
/tmp/hyprland.log
```