### PR TITLE
Add empty workspace style for Sway

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -182,5 +182,6 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
 - *#workspaces button.focused*
 - *#workspaces button.urgent*
 - *#workspaces button.persistent*
+- *#workspaces button.empty*
 - *#workspaces button.current_output*
 - *#workspaces button#sway-workspace-${name}*

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -322,6 +322,11 @@ auto Workspaces::update() -> void {
     } else {
       button.get_style_context()->remove_class("persistent");
     }
+    if ((*it)["nodes"].size() == 0) {
+      button.get_style_context()->add_class("empty");
+    } else {
+      button.get_style_context()->remove_class("empty");
+    }
     if ((*it)["output"].isString()) {
       if (((*it)["output"].asString()) == bar_.output->name) {
         button.get_style_context()->add_class("current_output");


### PR DESCRIPTION
Allows styling empty workspaces in Sway. While it is possible to do this using persistent tags, I feel like it may be a little confusing as persistent workspaces don't have to be empty. Thanks for reviewing! 