### PR TITLE
fix:the workspace data is null in a small probability

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -163,7 +163,11 @@ auto Workspaces::update() -> void {
   // add workspaces that wait to be created
   unsigned int currentCreateWorkspaceNum = 0;
   for (Json::Value const &workspaceToCreate : m_workspacesToCreate) {
-    createWorkspace(workspaceToCreate);
+    if (workspaceToCreate.isMember("name")) { //the data is ready
+      createWorkspace(workspaceToCreate);
+    } else {
+      break;
+    }
     currentCreateWorkspaceNum++;
   }
   for (unsigned int i = 0; i < currentCreateWorkspaceNum; i++) {


### PR DESCRIPTION
Hey, i found a small probability bug.

the `workspaceToCreate` json object is ready in here:
![image](https://github.com/Alexays/Waybar/assets/30348075/f3ae3d68-9663-4760-9594-32646ffb5fa5)

but sometime,when the `workspaceToCreate` json data which get from m_workspacesToCreate in here will be `null`.
![image](https://github.com/Alexays/Waybar/assets/30348075/b0ad923c-5b24-4547-bbda-65be212d86b4)
![image](https://github.com/Alexays/Waybar/assets/30348075/7f00a81d-fde8-4945-8731-305ad3e9677c)


i think that,when the data is push in m_workspacesToCreate is not ready, it already be read. so we need to judge whether the data is ready. 