### PR TITLE
Nix Flake: Fix overlay (again)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,10 +59,9 @@
         };
       };
 
-      packages = genSystems (pkgs:
-        let packages = self.overlays.default pkgs pkgs;
-        in packages // {
-          default = packages.waybar;
-        });
+      packages = genSystems (pkgs: {
+        default = self.packages.${pkgs.stdenv.hostPlatform.system}.waybar;
+        inherit (pkgs) waybar;
+      });
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
 
       overlays.default = final: prev: {
         waybar = final.callPackage ./nix/default.nix {
+          waybar = prev.waybar;
           # take the first "version: '...'" from meson.build
           version =
             (builtins.head (builtins.split "'"

--- a/flake.nix
+++ b/flake.nix
@@ -46,16 +46,19 @@
                 };
           });
 
-      overlays.default = final: prev: {
-        waybar = final.callPackage ./nix/default.nix {
-          waybar = prev.waybar;
-          # take the first "version: '...'" from meson.build
-          version =
-            (builtins.head (builtins.split "'"
-              (builtins.elemAt
-                (builtins.split " version: '" (builtins.readFile ./meson.build))
-                2)))
-            + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+      overlays = {
+        default = self.overlays.waybar;
+        waybar = final: prev: {
+          waybar = final.callPackage ./nix/default.nix {
+            waybar = prev.waybar;
+            # take the first "version: '...'" from meson.build
+            version =
+              (builtins.head (builtins.split "'"
+                (builtins.elemAt
+                  (builtins.split " version: '" (builtins.readFile ./meson.build))
+                  2)))
+              + "+date=" + (mkDate (self.lastModifiedDate or "19700101")) + "_" + (self.shortRev or "dirty");
+          };
         };
       };
 


### PR DESCRIPTION
Because last time I "fixed" it, I actually broke it, I forgot a line, but this time I changed other minor stuff (added `waybar`-named overlay and package, in addition to `default`, and the package output now is properly inherited from the overlay applied on top of Nixpkgs).