### PR TITLE
battery: Add {cycles}, {health} format replacements

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -32,7 +32,7 @@ class Battery : public ALabel {
   void refreshBatteries();
   void worker();
   const std::string getAdapterStatus(uint8_t capacity) const;
-  const std::tuple<uint8_t, float, std::string, float, uint16_t, float> getInfos();
+  std::tuple<uint8_t, float, std::string, float, uint16_t, float> getInfos();
   const std::string formatTimeRemaining(float hoursRemaining);
   void setBarClass(std::string&);
 

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -32,7 +32,7 @@ class Battery : public ALabel {
   void refreshBatteries();
   void worker();
   const std::string getAdapterStatus(uint8_t capacity) const;
-  const std::tuple<uint8_t, float, std::string, float> getInfos();
+  const std::tuple<uint8_t, float, std::string, float, uint16_t> getInfos();
   const std::string formatTimeRemaining(float hoursRemaining);
   void setBarClass(std::string&);
 

--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -32,7 +32,7 @@ class Battery : public ALabel {
   void refreshBatteries();
   void worker();
   const std::string getAdapterStatus(uint8_t capacity) const;
-  const std::tuple<uint8_t, float, std::string, float, uint16_t> getInfos();
+  const std::tuple<uint8_t, float, std::string, float, uint16_t, float> getInfos();
   const std::string formatTimeRemaining(float hoursRemaining);
   void setBarClass(std::string&);
 

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -121,6 +121,8 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 
 *{cycles}*: Amount of charge cycles the highest-capacity battery has seen. *(Linux only)*
 
+*{health}*: The percentage of the highest-capacity battery's original maximum charge it can still hold.
+
 # TIME FORMAT
 
 The *battery* module allows you to define how time should be formatted via *format-time*.

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -119,6 +119,8 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 
 *{time}*: Estimate of time until full or empty. Note that this is based on the power draw at the last refresh time, not an average.
 
+*{cycles}*: Amount of charge cycles the highest-capacity battery has seen. *(Linux only)*
+
 # TIME FORMAT
 
 The *battery* module allows you to define how time should be formatted via *format-time*.

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -357,22 +357,21 @@ std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::modules:
         std::ifstream(bat / "energy_full_design") >> energy_full_design;
       }
 
-      bool is_main_battery = charge_full_design >= largestDesignCapacity;
-      uint16_t cycle_count = 0;
+      uint16_t cycleCount = 0;
       if (fs::exists(bat / "cycle_count")) {
-        std::ifstream(bat / "cycle_count") >> cycle_count;
+        std::ifstream(bat / "cycle_count") >> cycleCount;
       }
-      if (is_main_battery) {
+      if (charge_full_design >= largestDesignCapacity) {
         largestDesignCapacity = charge_full_design;
 
-        if (cycle_count > mainBatCycleCount) {
-          mainBatCycleCount = cycle_count;
+        if (cycleCount > mainBatCycleCount) {
+          mainBatCycleCount = cycleCount;
         }
 
         if (charge_full_exists && charge_full_design_exists) {
-          float bat_health_percent = ((float)charge_full / charge_full_design) * 100;
-          if (mainBatHealthPercent == 0.0f || bat_health_percent < mainBatHealthPercent) {
-            mainBatHealthPercent = bat_health_percent;
+          float batHealthPercent = ((float)charge_full / charge_full_design) * 100;
+          if (mainBatHealthPercent == 0.0f || batHealthPercent < mainBatHealthPercent) {
+            mainBatHealthPercent = batHealthPercent;
           }
         }
       }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -234,7 +234,7 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
     }
 
     // spdlog::info("{} {} {} {}", capacity,time,status,rate);
-    return {capacity, time / 60.0, status, rate};
+    return {capacity, time / 60.0, status, rate, 0, 0.0F};
 
 #elif defined(__linux__)
     uint32_t total_power = 0;  // μW

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -371,7 +371,7 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
 
         if (charge_full_exists && charge_full_design_exists) {
           float bat_health_percent = ((float)charge_full / charge_full_design) * 100;
-          if (mainBatHealthPercent == 0.0f || bat_health_percent < main_bat_health_percent) {
+          if (mainBatHealthPercent == 0.0f || bat_health_percent < mainBatHealthPercent) {
             mainBatHealthPercent = bat_health_percent;
           }
         }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -370,7 +370,7 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
         }
 
         if (charge_full_exists && charge_full_design_exists) {
-          float bat_health_percent = ((float)charge_full_design / charge_full) * 100;
+          float bat_health_percent = ((float)charge_full / charge_full_design) * 100;
           if (main_bat_health_percent == 0.0f || bat_health_percent < main_bat_health_percent) {
             main_bat_health_percent = bat_health_percent;
           }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -252,9 +252,9 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
     uint32_t time_to_full_now = 0;
     bool time_to_full_now_exists = false;
 
-    uint32_t largest_design_capacity = 0;
-    uint16_t main_bat_cycle_count = 0;
-    float main_bat_health_percent = 0.0f;
+    uint32_t largestDesignCapacity = 0;
+    uint16_t mainBatCycleCount = 0;
+    float mainBatHealthPercent = 0.0F;
 
     std::string status = "Unknown";
     for (auto const& item : batteries_) {
@@ -357,22 +357,22 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
         std::ifstream(bat / "energy_full_design") >> energy_full_design;
       }
 
-      bool is_main_battery = charge_full_design >= largest_design_capacity;
+      bool is_main_battery = charge_full_design >= largestDesignCapacity;
       uint16_t cycle_count = 0;
       if (fs::exists(bat / "cycle_count")) {
         std::ifstream(bat / "cycle_count") >> cycle_count;
       }
       if (is_main_battery) {
-        largest_design_capacity = charge_full_design;
+        largestDesignCapacity = charge_full_design;
 
-        if (cycle_count > main_bat_cycle_count) {
-          main_bat_cycle_count = cycle_count;
+        if (cycle_count > mainBatCycleCount) {
+          mainBatCycleCount = cycle_count;
         }
 
         if (charge_full_exists && charge_full_design_exists) {
           float bat_health_percent = ((float)charge_full / charge_full_design) * 100;
-          if (main_bat_health_percent == 0.0f || bat_health_percent < main_bat_health_percent) {
-            main_bat_health_percent = bat_health_percent;
+          if (mainBatHealthPercent == 0.0f || bat_health_percent < main_bat_health_percent) {
+            mainBatHealthPercent = bat_health_percent;
           }
         }
       }
@@ -597,7 +597,7 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
     // still charging but not yet done
     if (cap == 100 && status == "Charging") status = "Full";
 
-    return {cap, time_remaining, status, total_power / 1e6, main_bat_cycle_count, main_bat_health_percent};
+    return {cap, time_remaining, status, total_power / 1e6, mainBatCycleCount, mainBatHealthPercent};
 #endif
   } catch (const std::exception& e) {
     spdlog::error("Battery: {}", e.what());

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -181,7 +181,7 @@ static bool status_gt(const std::string& a, const std::string& b) {
   return false;
 }
 
-const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::modules::Battery::getInfos() {
+std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::modules::Battery::getInfos() {
   std::lock_guard<std::mutex> guard(battery_list_mutex_);
 
   try {

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -361,9 +361,12 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t> waybar::modules::
       if (fs::exists(bat / "cycle_count")) {
         std::ifstream(bat / "cycle_count") >> cycle_count;
       }
-      if (is_main_battery && (cycle_count > main_bat_cycle_count)) {
+      if (is_main_battery) {
         largest_design_capacity = charge_full_design;
-        main_bat_cycle_count = cycle_count;
+
+        if (cycle_count > main_bat_cycle_count) {
+          main_bat_cycle_count = cycle_count;
+        }
       }
 
       if (!voltage_now_exists) {

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -369,9 +369,6 @@ const std::tuple<uint8_t, float, std::string, float, uint16_t, float> waybar::mo
           main_bat_cycle_count = cycle_count;
         }
 
-        std::string name;
-        std::ifstream(bat / "model_name") >> name;
-        spdlog::info("{} | full: {}, full_design: {}", name, energy_full, energy_full_design);
         if (charge_full_exists && charge_full_design_exists) {
           float bat_health_percent = ((float)charge_full_design / charge_full) * 100;
           if (main_bat_health_percent == 0.0f || bat_health_percent < main_bat_health_percent) {


### PR DESCRIPTION
This PR adds the following format replacements to the `battery` module (currently for Linux only):

- [x] `{cycles}` - Displays the amount of charge cycles the selected<sup>1</sup> battery has seen.
- [x] `{health}` Displays a percentage representing the selected<sup>1</sup> batteries max charge, relative to it's `design` (original) max charge.

## Battery selection<sup>1</sup>

Currently, both of the new format replacements select the battery candidate with the highest `charge_full_design`. This seemed the most intuitive for `{cycles}`, and I have applied the same logic to `{health}` to stay consistent with this. Should multiple batteries have the same `charge_full_design`, the "worse" value (i.e. higher cycle count, lower health percentage) is displayed.

However, I could also imagine using a `charge_full_design` weighted average of all eligible batteries' percentages for `{health}`, so it could represent the health of a full battery array.