### PR TITLE
custom: reap zombie processes on termination

### DIFF
--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -112,6 +112,10 @@ inline FILE* open(const std::string& cmd, int& pid) {
     execlp("/bin/sh", "sh", "-c", cmd.c_str(), (char*)0);
     exit(0);
   } else {
+    reap_mtx.lock();
+    reap.push_back(child_pid);
+    reap_mtx.unlock();
+
     ::close(fd[1]);
   }
   pid = child_pid;


### PR DESCRIPTION
When turning off/on the monitor it would lead to defunct processes started by custom modules. I don't know why this is needed since we are tracking the pid of forked processes and properly waiting them (either on `command::close` or on `Custom` destructor).
Fixes #1713 (and probably #2244).

