### PR TITLE
[hyprland/workspaces] New options to change on click behaviour and active workspace status

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -126,6 +126,8 @@ class Workspaces : public AModule, public EventHandler {
   auto allOutputs() const -> bool { return m_allOutputs; }
   auto showSpecial() const -> bool { return m_showSpecial; }
   auto activeOnly() const -> bool { return m_activeOnly; }
+  auto moveToMonitor() const -> bool { return m_moveToMonitor; }
+  auto activePerMonitor() const -> bool { return m_activePerMonitor; }
 
   auto getBarOutput() const -> std::string { return m_bar.output->name; }
 
@@ -182,6 +184,8 @@ class Workspaces : public AModule, public EventHandler {
   bool m_allOutputs = false;
   bool m_showSpecial = false;
   bool m_activeOnly = false;
+  bool m_moveToMonitor = false;
+  bool m_activePerMonitor = false;
   Json::Value m_persistentWorkspaceConfig;
 
   // Map for windows stored in workspaces not present in the current bar.

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -127,7 +127,6 @@ class Workspaces : public AModule, public EventHandler {
   auto showSpecial() const -> bool { return m_showSpecial; }
   auto activeOnly() const -> bool { return m_activeOnly; }
   auto moveToMonitor() const -> bool { return m_moveToMonitor; }
-  auto activePerMonitor() const -> bool { return m_activePerMonitor; }
 
   auto getBarOutput() const -> std::string { return m_bar.output->name; }
 
@@ -185,7 +184,6 @@ class Workspaces : public AModule, public EventHandler {
   bool m_showSpecial = false;
   bool m_activeOnly = false;
   bool m_moveToMonitor = false;
-  bool m_activePerMonitor = false;
   Json::Value m_persistentWorkspaceConfig;
 
   // Map for windows stored in workspaces not present in the current bar.

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -52,6 +52,21 @@ Addressed by *hyprland/workspaces*
 	default: false ++
 	If set to true, only the active workspace will be shown.
 
+*move-to-monitor*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, open the workspace on the current monitor when clicking on a workspace button.
+	Otherwise, the workspace will open on the monitor where it was previously assigned.
+	Analog to using `focusworkspaceoncurrentmonitor` dispatcher instead of `workspace` in Hyprland.
+
+*active-per-monitor*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, each bar on each monitor will show its separate active
+	workspace being the currently focused workspace on this monitor.
+	Otherwise, all bars on all monitors will show the same active workspace
+	being the currently focused workspace on the currently focused monitor.
+
 *ignore-workspaces*: ++
 	typeof: array ++
 	default: [] ++

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -59,14 +59,6 @@ Addressed by *hyprland/workspaces*
 	Otherwise, the workspace will open on the monitor where it was previously assigned.
 	Analog to using `focusworkspaceoncurrentmonitor` dispatcher instead of `workspace` in Hyprland.
 
-*active-per-monitor*: ++
-	typeof: bool ++
-	default: false ++
-	If set to true, each bar on each monitor will show its separate active
-	workspace being the currently focused workspace on this monitor.
-	Otherwise, all bars on all monitors will show the same active workspace
-	being the currently focused workspace on the currently focused monitor.
-
 *ignore-workspaces*: ++
 	typeof: array ++
 	default: [] ++

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -88,11 +88,6 @@ auto Workspaces::parseConfig(const Json::Value &config) -> void {
     m_moveToMonitor = configMoveToMonitor.asBool();
   }
 
-  auto configActivePerMonitor = config_["active-per-monitor"];
-  if (configActivePerMonitor.isBool()) {
-    m_activePerMonitor = configActivePerMonitor.asBool();
-  }
-
   auto configSortBy = config_["sort-by"];
   if (configSortBy.isString()) {
     auto sortByStr = configSortBy.asString();
@@ -331,14 +326,7 @@ void Workspaces::onEvent(const std::string &ev) {
 }
 
 void Workspaces::onWorkspaceActivated(std::string const &payload) {
-  if (!m_activePerMonitor) {
-    m_activeWorkspaceName = payload;
-    return;
-  }
-  auto activeWorkspace = gIPC->getSocket1JsonReply("activeworkspace");
-  if (m_bar.output->name == activeWorkspace["monitor"].asString()) {
-    m_activeWorkspaceName = payload;
-  }
+  m_activeWorkspaceName = payload;
 }
 
 void Workspaces::onSpecialWorkspaceActivated(std::string const &payload) {
@@ -391,16 +379,6 @@ void Workspaces::onWorkspaceMoved(std::string const &payload) {
   if (m_bar.output->name == monitorName) {
     Json::Value clientsData = gIPC->getSocket1JsonReply("clients");
     onWorkspaceCreated(workspaceName, clientsData);
-    if (m_activePerMonitor) {
-      for (Json::Value &monitor : gIPC->getSocket1JsonReply("monitors")) {
-        if (m_bar.output->name == monitor["name"].asString()) {
-          auto ws = monitor["activeWorkspace"];
-          if (ws.isObject() && (ws["name"].isString())) {
-            m_activeWorkspaceName = ws["name"].asString();
-          }
-        }
-      }
-    }
   } else {
     spdlog::debug("Removing workspace because it was moved to another monitor: {}");
     onWorkspaceDestroyed(workspaceName);
@@ -426,13 +404,10 @@ void Workspaces::onWorkspaceRenamed(std::string const &payload) {
 
 void Workspaces::onMonitorFocused(std::string const &payload) {
   spdlog::trace("Monitor focused: {}", payload);
-  auto monitorName = payload.substr(0, payload.find(','));
-  if (!m_activePerMonitor || m_bar.output->name == monitorName) {
-    m_activeWorkspaceName = payload.substr(payload.find(',') + 1);
-  }
+  m_activeWorkspaceName = payload.substr(payload.find(',') + 1);
 
   for (Json::Value &monitor : gIPC->getSocket1JsonReply("monitors")) {
-    if (monitor["name"].asString() == monitorName) {
+    if (monitor["name"].asString() == payload.substr(0, payload.find(','))) {
       auto name = monitor["specialWorkspace"]["name"].asString();
       m_activeSpecialWorkspaceName = !name.starts_with("special:") ? name : name.substr(8);
     }
@@ -834,18 +809,7 @@ void Workspaces::extendOrphans(int workspaceId, Json::Value const &clientsJson) 
 }
 
 void Workspaces::init() {
-  if (!m_activePerMonitor) {
-    m_activeWorkspaceName = (gIPC->getSocket1JsonReply("activeworkspace"))["name"].asString();
-  } else {
-    for (Json::Value &monitor : gIPC->getSocket1JsonReply("monitors")) {
-      if (m_bar.output->name == monitor["name"].asString()) {
-        auto ws = monitor["activeWorkspace"];
-        if (ws.isObject() && (ws["name"].isString())) {
-          m_activeWorkspaceName = ws["name"].asString();
-        }
-      }
-    }
-  }
+  m_activeWorkspaceName = (gIPC->getSocket1JsonReply("activeworkspace"))["name"].asString();
 
   initializeWorkspaces();
   updateWindowCount();


### PR DESCRIPTION
Option `move-to-monitor`:
Use `hyprctl dispatch focusworkspaceoncurrentmonitor` when clicking on workspace button

Option `active-per-monitor`:
Each bar on each monitor has its own active workspace. So instead of all the bars showing the same workspace which is currently active, each show the currently active workspace of the bar's monitor.

This may require additional testing. Also I hope this doesn't break backwards compatibility, especially with special workspaces. I didn't test, but it should be fine as I didn't change anything special workspace related.