### PR TITLE
fix build warning in bar.cpp

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -117,6 +117,7 @@ Glib::ustring to_string(Gtk::PositionType pos) {
     case Gtk::POS_BOTTOM:
       return "bottom";
   }
+  throw std::runtime_error("Invalid Gtk::PositionType");
 }
 
 /* Deserializer for JSON Object -> map<string compatible type, Value>


### PR DESCRIPTION
```
[1/2] Compiling C++ object waybar.p/src_bar.cpp.o
../src/bar.cpp: In function ‘Glib::ustring waybar::to_string(Gtk::PositionType)’:
../src/bar.cpp:120:1: warning: control reaches end of non-void function [-Wreturn-type]
  120 | }
      | ^
```