### PR TITLE
Add a way to hide keyboard state module when unlocked

### DIFF
--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -32,12 +32,15 @@ class KeyboardState : public AModule {
   Gtk::Label scrolllock_label_;
 
   std::string numlock_format_;
+  std::string numlock_locked_format_;
   std::string capslock_format_;
+  std::string capslock_locked_format_;
   std::string scrolllock_format_;
-  const std::chrono::seconds interval_;
+  std::string scrolllock_locked_format_;
   std::string icon_locked_;
   std::string icon_unlocked_;
   std::string devices_path_;
+  const std::chrono::seconds interval_;
 
   struct libinput* libinput_;
   std::unordered_map<std::string, struct libinput_device*> libinput_devices_;


### PR DESCRIPTION
Hi,

This MR adds new optional format options for the keyboard-state module when any of its element is locked. The main idea is to allow one to build invisible labels when unlocked, and only display something when locked (fix #1299). The initial problem being that GTK CSS does not offer any usable property in the matter (no support for `visibility`, `display` or even `width`).

The MR "works for me". However I’ve no strong opinion on how the setting should be done. Currently my implementation adds 3 new property in the `format` object, respectively `numlock-locked`, `capslock-locked`, `scrolllock-locked` to do something like:

```json
{
    …
    "keyboard-state": {
        "capslock": true,
        "format": {
            "capslock": "",
            "capslock-locked": " CAPS "
        }
    },
    …
}
```

But I’m not sure what would be best between that, or a whole new property `format-locked`, which might be just a string, as the `format` property:


```json
{
    …
    "keyboard-state": {
        "capslock": true,
        "format": "",
        "format-locked": " {name} "
    },
    …
}
```

or 


```json
{
    …
    "keyboard-state": {
        "capslock": true,
        "numlock": true,
        "format": "",
         "format-locked": {
            "capslock": " CAPS ",
            "numlock": " NUM "
        }
    },
    …
}
```

What do you think?