### PR TITLE
Sway/workspaces: fix persistent icon

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -314,7 +314,7 @@ std::string Workspaces::getIcon(const std::string &name, const Json::Value &node
       if (config_["format-icons"][key].isString() && node[key].asBool()) {
         return config_["format-icons"][key].asString();
       }
-    } else if (config_["format_icons"]["persistent"].isString() &&
+    } else if (config_["format-icons"]["persistent"].isString() &&
                node["target_output"].isString()) {
       return config_["format-icons"]["persistent"].asString();
     } else if (config_["format-icons"][key].isString()) {


### PR DESCRIPTION
Fix persistent icon in sway/workspaces module.
![2023-12-11-00_14_42](https://github.com/Alexays/Waybar/assets/153450059/21a60763-48da-4753-9a9f-7c624e3b8824)
![2023-12-11-00_15_07](https://github.com/Alexays/Waybar/assets/153450059/ac4820be-b64e-4209-a724-c6970ab73085)
