### PR TITLE
Fix segmentation fault in WirePlumber module

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -81,7 +81,7 @@ void waybar::modules::Wireplumber::updateNodeName(waybar::modules::Wireplumber* 
   auto nick = wp_properties_get(properties, "node.nick");
   auto description = wp_properties_get(properties, "node.description");
 
-  self->node_name_ = nick ? nick : description;
+  self->node_name_ = nick ? nick : description ? description : "Unknown node name";
   spdlog::debug("[{}]: Updating node name to: {}", self->name_, self->node_name_);
 }
 


### PR DESCRIPTION
The WirePlumber module assumes that either the node's name or description will not be null. This leads to a segmentation fault when both are.

The solution provided is to set self->node_name_ to a default value in this case.