### PR TITLE
tray: load_icon use request_size directly

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -356,32 +356,15 @@ Glib::RefPtr<Gdk::Pixbuf> Item::getIconPixbuf() {
 }
 
 Glib::RefPtr<Gdk::Pixbuf> Item::getIconByName(const std::string& name, int request_size) {
-  int tmp_size = 0;
   icon_theme->rescan_if_needed();
-  auto sizes = icon_theme->get_icon_sizes(name.c_str());
 
-  for (auto const& size : sizes) {
-    // -1 == scalable
-    if (size == request_size || size == -1) {
-      tmp_size = request_size;
-      break;
-    } else if (size < request_size) {
-      tmp_size = size;
-    } else if (size > tmp_size && tmp_size > 0) {
-      tmp_size = request_size;
-      break;
-    }
-  }
-  if (tmp_size == 0) {
-    tmp_size = request_size;
-  }
   if (!icon_theme_path.empty() &&
-      icon_theme->lookup_icon(name.c_str(), tmp_size,
+      icon_theme->lookup_icon(name.c_str(), request_size,
                               Gtk::IconLookupFlags::ICON_LOOKUP_FORCE_SIZE)) {
-    return icon_theme->load_icon(name.c_str(), tmp_size,
+    return icon_theme->load_icon(name.c_str(), request_size,
                                  Gtk::IconLookupFlags::ICON_LOOKUP_FORCE_SIZE);
   }
-  return DefaultGtkIconThemeWrapper::load_icon(name.c_str(), tmp_size,
+  return DefaultGtkIconThemeWrapper::load_icon(name.c_str(), request_size,
                                                Gtk::IconLookupFlags::ICON_LOOKUP_FORCE_SIZE);
 }
 


### PR DESCRIPTION
I delete tmp_size part, when call `load_icon` function, use request_size `icon_size * image.get_scale_factor()` like wlr/taskbar
`get_icon_sizes` doesn't handle scaling, if icon isn't scalable, tmp_size will be smaller size
https://github.com/Alexays/Waybar/blob/1149e51f7271fbb81b610c223dccc8181926c7e2/src/modules/wlr/taskbar.cpp#L181-L184

for example: nm-applet
![2023-11-01_22-38](https://github.com/Alexays/Waybar/assets/53224655/aac04016-6831-44d4-a8e0-85f717b1b123)
![2023-11-01_22-37](https://github.com/Alexays/Waybar/assets/53224655/66875a71-2797-48eb-92f0-73b8aa435bbe)

