### PR TITLE
Add ordinal date toolbar format specifier to clock module

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -8,6 +8,7 @@ namespace waybar::modules {
 
 const std::string kCldPlaceholder{"calendar"};
 const std::string kTZPlaceholder{"tz_list"};
+const std::string kOrdPlaceholder{"ordinal_date"};
 
 enum class CldMode { MONTH, YEAR };
 enum class WS { LEFT, RIGHT, HIDDEN };
@@ -56,6 +57,11 @@ class Clock final : public ALabel {
   int tzCurrIdx_;                         // current time zone index for tzList_
   std::string tzText_{""};                // time zones text to print
   util::SleeperThread thread_;
+
+  // ordinal date in tooltip
+  const bool ordInTooltip_;
+  std::string ordText_{""};
+  auto get_ordinal_date(const year_month_day& today) -> std::string;
 
   auto getTZtext(sys_seconds now) -> std::string;
   auto first_day_of_week() -> weekday;

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -2,8 +2,10 @@
 
 #include <spdlog/spdlog.h>
 
+#include <chrono>
 #include <iomanip>
 #include <regex>
+#include <sstream>
 
 #include "util/ustring_clen.hpp"
 
@@ -20,7 +22,8 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
       tlpFmt_{(config_["tooltip-format"].isString()) ? config_["tooltip-format"].asString() : ""},
       cldInTooltip_{tlpFmt_.find("{" + kCldPlaceholder + "}") != std::string::npos},
       tzInTooltip_{tlpFmt_.find("{" + kTZPlaceholder + "}") != std::string::npos},
-      tzCurrIdx_{0} {
+      tzCurrIdx_{0},
+      ordInTooltip_{tlpFmt_.find("{" + kOrdPlaceholder + "}") != std::string::npos} {
   tlpText_ = tlpFmt_;
 
   if (config_["timezones"].isArray() && !config_["timezones"].empty()) {
@@ -126,6 +129,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
   };
 }
 
+
 auto waybar::modules::Clock::update() -> void {
   auto tz{tzList_[tzCurrIdx_] ?: current_zone()};
   const zoned_time now{tz, floor<seconds>(system_clock::now())};
@@ -140,11 +144,13 @@ auto waybar::modules::Clock::update() -> void {
 
     if (tzInTooltip_) tzText_ = getTZtext(now.get_sys_time());
     if (cldInTooltip_) cldText_ = get_calendar(today, shiftedDay, tz);
-    if (tzInTooltip_ || cldInTooltip_) {
+    if (ordInTooltip_) ordText_ = get_ordinal_date(shiftedDay);
+    if (tzInTooltip_ || cldInTooltip_ || ordInTooltip_) {
       // std::vformat doesn't support named arguments.
       tlpText_ = std::regex_replace(tlpFmt_, std::regex("\\{" + kTZPlaceholder + "\\}"), tzText_);
       tlpText_ =
           std::regex_replace(tlpText_, std::regex("\\{" + kCldPlaceholder + "\\}"), cldText_);
+      tlpText_ = std::regex_replace(tlpText_, std::regex("\\{" + kOrdPlaceholder + "\\}"), ordText_);
     }
 
     tlpText_ = fmt_lib::vformat(locale_, tlpText_, fmt_lib::make_format_args(shiftedNow));
@@ -436,4 +442,38 @@ auto waybar::modules::Clock::first_day_of_week() -> weekday {
   }
 #endif
   return Sunday;
+}
+
+auto waybar::modules::Clock::get_ordinal_date(const year_month_day& today) -> std::string {
+  auto day = static_cast<unsigned int>(today.day());
+  switch (day) {
+    case 11:
+      return "11th";
+    case 12:
+      return "12th";
+    case 13:
+      return "13th";
+  }
+
+  std::stringstream res;
+  res << day;
+  if (day >= 11 && day <= 13) {
+    res << "th";
+    return res.str();
+  }
+
+  switch (day % 10) {
+    case 1:
+      res << "st";
+      break;
+    case 2:
+      res << "nd";
+      break;
+    case 3:
+      res << "rd";
+      break;
+    default:
+      res << "th";
+  }
+  return res.str();
 }


### PR DESCRIPTION
Implements https://github.com/Alexays/Waybar/issues/2878.

Ideally this would happen in the call to `fmt_lib::vformat` so it could be used outside of just the toolbar but, as described in the issue, format libraries do not support ordinals due to their extremely nonstandard nature across languages.

Perhaps better might be to have our own `format(...)` function that formats our own overrides before an underlying call to `fmt_lib::vformat` is made, but this would be a not insignificant refactor to how strings are currently formatted.