### PR TITLE
Specify config is JSONC

### DIFF
--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -6,7 +6,7 @@ waybar - configuration file
 
 # DESCRIPTION
 
-The configuration uses the JSONC file format and is named *config*.
+The configuration uses the JSONC file format and is named *config* or *config.jsonc*.
 
 Valid locations for this file are:
 

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -10,11 +10,11 @@ The configuration uses the JSONC file format and is named *config* or *config.js
 
 Valid locations for this file are:
 
-- *$XDG_CONFIG_HOME/waybar/config*
-- *~/.config/waybar/config*
-- *~/waybar/config*
-- */etc/xdg/waybar/config*
-- *@sysconfdir@/xdg/waybar/config*
+- *$XDG_CONFIG_HOME/waybar/*
+- *~/.config/waybar/*
+- *~/waybar/*
+- */etc/xdg/waybar/*
+- *@sysconfdir@/xdg/waybar/*
 
 A good starting point is the default configuration found at https://github.com/Alexays/Waybar/blob/master/resources/config
 Also, a minimal example configuration can be found at the bottom of this man page.

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -6,7 +6,7 @@ waybar - configuration file
 
 # DESCRIPTION
 
-The configuration uses the JSON file format and is named *config*.
+The configuration uses the JSONC file format and is named *config*.
 
 Valid locations for this file are:
 


### PR DESCRIPTION
I always find pure JSON cumbersome for configuration files due to the lack of support for comments. Seeing up-front that the configuration file is actually JSONC would have aided my adoption of waybar.

Changes proposed in this pull request:

- Clarify that the configuration file is JSON*C* format
- The configuration file can also be named config.jsonc
- Remove 'config' from list of documented valid locations