### PR TITLE
Fix use after free on task close

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -527,11 +527,11 @@ void Task::handle_closed() {
   spdlog::debug("{} closed", repr());
   zwlr_foreign_toplevel_handle_v1_destroy(handle_);
   handle_ = nullptr;
-  tbar_->remove_task(id_);
   if (button_visible_) {
     tbar_->remove_button(button);
     button_visible_ = false;
   }
+  tbar_->remove_task(id_);
 }
 
 bool Task::handle_clicked(GdkEventButton *bt) {


### PR DESCRIPTION
Found with address sanitizer.
```[2024-01-21 18:45:27.544] [info] Using configuration file /home/user/.config/waybar/config
[2024-01-21 18:45:27.544] [info] Including resource file: ~/.config/waybar/modules.json
[2024-01-21 18:45:27.550] [info] Discovered appearance 'dark'
[2024-01-21 18:45:27.550] [info] Using CSS file /home/user/.config/waybar/style.css
[2024-01-21 18:45:27.568] [info] Hyprland IPC starting
[2024-01-21 18:45:27.570] [warning] Mapping is not an object
[2024-01-21 18:45:27.950] [info] Bar configured (width: 3199, height: 37) for output: HDMI-A-1
=================================================================
==1859634==ERROR: AddressSanitizer: heap-use-after-free on address 0x6170001e74b0 at pc 0x559c25af1f77 bp 0x7ffd6a642b80 sp 0x7ffd6a642b70
READ of size 1 at 0x6170001e74b0 thread T0
    #0 0x559c25af1f76 in waybar::modules::wlr::Task::handle_closed() ../src/modules/wlr/taskbar.cpp:531
    #1 0x559c25aeb9cd in tl_handle_closed ../src/modules/wlr/taskbar.cpp:255
    #2 0x7f364c4934f5  (/usr/lib/libffi.so.8+0x74f5) (BuildId: 5c6b22b6624dd486a0783dfe74fee085b626b573)
    #3 0x7f364c48ff5d  (/usr/lib/libffi.so.8+0x3f5d) (BuildId: 5c6b22b6624dd486a0783dfe74fee085b626b573)
    #4 0x7f364c492b72 in ffi_call (/usr/lib/libffi.so.8+0x6b72) (BuildId: 5c6b22b6624dd486a0783dfe74fee085b626b573)
    #5 0x7f364e4f6644  (/usr/lib/libwayland-client.so.0+0x7644) (BuildId: e4a011d41a1dcd03e700f1b6c88f84409ed2191b)
    #6 0x7f364e4f6e72  (/usr/lib/libwayland-client.so.0+0x7e72) (BuildId: e4a011d41a1dcd03e700f1b6c88f84409ed2191b)
    #7 0x7f364e4f713b in wl_display_dispatch_queue_pending (/usr/lib/libwayland-client.so.0+0x813b) (BuildId: e4a011d41a1dcd03e700f1b6c88f84409ed2191b)
    #8 0x7f364cd6aa38  (/usr/lib/libgdk-3.so.0+0x64a38) (BuildId: f079f73a2d069886061139cda1c857c677aabede)
    #9 0x7f364cd36fa8 in gdk_display_get_event (/usr/lib/libgdk-3.so.0+0x30fa8) (BuildId: f079f73a2d069886061139cda1c857c677aabede)
    #10 0x7f364cd72237  (/usr/lib/libgdk-3.so.0+0x6c237) (BuildId: f079f73a2d069886061139cda1c857c677aabede)
    #11 0x7f364c94ff68  (/usr/lib/libglib-2.0.so.0+0x59f68) (BuildId: d310ee36df88b18d95f79813384e6f7decd59c68)
    #12 0x7f364c9ae366  (/usr/lib/libglib-2.0.so.0+0xb8366) (BuildId: d310ee36df88b18d95f79813384e6f7decd59c68)
    #13 0x7f364c94e161 in g_main_context_iteration (/usr/lib/libglib-2.0.so.0+0x58161) (BuildId: d310ee36df88b18d95f79813384e6f7decd59c68)
    #14 0x7f364cc0cb65 in g_application_run (/usr/lib/libgio-2.0.so.0+0xdfb65) (BuildId: 895d79e5cc47d609ac2f19b0d8174b11176cd967)
    #15 0x559c25912ffc in waybar::Client::main(int, char**) ../src/client.cpp:275
    #16 0x559c258c90b7 in main ../src/main.cpp:106
    #17 0x7f364c045ccf  (/usr/lib/libc.so.6+0x27ccf) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #18 0x7f364c045d89 in __libc_start_main (/usr/lib/libc.so.6+0x27d89) (BuildId: 8bfe03f6bf9b6a6e2591babd0bbc266837d8f658)
    #19 0x559c257f6a04 in _start (/home/user/Workspace/Waybar/build/waybar+0x122a04) (BuildId: af962d9dea8a574922fa12706cab057adda32b32)

0x6170001e74b0 is located 432 bytes inside of 648-byte region [0x6170001e7300,0x6170001e7588)
freed by thread T0 here:
    #0 0x7f364dee311a in operator delete(void*, unsigned long) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:164
    #1 0x559c25b0a09e in std::default_delete<waybar::modules::wlr::Task>::operator()(waybar::modules::wlr::Task*) const /usr/include/c++/13.2.1/bits/unique_ptr.h:99
    #2 0x559c25b0536c in std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >::~unique_ptr() /usr/include/c++/13.2.1/bits/unique_ptr.h:404
    #3 0x559c25b1479d in void std::destroy_at<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > >(std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >*) (/home/user/Workspace/Waybar/build/waybar+0x44079d) (BuildId: af962d9dea8a574922fa12706cab057adda32b32)
    #4 0x559c25b0aa33 in void std::allocator_traits<std::allocator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > > >::destroy<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > >(std::allocator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > >&, std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >*) /usr/include/c++/13.2.1/bits/alloc_traits.h:559
    #5 0x559c25b0aa33 in std::vector<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >, std::allocator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > > >::_M_erase(__gnu_cxx::__normal_iterator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >*, std::vector<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >, std::allocator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > > > >) /usr/include/c++/13.2.1/bits/vector.tcc:187
    #6 0x559c25b0572e in std::vector<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >, std::allocator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > > >::erase(__gnu_cxx::__normal_iterator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > const*, std::vector<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> >, std::allocator<std::unique_ptr<waybar::modules::wlr::Task, std::default_delete<waybar::modules::wlr::Task> > > > >) /usr/include/c++/13.2.1/bits/stl_vector.h:1532
    #7 0x559c25af9d2b in waybar::modules::wlr::Taskbar::remove_task(unsigned int) ../src/modules/wlr/taskbar.cpp:916
    #8 0x559c25af1f3e in waybar::modules::wlr::Task::handle_closed() ../src/modules/wlr/taskbar.cpp:530
    #9 0x559c25aeb9cd in tl_handle_closed ../src/modules/wlr/taskbar.cpp:255
    #10 0x7f364c4934f5  (/usr/lib/libffi.so.8+0x74f5) (BuildId: 5c6b22b6624dd486a0783dfe74fee085b626b573)

previously allocated by thread T0 here:
    #0 0x7f364dee2002 in operator new(unsigned long) /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x559c25b051c7 in std::__detail::_MakeUniq<waybar::modules::wlr::Task>::__single_object std::make_unique<waybar::modules::wlr::Task, waybar::Bar const&, Json::Value const&, waybar::modules::wlr::Taskbar*, zwlr_foreign_toplevel_handle_v1*&, wl_seat*&>(waybar::Bar const&, Json::Value const&, waybar::modules::wlr::Taskbar*&&, zwlr_foreign_toplevel_handle_v1*&, wl_seat*&) /usr/include/c++/13.2.1/bits/unique_ptr.h:1070
    #2 0x559c25af9487 in waybar::modules::wlr::Taskbar::handle_toplevel_create(zwlr_foreign_toplevel_handle_v1*) ../src/modules/wlr/taskbar.cpp:885
    #3 0x559c25af8cd0 in tm_handle_toplevel ../src/modules/wlr/taskbar.cpp:838
    #4 0x7f364c4934f5  (/usr/lib/libffi.so.8+0x74f5) (BuildId: 5c6b22b6624dd486a0783dfe74fee085b626b573)

SUMMARY: AddressSanitizer: heap-use-after-free ../src/modules/wlr/taskbar.cpp:531 in waybar::modules::wlr::Task::handle_closed()
Shadow bytes around the buggy address:
  0x6170001e7200: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x6170001e7280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x6170001e7300: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x6170001e7380: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x6170001e7400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
=>0x6170001e7480: fd fd fd fd fd fd[fd]fd fd fd fd fd fd fd fd fd
  0x6170001e7500: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x6170001e7580: fd fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x6170001e7600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x6170001e7680: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x6170001e7700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1859634==ABORTING
```