### PR TITLE
Improved hyprland/window by fixing icon search and implementing configurable spacing

### DIFF
--- a/include/modules/hyprland/window.hpp
+++ b/include/modules/hyprland/window.hpp
@@ -59,6 +59,7 @@ class Window : public waybar::AAppIconLabel, public EventHandler {
   bool allFloating_;
   bool swallowing_;
   bool fullscreen_;
+  bool focused_;
 };
 
 }  // namespace waybar::modules::hyprland

--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -24,7 +24,7 @@ AAppIconLabel::AAppIconLabel(const Json::Value& config, const std::string& name,
   image_.set_pixel_size(app_icon_size_);
 }
 
-std::string to_lowercase(const std::string& input) {
+std::string toLowerCase(const std::string& input) {
   std::string result = input;
   std::transform(result.begin(), result.end(), result.begin(),
                  [](unsigned char c) { return std::tolower(c); });
@@ -44,7 +44,7 @@ std::optional<std::string> getFileBySuffix(const std::string& dir, const std::st
       }
       if ((filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0) ||
           (check_lower_case && filename.compare(filename.size() - suffix.size(), suffix.size(),
-                                                to_lowercase(suffix)) == 0)) {
+                                                toLowerCase(suffix)) == 0)) {
         return entry.path().string();
       }
     }
@@ -97,16 +97,9 @@ std::optional<Glib::ustring> getIconName(const std::string& app_identifier,
       return app_identifier_desktop;
     }
 
-    const auto to_lower = [](const std::string& str) {
-      auto str_cpy = str;
-      std::transform(str_cpy.begin(), str_cpy.end(), str_cpy.begin(),
-                     [](unsigned char c) { return std::tolower(c); });
-      return str;
-    };
-
     const auto first_space = app_identifier.find_first_of(' ');
     if (first_space != std::string::npos) {
-      const auto first_word = to_lower(app_identifier.substr(0, first_space));
+      const auto first_word = toLowerCase(app_identifier.substr(0, first_space));
       if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
         return first_word;
       }
