### PR TITLE
Fix #2945: Persistent workspace disappear after being active

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -599,8 +599,7 @@ void Workspaces::createWorkspace(Json::Value const &workspace_data,
       });
 
   if (workspace != m_workspaces.end()) {
-    // don't recreate workspace, but update persistency if necessary
-    (*workspace)->setPersistent(workspace_data["persistent"].asBool());
+    // don't recreate workspace if it already exists
     return;
   }
 


### PR DESCRIPTION
If a user has a persistent workspace waybar config, and then switches to an empty workspace that is configured as persistent in the config, that empty workspace will be recreated with persistency disabled. 

This PR fixes this by not updating the persistency. In hindsight this line was never really needed in the first place.