### PR TITLE
clock: fix construction with calendar.format.today

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -84,7 +84,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
       fmtMap_.insert({3, config_[kCldPlaceholder]["format"]["today"].asString()});
       cldBaseDay_ =
           year_month_day{
-              floor<days>(zoned_time{nullptr, system_clock::now()}.get_local_time())}
+              floor<days>(zoned_time{current_zone(), system_clock::now()}.get_local_time())}
               .day();
     } else
       fmtMap_.insert({3, "{}"});


### PR DESCRIPTION
Fixes #2839.

I don't think the calendar will follow runtime timezone changes, but at least the clock will since #2838.