### PR TITLE
Added sudo, python3-pip & python3-venv to debian image, required for clang-tidy GH action

### DIFF
--- a/Dockerfiles/debian
+++ b/Dockerfiles/debian
@@ -2,6 +2,12 @@
 
 FROM debian:sid
 
-RUN apt-get update && \
-    apt-get install -y build-essential meson ninja-build git pkg-config libinput10 libpugixml-dev libinput-dev wayland-protocols libwayland-client0 libwayland-cursor0 libwayland-dev libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libxkbcommon-dev libudev-dev libpixman-1-dev libgtkmm-3.0-dev libjsoncpp-dev scdoc libdbusmenu-gtk3-dev libnl-3-dev libnl-genl-3-dev libpulse-dev libmpdclient-dev gobject-introspection libgirepository1.0-dev libxkbcommon-dev libxkbregistry-dev libxkbregistry0 libplayerctl-dev && \
-    apt-get clean
+RUN apt update && \
+    apt install -y \
+        build-essential meson ninja-build git pkg-config libinput10 libpugixml-dev libinput-dev     \
+        wayland-protocols libwayland-client0 libwayland-cursor0 libwayland-dev                      \
+        libegl1-mesa-dev libgles2-mesa-dev libgbm-dev libxkbcommon-dev libudev-dev libpixman-1-dev  \
+        libgtkmm-3.0-dev libjsoncpp-dev scdoc libdbusmenu-gtk3-dev libnl-3-dev libnl-genl-3-dev     \
+        libpulse-dev libmpdclient-dev gobject-introspection libgirepository1.0-dev libxkbcommon-dev \
+        libxkbregistry-dev libxkbregistry0 libplayerctl-dev sudo python3-venv python3-pip &&        \
+    apt clean


### PR DESCRIPTION
* Added `sudo python3-venv python3-pip`
* Formatted Dockerfile

These packages are required for the clang-tidy action we talked about here: https://github.com/Alexays/Waybar/pull/2720#issuecomment-1845155151

PR for clang-tidy action coming soon (after this is merged and a new debian image is uploaded).