### PR TITLE
feat(#2989): (optional) hover for all modules

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -38,6 +38,8 @@ class AModule : public IModule {
   Gtk::EventBox event_box_;
 
   virtual bool handleToggle(GdkEventButton *const &ev);
+  virtual bool handleMouseEnter(GdkEventCrossing *const &ev);
+  virtual bool handleMouseLeave(GdkEventCrossing *const &ev);
   virtual bool handleScroll(GdkEventScroll *);
   virtual bool handleRelease(GdkEventButton *const &ev);
 

--- a/man/waybar-styles.5.scd.in
+++ b/man/waybar-styles.5.scd.in
@@ -29,6 +29,16 @@ An example user-controlled stylesheet that just changes the color of the clock t
 }
 ```
 
+## Hover-effect
+
+You can apply special styling to any module for when the cursor hovers it.
+
+```
+#clock:hover {
+  background-color: #ffffff;
+}
+```
+
 # SEE ALSO
 
 - *waybar(5)*

--- a/resources/style.css
+++ b/resources/style.css
@@ -48,6 +48,11 @@ button:hover {
     box-shadow: inset 0 -3px #ffffff;
 }
 
+/* you can set a style on hover for any module like this */
+#pulseaudio:hover {
+    background-color: #a37800;
+}
+
 #workspaces button {
     padding: 0 5px;
     background-color: transparent;

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -27,6 +27,9 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
       spdlog::warn("Wrong actions section configuration. See config by index: {}", it.index());
   }
 
+  event_box_.signal_enter_notify_event().connect(sigc::mem_fun(*this, &AModule::handleMouseEnter));
+  event_box_.signal_leave_notify_event().connect(sigc::mem_fun(*this, &AModule::handleMouseLeave));
+
   // configure events' user commands
   // hasUserEvent is true if any element from eventMap_ is satisfying the condition in the lambda
   bool hasUserEvent =
@@ -81,6 +84,20 @@ auto AModule::doAction(const std::string& name) -> void {
     // Call overrided action if derrived class has implemented it
     if (recA != eventActionMap_.cend() && name != recA->second) this->doAction(recA->second);
   }
+}
+
+bool AModule::handleMouseEnter(GdkEventCrossing* const& e) {
+  if (auto* module = event_box_.get_child(); module != nullptr) {
+    module->set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  }
+  return true;
+}
+
+bool AModule::handleMouseLeave(GdkEventCrossing* const& e) {
+  if (auto* module = event_box_.get_child(); module != nullptr) {
+    module->unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  }
+  return true;
 }
 
 bool AModule::handleToggle(GdkEventButton* const& e) { return handleUserEvent(e); }


### PR DESCRIPTION
A second attempt at implementing hover for all modules in a much less intrusive way.

See https://github.com/Alexays/Waybar/pull/3139 also (the more naive implementation which I found a similar approach had been tried and reverted).

Let me know if any additional documentation is required to get this merged. Alternatively, I think this could just be merged directly exposing the functionality for the super users immediately and then improved upon later on.
