### PR TITLE
Add GitHub action for nightly Docker image building 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,31 @@
+name: Build and Push Docker Image
+
+on:
+  schedule:
+    # run every night at midnight
+    - cron: '0 0 * * *'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ 'alpine', 'archlinux', 'debian', 'fedora', 'gentoo', 'opensuse' ]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfiles/${{ matrix.os }}
+          push: true
+          tags: alexays/${{ matrix.os }}:latest

--- a/Dockerfiles/debian
+++ b/Dockerfiles/debian
@@ -34,7 +34,7 @@ RUN apt update && \
         libudev-dev \
         libupower-glib-dev \
         libwayland-dev \
-        libwireplumber-0.4-dev \
+        libwireplumber-0.5-dev \
         libxkbcommon-dev \
         libxkbregistry-dev \
         locales \


### PR DESCRIPTION
Initial test of a new GitHub action that will build and push all docker images in the Dockerfiles folder.

This will ensure all Dockerfiles are always up to date, avoiding issues like what's described in #3258