### PR TITLE
nix: build against wireplumber 0.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1704538339,
-        "narHash": "sha256-1734d3mQuux9ySvwf6axRWZRBhtcZA9Q8eftD6EZg6U=",
+        "lastModified": 1711163522,
+        "narHash": "sha256-YN/Ciidm+A0fmJPWlHBGvVkcarYWSC+s3NTPk/P+q3c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "46ae0210ce163b3cba6c7da08840c1d63de9c701",
+        "rev": "44d0940ea560dee511026a53f0e2e2cde489b4d4",
         "type": "github"
       },
       "original": {

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,10 @@ in
 
     mesonFlags = lib.remove "-Dgtk-layer-shell=enabled" oldAttrs.mesonFlags;
 
+    buildInputs = (builtins.filter (p: p.pname != "wireplumber") oldAttrs.buildInputs) ++ [
+        pkgs.wireplumber
+    ];
+
     postUnpack = ''
       pushd "$sourceRoot"
       cp -R --no-preserve=mode,ownership ${libcava.src} subprojects/cava-${libcava.version}


### PR DESCRIPTION
Current waybar from nixpkgs uses wireplumber 0.4, this updates the override to use wireplumber 0.5 instead.