### PR TITLE
Add check for tooltip-format for custom modules

### DIFF
--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -107,6 +107,11 @@ Addressed by *custom/<name>*
 	default: true ++
 	Option to disable tooltip on hover.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The tooltip format. If specified, overrides any tooltip output from the script in *exec*. ++
+	Uses the same format replacements as *format*.
+
 *escape*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -170,6 +170,12 @@ auto waybar::modules::Custom::update() -> void {
           if (label_.get_tooltip_markup() != str) {
             label_.set_tooltip_markup(str);
           }
+        } else if (config_["tooltip-format"].isString()) {
+          auto tooltip = config_["tooltip-format"].asString();
+          tooltip = fmt::format(fmt::runtime(tooltip), text_, fmt::arg("alt", alt_),
+                                fmt::arg("icon", getIcon(percentage_, alt_)),
+                                fmt::arg("percentage", percentage_));
+          label_.set_tooltip_markup(tooltip);
         } else {
           if (label_.get_tooltip_markup() != tooltip_) {
             label_.set_tooltip_markup(tooltip_);


### PR DESCRIPTION
Issue https://github.com/Alexays/Waybar/issues/2914 tries to use `tooltip-format` on a custom module without a script. This change results in `tooltip-format` entries in config being used as the tooltip format, _**over**_ any tooltip-related return from the output of a custom script if there is one.

This makes the most sense to me as it is the more visible change. If I see a `tooltip-format` entry in the config file, I expect that this is truth, not the output of a script in a different place. While it wouldn't be best practice to setting the tooltip in both places, I'd argue that a user would expect that their change to the config would be reflected in the case of using a 3rd party script they don't fully understand.