### PR TITLE
ci: move FreeBSD to ubuntu runners

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -8,19 +8,22 @@ concurrency:
 
 jobs:
   clang:
-    # Run actions in a FreeBSD VM on the macos-12 runner
+    # Run actions in a FreeBSD VM on the ubuntu runner
     # https://github.com/actions/runner/issues/385 - for FreeBSD runner support
-    # https://github.com/actions/virtual-environments/issues/4060 - for lack of VirtualBox on MacOS 11 runners
-    runs-on: macos-12
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Test in FreeBSD VM
-        uses: cross-platform-actions/action@v0.21.1
+        uses: cross-platform-actions/action@v0.23.0
         timeout-minutes: 180
+        env:
+          CPPFLAGS: '-isystem/usr/local/include'
+          LDFLAGS:  '-L/usr/local/lib'
         with:
           operating_system: freebsd
           version: "13.2"
-          environment_variables: CPPFLAGS=-isystem/usr/local/include LDFLAGS=-L/usr/local/lib
+          environment_variables: CPPFLAGS LDFLAGS
+          sync_files: runner-to-vm
           run: |
             sudo sed -i '' 's/quarterly/latest/' /etc/pkg/FreeBSD.conf
             sudo pkg install -y git #  subprojects/date


### PR DESCRIPTION
With the recent runner hardware upgrade[1] and support in the cross-platform-actions[2] it became possible to use a Linux runner for this workflow.
Linux-based configuration appears to be faster and stabler than macOS, so it's now recommended for use.

[1]: https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/
[2]: https://github.com/cross-platform-actions/action/releases/tag/v0.23.0