### PR TITLE
Hyprland workspaces `hosting-monitor` css class

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -82,6 +82,7 @@ class Workspace {
   void setVisible(bool value = true) { m_isVisible = value; };
   void setWindows(uint value) { m_windows = value; };
   void setName(std::string const& value) { m_name = value; };
+  void setOutput(std::string const& value) { m_output = value; };
   bool containsWindow(WindowAddress const& addr) const { return m_windowMap.contains(addr); }
   void insertWindow(WindowCreationPayload create_window_paylod);
   std::string removeWindow(WindowAddress const& addr);

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -158,3 +158,4 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces button.persistent*
 - *#workspaces button.special*
 - *#workspaces button.urgent*
+- *#workspaces button.hosting-monitor* (gets applied if workspace-monitor == waybar-monitor)

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -208,7 +208,7 @@ void Workspaces::doUpdate() {
   }
 
   spdlog::trace("Updating workspace states");
-  auto IPC_workspaces = gIPC->getSocket1JsonReply("workspaces");
+  auto updated_workspaces = gIPC->getSocket1JsonReply("workspaces");
   for (auto &workspace : m_workspaces) {
     // active
     workspace->setActive(workspace->name() == m_activeWorkspaceName ||
@@ -229,12 +229,13 @@ void Workspaces::doUpdate() {
     }
 
     // update m_output
-    auto IPC_workspace = std::find_if(IPC_workspaces.begin(), IPC_workspaces.end(), [&workspace](auto &w) {
-      auto wNameRaw = w["name"].asString();
-      auto wName = wNameRaw.starts_with("special:") ? wNameRaw.substr(8) : wNameRaw;
-      return wName == workspace->name();
-    });
-    workspace->setOutput((*IPC_workspace)["monitor"].asString());
+    auto updated_workspace =
+        std::find_if(updated_workspaces.begin(), updated_workspaces.end(), [&workspace](auto &w) {
+          auto wNameRaw = w["name"].asString();
+          auto wName = wNameRaw.starts_with("special:") ? wNameRaw.substr(8) : wNameRaw;
+          return wName == workspace->name();
+        });
+    workspace->setOutput((*updated_workspace)["monitor"].asString());
 
     workspace->update(m_format, workspaceIcon);
   }

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -872,7 +872,7 @@ void Workspace::update(const std::string &format, const std::string &icon) {
   addOrRemoveClass(styleContext, isPersistent(), "persistent");
   addOrRemoveClass(styleContext, isUrgent(), "urgent");
   addOrRemoveClass(styleContext, isVisible(), "visible");
-  addOrRemoveClass(styleContext, m_workspaceManager.getBarOutput() == output(), "onThisMonitor");
+  addOrRemoveClass(styleContext, m_workspaceManager.getBarOutput() == output(), "hosting-monitor");
 
   std::string windows;
   auto windowSeparator = m_workspaceManager.getWindowSeparator();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -871,6 +871,7 @@ void Workspace::update(const std::string &format, const std::string &icon) {
   addOrRemoveClass(styleContext, isPersistent(), "persistent");
   addOrRemoveClass(styleContext, isUrgent(), "urgent");
   addOrRemoveClass(styleContext, isVisible(), "visible");
+  addOrRemoveClass(styleContext, m_workspaceManager.getBarOutput() == output(), "onThisMonitor");
 
   std::string windows;
   auto windowSeparator = m_workspaceManager.getWindowSeparator();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -208,6 +208,7 @@ void Workspaces::doUpdate() {
   }
 
   spdlog::trace("Updating workspace states");
+  auto IPC_workspaces = gIPC->getSocket1JsonReply("workspaces");
   for (auto &workspace : m_workspaces) {
     // active
     workspace->setActive(workspace->name() == m_activeWorkspaceName ||
@@ -226,6 +227,15 @@ void Workspaces::doUpdate() {
     if (m_withIcon) {
       workspaceIcon = workspace->selectIcon(m_iconsMap);
     }
+
+    // update m_output
+    auto IPC_workspace = std::find_if(IPC_workspaces.begin(), IPC_workspaces.end(), [&workspace](auto &w) {
+      auto wNameRaw = w["name"].asString();
+      auto wName = wNameRaw.starts_with("special:") ? wNameRaw.substr(8) : wNameRaw;
+      return wName == workspace->name();
+    });
+    workspace->setOutput((*IPC_workspace)["monitor"].asString());
+
     workspace->update(m_format, workspaceIcon);
   }
 


### PR DESCRIPTION
Adds the css class `onThisMonitor`. 
This will make it possible to only style the waybar that a workspace is on.

Example:
```css
#workspaces .onThisMonitor {
  color:blue;
}

/* waybar of monitor 1 with workspace A open:   [    A       B    ]
 *                                                  blue   white
 *
 * waybar of monitor 2 with workspace B open:   [    A       B    ]
 *                                                 white    blue
 */
```

Closes #2959