### PR TITLE
Clear README.md from duplicated list of distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Waybar [![Licence](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE) [![Paypal Donate](https://img.shields.io/badge/Donate-Paypal-2244dd.svg)](https://paypal.me/ARouillard)<br>![Waybar](https://raw.githubusercontent.com/alexays/waybar/master/preview-2.png)
 
 > Highly customizable Wayland bar for Sway and Wlroots based compositors.<br>
-> Available in Arch [extra](https://www.archlinux.org/packages/extra/x86_64/waybar/) or
-[AUR](https://aur.archlinux.org/packages/waybar-git/), [Gentoo](https://packages.gentoo.org/packages/gui-apps/waybar), [openSUSE](https://build.opensuse.org/package/show/X11:Wayland/waybar), and [Alpine Linux](https://pkgs.alpinelinux.org/packages?name=waybar).<br>
+> Available in [all major distributions](https://github.com/Alexays/Waybar/wiki/Installation)<br>
 > *Waybar [examples](https://github.com/Alexays/Waybar/wiki/Examples)*
 
 #### Current features


### PR DESCRIPTION
It doesn’t make sense to keep the list in README.md when we maintain it in Wiki as well.