### PR TITLE
feat(#2989)!: hover for all modules

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -6,6 +6,7 @@
 #include <json/json.h>
 
 #include "IModule.hpp"
+#include "gtkmm/button.h"
 
 namespace waybar {
 
@@ -35,7 +36,7 @@ class AModule : public IModule {
 
   const std::string name_;
   const Json::Value &config_;
-  Gtk::EventBox event_box_;
+  Gtk::Button event_box_;
 
   virtual bool handleToggle(GdkEventButton *const &ev);
   virtual bool handleScroll(GdkEventScroll *);

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -36,8 +36,30 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
                config[eventEntry.second].isString();
       }) != eventMap_.cend();
 
+  event_box_.set_relief(Gtk::RELIEF_NONE);
+
   if (enable_click || hasUserEvent) {
     event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
+
+    // TODO: not ideal?
+    // seems like specifically click event of gtk button needs to be captured like this?
+    // construct the specific GdkEventButton manually
+    // and pass it through the generic handling is the idea
+    event_box_.signal_pressed().connect([this] {
+      GdkEventButton eventInstance;
+      eventInstance.button = 1;
+      eventInstance.type = GDK_BUTTON_PRESS;
+      GdkEventButton* event = &eventInstance;
+      this->handleToggle(event);
+    });
+    event_box_.signal_released().connect([this] {
+      GdkEventButton eventInstance;
+      eventInstance.button = 1;
+      eventInstance.type = GDK_BUTTON_RELEASE;
+      GdkEventButton* event = &eventInstance;
+      this->handleToggle(event);
+    });
+
     event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &AModule::handleToggle));
   }
 


### PR DESCRIPTION
I recognize that this change may break or change many existing `style.css` configurations due to the new buttons and the default configuration containing a general css rule for buttons.
I've just done the minimal job with this approach of implementing the feature. If this approach is acceptable even with breaking changes to existing configurations, I can continue finishing this up with some guiding feedback.

If this is not an acceptable approach, I've been thinking about a different approach of just adding a ".hover" class to the GTK label instead. I haven't really explored that possibility yet and I'm very new to GTK and C++, so I'm not sure about the details in that approach, but it sounds very doable and probably not hard to figure out how to implement. This approach would likely not breaking any existing configurations.
