### PR TITLE
Upower warning level

### DIFF
--- a/include/modules/upower/upower.hpp
+++ b/include/modules/upower/upower.hpp
@@ -71,6 +71,7 @@ class UPower : public AModule {
   GDBusConnection *login1_connection;
   std::unique_ptr<UPowerTooltip> upower_tooltip;
   std::string lastStatus;
+  const char *lastWarningLevel;
   bool showAltText;
   bool showIcon = true;
   bool upowerRunning;

--- a/src/modules/upower/upower.cpp
+++ b/src/modules/upower/upower.cpp
@@ -315,12 +315,12 @@ auto UPower::update() -> void {
     return;
   }
 
-  UpDeviceKind kind;
-  UpDeviceState state;
+  UpDeviceKind kind = UP_DEVICE_KIND_UNKNOWN;
+  UpDeviceState state = UP_DEVICE_STATE_UNKNOWN;
   UpDeviceLevel level = UP_DEVICE_LEVEL_UNKNOWN;
-  double percentage;
-  gint64 time_empty;
-  gint64 time_full;
+  double percentage = 0.0;
+  gint64 time_empty = 0;
+  gint64 time_full = 0;
   gchar* icon_name{(char*)'\0'};
   std::string percentString{""};
   std::string time_format{""};


### PR DESCRIPTION
Add CSS class based on the 'warning_level' field reported by UPower over D-Bus.  This makes it possible to add custom styling when the battery is near empty.


Example:

``` css
#upower {
	background-color: #24283b;
	color: #9ece6a;
}

#upower.low {
	background-color: #f7768e;
	color: #24283b;
}

@keyframes blink {
	to {
		background-color: #24283b;
	}
}

#upower.critical {
	background-color: #f7768e;
	color: #24283b;

	animation-name: blink;
	animation-duration: 0.5s;
	animation-timing-function: steps(12);
	animation-iteration-count: infinite;
	animation-direction: alternate;
}
```

Additionally, fixed some potential uninitialized reads.