### PR TITLE
Battery power draw decimals

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -634,6 +634,9 @@ auto waybar::modules::Battery::update() -> void {
   }
 #endif
   auto [capacity, time_remaining, status, power] = getInfos();
+  std::string power_string = std::to_string((int)round(power * 100));
+  power_string = power_string.insert(power_string.size() - 2, 1, '.');
+
   if (status == "Unknown") {
     status = getAdapterStatus(capacity);
   }
@@ -686,7 +689,7 @@ auto waybar::modules::Battery::update() -> void {
     event_box_.show();
     auto icons = std::vector<std::string>{status + "-" + state, status, state};
     label_.set_markup(fmt::format(
-        fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
+        fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power_string),
         fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted)));
   }
   // Call parent update

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -634,6 +634,8 @@ auto waybar::modules::Battery::update() -> void {
   }
 #endif
   auto [capacity, time_remaining, status, power] = getInfos();
+
+  // This guarantees exactly 2 decimals
   std::string power_string = std::to_string((int)round(power * 100));
   power_string = power_string.insert(power_string.size() - 2, 1, '.');
 


### PR DESCRIPTION
This keeps the number of decimals in the battery `power` format option at 2.

![image](https://github.com/Alexays/Waybar/assets/35172494/5121e1fc-03c3-4057-86f8-2253b341e78a)
top: old
bottom: new

Closes# #2963 
