### PR TITLE
Introduce a power-profiles-daemon module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 - Local time
 - Battery
 - UPower
+- Power profiles daemon
 - Network
 - Bluetooth
 - Pulseaudio

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -7,25 +7,25 @@
 
 namespace waybar::modules {
 
-typedef struct {
+struct Profile {
   std::string name;
   std::string driver;
-} Profile;
+};
 
 class PowerProfilesDaemon : public ALabel {
  public:
   PowerProfilesDaemon(const std::string&, const Json::Value&);
-  ~PowerProfilesDaemon();
+  ~PowerProfilesDaemon() override;
   auto update() -> void override;
-  void profileChanged_cb(const Gio::DBus::Proxy::MapChangedProperties&,
-                         const std::vector<Glib::ustring>&);
+  void profileChangedCb(const Gio::DBus::Proxy::MapChangedProperties&,
+                        const std::vector<Glib::ustring>&);
   void populateInitState();
-  virtual bool handleToggle(GdkEventButton* const& e);
+  bool handleToggle(GdkEventButton* const& e) override;
 
  private:
   // Look for a profile name in the list of available profiles and
   // switch activeProfile_ to it.
-  void switchToProfile_(std::string);
+  void switchToProfile(std::string const&);
   // Used to toggle/display the profiles
   std::vector<Profile> availableProfiles_;
   // Points to the active profile in the profiles list
@@ -33,7 +33,7 @@ class PowerProfilesDaemon : public ALabel {
   // Current CSS class applied to the label
   std::string currentStyle_;
   // DBus Proxy used to track the current active profile
-  Glib::RefPtr<Gio::DBus::Proxy> power_profiles_proxy_;
+  Glib::RefPtr<Gio::DBus::Proxy> powerProfilesProxy_;
   sigc::connection powerProfileChangeSignal_;
 };
 

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -1,0 +1,38 @@
+# pragma once
+
+#include <fmt/format.h>
+
+#include "ALabel.hpp"
+#include "giomm/dbusproxy.h"
+
+namespace waybar::modules {
+
+typedef struct {
+  std::string name;
+  std::string driver;
+} Profile;
+
+class PowerProfilesDaemon : public ALabel  {
+ public:
+  PowerProfilesDaemon(const std::string&, const Json::Value&);
+  ~PowerProfilesDaemon();
+  auto update() -> void override;
+  void profileChanged_cb( const Gio::DBus::Proxy::MapChangedProperties&, const std::vector<Glib::ustring>&);
+  void populateInitState();
+  virtual bool handleToggle(GdkEventButton* const& e);
+ private:
+  // Look for a profile name in the list of available profiles and
+  // switch activeProfile_ to it.
+  void switchToProfile_(std::string);
+  // Used to toggle/display the profiles
+  std::vector<Profile> availableProfiles_;
+  // Points to the active profile in the profiles list
+  std::vector<Profile>::iterator activeProfile_;
+  // Current CSS class applied to the label
+  std::string currentStyle_;
+  // DBus Proxy used to track the current active profile
+  Glib::RefPtr<Gio::DBus::Proxy> power_profiles_proxy_;
+  sigc::connection powerProfileChangeSignal_;
+};
+
+}

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -14,18 +14,24 @@ struct Profile {
 
 class PowerProfilesDaemon : public ALabel {
  public:
-  PowerProfilesDaemon(const std::string&, const Json::Value&);
+  PowerProfilesDaemon(const std::string &, const Json::Value &);
   ~PowerProfilesDaemon() override;
   auto update() -> void override;
-  void profileChangedCb(const Gio::DBus::Proxy::MapChangedProperties&,
-                        const std::vector<Glib::ustring>&);
+  void profileChangedCb(const Gio::DBus::Proxy::MapChangedProperties &,
+                        const std::vector<Glib::ustring> &);
+  void busConnectedCb(Glib::RefPtr<Gio::AsyncResult> &r);
+  void getAllPropsCb(Glib::RefPtr<Gio::AsyncResult> &r);
+  void setPropCb(Glib::RefPtr<Gio::AsyncResult> &r);
   void populateInitState();
-  bool handleToggle(GdkEventButton* const& e) override;
+  bool handleToggle(GdkEventButton *const &e) override;
 
  private:
+  // True if we're connected to the dbug interface. False if we're
+  // not.
+  bool connected_;
   // Look for a profile name in the list of available profiles and
   // switch activeProfile_ to it.
-  void switchToProfile(std::string const&);
+  void switchToProfile(std::string const &);
   // Used to toggle/display the profiles
   std::vector<Profile> availableProfiles_;
   // Points to the active profile in the profiles list

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -15,7 +15,6 @@ struct Profile {
 class PowerProfilesDaemon : public ALabel {
  public:
   PowerProfilesDaemon(const std::string &, const Json::Value &);
-  ~PowerProfilesDaemon() override;
   auto update() -> void override;
   void profileChangedCb(const Gio::DBus::Proxy::MapChangedProperties &,
                         const std::vector<Glib::ustring> &);
@@ -38,12 +37,10 @@ class PowerProfilesDaemon : public ALabel {
   std::vector<Profile>::iterator activeProfile_;
   // Current CSS class applied to the label
   std::string currentStyle_;
-  // Format strings
-  std::string labelFormat_;
+  // Format string
   std::string tooltipFormat_;
   // DBus Proxy used to track the current active profile
   Glib::RefPtr<Gio::DBus::Proxy> powerProfilesProxy_;
-  sigc::connection powerProfileChangeSignal_;
 };
 
 }  // namespace waybar::modules

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -32,6 +32,9 @@ class PowerProfilesDaemon : public ALabel {
   std::vector<Profile>::iterator activeProfile_;
   // Current CSS class applied to the label
   std::string currentStyle_;
+  // Format strings
+  std::string labelFormat_;
+  std::string tooltipFormat_;
   // DBus Proxy used to track the current active profile
   Glib::RefPtr<Gio::DBus::Proxy> powerProfilesProxy_;
   sigc::connection powerProfileChangeSignal_;

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -1,4 +1,4 @@
-# pragma once
+#pragma once
 
 #include <fmt/format.h>
 
@@ -12,14 +12,16 @@ typedef struct {
   std::string driver;
 } Profile;
 
-class PowerProfilesDaemon : public ALabel  {
+class PowerProfilesDaemon : public ALabel {
  public:
   PowerProfilesDaemon(const std::string&, const Json::Value&);
   ~PowerProfilesDaemon();
   auto update() -> void override;
-  void profileChanged_cb( const Gio::DBus::Proxy::MapChangedProperties&, const std::vector<Glib::ustring>&);
+  void profileChanged_cb(const Gio::DBus::Proxy::MapChangedProperties&,
+                         const std::vector<Glib::ustring>&);
   void populateInitState();
   virtual bool handleToggle(GdkEventButton* const& e);
+
  private:
   // Look for a profile name in the list of available profiles and
   // switch activeProfile_ to it.
@@ -35,4 +37,4 @@ class PowerProfilesDaemon : public ALabel  {
   sigc::connection powerProfileChangeSignal_;
 };
 
-}
+}  // namespace waybar::modules

--- a/man/waybar-power-profiles-daemon.5.scd
+++ b/man/waybar-power-profiles-daemon.5.scd
@@ -42,7 +42,7 @@ $XDG_CONFIG_HOME/waybar/config
 Compact display (default config):
 
 ```
-"power_profiles_daemon": {
+"power-profiles-daemon": {
   "format": "{icon}",
   "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
   "tooltip": true,
@@ -58,7 +58,7 @@ Compact display (default config):
 Display the full profile name:
 
 ```
-"power_profiles_daemon": {
+"power-profiles-daemon": {
   "format": "{icon}   {profile}",
   "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
   "tooltip": true,

--- a/man/waybar-power-profiles-daemon.5.scd
+++ b/man/waybar-power-profiles-daemon.5.scd
@@ -1,0 +1,72 @@
+waybar-power-profiles-daemon(5)
+
+# NAME
+
+waybar - power-profiles-daemon module
+
+# DESCRIPTION
+
+The *power-profiles-daemon* module displays the active power-profiles-daemon profile and cycle through the available profiles on click.
+
+# FILES
+
+$XDG_CONFIG_HOME/waybar/config
+
+# CONFIGURATION
+
+
+[- *Option*
+:- *Typeof*
+:- *Default*
+:= *Description*
+|[ *format*
+:[ string
+:[ "{icon}"
+:[ Message displayed on the bar. {icon} and {profile} are respectively substituted with the icon representing the active profile and its full name.
+|[ *tooltip-format*
+:[ string
+:[ "Power profile: {profile}\\nDriver: {driver}"
+:[ Messaged displayed in the module tooltip. {icon} and {profile} are respectively substituted with the icon representing the active profile and its full name.
+|[ *tooltip*
+:[ bool
+:[ true
+:[ Display the tooltip.
+|[ *format-icons*
+:[ object
+:[ See default value in the example below.
+:[ Icons used to represent the various power-profile. *Note*: the default configuration uses the font-awesome icons. You may want to override it if you don't have this font installed on your system.
+
+
+# CONFIGURATION EXAMPLES
+
+Compact display (default config):
+
+```
+"power_profiles_daemon": {
+  "format": "{icon}",
+  "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
+  "tooltip": true,
+  "format-icons": {
+    "default": "",
+    "performance": "",
+    "balanced": "",
+    "power-saver": ""
+  }
+}
+```
+
+Display the full profile name:
+
+```
+"power_profiles_daemon": {
+  "format": "{icon}   {profile}",
+  "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
+  "tooltip": true,
+  "format-icons": {
+    "default": "",
+    "performance": "",
+    "balanced": "",
+    "power-saver": ""
+  }
+}
+```

--- a/meson.build
+++ b/meson.build
@@ -222,6 +222,7 @@ if is_linux
         'man/waybar-cpu.5.scd',
         'man/waybar-memory.5.scd',
         'man/waybar-systemd-failed-units.5.scd',
+        'man/waybar-power-profiles-daemon.5.scd',
     )
 elif is_dragonfly or is_freebsd or is_netbsd or is_openbsd
     add_project_arguments('-DHAVE_CPU_BSD', language: 'cpp')
@@ -578,4 +579,3 @@ if clangtidy.found()
             '-p', meson.project_build_root()
         ] + src_files)
 endif
-

--- a/meson.build
+++ b/meson.build
@@ -212,6 +212,7 @@ if is_linux
         'src/modules/cpu_usage/linux.cpp',
         'src/modules/memory/common.cpp',
         'src/modules/memory/linux.cpp',
+        'src/modules/power_profiles_daemon.cpp',
         'src/modules/systemd_failed_units.cpp',
     )
     man_files += files(

--- a/resources/config.jsonc
+++ b/resources/config.jsonc
@@ -20,7 +20,7 @@
         "idle_inhibitor",
         "pulseaudio",
         "network",
-        "power_profiles_daemon",
+        "power-profiles-daemon",
         "cpu",
         "memory",
         "temperature",
@@ -148,7 +148,7 @@
     "battery#bat2": {
         "bat": "BAT2"
     },
-    "power_profiles_daemon": {
+    "power-profiles-daemon": {
       "format": "{icon}",
       "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
       "tooltip": true,

--- a/resources/config.jsonc
+++ b/resources/config.jsonc
@@ -148,6 +148,17 @@
     "battery#bat2": {
         "bat": "BAT2"
     },
+    "power_profiles_daemon": {
+      "format": "{icon}",
+      "tooltip-format": "Power profile: {profile}\nDriver: {driver}",
+      "tooltip": true,
+      "format-icons": {
+        "default": "",
+        "performance": "",
+        "balanced": "",
+        "power-saver": ""
+      }
+    },
     "network": {
         // "interface": "wlp2*", // (Optional) To force the use of this interface
         "format-wifi": "{essid} ({signalStrength}%) ",

--- a/resources/config.jsonc
+++ b/resources/config.jsonc
@@ -20,6 +20,7 @@
         "idle_inhibitor",
         "pulseaudio",
         "network",
+        "power_profiles_daemon",
         "cpu",
         "memory",
         "temperature",
@@ -188,4 +189,3 @@
         // "exec": "$HOME/.config/waybar/mediaplayer.py --player spotify 2> /dev/null" // Filter player based on name
     }
 }
-

--- a/resources/style.css
+++ b/resources/style.css
@@ -87,6 +87,7 @@ button:hover {
 #mode,
 #idle_inhibitor,
 #scratchpad,
+#power-profiles-daemon,
 #mpd {
     padding: 0 10px;
     color: #ffffff;
@@ -137,6 +138,21 @@ button:hover {
     animation-timing-function: steps(12);
     animation-iteration-count: infinite;
     animation-direction: alternate;
+}
+
+#power-profiles-daemon.performance {
+    background-color: #f53c3c;
+    color: #ffffff;
+}
+
+#power-profiles-daemon.balanced {
+    background-color: #2980b9;
+    color: #ffffff;
+}
+
+#power-profiles-daemon.power-saver {
+    background-color: #2ecc71;
+    color: #000000;
 }
 
 label:focus {

--- a/resources/style.css
+++ b/resources/style.css
@@ -140,6 +140,10 @@ button:hover {
     animation-direction: alternate;
 }
 
+#power-profiles-daemon {
+    padding-right: 15px;
+}
+
 #power-profiles-daemon.performance {
     background-color: #f53c3c;
     color: #ffffff;

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -283,7 +283,7 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
     if (ref == "bluetooth") {
       return new waybar::modules::Bluetooth(id, config_[name]);
     }
-    if (ref == "power_profiles_daemon") {
+    if (ref == "power-profiles-daemon") {
       return new waybar::modules::PowerProfilesDaemon(id, config_[name]);
     }
 #endif

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -86,6 +86,7 @@
 #endif
 #if defined(__linux__)
 #include "modules/bluetooth.hpp"
+#include "modules/power_profiles_daemon.hpp"
 #endif
 #ifdef HAVE_LOGIND_INHIBITOR
 #include "modules/inhibitor.hpp"
@@ -281,6 +282,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
 #if defined(__linux__)
     if (ref == "bluetooth") {
       return new waybar::modules::Bluetooth(id, config_[name]);
+    }
+    if (ref == "power_profiles_daemon") {
+      return new waybar::modules::PowerProfilesDaemon(id, config_[name]);
     }
 #endif
 #ifdef HAVE_LOGIND_INHIBITOR

--- a/src/modules/power_profiles_daemon.cpp
+++ b/src/modules/power_profiles_daemon.cpp
@@ -17,6 +17,18 @@ namespace waybar::modules {
 
 PowerProfilesDaemon::PowerProfilesDaemon(const std::string& id, const Json::Value& config)
     : ALabel(config, "power-profiles-daemon", id, "{profile}", 0, false, true) {
+  if (config_["format"].isString()) {
+    format_ = config_["format"].asString();
+  } else {
+    format_ = "{icon}";
+  }
+
+  if (config_["tooltip-format"].isString()) {
+    tooltipFormat_ = config_["tooltip-format"].asString();
+  } else {
+    tooltipFormat_ = "Power profile: {profile}\nDriver: {driver}";
+  }
+
   // NOTE: the DBus adresses are under migration. They should be
   // changed to org.freedesktop.UPower.PowerProfiles at some point.
   //
@@ -110,9 +122,11 @@ auto PowerProfilesDaemon::update() -> void {
   // Set label
   fmt::dynamic_format_arg_store<fmt::format_context> store;
   store.push_back(fmt::arg("profile", profile.name));
-  label_.set_markup(fmt::vformat("⚡ {profile}", store));
+  store.push_back(fmt::arg("driver", profile.driver));
+  store.push_back(fmt::arg("icon", getIcon(0, profile.name)));
+  label_.set_markup(fmt::vformat(format_, store));
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(fmt::format("Driver: {}", profile.driver));
+    label_.set_tooltip_text(fmt::vformat(tooltipFormat_, store));
   }
 
   // Set CSS class

--- a/src/modules/power_profiles_daemon.cpp
+++ b/src/modules/power_profiles_daemon.cpp
@@ -1,0 +1,146 @@
+#include "modules/power_profiles_daemon.hpp"
+
+// In the 80000 version of fmt library authors decided to optimize imports
+// and moved declarations required for fmt::dynamic_format_arg_store in new
+// header fmt/args.h
+#if (FMT_VERSION >= 80000)
+#include <fmt/args.h>
+#else
+#include <fmt/core.h>
+#endif
+
+#include <spdlog/spdlog.h>
+#include <glibmm.h>
+#include <glibmm/variant.h>
+
+
+
+namespace waybar::modules {
+
+PowerProfilesDaemon::PowerProfilesDaemon(const std::string& id, const Json::Value& config)
+  : ALabel(config, "power-profiles-daemon", id, "{profile}", 0, false, true)
+{
+  // NOTE: the DBus adresses are under migration. They should be
+  // changed to org.freedesktop.UPower.PowerProfiles at some point.
+  //
+  // See
+  // https://gitlab.freedesktop.org/upower/power-profiles-daemon/-/releases/0.20
+  //
+  // The old name is still announced for now. Let's rather use the old
+  // adresses for compatibility sake.
+  //
+  // Revisit this in 2026, systems should be updated by then.
+  power_profiles_proxy_ = Gio::DBus::Proxy::create_for_bus_sync(Gio::DBus::BusType::BUS_TYPE_SYSTEM,
+                                                        "net.hadess.PowerProfiles", "/net/hadess/PowerProfiles",
+                                                        "net.hadess.PowerProfiles");
+  if (!power_profiles_proxy_) {
+    spdlog::error("PowerProfilesDaemon: DBus error, cannot connect to net.hasdess.PowerProfile");
+  } else {
+    // Connect active profile callback
+    powerProfileChangeSignal_ = power_profiles_proxy_->signal_properties_changed()
+      .connect(sigc::mem_fun(*this, &PowerProfilesDaemon::profileChanged_cb));
+    populateInitState();
+    dp.emit();
+  }
+}
+
+// Look for the profile str in our internal profiles list. Using a
+// vector to store the profiles ain't the smartest move
+// complexity-wise, but it makes toggling between the mode easy. This
+// vector is 3 elements max, we'll be fine :P
+void PowerProfilesDaemon::switchToProfile_(std::string str) {
+  auto pred = [str](Profile p) { return p.name == str; };
+  activeProfile_ = std::find_if(availableProfiles_.begin(), availableProfiles_.end(), pred);
+  if (activeProfile_ == availableProfiles_.end()) {
+    throw std::runtime_error("FATAL, can't find the active profile in the available profiles list");
+  }
+}
+
+void PowerProfilesDaemon::populateInitState() {
+  // Retrieve current active profile
+  Glib::Variant<std::string> profileStr;
+  power_profiles_proxy_->get_cached_property(profileStr, "ActiveProfile");
+
+  // Retrieve profiles list, it's aa{sv}.
+  using ProfilesType = std::vector<std::map<Glib::ustring, Glib::Variant<std::string>>>;
+  Glib::Variant<ProfilesType> profilesVariant;
+  power_profiles_proxy_->get_cached_property(profilesVariant, "Profiles");
+  Glib::ustring name, driver;
+  Profile profile;
+  for (auto & variantDict: profilesVariant.get()) {
+    if (auto p = variantDict.find("Profile"); p != variantDict.end()) {
+      name = p->second.get();
+    }
+    if (auto d = variantDict.find("Driver"); d != variantDict.end()) {
+      driver = d->second.get();
+    }
+    profile = { name, driver };
+    availableProfiles_.push_back(profile);
+  }
+
+  // Find the index of the current activated mode (to toggle)
+  std::string str = profileStr.get();
+  switchToProfile_(str);
+
+  update();
+}
+
+PowerProfilesDaemon::~PowerProfilesDaemon() {
+  if (powerProfileChangeSignal_.connected()) {
+    powerProfileChangeSignal_.disconnect();
+  }
+  if (power_profiles_proxy_) {
+    power_profiles_proxy_.reset();
+  }
+}
+
+void PowerProfilesDaemon::profileChanged_cb(const Gio::DBus::Proxy::MapChangedProperties& changedProperties,
+                                            const std::vector<Glib::ustring>& invalidatedProperties) {
+  if (auto activeProfileVariant = changedProperties.find("ActiveProfile"); activeProfileVariant != changedProperties.end()) {
+    std::string activeProfile = Glib::VariantBase::cast_dynamic<Glib::Variant<std::string>>(activeProfileVariant->second).get();
+    switchToProfile_(activeProfile);
+    update();
+  }
+}
+
+auto PowerProfilesDaemon::update () -> void {
+  auto profile = (*activeProfile_);
+  // Set label
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  store.push_back(fmt::arg("profile", profile.name));
+  label_.set_markup(fmt::vformat("⚡ {profile}", store));
+  if (tooltipEnabled()) {
+    label_.set_tooltip_text(fmt::format("Driver: {}", profile.driver));
+  }
+
+  // Set CSS class
+  if (!currentStyle_.empty()) {
+    label_.get_style_context()->remove_class(currentStyle_);
+  }
+  label_.get_style_context()->add_class(profile.name);
+  currentStyle_ = profile.name;
+
+  ALabel::update();
+}
+
+
+bool PowerProfilesDaemon::handleToggle(GdkEventButton* const& e) {
+  if (e->type == GdkEventType::GDK_BUTTON_PRESS && power_profiles_proxy_) {
+    activeProfile_++;
+    if (activeProfile_ == availableProfiles_.end()) {
+      activeProfile_ = availableProfiles_.begin();
+    }
+
+    using VarStr = Glib::Variant<Glib::ustring>;
+    using SetPowerProfileVar = Glib::Variant<std::tuple<Glib::ustring,Glib::ustring,VarStr>>;
+    VarStr activeProfileVariant = VarStr::create(activeProfile_->name);
+    auto call_args = SetPowerProfileVar::create(std::make_tuple("net.hadess.PowerProfiles", "ActiveProfile", activeProfileVariant));
+    auto container = Glib::VariantBase::cast_dynamic<Glib::VariantContainerBase>(call_args);
+    power_profiles_proxy_->call_sync("org.freedesktop.DBus.Properties.Set", container);
+
+    update();
+  }
+  return true;
+}
+
+}


### PR DESCRIPTION
We introduce a module in charge to display and toggle on click the power profiles via power-profiles-daemon.

https://gitlab.freedesktop.org/upower/power-profiles-daemon

This daemon is pretty widespread. It's the component used by Gnome and KDE to manage the power profiles. The power management daemon is a pretty important software component for laptops and other battery-powered devices.

We're using the daemon DBus interface to:

- Fetch the available power profiles.
- Track the active power profile.
- Change the active power profile.

The original author recently gave up maintenance on the project. The Upower group took over the maintenance burden… …and created a new DBus name for the project. The old name is still advertised for now. We use the old name for compatibility sake: most distributions did not release 0.20, which introduces this new DBus name. We'll likely revisit
this in the future and point to the new bus name. See the inline comment for more details.

Given how widespread this daemon is, I activated the module in the default configuration. I'm not 100% sure about myself on that one though :)

Demo video: https://social.alternativebit.fr/media/514a598a09c6c9047e61af405d188aa7b99a5730015c95ad787f7c023ea1f461.mp4

