### PR TITLE
hyprland module: added sort_workspaces after rename occured

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -339,6 +339,7 @@ void Workspaces::on_workspace_renamed(std::string const &payload) {
       break;
     }
   }
+  sort_workspaces();
 }
 
 void Workspaces::on_monitor_focused(std::string const &payload) {


### PR DESCRIPTION
added sorting of workspaces after a rename event got handled. The solution was mentioned in #2271