### PR TITLE
Fix clock on-scroll value not being used for calendar

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -41,6 +41,7 @@ class Clock final : public ALabel {
   const int cldMonColLen_{20};   // calendar month column length
   WS cldWPos_{WS::HIDDEN};       // calendar week side to print
   months cldCurrShift_{0};       // calendar months shift
+  int cldShift_{1};              // calendar months shift factor
   year_month_day cldYearShift_;  // calendar Year mode. Cached ymd
   std::string cldYearCached_;    // calendar Year mode. Cached calendar
   year_month cldMonShift_;       // calendar Month mode. Cached ym

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -115,6 +115,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
     } else
       cldMonCols_ = 1;
     if (config_[kCldPlaceholder]["on-scroll"].isInt()) {
+      cldShift_ = config_[kCldPlaceholder]["on-scroll"].asInt();
       event_box_.add_events(Gdk::LEAVE_NOTIFY_MASK);
       event_box_.signal_leave_notify_event().connect([this](GdkEventCrossing*) {
         cldCurrShift_ = months{0};
@@ -405,10 +406,10 @@ void waybar::modules::Clock::cldModeSwitch() {
   cldMode_ = (cldMode_ == CldMode::YEAR) ? CldMode::MONTH : CldMode::YEAR;
 }
 void waybar::modules::Clock::cldShift_up() {
-  cldCurrShift_ += (months)((cldMode_ == CldMode::YEAR) ? 12 : 1);
+  cldCurrShift_ += (months)((cldMode_ == CldMode::YEAR) ? 12 : 1) * cldShift_;
 }
 void waybar::modules::Clock::cldShift_down() {
-  cldCurrShift_ -= (months)((cldMode_ == CldMode::YEAR) ? 12 : 1);
+  cldCurrShift_ -= (months)((cldMode_ == CldMode::YEAR) ? 12 : 1) * cldShift_;
 }
 void waybar::modules::Clock::tz_up() {
   const auto tzSize{tzList_.size()};


### PR DESCRIPTION
The functionality of being able to invert the month scrolling in the calendar by setting "on-scroll" to -1 appears to  have been broken in 86a3898.

This restores the ability to set the number of months that the scroll wheel scrolls, including negative numbers, as documented in the wiki https://github.com/Alexays/Waybar/wiki/Module:-Clock
