### PR TITLE
temperature: allow hwmon-path-abs as array

### DIFF
--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -25,6 +25,7 @@ Addressed by *temperature*
 *hwmon-path-abs*: ++
 	typeof: string ++
 	The path of the hwmon-directory of the device, e.g. */sys/devices/pci0000:00/0000:00:18.3/hwmon*. (Note that the subdirectory *hwmon/hwmon#*, where *#* is a number is not part of the path!) Has to be used together with *input-filename*.
+	This can also be an array of strings, for which, it just works like *hwmon-path*.
 
 *input-filename*: ++
 	typeof: string ++


### PR DESCRIPTION
Currently, only `hwmon-path` is allowed to have multiple path, however the hwmon ID is not stable, for which `hwmon-path-abs` is better, but it's supposed to be a string. This commit extends `hwmon-path-abs` and make it works like `hwmon-path`.