### PR TITLE
Add css classes to hyprland special workspaces

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -144,6 +144,7 @@ class Workspaces : public AModule, public EventHandler {
 
   // workspace events
   void onWorkspaceActivated(std::string const& payload);
+  void onSpecialWorkspaceActivated(std::string const& payload);
   void onWorkspaceDestroyed(std::string const& payload);
   void onWorkspaceCreated(std::string const& workspaceName,
                           Json::Value const& clientsData = Json::Value::nullRef);
@@ -199,6 +200,7 @@ class Workspaces : public AModule, public EventHandler {
   bool m_withIcon;
   uint64_t m_monitorId;
   std::string m_activeWorkspaceName;
+  std::string m_activeSpecialWorkspaceName;
   std::vector<std::unique_ptr<Workspace>> m_workspaces;
   std::vector<std::pair<Json::Value, Json::Value>> m_workspacesToCreate;
   std::vector<std::string> m_workspacesToRemove;

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -365,6 +365,13 @@ void Workspaces::onWorkspaceRenamed(std::string const &payload) {
 
 void Workspaces::onMonitorFocused(std::string const &payload) {
   m_activeWorkspaceName = payload.substr(payload.find(',') + 1);
+
+  for (Json::Value &monitor : gIPC->getSocket1JsonReply("monitors")) {
+    if (monitor["name"].asString() == payload.substr(0, payload.find(','))) {
+      auto name = monitor["specialWorkspace"]["name"].asString();
+      m_activeSpecialWorkspaceName = !name.starts_with("special:") ? name : name.substr(8);
+    }
+  }
 }
 
 void Workspaces::onWindowOpened(std::string const &payload) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -187,8 +187,7 @@ void Workspaces::doUpdate() {
     auto sws = monitor["specialWorkspace"];
     auto name = sws["name"].asString();
     if (sws.isObject() && (sws["name"].isString()) && !name.empty()) {
-      visibleWorkspaces.push_back(name == "special" ? "special"
-                                  : name.substr(8, name.length() - 8));
+      visibleWorkspaces.push_back(name.starts_with("special:") ? name : name.substr(8));
     }
   }
 
@@ -307,9 +306,7 @@ void Workspaces::onWorkspaceActivated(std::string const &payload) {
 
 void Workspaces::onSpecialWorkspaceActivated(std::string const &payload) {
   std::string name(begin(payload), begin(payload) + payload.find_first_of(','));
-  m_activeSpecialWorkspaceName = (
-    ( name == "special" || name == "" ) ? name : name.substr(8, name.length() - 8)
-  );
+  m_activeSpecialWorkspaceName = (!name.starts_with("special:") ? name : name.substr(8));
 }
 
 void Workspaces::onWorkspaceDestroyed(std::string const &payload) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -188,8 +188,8 @@ void Workspaces::doUpdate() {
 
   for (auto &workspace : m_workspaces) {
     // active
-    workspace->setActive( workspace->name() == m_activeWorkspaceName ||
-                         workspace->name() == m_activeSpecialWorkspaceName );
+    workspace->setActive(workspace->name() == m_activeWorkspaceName ||
+                         workspace->name() == m_activeSpecialWorkspaceName);
     // disable urgency if workspace is active
     if (workspace->name() == m_activeWorkspaceName && workspace->isUrgent()) {
       workspace->setUrgent(false);

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -184,6 +184,12 @@ void Workspaces::doUpdate() {
     if (ws.isObject() && (ws["name"].isString())) {
       visibleWorkspaces.push_back(ws["name"].asString());
     }
+    auto sws = monitor["specialWorkspace"];
+    auto name = sws["name"].asString();
+    if (sws.isObject() && (sws["name"].isString()) && !name.empty()) {
+      visibleWorkspaces.push_back(name == "special" ? "special"
+                                  : name.substr(8, name.length() - 8));
+    }
   }
 
   for (auto &workspace : m_workspaces) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -486,7 +486,10 @@ void Workspaces::updateWindowCount() {
   for (auto &workspace : m_workspaces) {
     auto workspaceJson = std::find_if(
         workspacesJson.begin(), workspacesJson.end(),
-        [&](Json::Value const &x) { return x["name"].asString() == workspace->name(); });
+        [&](Json::Value const &x) {
+          return x["name"].asString() == workspace->name() ||
+                 (workspace->isSpecial() && x["name"].asString() == "special:" + workspace->name());
+        });
     uint32_t count = 0;
     if (workspaceJson != workspacesJson.end()) {
       try {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -484,9 +484,8 @@ void Workspaces::onWindowTitleEvent(std::string const &payload) {
 void Workspaces::updateWindowCount() {
   const Json::Value workspacesJson = gIPC->getSocket1JsonReply("workspaces");
   for (auto &workspace : m_workspaces) {
-    auto workspaceJson = std::find_if(
-        workspacesJson.begin(), workspacesJson.end(),
-        [&](Json::Value const &x) {
+    auto workspaceJson =
+        std::find_if(workspacesJson.begin(), workspacesJson.end(), [&](Json::Value const &x) {
           return x["name"].asString() == workspace->name() ||
                  (workspace->isSpecial() && x["name"].asString() == "special:" + workspace->name());
         });

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -187,7 +187,7 @@ void Workspaces::doUpdate() {
     auto sws = monitor["specialWorkspace"];
     auto name = sws["name"].asString();
     if (sws.isObject() && (sws["name"].isString()) && !name.empty()) {
-      visibleWorkspaces.push_back(name.starts_with("special:") ? name : name.substr(8));
+      visibleWorkspaces.push_back(!name.starts_with("special:") ? name : name.substr(8));
     }
   }
 


### PR DESCRIPTION
This adds the following css classes to special workspaces in hyprland:
- active (+ correct behavior on monitor focus change)
- visible
- empty 

Styling only normal workspaces or only special workspaces is still possible. Example with `active`:

```css
#workspaces button.active:not(.special) {} /* only normal */
#workspaces button.active.special       {} /* only special */
```