### PR TITLE
Hyprland/Workspaces: Added option to hide non-visible special workspaces

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -38,6 +38,7 @@ class Workspaces : public AModule, public EventHandler {
   auto allOutputs() const -> bool { return m_allOutputs; }
   auto showSpecial() const -> bool { return m_showSpecial; }
   auto activeOnly() const -> bool { return m_activeOnly; }
+  auto specialVisibleOnly() const -> bool { return m_specialVisibleOnly; }
   auto moveToMonitor() const -> bool { return m_moveToMonitor; }
 
   auto getBarOutput() const -> std::string { return m_bar.output->name; }
@@ -113,6 +114,7 @@ class Workspaces : public AModule, public EventHandler {
   bool m_allOutputs = false;
   bool m_showSpecial = false;
   bool m_activeOnly = false;
+  bool m_specialVisibleOnly = false;
   bool m_moveToMonitor = false;
   Json::Value m_persistentWorkspaceConfig;
 

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -42,6 +42,11 @@ Addressed by *hyprland/workspaces*
 	default: false ++
 	If set to true, special workspaces will be shown.
 
+*special-visible-only*: ++
+	typeof: bool ++
+	default: false ++
+	If this and show-special are to true, special workspaces will be shown only if visible.
+
 *all-outputs*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -182,6 +182,10 @@ void Workspace::update(const std::string &format, const std::string &icon) {
     m_button.hide();
     return;
   }
+  if (this->m_workspaceManager.specialVisibleOnly() && this->isSpecial() && !this->isVisible()) {
+    m_button.hide();
+    return;
+  }
   m_button.show();
 
   auto styleContext = m_button.get_style_context();

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -576,6 +576,7 @@ auto Workspaces::parseConfig(const Json::Value &config) -> void {
 
   populateBoolConfig(config, "all-outputs", m_allOutputs);
   populateBoolConfig(config, "show-special", m_showSpecial);
+  populateBoolConfig(config, "special-visible-only", m_specialVisibleOnly);
   populateBoolConfig(config, "active-only", m_activeOnly);
   populateBoolConfig(config, "move-to-monitor", m_moveToMonitor);
 


### PR DESCRIPTION
If `special-visible-only` is set, special workspaces will be shown only if visible, they'll be hidden if they're not visible.