### PR TITLE
Fix reloading config

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -162,6 +162,7 @@ void Config::load(const std::string &config) {
   }
   config_file_ = file.value();
   spdlog::info("Using configuration file {}", config_file_);
+  config_ = Json::Value();
   setupConfig(config_, config_file_, 0);
 }
 


### PR DESCRIPTION
Fully clear the configuration before reloading, so that when the config is read and merged in there are no existing values which mergeConfig refuses to overwrite.