### PR TITLE
avoid converting to local_time when converting to zoned_time afterwards

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -173,7 +173,7 @@ auto waybar::modules::Clock::update() -> void {
   // Define shift local time
   const auto shiftedNow{date::make_zoned(
       tz, date::local_days(shiftedDay) +
-              (now.get_local_time() - date::floor<date::days>(now.get_local_time())))};
+              (now.get_sys_time() - date::floor<date::days>(now.get_sys_time())))};
 
   label_.set_markup(fmt::format(locale_, fmt::runtime(format_), now));
 


### PR DESCRIPTION
see [Issue 2615: Daylight saving hour breaks clock module](https://github.com/Alexays/Waybar/issues/2615)