### PR TITLE
Fix debian dockerfile

### DIFF
--- a/Dockerfiles/debian
+++ b/Dockerfiles/debian
@@ -34,7 +34,7 @@ RUN apt update && \
         libudev-dev \
         libupower-glib-dev \
         libwayland-dev \
-        libwireplumber-0.4-dev \
+        libwireplumber-0.5-dev \
         libxkbcommon-dev \
         libxkbregistry-dev \
         locales \


### PR DESCRIPTION
I investigated the issues with the clang-tidy action getting stuck when installing clang-tidy and clang-format. Apparently there's an issue in the current version of the `waybar:debian` image where any `apt install` command gets stuck. 
After updating the dockerfile to install the newer `libwireplumber-0.5-dev` package instead of `0.4`, apt works again.

Here's more info: https://github.com/cpp-linter/cpp-linter-action/issues/239