### PR TITLE
feat: implement cpufreq for bsd by sysctl

### DIFF
--- a/src/modules/cpu_frequency/bsd.cpp
+++ b/src/modules/cpu_frequency/bsd.cpp
@@ -1,15 +1,28 @@
 #include <spdlog/spdlog.h>
 
-#include <cmath>  // NAN
+#include <sys/sysctl.h>
 
 #include "modules/cpu_frequency.hpp"
 
 std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
-  static std::vector<float> frequencies;
+  std::vector<float> frequencies;
+  char buffer[256];
+  size_t len;
+  int32_t freq;
+  uint32_t i = 0;
+
+  while (true) {
+    len = 4;
+    snprintf(buffer, 256, "dev.cpu.%u.freq", i);
+    if (sysctlbyname(buffer, &freq, &len, NULL, 0) == -1 || len <= 0) break;
+    frequencies.push_back(freq);
+    ++i;
+  }
+
   if (frequencies.empty()) {
-    spdlog::warn(
-        "cpu/bsd: parseCpuFrequencies is not implemented, expect garbage in {*_frequency}");
+    spdlog::warn("cpu/bsd: parseCpuFrequencies failed, not found in sysctl");
     frequencies.push_back(NAN);
   }
+
   return frequencies;
 }


### PR DESCRIPTION
This patch implements cpu_frequency module for BSD by sysctl.

Currently, I search all OID until it cannot find more.