### PR TITLE
Fix module UPower display device poniter

### DIFF
--- a/include/modules/upower/upower.hpp
+++ b/include/modules/upower/upower.hpp
@@ -66,7 +66,7 @@ class UPower : public AModule {
   Devices devices;
   std::mutex m_Mutex;
   UpClient *client;
-  UpDevice *displayDevice;
+  UpDevice *displayDevice = nullptr;
   guint login1_id;
   GDBusConnection *login1_connection;
   std::unique_ptr<UPowerTooltip> upower_tooltip;


### PR DESCRIPTION
Force displayDevice to be a nullptr on class setup

Should fix seg faults and device not displaying

Current code expects UPower::displayDevice to be initially null. If it is not, as was the case on my box, it can lead to seg faults or the device not displaying information 