### PR TITLE
Improvements for Hyprland worskspaces & backend

### DIFF
--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -1,11 +1,9 @@
 #pragma once
 
-#include <functional>
 #include <list>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 #include <utility>
 
 #include "util/json.hpp"
@@ -25,16 +23,16 @@ class IPC {
   void registerForIPC(const std::string&, EventHandler*);
   void unregisterForIPC(EventHandler*);
 
-  std::string getSocket1Reply(const std::string& rq);
+  static std::string getSocket1Reply(const std::string& rq);
   Json::Value getSocket1JsonReply(const std::string& rq);
 
  private:
   void startIPC();
   void parseIPC(const std::string&);
 
-  std::mutex callbackMutex;
-  util::JsonParser parser_;
-  std::list<std::pair<std::string, EventHandler*>> callbacks;
+  std::mutex m_callbackMutex;
+  util::JsonParser m_parser;
+  std::list<std::pair<std::string, EventHandler*>> m_callbacks;
 };
 
 inline std::unique_ptr<IPC> gIPC;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -161,6 +161,8 @@ class Workspaces : public AModule, public EventHandler {
 
   int windowRewritePriorityFunction(std::string const& window_rule);
 
+  void doUpdate();
+
   bool m_allOutputs = false;
   bool m_showSpecial = false;
   bool m_activeOnly = false;


### PR DESCRIPTION

1. Fix warnings reported by clang tidy
2. (backend) Use unique lock instead of manully lock/unlock on mutex.
   The RAII style locking makes sure mutex is unlocked when exceptions are thrown
3. (workspaces) Utilize `m_mutex` to safeguard member fields of `hyprland::Workspaces` as they are modified by multiple threads, including the event listener thread and UI thread. This applies to all member fields, not just `m_workspacesToCreate`.
4. (workspaces) Tidy up the create/remove workspace code.
