### PR TITLE
Add `module` class to the root elements of the modules 

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -11,6 +11,8 @@ namespace waybar {
 
 class AModule : public IModule {
  public:
+  static constexpr const char *MODULE_CLASS = "module";
+
   virtual ~AModule();
   auto update() -> void override;
   virtual auto refresh(int) -> void{};

--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -62,7 +62,7 @@ class BarSurface {
   virtual void setLayer(bar_layer layer) = 0;
   virtual void setMargins(const struct bar_margins &margins) = 0;
   virtual void setPassThrough(bool enable) = 0;
-  virtual void setPosition(const std::string_view &position) = 0;
+  virtual void setPosition(Gtk::PositionType position) = 0;
   virtual void setSize(uint32_t width, uint32_t height) = 0;
   virtual void commit(){};
 
@@ -89,8 +89,9 @@ class Bar {
   Json::Value config;
   struct wl_surface *surface;
   bool visible = true;
-  bool vertical = false;
   Gtk::Window window;
+  Gtk::Orientation orientation = Gtk::ORIENTATION_HORIZONTAL;
+  Gtk::PositionType position = Gtk::POS_TOP;
 
   int x_global;
   int y_global;

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -20,6 +20,7 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
   if (!id.empty()) {
     label_.get_style_context()->add_class(id);
   }
+  label_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(label_);
   if (config_["max-length"].isUInt()) {
     label_.set_max_width_chars(config_["max-length"].asInt());

--- a/src/ASlider.cpp
+++ b/src/ASlider.cpp
@@ -13,6 +13,7 @@ ASlider::ASlider(const Json::Value& config, const std::string& name, const std::
   if (!id.empty()) {
     scale_.get_style_context()->add_class(id);
   }
+  scale_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(scale_);
   scale_.signal_value_changed().connect(sigc::mem_fun(*this, &ASlider::onValueChanged));
 

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -176,16 +176,18 @@ auto waybar::modules::Custom::update() -> void {
           }
         }
       }
-      auto classes = label_.get_style_context()->list_classes();
+      auto style = label_.get_style_context();
+      auto classes = style->list_classes();
       for (auto const& c : classes) {
         if (c == id_) continue;
-        label_.get_style_context()->remove_class(c);
+        style->remove_class(c);
       }
       for (auto const& c : class_) {
-        label_.get_style_context()->add_class(c);
+        style->add_class(c);
       }
-      label_.get_style_context()->add_class("flat");
-      label_.get_style_context()->add_class("text-button");
+      style->add_class("flat");
+      style->add_class("text-button");
+      style->add_class(MODULE_CLASS);
       event_box_.show();
     }
   }

--- a/src/modules/dwl/tags.cpp
+++ b/src/modules/dwl/tags.cpp
@@ -113,6 +113,7 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(box_);
 
   // Default to 9 tags, cap at 32

--- a/src/modules/dwl/tags.cpp
+++ b/src/modules/dwl/tags.cpp
@@ -93,7 +93,7 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
       status_manager_{nullptr},
       seat_{nullptr},
       bar_(bar),
-      box_{bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0},
+      box_{bar.orientation, 0},
       output_status_{nullptr} {
   struct wl_display *display = Client::inst()->wl_display;
   struct wl_registry *registry = wl_display_get_registry(display);

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -42,6 +42,7 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
   if (!id.empty()) {
     m_box.get_style_context()->add_class(id);
   }
+  m_box.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(m_box);
 
   if (!gIPC) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -34,9 +34,7 @@ int Workspaces::windowRewritePriorityFunction(std::string const &window_rule) {
 }
 
 Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value &config)
-    : AModule(config, "workspaces", id, false, false),
-      m_bar(bar),
-      m_box(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+    : AModule(config, "workspaces", id, false, false), m_bar(bar), m_box(bar.orientation, 0) {
   modulesReady = true;
   parseConfig(config);
 

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -7,6 +7,7 @@ waybar::modules::Image::Image(const std::string& id, const Json::Value& config)
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(box_);
 
   dp.emit();

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -81,7 +81,7 @@ auto supportsLockStates(const libevdev* dev) -> bool {
 waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& bar,
                                               const Json::Value& config)
     : AModule(config, "keyboard-state", id, false, !config["disable-scroll"].asBool()),
-      box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0),
+      box_(bar.orientation, 0),
       numlock_label_(""),
       capslock_label_(""),
       numlock_format_(config_["format"].isString() ? config_["format"].asString()

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -132,6 +132,7 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(box_);
 
   if (config_["device-path"].isString()) {

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -111,6 +111,7 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(box_);
 
   // Default to 9 tags, cap at 32

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -87,7 +87,7 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
       control_{nullptr},
       seat_{nullptr},
       bar_(bar),
-      box_{bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0},
+      box_{bar.orientation, 0},
       output_status_{nullptr} {
   struct wl_display *display = Client::inst()->wl_display;
   struct wl_registry *registry = wl_display_get_registry(display);

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -6,7 +6,7 @@ namespace waybar::modules::SNI {
 
 Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
     : AModule(config, "tray", id),
-      box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0),
+      box_(bar.orientation, 0),
       watcher_(SNI::Watcher::getInstance()),
       host_(nb_hosts_, config, bar, std::bind(&Tray::onAdd, this, std::placeholders::_1),
             std::bind(&Tray::onRemove, this, std::placeholders::_1)) {

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -15,6 +15,7 @@ Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   if (config_["spacing"].isUInt()) {
     box_.set_spacing(config_["spacing"].asUInt());
   }

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -27,7 +27,7 @@ int Workspaces::convertWorkspaceNameToNum(std::string name) {
 Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value &config)
     : AModule(config, "workspaces", id, false, !config["disable-scroll"].asBool()),
       bar_(bar),
-      box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+      box_(bar.orientation, 0) {
   if (config["format-icons"]["high-priority-named"].isArray()) {
     for (auto &it : config["format-icons"]["high-priority-named"]) {
       high_priority_named_.push_back(it.asString());

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -37,6 +37,7 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(box_);
   ipc_.subscribe(R"(["workspace"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &Workspaces::onEvent));

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -737,6 +737,7 @@ Taskbar::Taskbar(const std::string &id, const waybar::Bar &bar, const Json::Valu
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   box_.get_style_context()->add_class("empty");
   event_box_.add(box_);
 

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -277,7 +277,7 @@ Task::Task(const waybar::Bar &bar, const Json::Value &config, Taskbar *tbar,
       handle_{tl_handle},
       seat_{seat},
       id_{global_id++},
-      content_{bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0} {
+      content_{bar.orientation, 0} {
   zwlr_foreign_toplevel_handle_v1_add_listener(handle_, &toplevel_handle_impl, this);
 
   button.set_relief(Gtk::RELIEF_NONE);
@@ -730,7 +730,7 @@ static const wl_registry_listener registry_listener_impl = {.global = handle_glo
 Taskbar::Taskbar(const std::string &id, const waybar::Bar &bar, const Json::Value &config)
     : waybar::AModule(config, "taskbar", id, false, false),
       bar_(bar),
-      box_{bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0},
+      box_{bar.orientation, 0},
       manager_{nullptr},
       seat_{nullptr} {
   box_.set_name("taskbar");

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -21,9 +21,7 @@ std::map<std::string, std::string> Workspace::icons_map_;
 
 WorkspaceManager::WorkspaceManager(const std::string &id, const waybar::Bar &bar,
                                    const Json::Value &config)
-    : waybar::AModule(config, "workspaces", id, false, false),
-      bar_(bar),
-      box_(bar.vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0) {
+    : waybar::AModule(config, "workspaces", id, false, false), bar_(bar), box_(bar.orientation, 0) {
   auto config_sort_by_name = config_["sort-by-name"];
   if (config_sort_by_name.isBool()) {
     sort_by_name_ = config_sort_by_name.asBool();

--- a/src/modules/wlr/workspace_manager.cpp
+++ b/src/modules/wlr/workspace_manager.cpp
@@ -52,6 +52,7 @@ WorkspaceManager::WorkspaceManager(const std::string &id, const waybar::Bar &bar
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
   }
+  box_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(box_);
 
   add_registry_listener(this);


### PR DESCRIPTION
At some point, my draft style for Fedora configuration was looking like that:

<details>
<summary>Warning: ugly CSS fragment inside</summary>

```css
/* Common module rules */
.modules-left > widget > label,
.modules-center > widget > label,
.modules-right > widget > label {
  color: inherit;
  margin: 0;
  padding: 0 10px;
}

box.vertical.modules-left > widget > label,
box.vertical.modules-center > widget > label,
box.vertical.modules-right > widget > label {
  padding: 10px 0;
}

window#waybar:not(.bottom):not(.left):not(.right) .modules-left > widget > label,
window#waybar:not(.bottom):not(.left):not(.right) .modules-center > widget > label,
window#waybar:not(.bottom):not(.left):not(.right) .modules-right > widget > label {
  box-shadow: inset 0 -2px;
}

window#waybar.bottom .modules-left > widget > label,
window#waybar.bottom .modules-center > widget > label,
window#waybar.bottom .modules-right > widget > label {
  box-shadow: inset 0 2px;
}

window#waybar.left .modules-left > widget > label,
window#waybar.left .modules-center > widget > label,
window#waybar.left .modules-right > widget > label {
  box-shadow: inset -2px 0;
}

window#waybar.right .modules-left > widget > label,
window#waybar.right .modules-center > widget > label,
window#waybar.right .modules-right > widget > label {
  box-shadow: inset 2px 0;
}
```
(Actually, it was worse - there's also a `.modules-xxx > widget > box`. And `#image`)
</details>


Two obvious ideas to optimize that:
* Ensure that the position class on windows is always set and `:not(.bottom):not(.left):not(.right)` can be shortened to `.top`.
* Introduce a shorter selector for each module, like `label.module`/`box.module`/etc...

After that, the style was reduced to a rather tolerable
```css
/* Common module rules */
label.module { /* or .module:not(box) */
  color: inherit;
  margin: 0;
  padding: 0 10px;
}

box.vertical label.module {
  padding: 10px 0;
}

window#waybar.top label.module {
  box-shadow: inset 0 -2px;
}

window#waybar.bottom label.module {
  box-shadow: inset 0 2px;
}

window#waybar.left label.module {
  box-shadow: inset -2px 0;
}

window#waybar.right label.module {
  box-shadow: inset 2px 0;
}
```

Part of `bar.cpp` refactoring should also simplify adding support for `position` property of Sway IPC (see `sway-bar(5)`/`get_bar_config` in `sway-ipc(7)`). But that functionality does not belong here and is not finished yet.

***
A [Styling wiki](https://github.com/Alexays/Waybar/wiki/Styling) update could look like that (after [Module Group Styling](https://github.com/Alexays/Waybar/wiki/Styling#module-group-styling)):

### General module styles

A style with the `.module` selector would affect all the modules. In practice, you may prefer to use more specific `label.module` and `box.module` selectors.

```css
label.module {
    padding: 0 10px;
    box-shadow: inset 0 -3px;
}
box.module button:hover {
    box-shadow: inset 0 -3px #ffffff;
}
```

Selector [specificity](https://www.w3.org/TR/selectors-3/#specificity) should be taken into account when overwriting the general styles for a module:

```css
/*
 * Show border for all label modules when the bar is in a top or bottom position.
 * a=1 b=2 c=2 -> specificity = 122
 */
window#waybar.top label.module {
    box-shadow: inset 0 -3px;
}

window#waybar.bottom label.module {
    box-shadow: inset 0 3px;
}

/*
 * But hide the border for sway/window.
 * a=2 b=0 c=1 -> specificity = 201
 */
window#waybar #window {
    box-shadow: none;
}
```
