### PR TITLE
Bluetooth module: fetch battery percentage from upower if not found from bluez

### DIFF
--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -55,7 +55,7 @@ class Bluetooth : public ALabel {
                                                 GDBusProxy*, GVariant*, const gchar* const*,
                                                 gpointer) -> void;
 
-  auto getDeviceBatteryPercentage(GDBusObject*, GDBusProxy*) -> std::optional<unsigned char>;
+  auto getDeviceBatteryPercentage(GDBusObject*) -> std::optional<unsigned char>;
   auto getDeviceProperties(GDBusObject*, DeviceInfo&) -> bool;
   auto getControllerProperties(GDBusObject*, ControllerInfo&) -> bool;
 

--- a/include/modules/bluetooth.hpp
+++ b/include/modules/bluetooth.hpp
@@ -55,7 +55,7 @@ class Bluetooth : public ALabel {
                                                 GDBusProxy*, GVariant*, const gchar* const*,
                                                 gpointer) -> void;
 
-  auto getDeviceBatteryPercentage(GDBusObject*) -> std::optional<unsigned char>;
+  auto getDeviceBatteryPercentage(GDBusObject*, GDBusProxy*) -> std::optional<unsigned char>;
   auto getDeviceProperties(GDBusObject*, DeviceInfo&) -> bool;
   auto getControllerProperties(GDBusObject*, ControllerInfo&) -> bool;
 

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -340,13 +340,13 @@ auto waybar::modules::Bluetooth::getDeviceBatteryPercentage(GDBusObject* object)
     -> std::optional<unsigned char> {
   GDBusProxy* proxy_device_bat =
       G_DBUS_PROXY(g_dbus_object_get_interface(object, "org.bluez.Battery1"));
-  GDBusProxy* proxy_device = G_DBUS_PROXY(g_dbus_object_get_interface(object, "org.bluez.Device1"));
   if (proxy_device_bat != NULL) {
     unsigned char battery_percentage = getUcharProperty(proxy_device_bat, "Percentage");
     g_object_unref(proxy_device_bat);
 
     return battery_percentage;
   }
+  GDBusProxy* proxy_device = G_DBUS_PROXY(g_dbus_object_get_interface(object, "org.bluez.Device1"));
   if (proxy_device != nullptr) {
     auto serial = getStringProperty(proxy_device, "Address");
     std::transform(serial.begin(), serial.end(), serial.begin(),

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -336,11 +336,11 @@ auto waybar::modules::Bluetooth::onInterfaceProxyPropertiesChanged(
   }
 }
 
-auto waybar::modules::Bluetooth::getDeviceBatteryPercentage(GDBusObject* object,
-                                                            GDBusProxy* proxy_device)
+auto waybar::modules::Bluetooth::getDeviceBatteryPercentage(GDBusObject* object)
     -> std::optional<unsigned char> {
   GDBusProxy* proxy_device_bat =
       G_DBUS_PROXY(g_dbus_object_get_interface(object, "org.bluez.Battery1"));
+  GDBusProxy* proxy_device = G_DBUS_PROXY(g_dbus_object_get_interface(object, "org.bluez.Device1"));
   if (proxy_device_bat != NULL) {
     unsigned char battery_percentage = getUcharProperty(proxy_device_bat, "Percentage");
     g_object_unref(proxy_device_bat);
@@ -392,7 +392,7 @@ auto waybar::modules::Bluetooth::getDeviceProperties(GDBusObject* object, Device
 
     g_object_unref(proxy_device);
 
-    device_info.battery_percentage = getDeviceBatteryPercentage(object, proxy_device);
+    device_info.battery_percentage = getDeviceBatteryPercentage(object);
 
     return true;
   }


### PR DESCRIPTION
# What is this PR about?
Current bluetooth module shows battery percentage from bluez experimental features. This has two drawbacks:

1.  Not super user friendly, as users need to activate these features;
2. Most importantly, a lot of devices (at least in my experience) do not report battery percentage anyway, despite having it in upower;

## Upower implementation
In this PR, the bluetooth module will first try to fetch battery percentage from bluez and, if not available, will try fetching it from upower.

## Other details
At the moment, the code is getting all upower devices, and then looking for the one with the correct serial number. I don't know if there's a better way of doing this