### PR TITLE
Use a single EventBox to handle group drawer events

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -23,6 +23,7 @@ class Group : public AModule {
 
  protected:
   Gtk::Box box;
+  Gtk::EventBox event_box;
   Gtk::Box revealer_box;
   Gtk::Revealer revealer;
   bool is_first_widget = true;

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -14,7 +14,6 @@ class Group : public AModule {
   Group(const std::string&, const std::string&, const Json::Value&, bool);
   virtual ~Group() = default;
   auto update() -> void override;
-  operator Gtk::Widget&() override;
 
   virtual Gtk::Box& getBox();
   void addWidget(Gtk::Widget& widget);
@@ -23,7 +22,6 @@ class Group : public AModule {
 
  protected:
   Gtk::Box box;
-  Gtk::EventBox event_box;
   Gtk::Box revealer_box;
   Gtk::Revealer revealer;
   bool is_first_widget = true;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -79,10 +79,10 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
       box.pack_start(revealer);
     }
 
-    event_box.add(box);
-    event_box.set_above_child(true);
-    addHoverHandlerTo(event_box);
+    event_box_.set_above_child(true);
+    addHoverHandlerTo(event_box_);
   }
+  event_box_.add(box);
 }
 
 bool Group::handleMouseHover(GdkEventCrossing* const& e) {
@@ -123,7 +123,5 @@ void Group::addWidget(Gtk::Widget& widget) {
 
   is_first_widget = false;
 }
-
-Group::operator Gtk::Widget&() { return event_box; }
 
 }  // namespace waybar

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -79,7 +79,9 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
       box.pack_start(revealer);
     }
 
-    addHoverHandlerTo(revealer);
+    event_box.add(box);
+    event_box.set_above_child(true);
+    addHoverHandlerTo(event_box);
   }
 }
 
@@ -114,8 +116,6 @@ void Group::addWidget(Gtk::Widget& widget) {
   getBox().pack_start(widget, false, false);
 
   if (is_drawer) {
-    // Necessary because of GTK's hitbox detection
-    addHoverHandlerTo(widget);
     if (!is_first_widget) {
       widget.get_style_context()->add_class(add_class_to_drawer_children);
     }
@@ -124,6 +124,6 @@ void Group::addWidget(Gtk::Widget& widget) {
   is_first_widget = false;
 }
 
-Group::operator Gtk::Widget&() { return box; }
+Group::operator Gtk::Widget&() { return event_box; }
 
 }  // namespace waybar


### PR DESCRIPTION
Fixes #3029

TODO: contained widgets don't seem to receive any input events