### PR TITLE
c++20. clock chrono API. STL + format

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -40,7 +40,7 @@ class AModule : public IModule {
 
  private:
   bool handleUserEvent(GdkEventButton *const &ev);
-
+  const bool isTooltip;
   std::vector<int> pid_;
   gdouble distance_scrolled_y_;
   gdouble distance_scrolled_x_;

--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -6,38 +6,26 @@
 
 namespace waybar::modules {
 
-const std::string kCalendarPlaceholder = "calendar";
-const std::string KTimezonedTimeListPlaceholder = "timezoned_time_list";
-
-enum class WeeksSide {
-  LEFT,
-  RIGHT,
-  HIDDEN,
-};
+const std::string kCldPlaceholder{"calendar"};
+const std::string kTZPlaceholder{"tz_list"};
 
 enum class CldMode { MONTH, YEAR };
+enum class WS { LEFT, RIGHT, HIDDEN };
 
 class Clock final : public ALabel {
  public:
   Clock(const std::string&, const Json::Value&);
   virtual ~Clock() = default;
   auto update() -> void override;
-  auto doAction(const std::string& name) -> void override;
+  auto doAction(const std::string&) -> void override;
 
  private:
-  util::SleeperThread thread_;
-  std::locale locale_;
-  std::vector<const date::time_zone*> time_zones_;
-  int current_time_zone_idx_;
-  bool is_calendar_in_tooltip_;
-  bool is_timezoned_list_in_tooltip_;
-
-  auto first_day_of_week() -> date::weekday;
-  const date::time_zone* current_timezone();
-  auto timezones_text(std::chrono::system_clock::time_point now) -> std::string;
-
-  /*Calendar properties*/
-  WeeksSide cldWPos_{WeeksSide::HIDDEN};
+  const std::locale locale_;
+  // tooltip
+  const std::string tlpFmt_;
+  std::string tlpText_{""};  // tooltip text to print
+  // Calendar
+  const bool cldInTooltip_;  // calendar in tooltip
   /*
     0 - calendar.format.months
     1 - calendar.format.weekdays
@@ -47,28 +35,37 @@ class Clock final : public ALabel {
     5 - tooltip-format
    */
   std::map<int, std::string const> fmtMap_;
+  uint cldMonCols_{3};           // calendar count month columns
+  int cldWnLen_{3};              // calendar week number length
+  const int cldMonColLen_{20};   // calendar month column length
+  WS cldWPos_{WS::HIDDEN};       // calendar week side to print
+  months cldCurrShift_{0};       // calendar months shift
+  year_month_day cldYearShift_;  // calendar Year mode. Cached ymd
+  std::string cldYearCached_;    // calendar Year mode. Cached calendar
+  year_month cldMonShift_;       // calendar Month mode. Cached ym
+  std::string cldMonCached_;     // calendar Month mode. Cached calendar
+  day cldBaseDay_{0};            // calendar Cached day. Is used when today is changing(midnight)
+  std::string cldText_{""};      // calendar text to print
   CldMode cldMode_{CldMode::MONTH};
-  uint cldMonCols_{3};    // Count of the month in the row
-  int cldMonColLen_{20};  // Length of the month column
-  int cldWnLen_{3};       // Length of the week number
-  date::year_month_day cldYearShift_;
-  date::year_month cldMonShift_;
-  date::months cldCurrShift_{0};
-  date::months cldShift_{0};
-  std::string cldYearCached_{};
-  std::string cldMonCached_{};
-  date::day cldBaseDay_{0};
-  /*Calendar functions*/
-  auto get_calendar(const date::year_month_day& today, const date::year_month_day& ymd,
-                    const date::time_zone* tz) -> const std::string;
-  /*Clock actions*/
+  auto get_calendar(const year_month_day& today, const year_month_day& ymd, const time_zone* tz)
+      -> const std::string;
+
+  // time zoned time in tooltip
+  const bool tzInTooltip_;                // if need to print time zones text
+  std::vector<const time_zone*> tzList_;  // time zones list
+  int tzCurrIdx_;                         // current time zone index for tzList_
+  std::string tzText_{""};                // time zones text to print
+  util::SleeperThread thread_;
+
+  auto getTZtext(sys_seconds now) -> std::string;
+  auto first_day_of_week() -> weekday;
+  // Module actions
   void cldModeSwitch();
   void cldShift_up();
   void cldShift_down();
   void tz_up();
   void tz_down();
-
-  // ModuleActionMap
+  // Module Action Map
   static inline std::map<const std::string, void (waybar::modules::Clock::*const)()> actionMap_{
       {"mode", &waybar::modules::Clock::cldModeSwitch},
       {"shift_up", &waybar::modules::Clock::cldShift_up},
@@ -76,4 +73,5 @@ class Clock final : public ALabel {
       {"tz_up", &waybar::modules::Clock::tz_up},
       {"tz_down", &waybar::modules::Clock::tz_down}};
 };
+
 }  // namespace waybar::modules

--- a/include/util/date.hpp
+++ b/include/util/date.hpp
@@ -1,34 +1,52 @@
 #pragma once
 
-#include <fmt/format.h>
+#include <chrono>
 
 #if HAVE_CHRONO_TIMEZONES
-#include <chrono>
 #include <format>
-
-/* Compatibility layer for <date/tz.h> on top of C++20 <chrono> */
-namespace date {
-
-using namespace std::chrono;
-
-namespace literals {
-using std::chrono::last;
-}
-
-inline auto format(const std::string& spec, const auto& ztime) {
-  return spec.empty() ? "" : std::vformat("{:L" + spec + "}", std::make_format_args(ztime));
-}
-
-inline auto format(const std::locale& loc, const std::string& spec, const auto& ztime) {
-  return spec.empty() ? "" : std::vformat(loc, "{:L" + spec + "}", std::make_format_args(ztime));
-}
-
-}  // namespace date
-
 #else
 #include <date/tz.h>
+#include <fmt/format.h>
+
+#include <regex>
 #endif
 
+// Date
+namespace date {
+#if HAVE_CHRONO_TIMEZONES
+using namespace std::chrono;
+using namespace std;
+#else
+
+using system_clock = std::chrono::system_clock;
+using seconds = std::chrono::seconds;
+
+template <typename T>
+inline auto format(const char* spec, const T& arg) {
+  return date::format(std::regex_replace(spec, std::regex("\\{:L|\\}"), ""), arg);
+}
+
+template <typename T>
+inline auto format(const std::locale& loc, const char* spec, const T& arg) {
+  return date::format(loc, std::regex_replace(spec, std::regex("\\{:L|\\}"), ""), arg);
+}
+
+constexpr decltype(auto) operator""d(unsigned long long d) noexcept {
+  return date::operator""_d(d);  // very verbose, but it works
+}
+#endif
+}  // namespace date
+
+// Format
+namespace waybar::util::date::format {
+#if HAVE_CHRONO_TIMEZONES
+using namespace std;
+#else
+using namespace fmt;
+#endif
+}  // namespace waybar::util::date::format
+
+#if not HAVE_CHRONO_TIMEZONES
 template <typename Duration, typename TimeZonePtr>
 struct fmt::formatter<date::zoned_time<Duration, TimeZonePtr>> {
   std::string_view specs;
@@ -58,3 +76,6 @@ struct fmt::formatter<date::zoned_time<Duration, TimeZonePtr>> {
     return fmt::format_to(ctx.out(), "{}", date::format(fmt::to_string(specs), ztime));
   }
 };
+#endif
+
+using namespace date;

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -85,7 +85,7 @@ $XDG_CONFIG_HOME/waybar/config ++
 :[ same as format
 :[ Tooltip on hover
 
-View all valid format options in *strftime(3)* or have a look <https://fmt.dev/latest/syntax.html#chrono-specs>
+View all valid format options in *strftime(3)* or have a look https://en.cppreference.com/w/cpp/chrono/duration/formatter
 
 2. Addressed by *clock: calendar*
 [- *Option*
@@ -156,7 +156,7 @@ View all valid format options in *strftime(3)* or have a look <https://fmt.dev/l
 # FORMAT REPLACEMENTS
 
 - *{calendar}*: Current month calendar
-- *{timezoned_time_list}*: List of time in the rest timezones, if more than one timezone is set in the config
+- *{tz_list}*: List of time in the rest timezones, if more than one timezone is set in the config
 
 # EXAMPLES
 

--- a/meson.build
+++ b/meson.build
@@ -126,7 +126,22 @@ gtk_layer_shell = dependency('gtk-layer-shell-0',
 systemd = dependency('systemd', required: get_option('systemd'))
 
 cpp_lib_chrono = compiler.compute_int('__cpp_lib_chrono', prefix : '#include <chrono>')
-have_chrono_timezones = cpp_lib_chrono >= 201907
+have_chrono_timezones = cpp_lib_chrono >= 201611
+
+if have_chrono_timezones
+   code = '''
+#include <chrono>
+using namespace std::chrono;
+int main(int argc, char** argv) {
+   const time_zone* tz;
+   return 0;
+}
+'''
+   if not compiler.links(code)
+      have_chrono_timezones = false
+   endif
+endif
+
 if have_chrono_timezones
   tz_dep = declare_dependency()
 else

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -10,6 +10,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
                  bool enable_click, bool enable_scroll)
     : name_(std::move(name)),
       config_(std::move(config)),
+      isTooltip{config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true},
       distance_scrolled_y_(0.0),
       distance_scrolled_x_(0.0) {
   // Configure module action Map
@@ -189,9 +190,7 @@ bool AModule::handleScroll(GdkEventScroll* e) {
   return true;
 }
 
-bool AModule::tooltipEnabled() {
-  return config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true;
-}
+bool AModule::tooltipEnabled() { return isTooltip; }
 
 AModule::operator Gtk::Widget&() { return event_box_; }
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -1,325 +1,286 @@
 #include "modules/clock.hpp"
 
-#include <fmt/chrono.h>
 #include <spdlog/spdlog.h>
 
-#include <ctime>
 #include <iomanip>
 #include <regex>
-#include <sstream>
-#include <type_traits>
 
 #include "util/ustring_clen.hpp"
+
 #ifdef HAVE_LANGINFO_1STDAY
 #include <langinfo.h>
 #include <locale.h>
 #endif
 
+namespace fmt_lib = waybar::util::date::format;
+
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     : ALabel(config, "clock", id, "{:%H:%M}", 60, false, false, true),
-      current_time_zone_idx_{0},
-      is_calendar_in_tooltip_{false},
-      is_timezoned_list_in_tooltip_{false} {
+      locale_{std::locale(config_["locale"].isString() ? config_["locale"].asString() : "")},
+      tlpFmt_{(config_["tooltip-format"].isString()) ? config_["tooltip-format"].asString() : ""},
+      cldInTooltip_{tlpFmt_.find("{" + kCldPlaceholder + "}") != std::string::npos},
+      tzInTooltip_{tlpFmt_.find("{" + kTZPlaceholder + "}") != std::string::npos},
+      tzCurrIdx_{0} {
+  tlpText_ = tlpFmt_;
+
   if (config_["timezones"].isArray() && !config_["timezones"].empty()) {
     for (const auto& zone_name : config_["timezones"]) {
       if (!zone_name.isString()) continue;
       if (zone_name.asString().empty())
         // local time should be shown
-        time_zones_.push_back(date::current_zone());
+        tzList_.push_back(current_zone());
       else
         try {
-          time_zones_.push_back(date::locate_zone(zone_name.asString()));
+          tzList_.push_back(locate_zone(zone_name.asString()));
         } catch (const std::exception& e) {
           spdlog::warn("Timezone: {0}. {1}", zone_name.asString(), e.what());
         }
     }
   } else if (config_["timezone"].isString()) {
     if (config_["timezone"].asString().empty())
-      time_zones_.push_back(date::current_zone());
+      // local time should be shown
+      tzList_.push_back(current_zone());
     else
       try {
-        time_zones_.push_back(date::locate_zone(config_["timezone"].asString()));
+        tzList_.push_back(locate_zone(config_["timezone"].asString()));
       } catch (const std::exception& e) {
         spdlog::warn("Timezone: {0}. {1}", config_["timezone"].asString(), e.what());
       }
   }
+  if (!tzList_.size()) tzList_.push_back(current_zone());
 
-  // If all timezones are parsed and no one is good
-  if (!time_zones_.size()) {
-    time_zones_.push_back(date::current_zone());
-  }
-
-  // Check if a particular placeholder is present in the tooltip format, to know what to calculate
-  // on update.
-  if (config_["tooltip-format"].isString()) {
-    std::string trimmed_format{config_["tooltip-format"].asString()};
-    fmtMap_.insert({5, trimmed_format});
-    trimmed_format.erase(std::remove_if(trimmed_format.begin(), trimmed_format.end(),
-                                        [](unsigned char x) { return std::isspace(x); }),
-                         trimmed_format.end());
-
-    if (trimmed_format.find("{" + kCalendarPlaceholder + "}") != std::string::npos) {
-      is_calendar_in_tooltip_ = true;
-    }
-    if (trimmed_format.find("{" + KTimezonedTimeListPlaceholder + "}") != std::string::npos) {
-      is_timezoned_list_in_tooltip_ = true;
-    }
-  }
-
-  // Calendar configuration
-  if (is_calendar_in_tooltip_) {
-    if (config_[kCalendarPlaceholder]["weeks-pos"].isString()) {
-      if (config_[kCalendarPlaceholder]["weeks-pos"].asString() == "left") {
-        cldWPos_ = WeeksSide::LEFT;
-      } else if (config_[kCalendarPlaceholder]["weeks-pos"].asString() == "right") {
-        cldWPos_ = WeeksSide::RIGHT;
-      }
-    }
-    if (config_[kCalendarPlaceholder]["format"]["months"].isString())
-      fmtMap_.insert({0, config_[kCalendarPlaceholder]["format"]["months"].asString()});
-    else
-      fmtMap_.insert({0, "{}"});
-    if (config_[kCalendarPlaceholder]["format"]["days"].isString())
-      fmtMap_.insert({2, config_[kCalendarPlaceholder]["format"]["days"].asString()});
-    else
-      fmtMap_.insert({2, "{}"});
-    if (config_[kCalendarPlaceholder]["format"]["weeks"].isString() &&
-        cldWPos_ != WeeksSide::HIDDEN) {
-      fmtMap_.insert(
-          {4, std::regex_replace(config_[kCalendarPlaceholder]["format"]["weeks"].asString(),
-                                 std::regex("\\{\\}"),
-                                 (first_day_of_week() == date::Monday) ? "{:%W}" : "{:%U}")});
-      Glib::ustring tmp{std::regex_replace(fmtMap_[4], std::regex("</?[^>]+>|\\{.*\\}"), "")};
-      cldWnLen_ += tmp.size();
-    } else {
-      if (cldWPos_ != WeeksSide::HIDDEN)
-        fmtMap_.insert({4, (first_day_of_week() == date::Monday) ? "{:%W}" : "{:%U}"});
-      else
-        cldWnLen_ = 0;
-    }
-    if (config_[kCalendarPlaceholder]["format"]["weekdays"].isString())
-      fmtMap_.insert({1, config_[kCalendarPlaceholder]["format"]["weekdays"].asString()});
-    else
-      fmtMap_.insert({1, "{}"});
-    if (config_[kCalendarPlaceholder]["format"]["today"].isString()) {
-      fmtMap_.insert({3, config_[kCalendarPlaceholder]["format"]["today"].asString()});
-      cldBaseDay_ =
-          date::year_month_day{date::floor<date::days>(std::chrono::system_clock::now())}.day();
-    } else
-      fmtMap_.insert({3, "{}"});
-    if (config_[kCalendarPlaceholder]["mode"].isString()) {
-      const std::string cfgMode{(config_[kCalendarPlaceholder]["mode"].isString())
-                                    ? config_[kCalendarPlaceholder]["mode"].asString()
-                                    : "month"};
-      const std::map<std::string, const CldMode&> monthModes{{"month", CldMode::MONTH},
-                                                             {"year", CldMode::YEAR}};
+  // Calendar properties
+  if (cldInTooltip_) {
+    if (config_[kCldPlaceholder]["mode"].isString()) {
+      const std::string cfgMode{config_[kCldPlaceholder]["mode"].asString()};
+      const std::map<std::string_view, const CldMode&> monthModes{{"month", CldMode::MONTH},
+                                                                  {"year", CldMode::YEAR}};
       if (monthModes.find(cfgMode) != monthModes.end())
         cldMode_ = monthModes.at(cfgMode);
       else
         spdlog::warn(
-            "Clock calendar configuration \"mode\"\"\" \"{0}\" is not recognized. Mode = \"month\" "
-            "is using instead",
+            "Clock calendar configuration mode \"{0}\" is not recognized. Mode = \"month\" is "
+            "using instead",
             cfgMode);
     }
-    if (config_[kCalendarPlaceholder]["mode-mon-col"].isInt()) {
-      cldMonCols_ = config_[kCalendarPlaceholder]["mode-mon-col"].asInt();
-      if (cldMonCols_ == 0u || 12 % cldMonCols_ != 0u) {
-        cldMonCols_ = 3u;
+    if (config_[kCldPlaceholder]["weeks-pos"].isString()) {
+      if (config_[kCldPlaceholder]["weeks-pos"].asString() == "left") cldWPos_ = WS::LEFT;
+      if (config_[kCldPlaceholder]["weeks-pos"].asString() == "right") cldWPos_ = WS::RIGHT;
+    }
+    if (config_[kCldPlaceholder]["format"]["months"].isString())
+      fmtMap_.insert({0, config_[kCldPlaceholder]["format"]["months"].asString()});
+    else
+      fmtMap_.insert({0, "{}"});
+    if (config_[kCldPlaceholder]["format"]["weekdays"].isString())
+      fmtMap_.insert({1, config_[kCldPlaceholder]["format"]["weekdays"].asString()});
+    else
+      fmtMap_.insert({1, "{}"});
+
+    if (config_[kCldPlaceholder]["format"]["days"].isString())
+      fmtMap_.insert({2, config_[kCldPlaceholder]["format"]["days"].asString()});
+    else
+      fmtMap_.insert({2, "{}"});
+    if (config_[kCldPlaceholder]["format"]["today"].isString()) {
+      fmtMap_.insert({3, config_[kCldPlaceholder]["format"]["today"].asString()});
+      cldBaseDay_ =
+          year_month_day{
+              floor<days>(zoned_time{current_zone(), system_clock::now()}.get_local_time())}
+              .day();
+    } else
+      fmtMap_.insert({3, "{}"});
+    if (config_[kCldPlaceholder]["format"]["weeks"].isString() && cldWPos_ != WS::HIDDEN) {
+      fmtMap_.insert({4, std::regex_replace(config_[kCldPlaceholder]["format"]["weeks"].asString(),
+                                            std::regex("\\{\\}"),
+                                            (first_day_of_week() == Monday) ? "{:%W}" : "{:%U}")});
+      Glib::ustring tmp{std::regex_replace(fmtMap_[4], std::regex("</?[^>]+>|\\{.*\\}"), "")};
+      cldWnLen_ += tmp.size();
+    } else {
+      if (cldWPos_ != WS::HIDDEN)
+        fmtMap_.insert({4, (first_day_of_week() == Monday) ? "{:%W}" : "{:%U}"});
+      else
+        cldWnLen_ = 0;
+    }
+    if (config_[kCldPlaceholder]["mode-mon-col"].isInt()) {
+      cldMonCols_ = config_[kCldPlaceholder]["mode-mon-col"].asInt();
+      if (cldMonCols_ == 0u || (12 % cldMonCols_) != 0u) {
         spdlog::warn(
-            "Clock calendar configuration \"mode-mon-col\" = {0} must be one of [1, 2, 3, 4, 6, "
-            "12]. Value 3 is using instead",
+            "Clock calendar configuration mode-mon-col = {0} must be one of [1, 2, 3, 4, 6, 12]. "
+            "Value 3 is using instead",
             cldMonCols_);
+        cldMonCols_ = 3u;
       }
     } else
       cldMonCols_ = 1;
-    if (config_[kCalendarPlaceholder]["on-scroll"].isInt()) {
-      cldShift_ = date::months{config_[kCalendarPlaceholder]["on-scroll"].asInt()};
+    if (config_[kCldPlaceholder]["on-scroll"].isInt()) {
       event_box_.add_events(Gdk::LEAVE_NOTIFY_MASK);
       event_box_.signal_leave_notify_event().connect([this](GdkEventCrossing*) {
-        cldCurrShift_ = date::months{0};
+        cldCurrShift_ = months{0};
         return false;
       });
     }
   }
 
-  if (config_["locale"].isString())
-    locale_ = std::locale(config_["locale"].asString());
-  else
-    locale_ = std::locale("");
-
   thread_ = [this] {
     dp.emit();
-    auto now = std::chrono::system_clock::now();
-    /* difference with projected wakeup time */
-    auto diff = now.time_since_epoch() % interval_;
-    /* sleep until the next projected time */
-    thread_.sleep_for(interval_ - diff);
+    thread_.sleep_for(interval_ - system_clock::now().time_since_epoch() % interval_);
   };
 }
 
-const date::time_zone* waybar::modules::Clock::current_timezone() {
-  return time_zones_[current_time_zone_idx_];
-}
-
 auto waybar::modules::Clock::update() -> void {
-  const auto* tz{current_timezone()};
-  const date::zoned_time now{
-      tz,
-      date::floor<std::chrono::seconds>(
-          std::chrono::system_clock::now())};  // Define local time is based on provided time zone
-  const date::year_month_day today{
-      date::floor<date::days>(now.get_local_time())};            // Convert now to year_month_day
-  const date::year_month_day shiftedDay{today + cldCurrShift_};  // Shift today
-  // Define shift local time
-  const auto shiftedNow{date::make_zoned(
-      tz, date::local_days(shiftedDay) +
-              (now.get_sys_time() - date::floor<date::days>(now.get_sys_time())))};
+  auto tz{tzList_[tzCurrIdx_]};
+  const zoned_time now{tz, floor<seconds>(system_clock::now())};
 
-  label_.set_markup(fmt::format(locale_, fmt::runtime(format_), now));
+  label_.set_markup(fmt_lib::vformat(locale_, format_, fmt_lib::make_format_args(now)));
 
   if (tooltipEnabled()) {
-    const std::string tz_text{(is_timezoned_list_in_tooltip_) ? timezones_text(now.get_sys_time())
-                                                              : ""};
-    const std::string cld_text{(is_calendar_in_tooltip_) ? get_calendar(today, shiftedDay, tz)
-                                                         : ""};
+    const year_month_day today{floor<days>(now.get_local_time())};
+    const auto shiftedDay{today + cldCurrShift_};
+    const zoned_time shiftedNow{
+        tz, local_days(shiftedDay) + (now.get_local_time() - floor<days>(now.get_local_time()))};
 
-    const std::string text{fmt::format(locale_, fmt::runtime(fmtMap_[5]), shiftedNow,
-                                       fmt::arg(KTimezonedTimeListPlaceholder.c_str(), tz_text),
-                                       fmt::arg(kCalendarPlaceholder.c_str(), cld_text))};
-    label_.set_tooltip_markup(text);
+    if (tzInTooltip_) tzText_ = getTZtext(now.get_sys_time());
+    if (cldInTooltip_) cldText_ = get_calendar(today, shiftedDay, tz);
+    if (tzInTooltip_ || cldInTooltip_) {
+      // std::vformat doesn't support named arguments.
+      tlpText_ = std::regex_replace(tlpFmt_, std::regex("\\{" + kTZPlaceholder + "\\}"), tzText_);
+      tlpText_ =
+          std::regex_replace(tlpText_, std::regex("\\{" + kCldPlaceholder + "\\}"), cldText_);
+    }
+
+    tlpText_ = fmt_lib::vformat(locale_, tlpText_, fmt_lib::make_format_args(shiftedNow));
+
+    label_.set_tooltip_markup(tlpText_);
   }
 
-  // Call parent update
   ALabel::update();
 }
 
-auto waybar::modules::Clock::doAction(const std::string& name) -> void {
-  if ((actionMap_[name])) {
-    (this->*actionMap_[name])();
-    update();
-  } else
-    spdlog::error("Clock. Unsupported action \"{0}\"", name);
+auto waybar::modules::Clock::getTZtext(sys_seconds now) -> std::string {
+  if (tzList_.size() == 1) return "";
+
+  std::stringstream os;
+  for (size_t tz_idx{0}; tz_idx < tzList_.size(); ++tz_idx) {
+    if (static_cast<int>(tz_idx) == tzCurrIdx_) continue;
+    auto zt{zoned_time{tzList_[tz_idx], now}};
+    os << fmt_lib::vformat(locale_, format_, fmt_lib::make_format_args(zt)) << '\n';
+  }
+
+  return os.str();
 }
 
-// The number of weeks in calendar month layout plus 1 more for calendar titles
-const unsigned cldRowsInMonth(const date::year_month& ym, const date::weekday& firstdow) {
-  using namespace date;
-  return static_cast<unsigned>(
-             ceil<weeks>((weekday{ym / 1} - firstdow) + ((ym / last).day() - day{0})).count()) +
-         2;
+const unsigned cldRowsInMonth(const year_month& ym, const weekday& firstdow) {
+  return 2u + ceil<weeks>((weekday{ym / 1} - firstdow) + ((ym / last).day() - day{0})).count();
 }
 
-auto cldGetWeekForLine(const date::year_month& ym, const date::weekday& firstdow,
-                       unsigned const line) -> const date::year_month_weekday {
-  unsigned index = line - 2;
-  auto sd = date::sys_days{ym / 1};
-  if (date::weekday{sd} == firstdow) ++index;
-  auto ymdw = ym / firstdow[index];
-  return ymdw;
+auto cldGetWeekForLine(const year_month& ym, const weekday& firstdow, const unsigned line)
+    -> const year_month_weekday {
+  unsigned index{line - 2};
+  if (weekday{ym / 1} == firstdow) ++index;
+  return ym / firstdow[index];
 }
 
-auto getCalendarLine(const date::year_month_day& currDate, const date::year_month ym,
-                     const unsigned line, const date::weekday& firstdow,
-                     const std::locale* const locale_) -> std::string {
-  using namespace date::literals;
-  std::ostringstream res;
+auto getCalendarLine(const year_month_day& currDate, const year_month ym, const unsigned line,
+                     const weekday& firstdow, const std::locale* const locale_) -> std::string {
+  std::ostringstream os;
 
   switch (line) {
+    // Print month and year title
     case 0: {
-      // Output month and year title
-      res << date::format(*locale_, "%B %Y", ym);
+      os << date::format(*locale_, "{:L%B %Y}", ym);
       break;
     }
+    // Print weekday names title
     case 1: {
-      // Output weekday names title
       auto wd{firstdow};
+      Glib::ustring wdStr;
+      Glib::ustring::size_type wdLen{0};
+      int clen{0};
       do {
-        Glib::ustring wd_ustring{date::format(*locale_, "%a", wd)};
-        auto clen{ustring_clen(wd_ustring)};
-        auto wd_len{wd_ustring.length()};
+        wdStr = date::format(*locale_, "{:L%a}", wd);
+        clen = ustring_clen(wdStr);
+        wdLen = wdStr.length();
         while (clen > 2) {
-          wd_ustring = wd_ustring.substr(0, wd_len - 1);
-          --wd_len;
-          clen = ustring_clen(wd_ustring);
+          wdStr = wdStr.substr(0, wdLen - 1);
+          --wdLen;
+          clen = ustring_clen(wdStr);
         }
         const std::string pad(2 - clen, ' ');
 
-        if (wd != firstdow) res << ' ';
+        if (wd != firstdow) os << ' ';
 
-        res << pad << wd_ustring;
+        os << pad << wdStr;
       } while (++wd != firstdow);
       break;
     }
+    // Print first week prefixed with spaces if necessary
     case 2: {
-      // Output first week prefixed with spaces if necessary
-      auto wd = date::weekday{ym / 1};
-      res << std::string(static_cast<unsigned>((wd - firstdow).count()) * 3, ' ');
+      auto wd{weekday{ym / 1}};
+      os << std::string((wd - firstdow).count() * 3, ' ');
 
-      if (currDate.year() != ym.year() || currDate.month() != ym.month() || currDate != ym / 1_d)
-        res << date::format("%e", 1_d);
+      if (currDate != ym / 1d)
+        os << date::format(*locale_, "{:L%e}", 1d);
       else
-        res << "{today}";
+        os << "{today}";
 
-      auto d = 2_d;
-
+      auto d{2d};
       while (++wd != firstdow) {
-        if (currDate.year() != ym.year() || currDate.month() != ym.month() || currDate != ym / d)
-          res << date::format(" %e", d);
+        if (currDate != ym / d)
+          os << date::format(*locale_, " {:L%e}", d);
         else
-          res << " {today}";
+          os << " {today}";
 
         ++d;
       }
       break;
     }
+    // Print non-first week
     default: {
-      // Output a non-first week:
-      auto ymdw{cldGetWeekForLine(ym, firstdow, line)};
-      if (ymdw.ok()) {
-        auto d = date::year_month_day{ymdw}.day();
-        auto const e = (ym / last).day();
-        auto wd = firstdow;
+      auto ymdTmp{cldGetWeekForLine(ym, firstdow, line)};
+      if (ymdTmp.ok()) {
+        auto d{year_month_day{ymdTmp}.day()};
+        const auto dlast{(ym / last).day()};
+        auto wd{firstdow};
 
-        if (currDate.year() != ym.year() || currDate.month() != ym.month() || currDate != ym / d)
-          res << date::format("%e", d);
+        if (currDate != ym / d)
+          os << date::format(*locale_, "{:L%e}", d);
         else
-          res << "{today}";
+          os << "{today}";
 
-        while (++wd != firstdow && ++d <= e) {
-          if (currDate.year() != ym.year() || currDate.month() != ym.month() || currDate != ym / d)
-            res << date::format(" %e", d);
+        while (++wd != firstdow && ++d <= dlast) {
+          if (currDate != ym / d)
+            os << date::format(*locale_, " {:L%e}", d);
           else
-            res << " {today}";
+            os << " {today}";
         }
-        // Append row with spaces if the week did not complete
-        res << std::string(static_cast<unsigned>((firstdow - wd).count()) * 3, ' ');
+        // Append row with spaces if the week was not completed
+        os << std::string((firstdow - wd).count() * 3, ' ');
       }
       break;
     }
   }
 
-  return res.str();
+  return os.str();
 }
 
-auto waybar::modules::Clock::get_calendar(const date::year_month_day& today,
-                                          const date::year_month_day& ymd,
-                                          const date::time_zone* tz) -> const std::string {
+auto waybar::modules::Clock::get_calendar(const year_month_day& today, const year_month_day& ymd,
+                                          const time_zone* tz) -> const std::string {
+  const auto firstdow{first_day_of_week()};
+  const auto maxRows{12 / cldMonCols_};
   const auto ym{ymd.year() / ymd.month()};
   const auto y{ymd.year()};
   const auto d{ymd.day()};
-  const auto firstdow = first_day_of_week();
-  const auto maxRows{12 / cldMonCols_};
+
   std::ostringstream os;
   std::ostringstream tmp;
 
   if (cldMode_ == CldMode::YEAR) {
-    if (y / date::month{1} / 1 == cldYearShift_)
+    if (y / month{1} / 1 == cldYearShift_)
       if (d == cldBaseDay_ || (uint)cldBaseDay_ == 0u)
         return cldYearCached_;
       else
         cldBaseDay_ = d;
     else
-      cldYearShift_ = y / date::month{1} / 1;
+      cldYearShift_ = y / month{1} / 1;
   }
   if (cldMode_ == CldMode::MONTH) {
     if (ym == cldMonShift_)
@@ -330,67 +291,69 @@ auto waybar::modules::Clock::get_calendar(const date::year_month_day& today,
     else
       cldMonShift_ = ym;
   }
-
+  // Pad object
+  const std::string pads(cldWnLen_, ' ');
   // Compute number of lines needed for each calendar month
   unsigned ml[12]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
 
   for (auto& m : ml) {
     if (cldMode_ == CldMode::YEAR || m == static_cast<unsigned>(ymd.month()))
-      m = cldRowsInMonth(y / date::month{m}, firstdow);
+      m = cldRowsInMonth(y / month{m}, firstdow);
     else
       m = 0u;
   }
 
   for (auto row{0u}; row < maxRows; ++row) {
-    const auto lines = *std::max_element(std::begin(ml) + (row * cldMonCols_),
-                                         std::begin(ml) + ((row + 1) * cldMonCols_));
+    const auto lines{*std::max_element(std::begin(ml) + (row * cldMonCols_),
+                                       std::begin(ml) + ((row + 1) * cldMonCols_))};
     for (auto line{0u}; line < lines; ++line) {
       for (auto col{0u}; col < cldMonCols_; ++col) {
-        const auto mon{date::month{row * cldMonCols_ + col + 1}};
+        const auto mon{month{row * cldMonCols_ + col + 1}};
         if (cldMode_ == CldMode::YEAR || y / mon == ym) {
-          date::year_month ymTmp{y / mon};
-          if (col != 0 && cldMode_ == CldMode::YEAR) os << "   ";
+          const year_month ymTmp{y / mon};
+          if (col != 0 && cldMode_ == CldMode::YEAR) os << std::string(3, ' ');
 
           // Week numbers on the left
-          if (cldWPos_ == WeeksSide::LEFT && line > 0) {
+          if (cldWPos_ == WS::LEFT && line > 0) {
             if (line > 1) {
-              if (line < ml[static_cast<unsigned>(ymTmp.month()) - 1u])
-                os << fmt::format(fmt::runtime(fmtMap_[4]),
-                                  (line == 2)
-                                      ? date::zoned_seconds{tz, date::local_days{ymTmp / 1}}
-                                      : date::zoned_seconds{tz, date::local_days{cldGetWeekForLine(
-                                                                    ymTmp, firstdow, line)}})
+              if (line < ml[(unsigned)ymTmp.month() - 1u])
+                os << fmt_lib::vformat(
+                          locale_, fmtMap_[4],
+                          fmt_lib::make_format_args(
+                              (line == 2) ? zoned_seconds{tz, local_days{ymTmp / 1}}
+                                          : zoned_seconds{tz, local_days{cldGetWeekForLine(
+                                                                  ymTmp, firstdow, line)}}))
                    << ' ';
               else
-                os << std::string(cldWnLen_, ' ');
+                os << pads;
             }
           }
 
-          os << fmt::format(
-              fmt::runtime((cldWPos_ != WeeksSide::LEFT || line == 0) ? "{:<{}}" : "{:>{}}"),
-              getCalendarLine(today, ymTmp, line, firstdow, &locale_),
-              (cldMonColLen_ + ((line < 2) ? cldWnLen_ : 0)));
+          os << Glib::ustring::format((cldWPos_ != WS::LEFT || line == 0) ? std::left : std::right,
+                                      std::setfill(L' '),
+                                      std::setw(cldMonColLen_ + ((line < 2) ? cldWnLen_ : 0)),
+                                      getCalendarLine(today, ymTmp, line, firstdow, &locale_));
 
           // Week numbers on the right
-          if (cldWPos_ == WeeksSide ::RIGHT && line > 0) {
+          if (cldWPos_ == WS::RIGHT && line > 0) {
             if (line > 1) {
-              if (line < ml[static_cast<unsigned>(ymTmp.month()) - 1u])
+              if (line < ml[(unsigned)ymTmp.month() - 1u])
                 os << ' '
-                   << fmt::format(fmt::runtime(fmtMap_[4]),
-                                  (line == 2)
-                                      ? date::zoned_seconds{tz, date::local_days{ymTmp / 1}}
-                                      : date::zoned_seconds{tz, date::local_days{cldGetWeekForLine(
-                                                                    ymTmp, firstdow, line)}});
+                   << fmt_lib::vformat(
+                          locale_, fmtMap_[4],
+                          fmt_lib::make_format_args(
+                              (line == 2) ? zoned_seconds{tz, local_days{ymTmp / 1}}
+                                          : zoned_seconds{tz, local_days{cldGetWeekForLine(
+                                                                  ymTmp, firstdow, line)}}));
               else
-                os << std::string(cldWnLen_, ' ');
+                os << pads;
             }
           }
         }
       }
-
-      // Apply user formats to calendar
+      // Apply user's formats
       if (line < 2)
-        tmp << fmt::format(fmt::runtime(fmtMap_[line]), os.str());
+        tmp << fmt_lib::vformat(locale_, fmtMap_[line], fmt_lib::make_format_args(os.str()));
       else
         tmp << os.str();
       // Clear ostringstream
@@ -400,10 +363,10 @@ auto waybar::modules::Clock::get_calendar(const date::year_month_day& today,
     if (row + 1u != maxRows && cldMode_ == CldMode::YEAR) tmp << '\n';
   }
 
-  os << fmt::format(  // Apply days format
-      fmt::runtime(fmt::format(fmt::runtime(fmtMap_[2]), tmp.str())),
-      // Apply today format
-      fmt::arg("today", fmt::format(fmt::runtime(fmtMap_[3]), date::format("%e", d))));
+  os << std::regex_replace(
+      fmt_lib::vformat(locale_, fmtMap_[2], fmt_lib::make_format_args(tmp.str())),
+      std::regex("\\{today\\}"),
+      fmt_lib::vformat(locale_, fmtMap_[3], fmt_lib::make_format_args(date::format("{:L%e}", d))));
 
   if (cldMode_ == CldMode::YEAR)
     cldYearCached_ = os.str();
@@ -413,50 +376,34 @@ auto waybar::modules::Clock::get_calendar(const date::year_month_day& today,
   return os.str();
 }
 
-/*Clock actions*/
+// Actions handler
+auto waybar::modules::Clock::doAction(const std::string& name) -> void {
+  if (actionMap_[name]) {
+    (this->*actionMap_[name])();
+  } else
+    spdlog::error("Clock. Unsupported action \"{0}\"", name);
+}
+
+// Module actions
 void waybar::modules::Clock::cldModeSwitch() {
   cldMode_ = (cldMode_ == CldMode::YEAR) ? CldMode::MONTH : CldMode::YEAR;
 }
 void waybar::modules::Clock::cldShift_up() {
-  cldCurrShift_ += ((cldMode_ == CldMode::YEAR) ? 12 : 1) * cldShift_;
+  cldCurrShift_ += (months)((cldMode_ == CldMode::YEAR) ? 12 : 1);
 }
 void waybar::modules::Clock::cldShift_down() {
-  cldCurrShift_ -= ((cldMode_ == CldMode::YEAR) ? 12 : 1) * cldShift_;
+  cldCurrShift_ -= (months)((cldMode_ == CldMode::YEAR) ? 12 : 1);
 }
 void waybar::modules::Clock::tz_up() {
-  auto nr_zones = time_zones_.size();
-
-  if (nr_zones == 1) return;
-
-  size_t new_idx = current_time_zone_idx_ + 1;
-  current_time_zone_idx_ = new_idx == nr_zones ? 0 : new_idx;
+  const auto tzSize{tzList_.size()};
+  if (tzSize == 1) return;
+  size_t newIdx{tzCurrIdx_ + 1lu};
+  tzCurrIdx_ = (newIdx == tzSize) ? 0 : newIdx;
 }
 void waybar::modules::Clock::tz_down() {
-  auto nr_zones = time_zones_.size();
-
-  if (nr_zones == 1) return;
-
-  current_time_zone_idx_ = current_time_zone_idx_ == 0 ? nr_zones - 1 : current_time_zone_idx_ - 1;
-}
-
-auto waybar::modules::Clock::timezones_text(std::chrono::system_clock::time_point now)
-    -> std::string {
-  if (time_zones_.size() == 1) {
-    return "";
-  }
-  std::stringstream os;
-  for (size_t time_zone_idx = 0; time_zone_idx < time_zones_.size(); ++time_zone_idx) {
-    if (static_cast<int>(time_zone_idx) == current_time_zone_idx_) {
-      continue;
-    }
-    const date::time_zone* timezone = time_zones_[time_zone_idx];
-    if (!timezone) {
-      timezone = date::current_zone();
-    }
-    auto ztime = date::zoned_time{timezone, date::floor<std::chrono::seconds>(now)};
-    os << fmt::format(locale_, fmt::runtime(format_), ztime) << '\n';
-  }
-  return os.str();
+  const auto tzSize{tzList_.size()};
+  if (tzSize == 1) return;
+  tzCurrIdx_ = (tzCurrIdx_ == 0) ? tzSize - 1 : tzCurrIdx_ - 1;
 }
 
 #ifdef HAVE_LANGINFO_1STDAY
@@ -468,17 +415,16 @@ using deleting_unique_ptr = std::unique_ptr<T, deleter_from_fn<fn>>;
 #endif
 
 // Computations done similarly to Linux cal utility.
-auto waybar::modules::Clock::first_day_of_week() -> date::weekday {
+auto waybar::modules::Clock::first_day_of_week() -> weekday {
 #ifdef HAVE_LANGINFO_1STDAY
   deleting_unique_ptr<std::remove_pointer<locale_t>::type, freelocale> posix_locale{
       newlocale(LC_ALL, locale_.name().c_str(), nullptr)};
   if (posix_locale) {
-    const int i = (std::intptr_t)nl_langinfo_l(_NL_TIME_WEEK_1STDAY, posix_locale.get());
-    auto ymd = date::year(i / 10000) / (i / 100 % 100) / (i % 100);
-    auto wd = date::weekday(ymd);
-    uint8_t j = *nl_langinfo_l(_NL_TIME_FIRST_WEEKDAY, posix_locale.get());
-    return wd + date::days(j - 1);
+    const auto i{(int)((std::intptr_t)nl_langinfo_l(_NL_TIME_WEEK_1STDAY, posix_locale.get()))};
+    const weekday wd{year_month_day{year(i / 10000) / month(i / 100 % 100) / day(i % 100)}};
+    const auto j{(uint8_t)*nl_langinfo_l(_NL_TIME_FIRST_WEEKDAY, posix_locale.get())};
+    return wd + days{j - 1};
   }
 #endif
-  return date::Sunday;
+  return Sunday;
 }

--- a/test/date.cpp
+++ b/test/date.cpp
@@ -1,6 +1,5 @@
 #include "util/date.hpp"
 
-#include <chrono>
 #include <ctime>
 #include <iomanip>
 #include <sstream>
@@ -20,13 +19,13 @@
 #endif
 
 using namespace std::literals::chrono_literals;
-
+namespace fmt_lib = waybar::util::date::format;
 /*
  * Check that the date/time formatter with locale and timezone support is working as expected.
  */
 
-const date::zoned_time<std::chrono::seconds> TEST_TIME = date::zoned_time{
-    "UTC", date::local_days{date::Monday[1] / date::January / 2022} + 13h + 4min + 5s};
+const zoned_time<std::chrono::seconds> TEST_TIME{
+    "UTC", local_days{Monday[1] / January / 2022} + 13h + 4min + 5s};
 
 /*
  * Check if the date formatted with LC_TIME=en_US is within expectations.
@@ -52,10 +51,11 @@ static const bool LC_TIME_is_sane = []() {
 TEST_CASE("Format UTC time", "[clock][util]") {
   const auto loc = std::locale("C");
   const auto tm = TEST_TIME;
-
-  CHECK(fmt::format(loc, "{}", tm).empty());  // no format specified
-  CHECK(fmt::format(loc, "{:%c %Z}", tm) == "Mon Jan  3 13:04:05 2022 UTC");
-  CHECK(fmt::format(loc, "{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+#if not HAVE_CHRONO_TIMEZONES
+  CHECK(fmt_lib::format(loc, "{}", tm).empty());  // no format specified
+#endif
+  CHECK(fmt_lib::format(loc, "{:%c %Z}", tm) == "Mon Jan  3 13:04:05 2022 UTC");
+  CHECK(fmt_lib::format(loc, "{:%Y%m%d%H%M%S}", tm) == "20220103130405");
 
   if (!LC_TIME_is_sane) {
     SKIP("Locale support check failed, skip tests");
@@ -66,11 +66,15 @@ TEST_CASE("Format UTC time", "[clock][util]") {
     try {
       const auto loc = std::locale("en_US.UTF-8");
 
-      CHECK(fmt::format(loc, "{}", tm).empty());  // no format specified
-      CHECK_THAT(fmt::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
+#if not HAVE_CHRONO_TIMEZONES
+      CHECK(fmt_lib::format(loc, "{}", tm).empty());  // no format specified
+      CHECK_THAT(fmt_lib::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
                  Catch::Matchers::StartsWith("Mon 03 Jan 2022 01:04:05 PM"));
-      CHECK(fmt::format(loc, "{:%x %X}", tm) == "01/03/2022 01:04:05 PM");
-      CHECK(fmt::format(loc, "{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+      CHECK(fmt_lib::format(loc, "{:%x %X}", tm) == "01/03/2022 01:04:05 PM");
+#else
+      CHECK(fmt_lib::format(loc, "{:%F %r}", tm) == "2022-01-03 01:04:05 PM");
+#endif
+      CHECK(fmt_lib::format(loc, "{:%Y%m%d%H%M%S}", tm) == "20220103130405");
     } catch (const std::runtime_error &) {
       WARN("Locale en_US not found, skip tests");
     }
@@ -79,11 +83,15 @@ TEST_CASE("Format UTC time", "[clock][util]") {
     try {
       const auto loc = std::locale("en_GB.UTF-8");
 
-      CHECK(fmt::format(loc, "{}", tm).empty());  // no format specified
-      CHECK_THAT(fmt::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
+#if not HAVE_CHRONO_TIMEZONES
+      CHECK(fmt_lib::format(loc, "{}", tm).empty());  // no format specified
+      CHECK_THAT(fmt_lib::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
                  Catch::Matchers::StartsWith("Mon 03 Jan 2022 13:04:05"));
-      CHECK(fmt::format(loc, "{:%x %X}", tm) == "03/01/22 13:04:05");
-      CHECK(fmt::format(loc, "{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+      CHECK(fmt_lib::format(loc, "{:%x %X}", tm) == "03/01/22 13:04:05");
+#else
+      CHECK(fmt_lib::format(loc, "{:%F %T}", tm) == "2022-01-03 13:04:05");
+#endif
+      CHECK(fmt_lib::format(loc, "{:%Y%m%d%H%M%S}", tm) == "20220103130405");
     } catch (const std::runtime_error &) {
       WARN("Locale en_GB not found, skip tests");
     }
@@ -92,11 +100,15 @@ TEST_CASE("Format UTC time", "[clock][util]") {
     try {
       const auto loc = std::locale::global(std::locale("en_US.UTF-8"));
 
-      CHECK(fmt::format("{}", tm).empty());  // no format specified
-      CHECK_THAT(fmt::format("{:%c}", tm),   // HowardHinnant/date#704
+#if not HAVE_CHRONO_TIMEZONES
+      CHECK(fmt_lib::format("{}", tm).empty());  // no format specified
+      CHECK_THAT(fmt_lib::format("{:%c}", tm),   // HowardHinnant/date#704
                  Catch::Matchers::StartsWith("Mon 03 Jan 2022 01:04:05 PM"));
-      CHECK(fmt::format("{:%x %X}", tm) == "01/03/2022 01:04:05 PM");
-      CHECK(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103130405");
+      CHECK(fmt_lib::format("{:%x %X}", tm) == "01/03/2022 01:04:05 PM");
+#else
+      CHECK(fmt_lib::format("{:%F %r}", tm) == "2022-01-03 01:04:05 PM");
+#endif
+      CHECK(fmt_lib::format("{:%Y%m%d%H%M%S}", tm) == "20220103130405");
 
       std::locale::global(loc);
     } catch (const std::runtime_error &) {
@@ -107,11 +119,13 @@ TEST_CASE("Format UTC time", "[clock][util]") {
 
 TEST_CASE("Format zoned time", "[clock][util]") {
   const auto loc = std::locale("C");
-  const auto tm = date::zoned_time{"America/New_York", TEST_TIME};
+  const auto tm = zoned_time{"America/New_York", TEST_TIME};
 
-  CHECK(fmt::format(loc, "{}", tm).empty());  // no format specified
-  CHECK(fmt::format(loc, "{:%c %Z}", tm) == "Mon Jan  3 08:04:05 2022 EST");
-  CHECK(fmt::format(loc, "{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+#if not HAVE_CHRONO_TIMEZONES
+  CHECK(fmt_lib::format(loc, "{}", tm).empty());  // no format specified
+#endif
+  CHECK(fmt_lib::format(loc, "{:%c %Z}", tm) == "Mon Jan  3 08:04:05 2022 EST");
+  CHECK(fmt_lib::format(loc, "{:%Y%m%d%H%M%S}", tm) == "20220103080405");
 
   if (!LC_TIME_is_sane) {
     SKIP("Locale support check failed, skip tests");
@@ -122,11 +136,15 @@ TEST_CASE("Format zoned time", "[clock][util]") {
     try {
       const auto loc = std::locale("en_US.UTF-8");
 
-      CHECK(fmt::format(loc, "{}", tm).empty());  // no format specified
-      CHECK_THAT(fmt::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
+#if not HAVE_CHRONO_TIMEZONES
+      CHECK(fmt_lib::format(loc, "{}", tm).empty());  // no format specified
+      CHECK_THAT(fmt_lib::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
                  Catch::Matchers::StartsWith("Mon 03 Jan 2022 08:04:05 AM"));
-      CHECK(fmt::format(loc, "{:%x %X}", tm) == "01/03/2022 08:04:05 AM");
-      CHECK(fmt::format(loc, "{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+      CHECK(fmt_lib::format(loc, "{:%x %X}", tm) == "01/03/2022 08:04:05 AM");
+#else
+      CHECK(fmt_lib::format(loc, "{:%F %r}", tm) == "2022-01-03 08:04:05 AM");
+#endif
+      CHECK(fmt_lib::format(loc, "{:%Y%m%d%H%M%S}", tm) == "20220103080405");
     } catch (const std::runtime_error &) {
       WARN("Locale en_US not found, skip tests");
     }
@@ -135,11 +153,15 @@ TEST_CASE("Format zoned time", "[clock][util]") {
     try {
       const auto loc = std::locale("en_GB.UTF-8");
 
-      CHECK(fmt::format(loc, "{}", tm).empty());  // no format specified
-      CHECK_THAT(fmt::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
+#if not HAVE_CHRONO_TIMEZONES
+      CHECK(fmt_lib::format(loc, "{}", tm).empty());  // no format specified
+      CHECK_THAT(fmt_lib::format(loc, "{:%c}", tm),   // HowardHinnant/date#704
                  Catch::Matchers::StartsWith("Mon 03 Jan 2022 08:04:05"));
-      CHECK(fmt::format(loc, "{:%x %X}", tm) == "03/01/22 08:04:05");
-      CHECK(fmt::format(loc, "{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+      CHECK(fmt_lib::format(loc, "{:%x %X}", tm) == "03/01/22 08:04:05");
+#else
+      CHECK(fmt_lib::format(loc, "{:%F %T}", tm) == "2022-01-03 08:04:05");
+#endif
+      CHECK(fmt_lib::format(loc, "{:%Y%m%d%H%M%S}", tm) == "20220103080405");
     } catch (const std::runtime_error &) {
       WARN("Locale en_GB not found, skip tests");
     }
@@ -148,11 +170,15 @@ TEST_CASE("Format zoned time", "[clock][util]") {
     try {
       const auto loc = std::locale::global(std::locale("en_US.UTF-8"));
 
-      CHECK(fmt::format("{}", tm).empty());  // no format specified
-      CHECK_THAT(fmt::format("{:%c}", tm),   // HowardHinnant/date#704
+#if not HAVE_CHRONO_TIMEZONES
+      CHECK(fmt_lib::format("{}", tm).empty());  // no format specified
+      CHECK_THAT(fmt_lib::format("{:%c}", tm),   // HowardHinnant/date#704
                  Catch::Matchers::StartsWith("Mon 03 Jan 2022 08:04:05 AM"));
-      CHECK(fmt::format("{:%x %X}", tm) == "01/03/2022 08:04:05 AM");
-      CHECK(fmt::format("{arg:%Y%m%d%H%M%S}", fmt::arg("arg", tm)) == "20220103080405");
+      CHECK(fmt_lib::format("{:%x %X}", tm) == "01/03/2022 08:04:05 AM");
+#else
+      CHECK(fmt_lib::format("{:%F %r}", tm) == "2022-01-03 08:04:05 AM");
+#endif
+      CHECK(fmt_lib::format("{:%Y%m%d%H%M%S}", tm) == "20220103080405");
 
       std::locale::global(loc);
     } catch (const std::runtime_error &) {


### PR DESCRIPTION
Hi @Alexays ,
This PR is created in order to fully switch clock module to use standard chrono library + format library in c++20.  date library by @HowardHinnant has been taken into standard in C++20. STL format library supports chrono now.
So clock module under C++20 now no more using fmt library and construct necessary information using STL.
One more major change: clock module is fully rewritten and as a base is using TZ(zoned time). It should minimize time conversion between local and zoned time. 
Structure of the helper include/util/date.hpp now provides compile time switching between 
"date/tz.h" + "fmt/chrono.h" <-> \<chrono> + \<format>
timezoned_time_list placeholder now is renamed to tz_list . This change is attracted in man page too.
\+ it should solve any issues during compilation when compiler gets ambiguous errors of the date/format functions

----

This PR is also a prerequisite to start digging into different calendar implementation (what is raised in #2260)