### PR TITLE
Update Wireplumber API to 0.5

### DIFF
--- a/include/modules/wireplumber.hpp
+++ b/include/modules/wireplumber.hpp
@@ -17,12 +17,15 @@ class Wireplumber : public ALabel {
   auto update() -> void override;
 
  private:
-  void loadRequiredApiModules();
+  void asyncLoadRequiredApiModules();
   void prepare();
   void activatePlugins();
   static void updateVolume(waybar::modules::Wireplumber* self, uint32_t id);
   static void updateNodeName(waybar::modules::Wireplumber* self, uint32_t id);
   static void onPluginActivated(WpObject* p, GAsyncResult* res, waybar::modules::Wireplumber* self);
+  static void onDefaultNodesApiLoaded(WpObject* p, GAsyncResult* res,
+                                      waybar::modules::Wireplumber* self);
+  static void onMixerApiLoaded(WpObject* p, GAsyncResult* res, waybar::modules::Wireplumber* self);
   static void onObjectManagerInstalled(waybar::modules::Wireplumber* self);
   static void onMixerChanged(waybar::modules::Wireplumber* self, uint32_t id);
   static void onDefaultNodesApiChanged(waybar::modules::Wireplumber* self);

--- a/meson.build
+++ b/meson.build
@@ -92,7 +92,7 @@ libevdev = dependency('libevdev', required: get_option('libevdev'))
 libmpdclient = dependency('libmpdclient', required: get_option('mpd'))
 xkbregistry = dependency('xkbregistry')
 libjack = dependency('jack', required: get_option('jack'))
-libwireplumber = dependency('wireplumber-0.4', required: get_option('wireplumber'))
+libwireplumber = dependency('wireplumber-0.5', required: get_option('wireplumber'))
 
 libsndio = compiler.find_library('sndio', required: get_option('sndio'))
 if libsndio.found()

--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -18,31 +18,24 @@ waybar::modules::Wireplumber::Wireplumber(const std::string& id, const Json::Val
       min_step_(0.0),
       node_id_(0) {
   wp_init(WP_INIT_PIPEWIRE);
-  wp_core_ = wp_core_new(NULL, NULL);
+  wp_core_ = wp_core_new(nullptr, nullptr, nullptr);
   apis_ = g_ptr_array_new_with_free_func(g_object_unref);
   om_ = wp_object_manager_new();
 
   prepare();
 
-  loadRequiredApiModules();
+  spdlog::debug("[{}]: connecting to pipewire...", name_);
 
-  spdlog::debug("[{}]: connecting to pipewire...", this->name_);
-
-  if (!wp_core_connect(wp_core_)) {
-    spdlog::error("[{}]: Could not connect to PipeWire", this->name_);
+  if (wp_core_connect(wp_core_) == 0) {
+    spdlog::error("[{}]: Could not connect to PipeWire", name_);
     throw std::runtime_error("Could not connect to PipeWire\n");
   }
 
-  spdlog::debug("[{}]: connected!", this->name_);
+  spdlog::debug("[{}]: connected!", name_);
 
   g_signal_connect_swapped(om_, "installed", (GCallback)onObjectManagerInstalled, this);
 
-  activatePlugins();
-
-  dp.emit();
-
-  event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
-  event_box_.signal_scroll_event().connect(sigc::mem_fun(*this, &Wireplumber::handleScroll));
+  asyncLoadRequiredApiModules();
 }
 
 waybar::modules::Wireplumber::~Wireplumber() {
@@ -63,32 +56,36 @@ void waybar::modules::Wireplumber::updateNodeName(waybar::modules::Wireplumber* 
     return;
   }
 
-  auto proxy = static_cast<WpProxy*>(wp_object_manager_lookup(
-      self->om_, WP_TYPE_GLOBAL_PROXY, WP_CONSTRAINT_TYPE_G_PROPERTY, "bound-id", "=u", id, NULL));
+  auto* proxy = static_cast<WpProxy*>(wp_object_manager_lookup(self->om_, WP_TYPE_GLOBAL_PROXY,
+                                                               WP_CONSTRAINT_TYPE_G_PROPERTY,
+                                                               "bound-id", "=u", id, nullptr));
 
-  if (!proxy) {
+  if (proxy == nullptr) {
     auto err = fmt::format("Object '{}' not found\n", id);
     spdlog::error("[{}]: {}", self->name_, err);
     throw std::runtime_error(err);
   }
 
   g_autoptr(WpProperties) properties =
-      WP_IS_PIPEWIRE_OBJECT(proxy) ? wp_pipewire_object_get_properties(WP_PIPEWIRE_OBJECT(proxy))
-                                   : wp_properties_new_empty();
-  g_autoptr(WpProperties) global_p = wp_global_proxy_get_global_properties(WP_GLOBAL_PROXY(proxy));
+      WP_IS_PIPEWIRE_OBJECT(proxy) != 0
+          ? wp_pipewire_object_get_properties(WP_PIPEWIRE_OBJECT(proxy))
+          : wp_properties_new_empty();
+  g_autoptr(WpProperties) globalP = wp_global_proxy_get_global_properties(WP_GLOBAL_PROXY(proxy));
   properties = wp_properties_ensure_unique_owner(properties);
-  wp_properties_add(properties, global_p);
-  wp_properties_set(properties, "object.id", NULL);
-  auto nick = wp_properties_get(properties, "node.nick");
-  auto description = wp_properties_get(properties, "node.description");
+  wp_properties_add(properties, globalP);
+  wp_properties_set(properties, "object.id", nullptr);
+  const auto* nick = wp_properties_get(properties, "node.nick");
+  const auto* description = wp_properties_get(properties, "node.description");
 
-  self->node_name_ = nick ? nick : description ? description : "Unknown node name";
+  self->node_name_ = nick != nullptr          ? nick
+                     : description != nullptr ? description
+                                              : "Unknown node name";
   spdlog::debug("[{}]: Updating node name to: {}", self->name_, self->node_name_);
 }
 
 void waybar::modules::Wireplumber::updateVolume(waybar::modules::Wireplumber* self, uint32_t id) {
   spdlog::debug("[{}]: updating volume", self->name_);
-  GVariant* variant = NULL;
+  GVariant* variant = nullptr;
 
   if (!isValidNodeId(id)) {
     spdlog::error("[{}]: '{}' is not a valid node ID. Ignoring volume update.", self->name_, id);
@@ -97,7 +94,7 @@ void waybar::modules::Wireplumber::updateVolume(waybar::modules::Wireplumber* se
 
   g_signal_emit_by_name(self->mixer_api_, "get-volume", id, &variant);
 
-  if (!variant) {
+  if (variant == nullptr) {
     auto err = fmt::format("Node {} does not support volume\n", id);
     spdlog::error("[{}]: {}", self->name_, err);
     throw std::runtime_error(err);
@@ -115,9 +112,9 @@ void waybar::modules::Wireplumber::onMixerChanged(waybar::modules::Wireplumber* 
   spdlog::debug("[{}]: (onMixerChanged) - id: {}", self->name_, id);
 
   g_autoptr(WpNode) node = static_cast<WpNode*>(wp_object_manager_lookup(
-      self->om_, WP_TYPE_NODE, WP_CONSTRAINT_TYPE_G_PROPERTY, "bound-id", "=u", id, NULL));
+      self->om_, WP_TYPE_NODE, WP_CONSTRAINT_TYPE_G_PROPERTY, "bound-id", "=u", id, nullptr));
 
-  if (!node) {
+  if (node == nullptr) {
     spdlog::warn("[{}]: (onMixerChanged) - Object with id {} not found", self->name_, id);
     return;
   }
@@ -140,49 +137,49 @@ void waybar::modules::Wireplumber::onMixerChanged(waybar::modules::Wireplumber* 
 void waybar::modules::Wireplumber::onDefaultNodesApiChanged(waybar::modules::Wireplumber* self) {
   spdlog::debug("[{}]: (onDefaultNodesApiChanged)", self->name_);
 
-  uint32_t default_node_id;
-  g_signal_emit_by_name(self->def_nodes_api_, "get-default-node", "Audio/Sink", &default_node_id);
+  uint32_t defaultNodeId;
+  g_signal_emit_by_name(self->def_nodes_api_, "get-default-node", "Audio/Sink", &defaultNodeId);
 
-  if (!isValidNodeId(default_node_id)) {
+  if (!isValidNodeId(defaultNodeId)) {
     spdlog::warn("[{}]: '{}' is not a valid node ID. Ignoring node change.", self->name_,
-                 default_node_id);
+                 defaultNodeId);
     return;
   }
 
   g_autoptr(WpNode) node = static_cast<WpNode*>(
       wp_object_manager_lookup(self->om_, WP_TYPE_NODE, WP_CONSTRAINT_TYPE_G_PROPERTY, "bound-id",
-                               "=u", default_node_id, NULL));
+                               "=u", defaultNodeId, nullptr));
 
-  if (!node) {
+  if (node == nullptr) {
     spdlog::warn("[{}]: (onDefaultNodesApiChanged) - Object with id {} not found", self->name_,
-                 default_node_id);
+                 defaultNodeId);
     return;
   }
 
-  const gchar* default_node_name =
+  const gchar* defaultNodeName =
       wp_pipewire_object_get_property(WP_PIPEWIRE_OBJECT(node), "node.name");
 
   spdlog::debug(
       "[{}]: (onDefaultNodesApiChanged) - got the following default node: Node(name: {}, id: {})",
-      self->name_, default_node_name, default_node_id);
+      self->name_, defaultNodeName, defaultNodeId);
 
-  if (g_strcmp0(self->default_node_name_, default_node_name) == 0) {
+  if (g_strcmp0(self->default_node_name_, defaultNodeName) == 0) {
     spdlog::debug(
         "[{}]: (onDefaultNodesApiChanged) - Default node has not changed. Node(name: {}, id: {}). "
         "Ignoring.",
-        self->name_, self->default_node_name_, default_node_id);
+        self->name_, self->default_node_name_, defaultNodeId);
     return;
   }
 
   spdlog::debug(
       "[{}]: (onDefaultNodesApiChanged) - Default node changed to -> Node(name: {}, id: {})",
-      self->name_, default_node_name, default_node_id);
+      self->name_, defaultNodeName, defaultNodeId);
 
   g_free(self->default_node_name_);
-  self->default_node_name_ = g_strdup(default_node_name);
-  self->node_id_ = default_node_id;
-  updateVolume(self, default_node_id);
-  updateNodeName(self, default_node_id);
+  self->default_node_name_ = g_strdup(defaultNodeName);
+  self->node_id_ = defaultNodeId;
+  updateVolume(self, defaultNodeId);
+  updateNodeName(self, defaultNodeId);
 }
 
 void waybar::modules::Wireplumber::onObjectManagerInstalled(waybar::modules::Wireplumber* self) {
@@ -190,14 +187,14 @@ void waybar::modules::Wireplumber::onObjectManagerInstalled(waybar::modules::Wir
 
   self->def_nodes_api_ = wp_plugin_find(self->wp_core_, "default-nodes-api");
 
-  if (!self->def_nodes_api_) {
+  if (self->def_nodes_api_ == nullptr) {
     spdlog::error("[{}]: default nodes api is not loaded.", self->name_);
     throw std::runtime_error("Default nodes API is not loaded\n");
   }
 
   self->mixer_api_ = wp_plugin_find(self->wp_core_, "mixer-api");
 
-  if (!self->mixer_api_) {
+  if (self->mixer_api_ == nullptr) {
     spdlog::error("[{}]: mixer api is not loaded.", self->name_);
     throw std::runtime_error("Mixer api is not loaded\n");
   }
@@ -206,7 +203,7 @@ void waybar::modules::Wireplumber::onObjectManagerInstalled(waybar::modules::Wir
                         &self->default_node_name_);
   g_signal_emit_by_name(self->def_nodes_api_, "get-default-node", "Audio/Sink", &self->node_id_);
 
-  if (self->default_node_name_) {
+  if (self->default_node_name_ != nullptr) {
     spdlog::debug("[{}]: (onObjectManagerInstalled) - default configured node name: {} and id: {}",
                   self->name_, self->default_node_name_, self->node_id_);
   }
@@ -221,11 +218,11 @@ void waybar::modules::Wireplumber::onObjectManagerInstalled(waybar::modules::Wir
 
 void waybar::modules::Wireplumber::onPluginActivated(WpObject* p, GAsyncResult* res,
                                                      waybar::modules::Wireplumber* self) {
-  auto plugin_name = wp_plugin_get_name(WP_PLUGIN(p));
-  spdlog::debug("[{}]: onPluginActivated: {}", self->name_, plugin_name);
-  g_autoptr(GError) error = NULL;
+  const auto* pluginName = wp_plugin_get_name(WP_PLUGIN(p));
+  spdlog::debug("[{}]: onPluginActivated: {}", self->name_, pluginName);
+  g_autoptr(GError) error = nullptr;
 
-  if (!wp_object_activate_finish(p, res, &error)) {
+  if (wp_object_activate_finish(p, res, &error) == 0) {
     spdlog::error("[{}]: error activating plugin: {}", self->name_, error->message);
     throw std::runtime_error(error->message);
   }
@@ -240,7 +237,7 @@ void waybar::modules::Wireplumber::activatePlugins() {
   for (uint16_t i = 0; i < apis_->len; i++) {
     WpPlugin* plugin = static_cast<WpPlugin*>(g_ptr_array_index(apis_, i));
     pending_plugins_++;
-    wp_object_activate(WP_OBJECT(plugin), WP_PLUGIN_FEATURE_ENABLED, NULL,
+    wp_object_activate(WP_OBJECT(plugin), WP_PLUGIN_FEATURE_ENABLED, nullptr,
                        (GAsyncReadyCallback)onPluginActivated, this);
   }
 }
@@ -248,34 +245,67 @@ void waybar::modules::Wireplumber::activatePlugins() {
 void waybar::modules::Wireplumber::prepare() {
   spdlog::debug("[{}]: preparing object manager", name_);
   wp_object_manager_add_interest(om_, WP_TYPE_NODE, WP_CONSTRAINT_TYPE_PW_PROPERTY, "media.class",
-                                 "=s", "Audio/Sink", NULL);
+                                 "=s", "Audio/Sink", nullptr);
 }
 
-void waybar::modules::Wireplumber::loadRequiredApiModules() {
-  spdlog::debug("[{}]: loading required modules", name_);
-  g_autoptr(GError) error = NULL;
+void waybar::modules::Wireplumber::onDefaultNodesApiLoaded(WpObject* p, GAsyncResult* res,
+                                                           waybar::modules::Wireplumber* self) {
+  gboolean success = FALSE;
+  g_autoptr(GError) error = nullptr;
 
-  if (!wp_core_load_component(wp_core_, "libwireplumber-module-default-nodes-api", "module", NULL,
-                              &error)) {
+  spdlog::debug("[{}]: callback loading default node api module", self->name_);
+
+  success = wp_core_load_component_finish(self->wp_core_, res, &error);
+
+  if (success == FALSE) {
+    spdlog::error("[{}]: default nodes API load failed", self->name_);
+    throw std::runtime_error(error->message);
+  }
+  spdlog::debug("[{}]: loaded default nodes api", self->name_);
+  g_ptr_array_add(self->apis_, wp_plugin_find(self->wp_core_, "default-nodes-api"));
+
+  spdlog::debug("[{}]: loading mixer api module", self->name_);
+  wp_core_load_component(self->wp_core_, "libwireplumber-module-mixer-api", "module", nullptr,
+                         "mixer-api", nullptr, (GAsyncReadyCallback)onMixerApiLoaded, self);
+}
+
+void waybar::modules::Wireplumber::onMixerApiLoaded(WpObject* p, GAsyncResult* res,
+                                                    waybar::modules::Wireplumber* self) {
+  gboolean success = FALSE;
+  g_autoptr(GError) error = nullptr;
+
+  success = wp_core_load_component_finish(self->wp_core_, res, nullptr);
+
+  if (success == FALSE) {
+    spdlog::error("[{}]: mixer API load failed", self->name_);
     throw std::runtime_error(error->message);
   }
 
-  if (!wp_core_load_component(wp_core_, "libwireplumber-module-mixer-api", "module", NULL,
-                              &error)) {
-    throw std::runtime_error(error->message);
-  }
-
-  g_ptr_array_add(apis_, wp_plugin_find(wp_core_, "default-nodes-api"));
-  g_ptr_array_add(apis_, ({
-                    WpPlugin* p = wp_plugin_find(wp_core_, "mixer-api");
-                    g_object_set(G_OBJECT(p), "scale", 1 /* cubic */, NULL);
+  spdlog::debug("[{}]: loaded mixer API", self->name_);
+  g_ptr_array_add(self->apis_, ({
+                    WpPlugin* p = wp_plugin_find(self->wp_core_, "mixer-api");
+                    g_object_set(G_OBJECT(p), "scale", 1 /* cubic */, nullptr);
                     p;
                   }));
+
+  self->activatePlugins();
+
+  self->dp.emit();
+
+  self->event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
+  self->event_box_.signal_scroll_event().connect(sigc::mem_fun(*self, &Wireplumber::handleScroll));
+}
+
+void waybar::modules::Wireplumber::asyncLoadRequiredApiModules() {
+  spdlog::debug("[{}]: loading default nodes api module", name_);
+  wp_core_load_component(wp_core_, "libwireplumber-module-default-nodes-api", "module", nullptr,
+                         "default-nodes-api", nullptr, (GAsyncReadyCallback)onDefaultNodesApiLoaded,
+                         this);
 }
 
 auto waybar::modules::Wireplumber::update() -> void {
   auto format = format_;
-  std::string tooltip_format;
+  std::string tooltipFormat;
 
   if (muted_) {
     format = config_["format-muted"].isString() ? config_["format-muted"].asString() : format;
@@ -292,12 +322,12 @@ auto waybar::modules::Wireplumber::update() -> void {
   getState(vol);
 
   if (tooltipEnabled()) {
-    if (tooltip_format.empty() && config_["tooltip-format"].isString()) {
-      tooltip_format = config_["tooltip-format"].asString();
+    if (tooltipFormat.empty() && config_["tooltip-format"].isString()) {
+      tooltipFormat = config_["tooltip-format"].asString();
     }
 
-    if (!tooltip_format.empty()) {
-      label_.set_tooltip_text(fmt::format(fmt::runtime(tooltip_format),
+    if (!tooltipFormat.empty()) {
+      label_.set_tooltip_text(fmt::format(fmt::runtime(tooltipFormat),
                                           fmt::arg("node_name", node_name_),
                                           fmt::arg("volume", vol), fmt::arg("icon", getIcon(vol))));
     } else {
@@ -317,31 +347,31 @@ bool waybar::modules::Wireplumber::handleScroll(GdkEventScroll* e) {
   if (dir == SCROLL_DIR::NONE) {
     return true;
   }
-  double max_volume = 1;
+  double maxVolume = 1;
   double step = 1.0 / 100.0;
   if (config_["scroll-step"].isDouble()) {
     step = config_["scroll-step"].asDouble() / 100.0;
   }
   if (config_["max-volume"].isDouble()) {
-    max_volume = config_["max-volume"].asDouble() / 100.0;
+    maxVolume = config_["max-volume"].asDouble() / 100.0;
   }
 
   if (step < min_step_) step = min_step_;
 
-  double new_vol = volume_;
+  double newVol = volume_;
   if (dir == SCROLL_DIR::UP) {
-    if (volume_ < max_volume) {
-      new_vol = volume_ + step;
-      if (new_vol > max_volume) new_vol = max_volume;
+    if (volume_ < maxVolume) {
+      newVol = volume_ + step;
+      if (newVol > maxVolume) newVol = maxVolume;
     }
   } else if (dir == SCROLL_DIR::DOWN) {
     if (volume_ > 0) {
-      new_vol = volume_ - step;
-      if (new_vol < 0) new_vol = 0;
+      newVol = volume_ - step;
+      if (newVol < 0) newVol = 0;
     }
   }
-  if (new_vol != volume_) {
-    GVariant* variant = g_variant_new_double(new_vol);
+  if (newVol != volume_) {
+    GVariant* variant = g_variant_new_double(newVol);
     gboolean ret;
     g_signal_emit_by_name(mixer_api_, "set-volume", node_id_, variant, &ret);
   }


### PR DESCRIPTION
Wireplumber 0.5 has an incompatible API. This is a first WIP crack at updating. Would fix #2873 (but should not be merged currently).

Two current problems:
- Ignores the results of the two setup calls changed which are now async.
- Doesn't actually seem to work, adding extra logging shows that volume is not actually returned.

However it does build at least... I don't know the WP API well enough to add much more.

[EDIT]: As below now updated to use the new async API and working, ready for review.