### PR TITLE
Fix build warnings

### DIFF
--- a/include/modules/systemd_failed_units.hpp
+++ b/include/modules/systemd_failed_units.hpp
@@ -19,8 +19,8 @@ class SystemdFailedUnits : public ALabel {
   std::string format_ok;
 
   bool update_pending;
-  std::string last_status;
   uint32_t nr_failed_system, nr_failed_user;
+  std::string last_status;
   Glib::RefPtr<Gio::DBus::Proxy> system_proxy, user_proxy;
 
   void notify_cb(const Glib::ustring &sender_name, const Glib::ustring &signal_name,


### PR DESCRIPTION
Fixes this warning:
```
In file included from ../waybar-git/src/modules/systemd_failed_units.cpp:1:
../waybar-git/include/modules/systemd_failed_units.hpp: In constructor ‘waybar::modules::SystemdFailedUnits::SystemdFailedUnits(const std::string&, const Json::Value&)’:
../waybar-git/include/modules/systemd_failed_units.hpp:23:30: warning: ‘waybar::modules::SystemdFailedUnits::nr_failed_user’ will be initialized after [-Wreorder]
   23 |   uint32_t nr_failed_system, nr_failed_user;
      |                              ^~~~~~~~~~~~~~
../waybar-git/include/modules/systemd_failed_units.hpp:22:15: warning:   ‘std::string waybar::modules::SystemdFailedUnits::last_status’ [-Wreorder]
   22 |   std::string last_status;
      |               ^~~~~~~~~~~
../waybar-git/src/modules/systemd_failed_units.cpp:13:1: warning:   when initialized here [-Wreorder]
   13 | SystemdFailedUnits::SystemdFailedUnits(const std::string& id, const Json::Value& config)
      | ^~~~~~~~~~~~~~~~~~
```