### PR TITLE
cpu_usage/linux: count iowait toward idle time

### DIFF
--- a/src/modules/cpu_usage/linux.cpp
+++ b/src/modules/cpu_usage/linux.cpp
@@ -21,8 +21,9 @@ std::vector<std::tuple<size_t, size_t>> waybar::modules::CpuUsage::parseCpuinfo(
 
     size_t idle_time = 0;
     size_t total_time = 0;
-    if (times.size() >= 4) {
-      idle_time = times[3];
+    if (times.size() >= 5) {
+      // idle + iowait
+      idle_time = times[3] + times[4];
       total_time = std::accumulate(times.begin(), times.end(), 0);
     }
     cpuinfo.emplace_back(idle_time, total_time);


### PR DESCRIPTION
The ```iowait``` time present in ```/proc/stat``` is a sub-category of idle, and therefore shouldn't count toward CPU usage. However, Waybar doesn't account for it when calculating the idle time, giving wrong results in some cases.

For example, when running the following command on an idle system, to create a completely I/O bound task pinned to the first CPU:

    taskset 1 dd if=/dev/sda of=/dev/null bs=1MB

Waybar displays the first CPU at 100% usage, which is incorrect, since the CPU is idle most of the time waiting for I/O, while other tools such as ```htop``` display the same CPU fairly close to 0%.