### PR TITLE
fix: update clock tooltip without placeholders

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -152,6 +152,8 @@ auto waybar::modules::Clock::update() -> void {
           std::regex_replace(tlpText_, std::regex("\\{" + kCldPlaceholder + "\\}"), cldText_);
       tlpText_ =
           std::regex_replace(tlpText_, std::regex("\\{" + kOrdPlaceholder + "\\}"), ordText_);
+    } else {
+      tlpText_ = tlpFmt_;
     }
 
     tlpText_ = fmt_lib::vformat(locale_, tlpText_, fmt_lib::make_format_args(shiftedNow));


### PR DESCRIPTION
Currently the tooltip is updated only if a placeholder (like `calendar`, `tz_list`, `ordinal_date`) is present, because the formatting string `tlpFmt_` is taken as reference, while if no placeholder is present, the tooltip will get the text formatted processed at the first time, then it will never be updated. To ensure that the tooltip will update in this scenario, we can set the tooltip string back as the formatting string, before the formatting occurs.

Here is the config to test it:
```
    "clock": {
        "tooltip-format": "{:%H:%M %Y-%m-%d}",
        "format": "{:%H:%M %Y-%m-%d}",
    }
```