### PR TITLE
fix: custom: do not crash if input text is not valid utf-8

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -155,6 +155,7 @@ auto waybar::modules::Custom::update() -> void {
     } else {
       parseOutputRaw();
     }
+
     auto str = fmt::format(fmt::runtime(format_), text_, fmt::arg("alt", alt_),
                            fmt::arg("icon", getIcon(percentage_, alt_)),
                            fmt::arg("percentage", percentage_));
@@ -195,18 +196,23 @@ void waybar::modules::Custom::parseOutputRaw() {
   std::string line;
   int i = 0;
   while (getline(output, line)) {
+    Glib::ustring validated_line = line;
+    if(!validated_line.validate()) {
+      validated_line = validated_line.make_valid();
+    }
+
     if (i == 0) {
       if (config_["escape"].isBool() && config_["escape"].asBool()) {
-        text_ = Glib::Markup::escape_text(line);
+        text_ = Glib::Markup::escape_text(validated_line);
       } else {
-        text_ = line;
+        text_ = validated_line;
       }
-      tooltip_ = line;
+      tooltip_ = validated_line;
       class_.clear();
     } else if (i == 1) {
-      tooltip_ = line;
+      tooltip_ = validated_line;
     } else if (i == 2) {
-      class_.push_back(line);
+      class_.push_back(validated_line);
     } else {
       break;
     }


### PR DESCRIPTION
This is the fix for the issue described in #2621: We should not crash if the input to a custom widget is invalid utf-8.
Instead, invalid characters are now shown as appropriate characters in your font:

![image](https://github.com/Alexays/Waybar/assets/376651/bb342fdc-5c85-4256-b4d4-8f99ca736e83)

I did not touch the JSON input code, since it should be fine as JSON should be valid UTF-8. I suspect there are other places in Waybar that needs similar treatment. This is beyond the scope of this PR though.

Please double check for potential memory leaks, as my C++ is rusty (no pun intended).
