### PR TITLE
fix(tray): completely hide tray when it is empty

### DIFF
--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -38,7 +38,7 @@ void Tray::onRemove(std::unique_ptr<Item>& item) {
 
 auto Tray::update() -> void {
   // Show tray only when items are available
-  box_.set_visible(!box_.get_children().empty());
+  event_box_.set_visible(!box_.get_children().empty());
   // Call parent update
   AModule::update();
 }


### PR DESCRIPTION
Given the following tray:
![populated](https://github.com/Alexays/Waybar/assets/61563764/1a595756-d399-48c4-b649-8668c2dcf7aa)


Before when empty:
![space](https://github.com/Alexays/Waybar/assets/61563764/5de32452-b0d0-489b-88c1-ef0d7a4b414a)


After when empty:
![no-space](https://github.com/Alexays/Waybar/assets/61563764/8b6c6d61-5346-4aea-b877-44c9f2e06153)