### PR TITLE
hyprland/workspaces: Improve the workspaces persistency logic

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -70,14 +70,17 @@ class Workspace {
   std::string output() const { return m_output; };
   bool isActive() const { return m_isActive; };
   bool isSpecial() const { return m_isSpecial; };
-  bool isPersistent() const { return m_isPersistent; };
+  bool isPersistent() const { return m_isPersistentRule || m_isPersistentConfig; };
+  bool isPersistentConfig() const { return m_isPersistentConfig; };
+  bool isPersistentRule() const { return m_isPersistentRule; };
   bool isVisible() const { return m_isVisible; };
   bool isEmpty() const { return m_windows == 0; };
   bool isUrgent() const { return m_isUrgent; };
 
   bool handleClicked(GdkEventButton* bt) const;
   void setActive(bool value = true) { m_isActive = value; };
-  void setPersistent(bool value = true) { m_isPersistent = value; };
+  void setPersistentRule(bool value = true) { m_isPersistentRule = value; };
+  void setPersistentConfig(bool value = true) { m_isPersistentConfig = value; };
   void setUrgent(bool value = true) { m_isUrgent = value; };
   void setVisible(bool value = true) { m_isVisible = value; };
   void setWindows(uint value) { m_windows = value; };
@@ -101,7 +104,10 @@ class Workspace {
   uint m_windows;
   bool m_isActive = false;
   bool m_isSpecial = false;
-  bool m_isPersistent = false;
+  // m_isPersistentRule represents the persistent state in hyprland
+  bool m_isPersistentRule = false;
+  // m_isPersistentConfig represents the persistent state in the Waybar config
+  bool m_isPersistentConfig = false;
   bool m_isUrgent = false;
   bool m_isVisible = false;
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -104,10 +104,8 @@ class Workspace {
   uint m_windows;
   bool m_isActive = false;
   bool m_isSpecial = false;
-  // m_isPersistentRule represents the persistent state in hyprland
-  bool m_isPersistentRule = false;
-  // m_isPersistentConfig represents the persistent state in the Waybar config
-  bool m_isPersistentConfig = false;
+  bool m_isPersistentRule = false;    // represents the persistent state in hyprland
+  bool m_isPersistentConfig = false;  // represents the persistent state in the Waybar config
   bool m_isUrgent = false;
   bool m_isVisible = false;
 


### PR DESCRIPTION
Fixes #2945

Split the config and rule persistency in 2 attributes, one storing the persistency as set in Waybar's config, the other one storing the persistency as set in Hyprland.

It fixes some conflicts between the persistency state of a workspace as set in Waybar's config and its dynamic state in Hyprland.

It allows to remove a persistent workspace in Waybar if this workspace is removed from Hyprland and if the workspace is not set as persistent in Waybar's config.