### PR TITLE
Make battery estimate inaccessible in the "Full" state on default config

### DIFF
--- a/resources/config
+++ b/resources/config
@@ -113,6 +113,7 @@
             "critical": 15
         },
         "format": "{capacity}% {icon}",
+        "format-full": "{capacity}% {icon}",
         "format-charging": "{capacity}% ",
         "format-plugged": "{capacity}% ",
         "format-alt": "{time} {icon}",


### PR DESCRIPTION
Fixes #2893

This PR makes it so that, when the `battery` module is in the `Full` state, the battery life estimate is inaccessible similarly to how the module acts in the `Charging` and `Plugged` states.

This is done by adding a line in the default config which sets a format for the `Full` state. Setting a format for a given state disables access to the `format-alt` display while that state is active.

There are possibly better ways to approach this than a config change, but I couldn't think of any that wouldn't limit the functionality of other configs that may use `format-alt` here for things other than displaying a battery estimate, in which case the issue wouldn't occur.

If there is a better solution to this problem, please let me know and I'll look into that instead.