### PR TITLE
(Fix) Alt format on group modules

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -449,7 +449,17 @@ void waybar::Bar::setupAltFormatKeyForModuleList(const char* module_list_name) {
     Json::Value& modules = config[module_list_name];
     for (const Json::Value& module_name : modules) {
       if (module_name.isString()) {
-        setupAltFormatKeyForModule(module_name.asString());
+        auto ref = module_name.asString();
+        if (ref.compare(0, 6, "group/") == 0 && ref.size() > 6) {
+          Json::Value& group_modules = config[ref]["modules"];
+          for (const Json::Value& module_name : group_modules) {
+            if (module_name.isString()) {
+              setupAltFormatKeyForModule(module_name.asString());
+            }
+          }
+        } else {
+          setupAltFormatKeyForModule(ref);
+        }
       }
     }
   }


### PR DESCRIPTION
fix for #2685 

During the strings conversion in `setupAltFormatKeyForModuleList` for the modules left/center/right, we need to check for group modules and iterate their array to add alt-format support to their modules as well.