### PR TITLE
ci: fix clang-tidy action

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -17,6 +17,10 @@ jobs:
         run: |
           meson -Dcpp_std=c++20 build  # necessary to generate compile_commands.json
           ninja -C build               # necessary to find certain .h files (xdg, wayland, etc.)
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'   # to be kept in sync with cpp-linter-action
+          update-environment: true # the python dist installed by the action needs LD_LIBRARY_PATH to work
       - uses: cpp-linter/cpp-linter-action@v2.9.1
         name: clang-tidy
         id: clang-tidy-check


### PR DESCRIPTION
The problem with cpp-linter-action is that they bring their own Python (via `actions/setup-python`), but fail to ensure that the dynamically-linked interpreter can find the `libpython3.xx.so`, either via `DT_RPATH` or with `LD_LIBRARY_PATH`:

```
/__t/Python/3.11.8/x64/bin/python: error while loading shared libraries: libpython3.11.so.1.0: cannot open shared object file: No such file or directory
```

The suggested fix is to have a matching version of libpython in the container, which... isn't optimal: the container (Debian) Python can have different patch release and build configuration.

Here I'm trying a different thing &mdash; run the same `setup-python` action but allow it to export `LD_LIBRARY_PATH`. And if that works, we can drop python3-pip/python3-venv packages from the debian dockerfile.

