### PR TITLE
Add "empty" class for Image module when path/exec is returning an empty value.

### DIFF
--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -87,3 +87,4 @@ $path\\n$tooltip
 # STYLE
 
 - *#image*
+- *#image.empty*

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -63,9 +63,11 @@ auto waybar::modules::Image::update() -> void {
     }
     image_.set(pixbuf);
     image_.show();
+    image_.get_style_context()->remove_class("empty");
   } else {
     image_.clear();
     image_.hide();
+    image_.get_style_context()->add_class("empty");
   }
 
   AModule::update();


### PR DESCRIPTION
If `path` or returned value by `exec`, adds the `.empty` CSS class.

style.css:
```css
#image {
    background-color: green;
    padding: 10px; 
}

#image.empty {
    padding: 0px;
}
```

results in totally hiding the module.