### PR TITLE
refactor(backlight): use concrete types for some helper functions

### DIFF
--- a/include/util/backlight_backend.hpp
+++ b/include/util/backlight_backend.hpp
@@ -20,7 +20,7 @@
     std::scoped_lock<std::mutex> lock((backend).udev_thread_mutex_); \
     __devices = (backend).devices_;                                  \
   }                                                                  \
-  auto varname = (backend).best_device(__devices.cbegin(), __devices.cend(), preferred_device);
+  auto varname = (backend).best_device(__devices, preferred_device);
 
 namespace waybar::util {
 
@@ -61,16 +61,10 @@ class BacklightBackend {
   void set_scaled_brightness(std::string preferred_device, int brightness);
   int get_scaled_brightness(std::string preferred_device);
 
-  template <class ForwardIt, class Inserter>
-  static void upsert_device(ForwardIt first, ForwardIt last, Inserter inserter, udev_device *dev);
-
-  template <class ForwardIt, class Inserter>
-  static void enumerate_devices(ForwardIt first, ForwardIt last, Inserter inserter, udev *udev);
-
   bool is_login_proxy_initialized() const { return static_cast<bool>(login_proxy_); }
 
-  template <class ForwardIt>
-  static const BacklightDevice *best_device(ForwardIt first, ForwardIt last, std::string_view);
+  static const BacklightDevice *best_device(const std::vector<BacklightDevice> &devices,
+                                            std::string_view);
 
   std::vector<BacklightDevice> devices_;
   std::mutex udev_thread_mutex_;

--- a/src/util/backlight_backend.cpp
+++ b/src/util/backlight_backend.cpp
@@ -73,6 +73,54 @@ void check_nn(const void *ptr, const char *message = "ptr was null") {
 
 namespace waybar::util {
 
+static void upsert_device(std::vector<BacklightDevice> &devices, udev_device *dev) {
+  const char *name = udev_device_get_sysname(dev);
+  check_nn(name);
+
+  const char *actual_brightness_attr =
+      strncmp(name, "amdgpu_bl", 9) == 0 || strcmp(name, "apple-panel-bl") == 0
+          ? "brightness"
+          : "actual_brightness";
+
+  const char *actual = udev_device_get_sysattr_value(dev, actual_brightness_attr);
+  const char *max = udev_device_get_sysattr_value(dev, "max_brightness");
+  const char *power = udev_device_get_sysattr_value(dev, "bl_power");
+
+  auto found = std::find_if(devices.begin(), devices.end(), [name](const BacklightDevice &device) {
+    return device.name() == name;
+  });
+  if (found != devices.end()) {
+    if (actual != nullptr) {
+      found->set_actual(std::stoi(actual));
+    }
+    if (max != nullptr) {
+      found->set_max(std::stoi(max));
+    }
+    if (power != nullptr) {
+      found->set_powered(std::stoi(power) == 0);
+    }
+  } else {
+    const int actual_int = actual == nullptr ? 0 : std::stoi(actual);
+    const int max_int = max == nullptr ? 0 : std::stoi(max);
+    const bool power_bool = power == nullptr ? true : std::stoi(power) == 0;
+    devices.emplace_back(name, actual_int, max_int, power_bool);
+  }
+}
+
+static void enumerate_devices(std::vector<BacklightDevice> &devices, udev *udev) {
+  std::unique_ptr<udev_enumerate, UdevEnumerateDeleter> enumerate{udev_enumerate_new(udev)};
+  udev_enumerate_add_match_subsystem(enumerate.get(), "backlight");
+  udev_enumerate_scan_devices(enumerate.get());
+  udev_list_entry *enum_devices = udev_enumerate_get_list_entry(enumerate.get());
+  udev_list_entry *dev_list_entry;
+  udev_list_entry_foreach(dev_list_entry, enum_devices) {
+    const char *path = udev_list_entry_get_name(dev_list_entry);
+    std::unique_ptr<udev_device, UdevDeviceDeleter> dev{udev_device_new_from_syspath(udev, path)};
+    check_nn(dev.get(), "dev new failed");
+    upsert_device(devices, dev.get());
+  }
+}
+
 BacklightDevice::BacklightDevice(std::string name, int actual, int max, bool powered)
     : name_(name), actual_(actual), max_(max), powered_(powered) {}
 
@@ -95,8 +143,7 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
     : on_updated_cb_(on_updated_cb), polling_interval_(interval), previous_best_({}) {
   std::unique_ptr<udev, UdevDeleter> udev_check{udev_new()};
   check_nn(udev_check.get(), "Udev check new failed");
-  enumerate_devices(devices_.begin(), devices_.end(), std::back_inserter(devices_),
-                    udev_check.get());
+  enumerate_devices(devices_, udev_check.get());
   if (devices_.empty()) {
     throw std::runtime_error("No backlight found");
   }
@@ -145,12 +192,12 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
         check_eq(event.data.fd, udev_fd, "unexpected udev fd");
         std::unique_ptr<udev_device, UdevDeviceDeleter> dev{udev_monitor_receive_device(mon.get())};
         check_nn(dev.get(), "epoll dev was null");
-        upsert_device(devices.begin(), devices.end(), std::back_inserter(devices), dev.get());
+        upsert_device(devices, dev.get());
       }
 
       // Refresh state if timed out
       if (event_count == 0) {
-        enumerate_devices(devices.begin(), devices.end(), std::back_inserter(devices), udev.get());
+        enumerate_devices(devices, udev.get());
       }
       {
         std::scoped_lock<std::mutex> lock(udev_thread_mutex_);
@@ -161,19 +208,20 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
   };
 }
 
-template <class ForwardIt>
-const BacklightDevice *BacklightBackend::best_device(ForwardIt first, ForwardIt last,
+const BacklightDevice *BacklightBackend::best_device(const std::vector<BacklightDevice> &devices,
                                                      std::string_view preferred_device) {
   const auto found = std::find_if(
-      first, last, [preferred_device](const auto &dev) { return dev.name() == preferred_device; });
-  if (found != last) {
+      devices.begin(), devices.end(),
+      [preferred_device](const BacklightDevice &dev) { return dev.name() == preferred_device; });
+  if (found != devices.end()) {
     return &(*found);
   }
 
   const auto max = std::max_element(
-      first, last, [](const auto &l, const auto &r) { return l.get_max() < r.get_max(); });
+      devices.begin(), devices.end(),
+      [](const BacklightDevice &l, const BacklightDevice &r) { return l.get_max() < r.get_max(); });
 
-  return max == last ? nullptr : &(*max);
+  return max == devices.end() ? nullptr : &(*max);
 }
 
 const BacklightDevice *BacklightBackend::get_previous_best_device() {
@@ -231,58 +279,6 @@ int BacklightBackend::get_scaled_brightness(std::string preferred_device) {
   }
 
   return 0;
-}
-
-template <class ForwardIt, class Inserter>
-void BacklightBackend::upsert_device(ForwardIt first, ForwardIt last, Inserter inserter,
-                                     udev_device *dev) {
-  const char *name = udev_device_get_sysname(dev);
-  check_nn(name);
-
-  const char *actual_brightness_attr =
-      strncmp(name, "amdgpu_bl", 9) == 0 || strcmp(name, "apple-panel-bl") == 0
-          ? "brightness"
-          : "actual_brightness";
-
-  const char *actual = udev_device_get_sysattr_value(dev, actual_brightness_attr);
-  const char *max = udev_device_get_sysattr_value(dev, "max_brightness");
-  const char *power = udev_device_get_sysattr_value(dev, "bl_power");
-
-  auto found =
-      std::find_if(first, last, [name](const auto &device) { return device.name() == name; });
-  if (found != last) {
-    if (actual != nullptr) {
-      found->set_actual(std::stoi(actual));
-    }
-    if (max != nullptr) {
-      found->set_max(std::stoi(max));
-    }
-    if (power != nullptr) {
-      found->set_powered(std::stoi(power) == 0);
-    }
-  } else {
-    const int actual_int = actual == nullptr ? 0 : std::stoi(actual);
-    const int max_int = max == nullptr ? 0 : std::stoi(max);
-    const bool power_bool = power == nullptr ? true : std::stoi(power) == 0;
-    *inserter = BacklightDevice{name, actual_int, max_int, power_bool};
-    ++inserter;
-  }
-}
-
-template <class ForwardIt, class Inserter>
-void BacklightBackend::enumerate_devices(ForwardIt first, ForwardIt last, Inserter inserter,
-                                         udev *udev) {
-  std::unique_ptr<udev_enumerate, UdevEnumerateDeleter> enumerate{udev_enumerate_new(udev)};
-  udev_enumerate_add_match_subsystem(enumerate.get(), "backlight");
-  udev_enumerate_scan_devices(enumerate.get());
-  udev_list_entry *enum_devices = udev_enumerate_get_list_entry(enumerate.get());
-  udev_list_entry *dev_list_entry;
-  udev_list_entry_foreach(dev_list_entry, enum_devices) {
-    const char *path = udev_list_entry_get_name(dev_list_entry);
-    std::unique_ptr<udev_device, UdevDeviceDeleter> dev{udev_device_new_from_syspath(udev, path)};
-    check_nn(dev.get(), "dev new failed");
-    upsert_device(first, last, inserter, dev.get());
-  }
 }
 
 }  // namespace waybar::util


### PR DESCRIPTION
Doesn't look like there was any use for being so generic. This fixes linking of the best_device() function with 'mold' linker.
I didn't test if the backlight module still works fine - I don't have a device that supports it in easy availability, but I didn't touch any functionality either.

Fixes error `mold: error: undefined symbol: waybar::util::BacklightDevice const* waybar::util::BacklightBackend::best_device<__gnu_cxx::__normal_iterator<waybar::util::BacklightDevice const*, std::vector<waybar::util::BacklightDevice, std::allocator<waybar::util::BacklightDevice> > > >(__gnu_cxx::__normal_iterator<waybar::util::BacklightDevice const*, std::vector<waybar::util::BacklightDevice, std::allocator<waybar::util::BacklightDevice> > >, __gnu_cxx::__normal_iterator<waybar::util::BacklightDevice const*, std::vector<waybar::util::BacklightDevice, std::allocator<waybar::util::BacklightDevice> > >, std::basic_string_view<char, std::char_traits<char> >)`