@@ -114,7 +107,7 @@ std::optional<Glib::ustring> getIconName(const std::string& app_identifier,
 
     const auto first_dash = app_identifier.find_first_of('-');
     if (first_dash != std::string::npos) {
-      const auto first_word = to_lower(app_identifier.substr(0, first_dash));
+      const auto first_word = toLowerCase(app_identifier.substr(0, first_dash));
       if (DefaultGtkIconThemeWrapper::has_icon(first_word)) {
         return first_word;
       }

--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -24,18 +24,57 @@ AAppIconLabel::AAppIconLabel(const Json::Value& config, const std::string& name,
   image_.set_pixel_size(app_icon_size_);
 }
 
+std::string to_lowercase(const std::string& input) {
+  std::string result = input;
+  std::transform(result.begin(), result.end(), result.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+  return result;
+}
+
+std::optional<std::string> getFileBySuffix(const std::string& dir, const std::string& suffix,
+                                           bool check_lower_case) {
+  if (!std::filesystem::exists(dir)) {
+    return {};
+  }
+  for (const auto& entry : std::filesystem::recursive_directory_iterator(dir)) {
+    if (entry.is_regular_file()) {
+      std::string filename = entry.path().filename().string();
+      if (filename.size() < suffix.size()) {
+        continue;
+      }
+      if ((filename.compare(filename.size() - suffix.size(), suffix.size(), suffix) == 0) ||
+          (check_lower_case && filename.compare(filename.size() - suffix.size(), suffix.size(),
+                                                to_lowercase(suffix)) == 0)) {
+        return entry.path().string();
+      }
+    }
+  }
+
+  return {};
+}
+
+std::optional<std::string> getFileBySuffix(const std::string& dir, const std::string& suffix) {
+  return getFileBySuffix(dir, suffix, false);
+}
+
 std::optional<std::string> getDesktopFilePath(const std::string& app_identifier,
                                               const std::string& alternative_app_identifier) {
   const auto data_dirs = Glib::get_system_data_dirs();
   for (const auto& data_dir : data_dirs) {
-    const auto data_app_dir = data_dir + "applications/";
-    auto desktop_file_path = data_app_dir + app_identifier + ".desktop";
-    if (std::filesystem::exists(desktop_file_path)) {
+    const auto data_app_dir = data_dir + "/applications/";
+    auto desktop_file_suffix = app_identifier + ".desktop";
+    // searching for file by suffix catches cases like terminal emulator "foot" where class is
+    // "footclient" and desktop file is named "org.codeberg.dnkl.footclient.desktop"
+    auto desktop_file_path = getFileBySuffix(data_app_dir, desktop_file_suffix, true);
+    // "true" argument allows checking for lowercase - this catches cases where class name is
+    // "LibreWolf" and desktop file is named "librewolf.desktop"
+    if (desktop_file_path.has_value()) {
       return desktop_file_path;
     }
     if (!alternative_app_identifier.empty()) {
-      desktop_file_path = data_app_dir + alternative_app_identifier + ".desktop";
-      if (std::filesystem::exists(desktop_file_path)) {
+      desktop_file_suffix = alternative_app_identifier + ".desktop";
+      desktop_file_path = getFileBySuffix(data_app_dir, desktop_file_suffix, true);
+      if (desktop_file_path.has_value()) {
         return desktop_file_path;
       }
     }

--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -59,6 +59,10 @@ std::optional<std::string> getFileBySuffix(const std::string& dir, const std::st
 
 std::optional<std::string> getDesktopFilePath(const std::string& app_identifier,
                                               const std::string& alternative_app_identifier) {
+  if (app_identifier.empty()) {
+    return {};
+  }
+
   const auto data_dirs = Glib::get_system_data_dirs();
   for (const auto& data_dir : data_dirs) {
     const auto data_app_dir = data_dir + "/applications/";

--- a/src/AIconLabel.cpp
+++ b/src/AIconLabel.cpp
@@ -10,7 +10,14 @@ AIconLabel::AIconLabel(const Json::Value &config, const std::string &name, const
     : ALabel(config, name, id, format, interval, ellipsize, enable_click, enable_scroll) {
   event_box_.remove();
   box_.set_orientation(Gtk::Orientation::ORIENTATION_HORIZONTAL);
-  box_.set_spacing(8);
+
+  // set aesthetic default spacing
+  int spacing = config_["icon-spacing"].isInt() ? config_["icon-spacing"].asInt() : -5;
+  box_.set_spacing(spacing);
+
+  int margin_top = config_["margin-top"].isInt() ? config_["margin-top"].asInt() : 6;
+  box_.set_margin_top(margin_top);
+
   box_.add(image_);
   box_.add(label_);
   event_box_.add(box_);

--- a/src/AIconLabel.cpp
+++ b/src/AIconLabel.cpp
@@ -9,17 +9,20 @@ AIconLabel::AIconLabel(const Json::Value &config, const std::string &name, const
                        bool enable_click, bool enable_scroll)
     : ALabel(config, name, id, format, interval, ellipsize, enable_click, enable_scroll) {
   event_box_.remove();
+  label_.unset_name();
+  label_.get_style_context()->remove_class(MODULE_CLASS);
+  box_.get_style_context()->add_class(MODULE_CLASS);
+  if (!id.empty()) {
+    label_.get_style_context()->remove_class(id);
+    box_.get_style_context()->add_class(id);
+  }
+
   box_.set_orientation(Gtk::Orientation::ORIENTATION_HORIZONTAL);
-
-  // set aesthetic default spacing
-  int spacing = config_["icon-spacing"].isInt() ? config_["icon-spacing"].asInt() : -5;
-  box_.set_spacing(spacing);
-
-  int margin_top = config_["margin-top"].isInt() ? config_["margin-top"].asInt() : 6;
-  box_.set_margin_top(margin_top);
+  box_.set_name(name);
 
   box_.add(image_);
   box_.add(label_);
+
   event_box_.add(box_);
 }
 

--- a/src/AIconLabel.cpp
+++ b/src/AIconLabel.cpp
@@ -20,7 +20,7 @@ AIconLabel::AIconLabel(const Json::Value &config, const std::string &name, const
   box_.set_orientation(Gtk::Orientation::ORIENTATION_HORIZONTAL);
   box_.set_name(name);
 
-  int spacing = config_["icon-spacing"].isInt() ? config_["icon-spacing"].asInt() : 6;
+  int spacing = config_["icon-spacing"].isInt() ? config_["icon-spacing"].asInt() : 8;
   box_.set_spacing(spacing);
 
   box_.add(image_);

--- a/src/AIconLabel.cpp
+++ b/src/AIconLabel.cpp
@@ -20,6 +20,9 @@ AIconLabel::AIconLabel(const Json::Value &config, const std::string &name, const
   box_.set_orientation(Gtk::Orientation::ORIENTATION_HORIZONTAL);
   box_.set_name(name);
 
+  int spacing = config_["icon-spacing"].isInt() ? config_["icon-spacing"].asInt() : 6;
+  box_.set_spacing(spacing);
+
   box_.add(image_);
   box_.add(label_);
 

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -62,6 +62,12 @@ auto Window::update() -> void {
     label_.hide();
   }
 
+  if (focused_) {
+    image_.show();
+  } else {
+    image_.hide();
+  }
+
   setClass("empty", workspace_.windows == 0);
   setClass("solo", solo_);
   setClass("floating", allFloating_);
@@ -137,13 +143,16 @@ void Window::queryActiveWorkspace() {
     workspace_ = getActiveWorkspace();
   }
 
+  focused_ = true;
   if (workspace_.windows > 0) {
     const auto clients = gIPC->getSocket1JsonReply("clients");
     assert(clients.isArray());
     auto activeWindow = std::find_if(clients.begin(), clients.end(), [&](Json::Value window) {
       return window["address"] == workspace_.last_window;
     });
+
     if (activeWindow == std::end(clients)) {
+      focused_ = false;
       return;
     }
 
@@ -185,6 +194,7 @@ void Window::queryActiveWorkspace() {
       soloClass_ = "";
     }
   } else {
+    focused_ = false;
     windowData_ = WindowData{};
     allFloating_ = false;
     swallowing_ = false;


### PR DESCRIPTION
I noticed that some windows were displaying icons, while others weren't. I also found the gap between the icon and the window descriptor slightly excessive, and the module to be placed slightly too highly. This pull request aims to fix this.

### Search
I fixed the icon issue by matching the app descriptor with the suffix of the .desktop file, instead of the whole file name. I did this because I noticed that some applications like the terminal emulator "Foot", had "footclient" as the class name but "org.codeberg.dnkl.footclient.desktop" as the file name.

I also made it so that the search attempts to match the lowercase string version of the class name to its respective .desktop file, as well as the original. I did this because I noticed that some applications like LibreWolf had "LibreWolf" as the class name but "librewolf.desktop" as the file name.

#### Implementation Details
This is my first time making a pull request here, so I'm not sure how tight the coding standards are. I tried to follow conventions in the codebase where possible, but I will explain some areas I wasn't sure about - feel free to critique my code and suggest any improvements - I would fix them promptly.

To fix the search, I made some utility functions like `to_lowercase`, and `getFileBySuffix`. These functions are reusable, so I wasn't sure whether to put them in the `waybar` namespace or not. I did anyways, but if someone suggests that I put them outside the namespace, or define them in a separate utility functions file (since that is what I would do), I'm happy to do so.

In my `getFileBySuffix` function, I added overloading for a `check_lower_case` boolean value which is false by default. I did this as file names are case sensitive, so I did not want to check for lower and uppercase by default.

### Spacing
I'm not sure if this is an issue on my system specifically, but the spacing for me was rather jarring. I made the icon and window descriptor closer together, and moved them both down by default. You may wonder why I moved them down in the code instead of allowing the user to do this through CSS, and that's because for some reason, CSS margins and padding only affect the window descriptor, not the icon.

~To try to be less opinionated, I made them both configurable in the `config` file under names `icon-spacing` and `margin-top`. I didn't think to add any other margin types, because horizontal spacing can be changed in the waybar config file, and vertical spacing can be controlled completely with `margin-top` as when this is set to 0, the box is right at the top of the bar.~ (See EDIT/UPDATE below)

I added comments where I thought necessary - let me know if they're too excessive or if there aren't enough of them.

For context, here are some screenshots of what it looked like before (with icon set to true):
![2024-02-25T23:45:50,265900253+00:00](https://github.com/Alexays/Waybar/assets/67590754/cb655132-76ca-4ea2-860d-761887250b06)
![2024-02-25T23:46:27,200110035+00:00](https://github.com/Alexays/Waybar/assets/67590754/31ad796a-e6dd-4cf3-b581-7fbaf29e1070)
And here are some after:
![2024-02-25T23:46:58,382988289+00:00](https://github.com/Alexays/Waybar/assets/67590754/b298387b-cdd6-4095-995c-818839b48e82)
![2024-02-25T23:47:10,738484331+00:00](https://github.com/Alexays/Waybar/assets/67590754/8fdfd2f2-6872-4e84-977e-43a0004837c8)

### EDIT/UPDATE:
As per changes recommended by @alebastr, the `#window` selector now refers to the container box of both the image and label, as opposed to just the label. Each can be styled individually with `#window > label` and `#window > image`. The aforementioned configuration options have been removed in favour of this.
