### PR TITLE
Fix Clock. Tooltip calendar text overflows(#2240)

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -21,10 +21,12 @@ class Clock final : public ALabel {
   auto doAction(const std::string&) -> void override;
 
  private:
-  const std::locale locale_;
+  const std::locale m_locale_;
   // tooltip
-  const std::string tlpFmt_;
-  std::string tlpText_{""};  // tooltip text to print
+  const std::string m_tlpFmt_;
+  std::string m_tlpText_{""};                 // tooltip text to print
+  const Glib::RefPtr<Gtk::Label> m_tooltip_;  // tooltip as a separate Gtk::Label
+  bool query_tlp_cb(int, int, bool, const Glib::RefPtr<Gtk::Tooltip>& tooltip);
   // Calendar
   const bool cldInTooltip_;  // calendar in tooltip
   /*


### PR DESCRIPTION
Hi @Alexays, @FilippoBonazziSUSE this MR solves #2240 
Actually here it's GtkLabel wrong behavior with tooltips. Even @BrianCArnold has found workaround it's better to have code fixed. 
Temporary for now I replaced clock label with Gtk::TextView.  In order to have the same styling as it was for tooltips in the system, users should use next css styling
```css
textview#clock.tooltip, textview#clock.tooltip text {
   background-color: inherit;
   padding: inherit;
}
```

For now I'm trying to write test case in pure C in order to provide it gtk maintainers to fix gtk

So fixed variant looks good
![ps_2024-05-11-01_06_12](https://github.com/Alexays/Waybar/assets/23121044/afe24040-9ee3-4c41-adc4-572109dc755d)
