### PR TITLE
Bump clang-tidy cpp-linter-action version to v2.7.5

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           meson -Dcpp_std=c++20 build  # necessary to generate compile_commands.json
           ninja -C build               # necessary to find certain .h files (xdg, wayland, etc.)
-      - uses: zjeffer/cpp-linter-action@test/process-compilation-database
+      - uses: cpp-linter/cpp-linter-action@v2.7.5
         name: clang-tidy
         id: clang-tidy-check
         env:


### PR DESCRIPTION
Reason: https://github.com/Alexays/Waybar/pull/2755#discussion_r1435861701

Thanks for all the help @2bndy5!