### PR TITLE
calendar: add shift_reset action

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -73,6 +73,7 @@ class Clock final : public ALabel {
   void cldModeSwitch();
   void cldShift_up();
   void cldShift_down();
+  void cldShift_reset();
   void tz_up();
   void tz_down();
   // Module Action Map
@@ -80,6 +81,7 @@ class Clock final : public ALabel {
       {"mode", &waybar::modules::Clock::cldModeSwitch},
       {"shift_up", &waybar::modules::Clock::cldShift_up},
       {"shift_down", &waybar::modules::Clock::cldShift_down},
+      {"shift_reset", &waybar::modules::Clock::cldShift_reset},
       {"tz_up", &waybar::modules::Clock::tz_up},
       {"tz_down", &waybar::modules::Clock::tz_down}};
 };

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -423,6 +423,9 @@ void waybar::modules::Clock::cldShift_up() {
 void waybar::modules::Clock::cldShift_down() {
   cldCurrShift_ -= (months)((cldMode_ == CldMode::YEAR) ? 12 : 1) * cldShift_;
 }
+void waybar::modules::Clock::cldShift_reset() {
+  cldCurrShift_ = (months)0;
+}
 void waybar::modules::Clock::tz_up() {
   const auto tzSize{tzList_.size()};
   if (tzSize == 1) return;


### PR DESCRIPTION
Added `shift_reset` action to the calendar in the clock module. This is handy, when you go back a couple of months and want to jump back to current date.