### PR TITLE
hyprland/workspaces: allow using the original window class/title

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -24,7 +24,7 @@ Addressed by *hyprland/workspaces*
 *window-rewrite*: ++
 	typeof: object ++
 	Regex rules to map window class to an icon or preferred method of representation for a workspace's window.
-	Keys are the rules, while the values are the methods of representation.
+	Keys are the rules, while the values are the methods of representation. Values may use the placeholders {class} and {title} to use the window's original class and/or title respectively.
 	Rules may specify `class<...>`, `title<...>`, or both in order to fine-tune the matching.
 
 *window-rewrite-default*:

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -891,7 +891,9 @@ std::string Workspaces::getRewrite(std::string window_class, std::string window_
   } else {
     windowReprKey = fmt::format("class<{}>", window_class);
   }
-  return m_windowRewriteRules.get(windowReprKey);
+  auto const rewriteRule = m_windowRewriteRules.get(windowReprKey);
+  return fmt::format(fmt::runtime(rewriteRule), fmt::arg("class", window_class),
+                     fmt::arg("title", window_title));
 }
 
 WindowCreationPayload::WindowCreationPayload(std::string workspace_name,


### PR DESCRIPTION
This turns the values of window rewrite rules in hyprland/workspaces from static strings to format strings with the values {class} and {title} available.

For example, I'm now doing this to list windows in each workspace without having to add a rule for every application I use:
```
  "hyprland/workspaces": {
    "format": "{name}: {windows}",
    "window-rewrite-default": "{class}",
  },
```

![image](https://github.com/Alexays/Waybar/assets/2174843/c770f24e-6791-4057-87cb-9308fa8f1c15)
