### PR TITLE
Search for the first hwmon* directory

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -24,11 +24,15 @@ waybar::modules::Temperature::Temperature(const std::string& id, const Json::Val
       }
     }
   } else if (config_["hwmon-path-abs"].isString() && config_["input-filename"].isString()) {
-    file_path_ = (*std::filesystem::directory_iterator(config_["hwmon-path-abs"].asString()))
-                     .path()
-                     .string() +
-                 "/" + config_["input-filename"].asString();
-  } else {
+    for (const auto& hwmon : std::filesystem::directory_iterator(config_["hwmon-path-abs"].asString())) {
+      if (hwmon.path().filename().string().starts_with("hwmon")) {
+        file_path_ = hwmon.path().string() + "/" + config_["input-filename"].asString();
+        break;
+      }
+    }
+  }
+
+  if (file_path_.empty()) {
     auto zone = config_["thermal-zone"].isInt() ? config_["thermal-zone"].asInt() : 0;
     file_path_ = fmt::format("/sys/class/thermal/thermal_zone{}/temp", zone);
   }


### PR DESCRIPTION
Background and Motivation
-------------------------
When the `hwmon-path-abs` and the `input-filename` fields are used for the temperature module, we evaluated the following path:

```
[hwmon-path-abs] / [gap] / [input-filename]
```

where `gap` is the first file or directory in the `hwmon-path-abs` directory. This usually works but it doesn't seem to work for NVME or WiFi temperature sensors. For those cases, there are a bunch of other files in the `hwmon-path-abs` directory. In the bad case, the first selected file is not the one with the prefix `hwmon` and we end up checking the wrong location for the `input-filename`.

Change description
------------------
We are simply going through the `hwmon-path-abs` directory and searching for the first file/directory that begins with `hwmon`.

Test case
---------
I tested this on a AMD based Framework 13 laptop.