### PR TITLE
Fixed window#waybar.swallowing for module hyprland/window

### DIFF
--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -151,7 +151,7 @@ void Window::queryActiveWorkspace() {
                    return window["workspace"]["id"] == workspace_.id && window["mapped"].asBool();
                  });
     swallowing_ = std::any_of(workspace_windows.begin(), workspace_windows.end(),
-                              [&](Json::Value window) { return window["swallowing"].asString() != "0x0"; });
+                              [&](Json::Value window) { return !window["swallowing"].isNull() && window["swallowing"].asString() != "0x0"; });
     std::vector<Json::Value> visible_windows;
     std::copy_if(workspace_windows.begin(), workspace_windows.end(),
                  std::back_inserter(visible_windows),

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -151,7 +151,7 @@ void Window::queryActiveWorkspace() {
                    return window["workspace"]["id"] == workspace_.id && window["mapped"].asBool();
                  });
     swallowing_ = std::any_of(workspace_windows.begin(), workspace_windows.end(),
-                              [&](Json::Value window) { return !window["swallowing"].isNull(); });
+                              [&](Json::Value window) { return window["swallowing"].asString() != "0x0"; });
     std::vector<Json::Value> visible_windows;
     std::copy_if(workspace_windows.begin(), workspace_windows.end(),
                  std::back_inserter(visible_windows),


### PR DESCRIPTION
Due to [this change](https://github.com/hyprwm/Hyprland/pull/3186) in hyprland, the json value of the `"swallowing"` field is `"0x0"` when no window is swallowed, compared to `null` before.