### PR TITLE
fix:dwl tag crash when use wlr-randr enable monitor

### DIFF
--- a/src/modules/dwl/tags.cpp
+++ b/src/modules/dwl/tags.cpp
@@ -155,6 +155,9 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
 }
 
 Tags::~Tags() {
+  if(output_status_) {
+    zdwl_ipc_output_v2_destroy(output_status_);
+  }
   if (status_manager_) {
     zdwl_ipc_manager_v2_destroy(status_manager_);
   }


### PR DESCRIPTION
fix: #3014

After disabling a monitor using wlr-randr,waybar destroys the monitor-associated Tag object, but does not remove the monitor-associated event listener.

when use wlr-randr enable the monitor again ,the old listener still listening .

when dwl makes a set_tag request to the monitor and waybar will tries to use the Tag resource that has been freed.