### PR TITLE
Add support of nvidia graphics using nvidia-smi

### DIFF
--- a/include/modules/nvidia_monitor.hpp
+++ b/include/modules/nvidia_monitor.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <filesystem>
+#include <string>
+
+#include "ALabel.hpp"
+#include "util/sleeper_thread.hpp"
+
+namespace waybar::modules {
+
+class NvidiaMonitor : public ALabel {
+ public:
+  NvidiaMonitor(const std::string&, const Json::Value&);
+  ~NvidiaMonitor() override;
+  auto update() -> void override;
+
+  static const std::size_t ARGUMENTS_COUNT{5};
+  using NvidiaSmiArgumentsTable = std::array<char*, ARGUMENTS_COUNT>;
+  using GpuData = std::vector<std::string>;
+
+ private:
+
+  util::SleeperThread thread_;
+
+  std::string nvidiaSmiCmd_{"nvidia-smi"};
+  std::string nvidiaSmiArgvQuery_{
+      "--query-gpu=timestamp,name,pci.bus_id,driver_version,pstate,pcie.link.gen.max,pcie.link.gen."
+      "current,temperature.gpu,utilization.gpu,utilization.memory,memory.total,memory.free,memory."
+      "used,power.draw,clocks.sm,clocks.mem,clocks.gr"};
+  std::string nvidiaSmiArgvFormat_{"--format=csv,noheader"};
+  std::filesystem::path gpuExchangeFilePath_{"gpu_data.csv"};
+  std::string nvidiaSmiArgvFileName_{"--filename="};
+
+  NvidiaSmiArgumentsTable programArgv_{nvidiaSmiCmd_.data(), nvidiaSmiArgvQuery_.data(),
+                                       nvidiaSmiArgvFormat_.data(), nvidiaSmiArgvFileName_.data(),
+                                       nullptr};
+
+  void runNvidiaSmiOnce();
+  static std::string generateTemporaryFileName();
+  std::ifstream openExchangeFile();
+  std::optional<GpuData> loadDataFromFile(std::ifstream);
+  void formatBar(const GpuData&);
+  void formatTooltip(const GpuData&);
+
+};
+
+}  // namespace waybar::modules

--- a/man/waybar-nvidia-monitor.5.scd
+++ b/man/waybar-nvidia-monitor.5.scd
@@ -1,0 +1,68 @@
+waybar-nvidia-monitor(5)
+
+# NAME
+
+waybar - nvidia monitor
+
+# DESCRIPTION
+
+The *nvidia monitor* module gathers data from Nvidia's GPUs via nvidia-smi program.
+
+# CONFIGURATION
+
+For proper use of this module, *nvidia-smi* must be present in the system.
+Additionally, the module requires an exchange file to be set up. If a path is not specified, the default is on '/$TEMP/waybar/' or if '$TEMP' is not defined then '/tmp/waybar'.
+
+*data-exchange-path*: ++
+  typeof: string ++
+  default: '/$TEMP/waybar' or '/tmp/waybar' ++
+  The path to the exchange file between 'nvidia-smi' and the module.
+
+*format*: ++
+	typeof: string  ++
+	default: {gpuTemp}% ++
+	The format, how information should be displayed. On {} data gets inserted.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
+*tooltip-format*: ++
+	typeof: string  ++
+	default: {gpuTemp}°C ++
+	The format for the tooltip
+
+# FORMAT REPLACEMENTS
+
+*{name}*: Current graphics card name.
+*{busId}*: The bus id.
+*{driverVersion}*: Current driver version, only major and minor numbers.
+*{powerState}*: The actual performance state, states range from P0 (max performance) to P12 (minimum performance).
+*{pcieLinkMax}*: Maximum PCIE link available in the GPU or in the system.
+*{pcieLinkCurr}*: Current PCIE link, could be reduce if GPU is not performing.
+*{gpuTemp}*: Current GPU temperature. The format is Celsius.
+*{gpuUtilization}*: Current GPU utilization.
+*{memUtilization}*: Current memory utilization.
+*{memTotal}*: Total amount of the available memory. The format is fixed to MiB.
+*{memFree}*: Total amount of the free memory. The format is fixed to MiB.
+*{memUsed}*: Total amount of the used memory. The format is fixed to MiB.
+*{powerDraw}*: Current power draw presented with Watts.
+*{clocksSm}*: Current frequency of streaming multiprocessor clock.
+*{clocksMem}*: Current frequency of memory clock.
+*{clocksGr}*: Current frequency of graphics (shader) clock.
+
+# EXAMPLES
+
+Example configuration:
+
+```
+  "modules-right": [
+    "nvidia_monitor",
+  ],
+  "nvidia_monitor": {
+    "format": "{gpuTemp}°C",
+    "tooltip": true,
+    "tooltip-format": "{name}\n{driverVersion}\n{memTotal}\n{memFree}\n{memUsed}\n{powerDraw}"
+  }
+```

