### PR TITLE
upower: show-icon config option

### DIFF
--- a/include/modules/upower/upower.hpp
+++ b/include/modules/upower/upower.hpp
@@ -72,6 +72,7 @@ class UPower : public AModule {
   std::unique_ptr<UPowerTooltip> upower_tooltip;
   std::string lastStatus;
   bool showAltText;
+  bool showIcon = true;
   bool upowerRunning;
   guint upowerWatcher_id;
   std::string nativePath_;

--- a/man/waybar-upower.5.scd
+++ b/man/waybar-upower.5.scd
@@ -57,6 +57,11 @@ compatible devices in the tooltip.
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*show-icon*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable battery icon
+
 # FORMAT REPLACEMENTS
 
 *{percentage}*: The battery capacity in percentage
@@ -93,6 +98,15 @@ depending on the charging state.
 	"tooltip": true,
 	"tooltip-spacing": 20
 }
+```
+```
+"upower": {
+	"show-icon": false,
+	"hide-if-empty": true,
+	"tooltip": true,
+	"tooltip-spacing": 20
+}
+
 ```
 
 # STYLE

--- a/man/waybar-upower.5.scd
+++ b/man/waybar-upower.5.scd
@@ -60,7 +60,7 @@ compatible devices in the tooltip.
 *show-icon*: ++
 	typeof: bool ++
 	default: true ++
-	Option to disable battery icon
+	Option to disable battery icon.
 
 # FORMAT REPLACEMENTS
 

--- a/src/modules/upower/upower.cpp
+++ b/src/modules/upower/upower.cpp
@@ -18,7 +18,15 @@ UPower::UPower(const std::string& id, const Json::Value& config)
       m_Mutex(),
       client(),
       showAltText(false) {
-  box_.pack_start(icon_);
+  // Show icon only when "show-icon" isn't set to false
+  if (config_["show-icon"].isBool()) {
+    showIcon = config_["show-icon"].asBool();
+  }
+
+  if (showIcon) {
+    box_.pack_start(icon_);
+  }
+
   box_.pack_start(label_);
   box_.set_name(name_);
   event_box_.add(box_);


### PR DESCRIPTION
Adds the ability to hide the battery icon in the upower module. ie.
```json
    "upower": {
      "show-icon": false,
      "hide-if-empty": false,
      "tooltip": true,
      "tooltip-spacing": 20,
      "format": "{percentage}",
      "format-alt": "{percentage} {time}"
   }
```