### PR TITLE
fix(sway/workspaces): Visible class doesn't work on visible and empty workspaces

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -304,7 +304,7 @@ auto Workspaces::update() -> void {
     } else {
       button.get_style_context()->remove_class("focused");
     }
-    if (hasFlag((*it), "visible")) {
+    if (hasFlag((*it), "visible") || ((*it)["output"].isString() && (*it)["nodes"].size() == 0)) {
       button.get_style_context()->add_class("visible");
     } else {
       button.get_style_context()->remove_class("visible");


### PR DESCRIPTION
This fix is necessary to correctly apply the `#workspaces button.visible` style to all visible workspaces. This includes cases where workspaces are empty but still visible on the screen. This issue was introduced in #2944, which changes `ipc_.sendCmd(IPC_GET_WORKSPACES)` to `ipc_.sendCmd(IPC_GET_TREE)`. Therefore, the logic should be adjusted to handle the new IPC response correctly.