### PR TITLE
upower: fix segfault by initializing lastWarningLevel

### DIFF
--- a/include/modules/upower/upower.hpp
+++ b/include/modules/upower/upower.hpp
@@ -71,7 +71,7 @@ class UPower : public AModule {
   GDBusConnection *login1_connection;
   std::unique_ptr<UPowerTooltip> upower_tooltip;
   std::string lastStatus;
-  const char *lastWarningLevel;
+  const char *lastWarningLevel = nullptr;
   bool showAltText;
   bool showIcon = true;
   bool upowerRunning;


### PR DESCRIPTION
fixes bd8b215416cdca6ed0c929c18cede7dfb907edf0