### PR TITLE
Fix for #2646

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -311,7 +311,8 @@ void Workspaces::on_workspace_created(std::string const &payload) {
 void Workspaces::on_workspace_moved(std::string const &payload) {
   std::string workspace = payload.substr(0, payload.find(','));
   std::string new_output = payload.substr(payload.find(',') + 1);
-  if (bar_.output->name == new_output) {  // TODO: implement this better
+  bool should_show = show_special() || ! workspace.starts_with("special");
+  if (should_show && bar_.output->name == new_output) {  // TODO: implement this better
     const Json::Value workspaces_json = gIPC->getSocket1JsonReply("workspaces");
     for (Json::Value workspace_json : workspaces_json) {
       std::string name = workspace_json["name"].asString();


### PR DESCRIPTION
When using more than one monitor, special workspaces may show in the workspace list while they don't with a single screen.
This patch addresses this issue.