--- a/meson.build
+++ b/meson.build
@@ -167,6 +167,7 @@ src_files = files(
     'src/modules/idle_inhibitor.cpp',
     'src/modules/image.cpp',
     'src/modules/load.cpp',
+    'src/modules/nvidia_monitor.cpp',
     'src/modules/temperature.cpp',
     'src/modules/user.cpp',
     'src/ASlider.cpp',

--- a/meson.build
+++ b/meson.build
@@ -167,7 +167,6 @@ src_files = files(
     'src/modules/idle_inhibitor.cpp',
     'src/modules/image.cpp',
     'src/modules/load.cpp',
-    'src/modules/nvidia_monitor.cpp',
     'src/modules/temperature.cpp',
     'src/modules/user.cpp',
     'src/ASlider.cpp',
@@ -474,6 +473,16 @@ if cava.found()
    add_project_arguments('-DHAVE_LIBCAVA', language: 'cpp')
    src_files += files('src/modules/cava.cpp')
    man_files += files('man/waybar-cava.5.scd')
+endif
+
+if true
+    add_project_arguments('-DHAVE_NVIDIA_MONITOR', language: 'cpp')
+    src_files += files(
+        'src/modules/nvidia_monitor.cpp',
+    )
+    man_files += files(
+        'man/waybar-nvidia-monitor.5.scd',
+    )
 endif
 
 subdir('protocol')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,3 +19,4 @@ option('experimental', type : 'boolean', value : false, description: 'Enable exp
 option('jack', type: 'feature', value: 'auto', description: 'Enable support for JACK')
 option('wireplumber', type: 'feature', value: 'auto', description: 'Enable support for WirePlumber')
 option('cava', type: 'feature', value: 'auto', description: 'Enable support for Cava')
+option('nvidia_monitor', type: 'feature', value: 'auto', description: 'Enable support for the Nvidia gpu monitor')

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -107,6 +107,7 @@
 #include "modules/cffi.hpp"
 #include "modules/custom.hpp"
 #include "modules/image.hpp"
+#include "modules/nvidia_monitor.hpp"
 #include "modules/temperature.hpp"
 #include "modules/user.hpp"
 
@@ -318,6 +319,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
 #endif
     if (ref == "temperature") {
       return new waybar::modules::Temperature(id, config_[name]);
+    }
+    if (ref == "nvidia_monitor") {
+      return new waybar::modules::NvidiaMonitor(id, config_[name]);
     }
     if (ref.compare(0, 7, "custom/") == 0 && ref.size() > 7) {
       return new waybar::modules::Custom(ref.substr(7), id, config_[name], bar_.output->name);

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -104,10 +104,12 @@
 #ifdef HAVE_SYSTEMD_MONITOR
 #include "modules/systemd_failed_units.hpp"
 #endif
+#ifdef HAVE_NVIDIA_MONITOR
+#include "modules/nvidia_monitor.hpp"
+#endif
 #include "modules/cffi.hpp"
 #include "modules/custom.hpp"
 #include "modules/image.hpp"
-#include "modules/nvidia_monitor.hpp"
 #include "modules/temperature.hpp"
 #include "modules/user.hpp"
 
@@ -317,11 +319,13 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
       return new waybar::modules::SystemdFailedUnits(id, config_[name]);
     }
 #endif
-    if (ref == "temperature") {
-      return new waybar::modules::Temperature(id, config_[name]);
-    }
+#ifdef HAVE_NVIDIA_MONITOR
     if (ref == "nvidia_monitor") {
       return new waybar::modules::NvidiaMonitor(id, config_[name]);
+    }
+#endif
+    if (ref == "temperature") {
+      return new waybar::modules::Temperature(id, config_[name]);
     }
     if (ref.compare(0, 7, "custom/") == 0 && ref.size() > 7) {
       return new waybar::modules::Custom(ref.substr(7), id, config_[name], bar_.output->name);

--- a/src/modules/nvidia_monitor.cpp
+++ b/src/modules/nvidia_monitor.cpp
@@ -1,0 +1,154 @@
+#include "modules/nvidia_monitor.hpp"
+
+#include <fmt/core.h>
+#include <json/value.h>
+#include <spdlog/spdlog.h>
+#include <unistd.h>
+
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+
+waybar::modules::NvidiaMonitor::NvidiaMonitor(const std::string& id, const Json::Value& config)
+    : ALabel(config, "nvidia_monitor", id, "{gpuTemp}°C", 10),
+      gpuExchangeFilePath_{config_["data-exchange-path"].asString()},
+      nvidiaSmiArgvFileName_{"--filename=" + gpuExchangeFilePath_.string()} {
+  if (!config_["data-exchange-path"].isString()) {
+    gpuExchangeFilePath_ =
+        std::filesystem::temp_directory_path() / "waybar" / generateTemporaryFileName();
+    nvidiaSmiArgvFileName_ = "--filename=" + gpuExchangeFilePath_.string();
+    std::filesystem::create_directory(gpuExchangeFilePath_.parent_path());
+    std::ofstream exchangeFile(gpuExchangeFilePath_);
+    exchangeFile.close();
+    spdlog::debug("[{}]: The exchange path not found in config.\nCreating exchange file in: {}",
+                  name_, gpuExchangeFilePath_.string());
+    programArgv_[3] = nvidiaSmiArgvFileName_.data();
+  }
+
+  thread_ = [this] {
+    dp.emit();
+    thread_.sleep_for(interval_);
+  };
+}
+
+waybar::modules::NvidiaMonitor::~NvidiaMonitor() {
+  std::filesystem::remove_all(gpuExchangeFilePath_.parent_path());
+}
+
+auto waybar::modules::NvidiaMonitor::update() -> void {
+  runNvidiaSmiOnce();
+  auto data = loadDataFromFile(openExchangeFile());
+
+  if (data.has_value()) {
+    auto gpuData = data.value();
+
+    formatBar(gpuData);
+    formatTooltip(gpuData);
+  }
+
+  ALabel::update();
+}
+
+void waybar::modules::NvidiaMonitor::runNvidiaSmiOnce() {
+  auto pid = fork();
+  if (pid == 0) {
+    for (auto& item : programArgv_) {
+      spdlog::debug("[{}]: {}", name_, item);
+    }
+    auto isError = execvp(nvidiaSmiCmd_.c_str(), programArgv_.data());
+    if (isError < 0) {
+      perror("execve");
+      throw std::runtime_error("Can't run nvidia-smi.");
+    }
+  }
+}
+
+std::string waybar::modules::NvidiaMonitor::generateTemporaryFileName() {
+  std::size_t h1 = std::hash<std::string>{}(
+      std::to_string(std::chrono::system_clock::now().time_since_epoch().count()));
+  std::size_t h2 = std::hash<std::string>{}(std::to_string(static_cast<int>(getpid())));
+  return std::to_string(h1 ^ (h2 << 1));
+}
+
+std::ifstream waybar::modules::NvidiaMonitor::openExchangeFile() {
+  auto gpuDataFile{std::ifstream(gpuExchangeFilePath_)};
+  if (gpuDataFile.is_open()) {
+    gpuDataFile.seekg(0);
+    spdlog::debug("[{}]: File is open", name_);
+    return gpuDataFile;
+  }
+  spdlog::error("Invalid file {}", gpuExchangeFilePath_.string());
+  spdlog::error("{}", nvidiaSmiArgvFileName_);
+  throw std::runtime_error("Can't open the exchange file");
+}
+
+std::optional<waybar::modules::NvidiaMonitor::GpuData>
+waybar::modules::NvidiaMonitor::loadDataFromFile(std::ifstream gpuDataFile) {
+  GpuData gpuData;
+  std::string buff;
+  while (std::getline(gpuDataFile, buff, ',')) {
+    spdlog::debug("[{}]: Data: {}", name_, buff);
+    gpuData.emplace_back(buff);
+  }
+
+  if (gpuData.empty()) {
+    spdlog::warn("[{}]: Exchange file empty", name_);
+    return std::nullopt;
+  }
+
+  return std::make_optional(gpuData);
+}
+
+void waybar::modules::NvidiaMonitor::formatBar(const GpuData& gpuData) {
+  auto barText = fmt::format(
+      fmt::runtime(format_), fmt::arg("name", gpuData[1]), fmt::arg("busId", gpuData[2]),
+      fmt::arg("driverVersion", gpuData[3]), fmt::arg("powerState", gpuData[4]),
+      fmt::arg("pcieLinkMax", gpuData[5]), fmt::arg("pcieLinkCurr", gpuData[6]),
+      fmt::arg("gpuTemp", gpuData[7]), fmt::arg("gpuUtilization", gpuData[8]),
+      fmt::arg("memUtilization", gpuData[9]), fmt::arg("memTotal", gpuData[10]),
+      fmt::arg("memFree", gpuData[11]), fmt::arg("memUsed", gpuData[12]),
+      fmt::arg("powerDraw", gpuData[13]), fmt::arg("clocksSm", gpuData[14]),
+      fmt::arg("clocksMem", gpuData[15]), fmt::arg("clocksGr", gpuData[16]));
+
+  label_.set_markup(barText);
+}
+
+void waybar::modules::NvidiaMonitor::formatTooltip(const GpuData& gpuData) {
+  std::string tooltipFormat;
+  auto defaultTooltipText = fmt::format(
+      fmt::runtime(format_), fmt::arg("name", gpuData[1]), fmt::arg("busId", gpuData[2]),
+      fmt::arg("driverVersion", gpuData[3]), fmt::arg("powerState", gpuData[4]),
+      fmt::arg("pcieLinkMax", gpuData[5]), fmt::arg("pcieLinkCurr", gpuData[6]),
+      fmt::arg("gpuTemp", gpuData[7]), fmt::arg("gpuUtilization", gpuData[8]),
+      fmt::arg("memUtilization", gpuData[9]), fmt::arg("memTotal", gpuData[10]),
+      fmt::arg("memFree", gpuData[11]), fmt::arg("memUsed", gpuData[12]),
+      fmt::arg("powerDraw", gpuData[13]), fmt::arg("clocksSm", gpuData[14]),
+      fmt::arg("clocksMem", gpuData[15]), fmt::arg("clocksGr", gpuData[16]));
+
+  if (tooltipEnabled()) {
+    label_.set_tooltip_markup(defaultTooltipText);
+    if (config_["tooltip-format"].isString()) {
+      tooltipFormat = config_["tooltip-format"].asString();
+    }
+    if (tooltipFormat.empty()) {
+      label_.set_tooltip_markup(defaultTooltipText);
+    } else {
+      auto tooltipText = fmt::format(
+          fmt::runtime(tooltipFormat), fmt::arg("name", gpuData[1]), fmt::arg("busId", gpuData[2]),
+          fmt::arg("driverVersion", gpuData[3]), fmt::arg("powerState", gpuData[4]),
+          fmt::arg("pcieLinkMax", gpuData[5]), fmt::arg("pcieLinkCurr", gpuData[6]),
+          fmt::arg("gpuTemp", gpuData[7]), fmt::arg("gpuUtilization", gpuData[8]),
+          fmt::arg("memUtilization", gpuData[9]), fmt::arg("memTotal", gpuData[10]),
+          fmt::arg("memFree", gpuData[11]), fmt::arg("memUsed", gpuData[12]),
+          fmt::arg("powerDraw", gpuData[13]), fmt::arg("clocksSm", gpuData[14]),
+          fmt::arg("clocksMem", gpuData[15]), fmt::arg("clocksGr", gpuData[16]));
+
+      label_.set_tooltip_markup(tooltipText);
+    }
+  }
+}


### PR DESCRIPTION
Hi!
I've introduced the new module which pulls data from the external 'nvidia-smi' program.
The module runs 'nvidia-smi' as a forked process and saves GPU monitor data into the exchange file. If not specified in the configuration file, the file is created in the system's temporary directory. You can define your own exchange file, but you must ensure that it exists and has proper privileges set.
Since this is my first contribution here, I'm eager to receive feedback on any areas that could be improved.