### PR TITLE
Fix/Hyprland/Workspaces: Window Rewrite on multiple non-overlapping bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 #### Current features
 - Sway (Workspaces, Binding mode, Focused window name)
 - River (Mapping mode, Tags, Focused window name)
-- Hyprland (Focused window name)
+- Hyprland (Window Icons, Workspaces, Focused window name)
 - DWL (Tags) [requires dwl ipc patch](https://github.com/djpohly/dwl/wiki/ipc)
 - Tray [#21](https://github.com/Alexays/Waybar/issues/21)
 - Local time

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -163,9 +163,17 @@ class Workspaces : public AModule, public EventHandler {
 
   void doUpdate();
 
+  void extendOrphans(int workspaceId, Json::Value const& clientsJson);
+  void registerOrphanWindow(WindowCreationPayload create_window_paylod);
+
   bool m_allOutputs = false;
   bool m_showSpecial = false;
   bool m_activeOnly = false;
+
+  // Map for windows stored in workspaces not present in the current bar.
+  // This happens when the user has multiple monitors (hence, multiple bars)
+  // and doesn't share windows accross bars (a.k.a `all-outputs` = false)
+  std::map<WindowAddress, std::string> m_orphanWindowMap;
 
   enum class SortMethod { ID, NAME, NUMBER, DEFAULT };
   util::EnumParser<SortMethod> m_enumParser;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -145,7 +145,8 @@ class Workspaces : public AModule, public EventHandler {
   // workspace events
   void onWorkspaceActivated(std::string const& payload);
   void onWorkspaceDestroyed(std::string const& payload);
-  void onWorkspaceCreated(std::string const& payload);
+  void onWorkspaceCreated(std::string const& workspaceName,
+                          Json::Value const& clientsData = Json::Value::nullRef);
   void onWorkspaceMoved(std::string const& payload);
   void onWorkspaceRenamed(std::string const& payload);
 
@@ -199,7 +200,7 @@ class Workspaces : public AModule, public EventHandler {
   uint64_t m_monitorId;
   std::string m_activeWorkspaceName;
   std::vector<std::unique_ptr<Workspace>> m_workspaces;
-  std::vector<Json::Value> m_workspacesToCreate;
+  std::vector<std::pair<Json::Value, Json::Value>> m_workspacesToCreate;
   std::vector<std::string> m_workspacesToRemove;
   std::vector<WindowCreationPayload> m_windowsToCreate;
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1023,6 +1023,11 @@ void WindowCreationPayload::clearWorkspaceName() {
     m_workspaceName = m_workspaceName.substr(
         SPECIAL_QUALIFIER_PREFIX_LEN, m_workspaceName.length() - SPECIAL_QUALIFIER_PREFIX_LEN);
   }
+
+  std::size_t spaceFound = m_workspaceName.find(' ');
+  if (spaceFound != std::string::npos) {
+    m_workspaceName.erase(m_workspaceName.begin() + spaceFound, m_workspaceName.end());
+  }
 }
 
 void WindowCreationPayload::moveToWorksace(std::string &new_workspace_name) {


### PR DESCRIPTION


## About the Problem

An issue exists when using the Window Rewrite feature on Hyprland/Workspaces. The issue manifests only when the user has `all_outputs = false` on their configuration and moves a window from one of monitor A's workspaces to one of monitor B's workspaces. When that happens, the window's icon vanishes, and can only be seen again if the bar is restarted.

This happens because on this setup, not all workspaces exist accross all bar instances. The way that window moving works is that it "cuts" the icon from workspace 1 and "pastes" it to workspace 2, avoiding having to re-process the window's icon. However, since the origin workspace might not exist on one of the bar's instances, the window is rendered empty.

## About the Solution

This PR introduces a new map `Workspacess::m_orphanWindowMap` which will now hold every window that couldn't be assigned to a workspace. This is then used when moving windows around if the origin workspace is not present on that bar's instance.

## Related PRs

Although #2809 also fixes the same issue, it does so by fetching the `clients` data on every call to `Workspaces::update()`. The solution being introduced here should hopefully be enough to avoid what might be a resource-intensive call.

CC: @zjeffer @khaneliman