### PR TITLE
feat(#3174): hover for whole group

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -19,7 +19,7 @@ class Group : public AModule {
   virtual Gtk::Box& getBox();
   void addWidget(Gtk::Widget& widget);
 
-  bool handleMouseHover(GdkEventCrossing* const& e);
+  bool handleModuleMouseHover(GdkEventCrossing* const& e);
 
  protected:
   Gtk::Box box;
@@ -28,6 +28,8 @@ class Group : public AModule {
   bool is_first_widget = true;
   bool is_drawer = false;
   std::string add_class_to_drawer_children;
+  bool handleMouseEnter(GdkEventCrossing *const &ev) override;
+  bool handleMouseLeave(GdkEventCrossing *const &ev) override;
 
   void addHoverHandlerTo(Gtk::Widget& widget);
 };

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -19,8 +19,6 @@ class Group : public AModule {
   virtual Gtk::Box& getBox();
   void addWidget(Gtk::Widget& widget);
 
-  bool handleModuleMouseHover(GdkEventCrossing* const& e);
-
  protected:
   Gtk::Box box;
   Gtk::Box revealer_box;
@@ -30,8 +28,6 @@ class Group : public AModule {
   std::string add_class_to_drawer_children;
   bool handleMouseEnter(GdkEventCrossing *const &ev) override;
   bool handleMouseLeave(GdkEventCrossing *const &ev) override;
-
-  void addHoverHandlerTo(Gtk::Widget& widget);
 };
 
 }  // namespace waybar

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -11,13 +11,13 @@ namespace waybar {
 
 class Group : public AModule {
  public:
-  Group(const std::string&, const std::string&, const Json::Value&, bool);
+  Group(const std::string &, const std::string &, const Json::Value &, bool);
   virtual ~Group() = default;
   auto update() -> void override;
-  operator Gtk::Widget&() override;
+  operator Gtk::Widget &() override;
 
-  virtual Gtk::Box& getBox();
-  void addWidget(Gtk::Widget& widget);
+  virtual Gtk::Box &getBox();
+  void addWidget(Gtk::Widget &widget);
 
  protected:
   Gtk::Box box;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -89,6 +89,8 @@ bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
   return false;
 }
 
+
+
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
   box.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   revealer.set_reveal_child(false);

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -4,7 +4,6 @@
 
 #include <util/command.hpp>
 
-#include "gdkmm/device.h"
 #include "gtkmm/enums.h"
 #include "gtkmm/widget.h"
 
@@ -79,8 +78,6 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     } else {
       box.pack_start(revealer);
     }
-
-    addHoverHandlerTo(revealer);
   }
 
   event_box_.add(box);
@@ -88,32 +85,14 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
 
 bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
   event_box_.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  revealer.set_reveal_child(true);
   return false;
 }
 
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
   event_box_.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  revealer.set_reveal_child(false);
   return false;
-}
-
-bool Group::handleModuleMouseHover(GdkEventCrossing* const& e) {
-  switch (e->type) {
-    case GDK_ENTER_NOTIFY:
-      revealer.set_reveal_child(true);
-      break;
-    case GDK_LEAVE_NOTIFY:
-      revealer.set_reveal_child(false);
-      break;
-    default:
-      break;
-  }
-  return false;
-}
-
-void Group::addHoverHandlerTo(Gtk::Widget& widget) {
-  widget.add_events(Gdk::EventMask::ENTER_NOTIFY_MASK | Gdk::EventMask::LEAVE_NOTIFY_MASK);
-  widget.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Group::handleModuleMouseHover));
-  widget.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Group::handleModuleMouseHover));
 }
 
 auto Group::update() -> void {
@@ -125,12 +104,8 @@ Gtk::Box& Group::getBox() { return is_drawer ? (is_first_widget ? box : revealer
 void Group::addWidget(Gtk::Widget& widget) {
   getBox().pack_start(widget, false, false);
 
-  if (is_drawer) {
-    // Necessary because of GTK's hitbox detection
-    addHoverHandlerTo(widget);
-    if (!is_first_widget) {
-      widget.get_style_context()->add_class(add_class_to_drawer_children);
-    }
+  if (is_drawer && !is_first_widget) {
+    widget.get_style_context()->add_class(add_class_to_drawer_children);
   }
 
   is_first_widget = false;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -83,9 +83,6 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     addHoverHandlerTo(revealer);
   }
 
-  event_box_.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Group::handleMouseEnter));
-  event_box_.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Group::handleMouseLeave));
-
   event_box_.add(box);
 }
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -32,7 +32,7 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
       revealer_box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0} {
   event_box_.set_name(name_);
   if (!id.empty()) {
-    box.get_style_context()->add_class(id);
+    event_box_.get_style_context()->add_class(id);
   }
 
   // default orientation: orthogonal to parent

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -29,9 +29,9 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     : AModule(config, name, id, true, true),
       box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0},
       revealer_box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0} {
-  event_box_.set_name(name_);
+  box.set_name(name_);
   if (!id.empty()) {
-    event_box_.get_style_context()->add_class(id);
+    box.get_style_context()->add_class(id);
   }
 
   // default orientation: orthogonal to parent
@@ -84,13 +84,13 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
 }
 
 bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
-  event_box_.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  box.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   revealer.set_reveal_child(true);
   return false;
 }
 
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
-  event_box_.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  box.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   revealer.set_reveal_child(false);
   return false;
 }


### PR DESCRIPTION
Adds hover targeting for the whole group.

![image](https://github.com/Alexays/Waybar/assets/31956036/0cc82e50-31cd-48be-be15-3df19a637ca9)

Not a great gif to demonstrate the fix, but without the patch, there's a transparent background instead of black.

```
#power {
  background-color: transparent;
  color: white;
}

#power *:hover {
  background-color: white;
  color: black;
}

#power:hover {
  background-color: black;
  color: white;
}
```

```
  "group/power": {
    "orientation": "inherit",
    "drawer": {
      "transition-duration": 500,
      "children-class": "not-power",
      "transition-left-to-right": false,
    },
    "modules": [
      "custom/lock",
      "custom/quit",
      "custom/suspend",
      "custom/reboot",
    ],
  },
```

```
      widget:dir(ltr)
        box#power.horizontal:dir(ltr)
          revealer.drawer:dir(ltr)
            box.horizontal:dir(ltr)
              widget.not-power:dir(ltr)
                label#custom-quit.module:dir(ltr)
              widget.not-power:dir(ltr)
                label#custom-suspend.module:dir(ltr)
              widget.not-power:dir(ltr)
                label#custom-reboot.module:dir(ltr)
          widget:dir(ltr)
            label#custom-lock.module:dir(ltr)

```

