### PR TITLE
Update libwireplumber to >=0.4.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -92,7 +92,7 @@ libevdev = dependency('libevdev', required: get_option('libevdev'))
 libmpdclient = dependency('libmpdclient', required: get_option('mpd'))
 xkbregistry = dependency('xkbregistry')
 libjack = dependency('jack', required: get_option('jack'))
-libwireplumber = dependency('wireplumber-0.4', required: get_option('wireplumber'))
+libwireplumber = dependency('wireplumber-0.5', required: get_option('wireplumber'))
 
 libsndio = compiler.find_library('sndio', required: get_option('sndio'))
 if libsndio.found()

--- a/meson.build
+++ b/meson.build
@@ -92,7 +92,7 @@ libevdev = dependency('libevdev', required: get_option('libevdev'))
 libmpdclient = dependency('libmpdclient', required: get_option('mpd'))
 xkbregistry = dependency('xkbregistry')
 libjack = dependency('jack', required: get_option('jack'))
-libwireplumber = dependency('wireplumber-0.5', required: get_option('wireplumber'))
+libwireplumber = dependency('wireplumber', version:' >=0.4.0', required: get_option('wireplumber'))
 
 libsndio = compiler.find_library('sndio', required: get_option('sndio'))
 if libsndio.found()

--- a/src/modules/privacy/privacy.cpp
+++ b/src/modules/privacy/privacy.cpp
@@ -121,7 +121,7 @@ void Privacy::onPrivacyNodesChanged() {
 
 auto Privacy::update() -> void {
   mutex_.lock();
-  bool screenshare, audio_in, audio_out;
+  bool screenshare = false, audio_in = false, audio_out = false;
 
   for (Gtk::Widget* widget : box_.get_children()) {
     PrivacyItem* module = dynamic_cast<PrivacyItem*>(widget);


### PR DESCRIPTION
Waybar fails to compile on the newer version of libwireplumber release (0.5.0).
Just changed the dependency.
Fixes Issue #3035 