### PR TITLE
battery: remove inotify since it doesn't serve much purpose

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -1,14 +1,12 @@
 #pragma once
 
+#include <unordered_set>
 #ifdef FILESYSTEM_EXPERIMENTAL
 #include <experimental/filesystem>
 #else
 #include <filesystem>
 #endif
 #include <fmt/format.h>
-#if defined(__linux__)
-#include <sys/inotify.h>
-#endif
 
 #include <algorithm>
 #include <fstream>
@@ -35,23 +33,16 @@ class Battery : public ALabel {
  private:
   static inline const fs::path data_dir_ = "/sys/class/power_supply/";
 
-  void refreshBatteries();
-  void worker();
+  void findBatteries();
   const std::string getAdapterStatus(uint8_t capacity) const;
   const std::tuple<uint8_t, float, std::string, float> getInfos();
   const std::string formatTimeRemaining(float hoursRemaining);
 
-  int global_watch;
-  std::map<fs::path, int> batteries_;
+  std::unordered_set<fs::path> batteries_;
   fs::path adapter_;
-  int battery_watch_fd_;
-  int global_watch_fd_;
-  std::mutex battery_list_mutex_;
   std::string old_status_;
   bool warnFirstTime_{true};
 
-  util::SleeperThread thread_;
-  util::SleeperThread thread_battery_update_;
   util::SleeperThread thread_timer_;
 };
 

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -7,90 +7,21 @@
 #include <iostream>
 waybar::modules::Battery::Battery(const std::string& id, const Json::Value& config)
     : ALabel(config, "battery", id, "{capacity}%", 60) {
-#if defined(__linux__)
-  battery_watch_fd_ = inotify_init1(IN_CLOEXEC);
-  if (battery_watch_fd_ == -1) {
-    throw std::runtime_error("Unable to listen batteries.");
-  }
-
-  global_watch_fd_ = inotify_init1(IN_CLOEXEC);
-  if (global_watch_fd_ == -1) {
-    throw std::runtime_error("Unable to listen batteries.");
-  }
-
-  // Watch the directory for any added or removed batteries
-  global_watch = inotify_add_watch(global_watch_fd_, data_dir_.c_str(), IN_CREATE | IN_DELETE);
-  if (global_watch < 0) {
-    throw std::runtime_error("Could not watch for battery plug/unplug");
-  }
-#endif
-  worker();
-}
-
-waybar::modules::Battery::~Battery() {
-#if defined(__linux__)
-  std::lock_guard<std::mutex> guard(battery_list_mutex_);
-
-  if (global_watch >= 0) {
-    inotify_rm_watch(global_watch_fd_, global_watch);
-  }
-  close(global_watch_fd_);
-
-  for (auto it = batteries_.cbegin(), next_it = it; it != batteries_.cend(); it = next_it) {
-    ++next_it;
-    auto watch_id = (*it).second;
-    if (watch_id >= 0) {
-      inotify_rm_watch(battery_watch_fd_, watch_id);
-    }
-    batteries_.erase(it);
-  }
-  close(battery_watch_fd_);
-#endif
-}
-
-void waybar::modules::Battery::worker() {
-#if defined(__FreeBSD__)
+  findBatteries();
   thread_timer_ = [this] {
     dp.emit();
     thread_timer_.sleep_for(interval_);
   };
-#else
-  thread_timer_ = [this] {
-    // Make sure we eventually update the list of batteries even if we miss an
-    // inotify event for some reason
-    refreshBatteries();
-    dp.emit();
-    thread_timer_.sleep_for(interval_);
-  };
-  thread_ = [this] {
-    struct inotify_event event = {0};
-    int nbytes = read(battery_watch_fd_, &event, sizeof(event));
-    if (nbytes != sizeof(event) || event.mask & IN_IGNORED) {
-      thread_.stop();
-      return;
-    }
-    dp.emit();
-  };
-  thread_battery_update_ = [this] {
-    struct inotify_event event = {0};
-    int nbytes = read(global_watch_fd_, &event, sizeof(event));
-    if (nbytes != sizeof(event) || event.mask & IN_IGNORED) {
-      thread_.stop();
-      return;
-    }
-    refreshBatteries();
-    dp.emit();
-  };
-#endif
 }
 
-void waybar::modules::Battery::refreshBatteries() {
+waybar::modules::Battery::~Battery() {}
+
+void waybar::modules::Battery::findBatteries() {
 #if defined(__linux__)
-  std::lock_guard<std::mutex> guard(battery_list_mutex_);
   // Mark existing list of batteries as not necessarily found
   std::map<fs::path, bool> check_map;
   for (auto const& bat : batteries_) {
-    check_map[bat.first] = false;
+    check_map[bat] = false;
   }
 
   try {
@@ -122,13 +53,7 @@ void waybar::modules::Battery::refreshBatteries() {
           check_map[node.path()] = true;
           auto search = batteries_.find(node.path());
           if (search == batteries_.end()) {
-            // We've found a new battery save it and start listening for events
-            auto event_path = (node.path() / "uevent");
-            auto wd = inotify_add_watch(battery_watch_fd_, event_path.c_str(), IN_ACCESS);
-            if (wd < 0) {
-              throw std::runtime_error("Could not watch events for " + node.path().string());
-            }
-            batteries_[node.path()] = wd;
+            batteries_.insert(node.path());
           }
         }
       }
@@ -154,10 +79,6 @@ void waybar::modules::Battery::refreshBatteries() {
   // Remove any batteries that are no longer present and unwatch them
   for (auto const& check : check_map) {
     if (!check.second) {
-      auto watch_id = batteries_[check.first];
-      if (watch_id >= 0) {
-        inotify_rm_watch(battery_watch_fd_, watch_id);
-      }
       batteries_.erase(check.first);
     }
   }
@@ -180,8 +101,6 @@ static bool status_gt(const std::string& a, const std::string& b) {
 }
 
 const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::getInfos() {
-  std::lock_guard<std::mutex> guard(battery_list_mutex_);
-
   try {
 #if defined(__FreeBSD__)
     /* Allocate state of battery units reported via ACPI. */
@@ -252,7 +171,7 @@ const std::tuple<uint8_t, float, std::string, float> waybar::modules::Battery::g
 
     std::string status = "Unknown";
     for (auto const& item : batteries_) {
-      auto bat = item.first;
+      auto bat = item;
       std::string _status;
 
       /* Check for adapter status if battery is not available */


### PR DESCRIPTION
> Inotify  reports  only  events that a user-space program triggers through the filesystem API.  As a result, it does not
> catch remote events that occur on network filesystems.  (Applications must fall back to polling the filesystem to catch
> such  events.)  Furthermore, various pseudo-filesystems such as /proc, /sys, and /dev/pts are not monitorable with inotify.
-- [inotify(7) manpage](https://man7.org/linux/man-pages/man7/inotify.7.html)

Relevant issue: https://github.com/Alexays/Waybar/issues/2662

This pull request removes inotify integration for the battery module because inotify can't observe changes to the /sys filesystem when made from the kernel-side. This leads to behaviour where the widget only updates on interval or when something else accesses one of the files (eg. `cat /sys/class/power_supply/BAT0/uevent`). Now this also means that removing/adding new batteries isn't handled properly.

So maybe the actual solution is to copy whatever upower does or just deprecate the battery module?