### PR TITLE
pulseaudio: reconnect context when pulseaudio server restarts

### DIFF
--- a/include/util/audio_backend.hpp
+++ b/include/util/audio_backend.hpp
@@ -22,6 +22,7 @@ class AudioBackend {
   static void sourceInfoCb(pa_context*, const pa_source_info* i, int, void* data);
   static void serverInfoCb(pa_context*, const pa_server_info*, void*);
   static void volumeModifyCb(pa_context*, int, void*);
+  void connectContext();
 
   pa_threaded_mainloop* mainloop_;
   pa_mainloop_api* mainloop_api_;


### PR DESCRIPTION
For some reason, I sometimes restart the pulseaudio server (pipewire-pulse actually). But after restart, waybar's pulseaudio module just stop updating. The solution is to restart the whole waybar.
So I think it would be better if waybar itself could reconnect to pulseaudio server after it restarts.
The pulseaudio context connection would failed according to the [documentation](https://freedesktop.org/software/pulseaudio/doxygen/def_8h.html#a892684c03cf9edaed1a95e609ec7573c). So we can simply reconnect the context there.

Tested on waybar latest git version and pipewire-pulse 1.0.0

Fixes: #2619

PS: I am not so good at C++ actually. So I am sorry if I do something stupid. :)