### PR TITLE
Bump cross-platform-action to attempt fixing freebsd runner

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Test in FreeBSD VM
-        uses: cross-platform-actions/action@v0.19.1
+        uses: cross-platform-actions/action@v0.21.1
         timeout-minutes: 180
         with:
           operating_system: freebsd


### PR DESCRIPTION
I noticed the freebsd action fails more than half the time during teardown of the VM, so I thought maybe updating the action to the latest release would fix this. Last release was from 2023-10-07, now updating to the release from 2023-11-03. 