### PR TITLE
Fixes for hyprland/workspaces

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -194,6 +194,10 @@ void Workspaces::doUpdate() {
   for (auto &[workspaceData, clientsData] : m_workspacesToCreate) {
     createWorkspace(workspaceData, clientsData);
   }
+  if (!m_workspacesToCreate.empty()) {
+    updateWindowCount();
+    sortWorkspaces();
+  }
   m_workspacesToCreate.clear();
 
   // get all active workspaces
@@ -391,8 +395,7 @@ void Workspaces::onWorkspaceMoved(std::string const &payload) {
   // Update active workspace
   m_activeWorkspaceName = (gIPC->getSocket1JsonReply("activeworkspace"))["name"].asString();
 
-  if (allOutputs())
-    return;
+  if (allOutputs()) return;
 
   std::string workspaceName = payload.substr(0, payload.find(','));
   std::string monitorName = payload.substr(payload.find(',') + 1);
@@ -833,8 +836,6 @@ void Workspaces::init() {
   m_activeWorkspaceName = (gIPC->getSocket1JsonReply("activeworkspace"))["name"].asString();
 
   initializeWorkspaces();
-  updateWindowCount();
-  sortWorkspaces();
   dp.emit();
 }
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -318,7 +318,7 @@ void Workspaces::onEvent(const std::string &ev) {
     onWorkspaceCreated(payload);
   } else if (eventName == "focusedmon") {
     onMonitorFocused(payload);
-  } else if (eventName == "moveworkspace" && !allOutputs()) {
+  } else if (eventName == "moveworkspace") {
     onWorkspaceMoved(payload);
   } else if (eventName == "openwindow") {
     onWindowOpened(payload);
@@ -387,6 +387,13 @@ void Workspaces::onWorkspaceCreated(std::string const &workspaceName,
 
 void Workspaces::onWorkspaceMoved(std::string const &payload) {
   spdlog::debug("Workspace moved: {}", payload);
+
+  // Update active workspace
+  m_activeWorkspaceName = (gIPC->getSocket1JsonReply("activeworkspace"))["name"].asString();
+
+  if (allOutputs())
+    return;
+
   std::string workspaceName = payload.substr(0, payload.find(','));
   std::string monitorName = payload.substr(payload.find(',') + 1);
 


### PR DESCRIPTION
- Update active workspace on worskpace moved. Fixes #3121 
  - It should also cover #3074 . This PR solution is simpler than #3074 

- Don't update window count and sort workspace during init but AFTER their creation. It did nothing during init because the objects did not exist yet. It fixes a problem I had when configuring waybar where I launched it with already opened windows. This bug was not usually encountered because waybar usually starts with hyprland when there are no windows yet.