### PR TITLE
fix(battery): Fix `{health}` format replacement

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -712,10 +712,10 @@ auto waybar::modules::Battery::update() -> void {
     event_box_.show();
     auto icons = std::vector<std::string>{status + "-" + state, status, state};
     label_.set_markup(
-        fmt::format(fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
-                    fmt::arg("icon", getIcon(capacity, icons)),
-                    fmt::arg("time", time_remaining_formatted), fmt::arg("cycles", cycles),
-                    fmt::arg("health", fmt::format("{:.3}", health))));
+      label_.set_markup(fmt::format(
+        fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
+        fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted),
+        fmt::arg("cycles", cycles), fmt::arg("health", fmt::format("{:.3}", health))));
   }
   // Call parent update
   ALabel::update();

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -714,7 +714,8 @@ auto waybar::modules::Battery::update() -> void {
     label_.set_markup(
         fmt::format(fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
                     fmt::arg("icon", getIcon(capacity, icons)),
-                    fmt::arg("time", time_remaining_formatted), fmt::arg("cycles", cycles)));
+                    fmt::arg("time", time_remaining_formatted), fmt::arg("cycles", cycles),
+                    fmt::arg("health", fmt::format("{:.3}", health))));
   }
   // Call parent update
   ALabel::update();

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -711,11 +711,10 @@ auto waybar::modules::Battery::update() -> void {
   } else {
     event_box_.show();
     auto icons = std::vector<std::string>{status + "-" + state, status, state};
-    label_.set_markup(
-      label_.set_markup(fmt::format(
-        fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
-        fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted),
-        fmt::arg("cycles", cycles), fmt::arg("health", fmt::format("{:.3}", health))));
+    label_.set_markup(fmt::format(
+      fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
+      fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted),
+      fmt::arg("cycles", cycles), fmt::arg("health", fmt::format("{:.3}", health))));
   }
   // Call parent update
   ALabel::update();

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -371,12 +371,12 @@ waybar::modules::Battery::getInfos() {
 
         if (charge_full_exists && charge_full_design_exists) {
           float batHealthPercent = ((float)charge_full / charge_full_design) * 100;
-          if (mainBatHealthPercent == 0.0f || batHealthPercent < mainBatHealthPercent) {
+          if (mainBatHealthPercent == 0.0F || batHealthPercent < mainBatHealthPercent) {
             mainBatHealthPercent = batHealthPercent;
           }
         } else if (energy_full_exists && energy_full_design_exists) {
           float batHealthPercent = ((float)energy_full / energy_full_design) * 100;
-          if (mainBatHealthPercent == 0.0f || batHealthPercent < mainBatHealthPercent) {
+          if (mainBatHealthPercent == 0.0F || batHealthPercent < mainBatHealthPercent) {
             mainBatHealthPercent = batHealthPercent;
           }
         }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -374,6 +374,11 @@ waybar::modules::Battery::getInfos() {
           if (mainBatHealthPercent == 0.0f || batHealthPercent < mainBatHealthPercent) {
             mainBatHealthPercent = batHealthPercent;
           }
+        } else if (energy_full_exists && energy_full_design_exists) {
+          float batHealthPercent = ((float)energy_full / energy_full_design) * 100;
+          if (mainBatHealthPercent == 0.0f || batHealthPercent < mainBatHealthPercent) {
+            mainBatHealthPercent = batHealthPercent;
+          }
         }
       }
 

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -712,9 +712,9 @@ auto waybar::modules::Battery::update() -> void {
     event_box_.show();
     auto icons = std::vector<std::string>{status + "-" + state, status, state};
     label_.set_markup(fmt::format(
-      fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
-      fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted),
-      fmt::arg("cycles", cycles), fmt::arg("health", fmt::format("{:.3}", health))));
+        fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
+        fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted),
+        fmt::arg("cycles", cycles), fmt::arg("health", fmt::format("{:.3}", health))));
   }
   // Call parent update
   ALabel::update();


### PR DESCRIPTION
Looks like I forgot to register the `{health}` replacement for the "default" (i.e. non-tooltip) replacements.

Also, some batteries report their `{health}` related data as `energy_full` and `energy_full_design` instead of `charge_full` and `charge_full_design`. This PR ~~will~~ also implements support for that.

For more information see the conversation below #3130 

---

~~Marking as draft since~~
- ~~I haven't tested this yet (quick commit from the web editor)~~
- ~~there might actually be another / more issue(s) with `{cycles}` and `{health}` in `format-alt`~~

Issues reported by @nebulosa2007 under the original PR for `{cycles}` and `{health}` (#3130)