### PR TITLE
flake: fix overlay not actually being applied

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,12 @@
         "x86_64-linux"
         "aarch64-linux"
       ]
-        (system: func (import nixpkgs { inherit system; }));
+        (system: func (import nixpkgs {
+          inherit system;
+          overlays = with self.overlays; [
+            waybar
+          ];
+        }));
 
       mkDate = longDate: (lib.concatStringsSep "-" [
         (builtins.substring 0 4 longDate)


### PR DESCRIPTION
#3196 made some changes to `flake.nix`. In [this line](https://github.com/Alexays/Waybar/blob/231d6972d7a023e9358ab7deda509baac49006cb/flake.nix#L67) flake's `waybar` package was defined to be the one in `nixpkgs` because the function that was passed to `genSystems` argument was called with `nixpkgs` without the flake's overlay applied. I changed the `genSystems` function to pass `nixpkgs` that uses the flake's overlay so the package comes from the flake itself and not `nixpkgs`.