### PR TITLE
fix `restart-interval` being ignored while `signal` is defined (#2650)

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -14,7 +14,8 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
       fp_(nullptr),
       pid_(-1) {
   dp.emit();
-  if (!config_["signal"].empty() && config_["interval"].empty() && config_["restart-interval"].empty()) {
+  if (!config_["signal"].empty() && config_["interval"].empty() && 
+      config_["restart-interval"].empty()) {
     waitingWorker();
   } else if (interval_.count() > 0) {
     delayWorker();

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -14,7 +14,7 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
       fp_(nullptr),
       pid_(-1) {
   dp.emit();
-  if (!config_["signal"].empty() && config_["interval"].empty() && 
+  if (!config_["signal"].empty() && config_["interval"].empty() &&
       config_["restart-interval"].empty()) {
     waitingWorker();
   } else if (interval_.count() > 0) {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -14,7 +14,7 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
       fp_(nullptr),
       pid_(-1) {
   dp.emit();
-  if (!config_["signal"].empty() && config_["interval"].empty()) {
+  if (!config_["signal"].empty() && config_["interval"].empty() && config_["restart-interval"].empty()) {
     waitingWorker();
   } else if (interval_.count() > 0) {
     delayWorker();


### PR DESCRIPTION
Bug popped up from my previous PR (#2517) where users with modules that had both a `restart-interval` and `signal` defined would end up with a module that behaves as though only a signal is defined.

This PR fixes this issue (#2650).