### PR TITLE
clang-tidy fixes in the privacy module

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,15 +15,15 @@ Checks: >
   -readability-redundant-member-init,
   -readability-redundant-string-init,
   -readability-identifier-length
-CheckOptions:
-  - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
-  - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
-  - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
-  - { key: readability-identifier-naming.FunctionCase,           value: camelBack  }
-  - { key: readability-identifier-naming.VariableCase,           value: camelBack  }
-  - { key: readability-identifier-naming.PrivateMemberCase,      value: camelBack  }
-  - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
-  - { key: readability-identifier-naming.EnumCase,               value: CamelCase  }
-  - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
-  - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
-  - { key: readability-identifier-naming.StaticConstantCase,     value: UPPER_CASE }
+# CheckOptions:
+#   - { key: readability-identifier-naming.NamespaceCase,          value: lower_case }
+#   - { key: readability-identifier-naming.ClassCase,              value: CamelCase  }
+#   - { key: readability-identifier-naming.StructCase,             value: CamelCase  }
+#   - { key: readability-identifier-naming.FunctionCase,           value: camelBack  }
+#   - { key: readability-identifier-naming.VariableCase,           value: camelBack  }
+#   - { key: readability-identifier-naming.PrivateMemberCase,      value: camelBack  }
+#   - { key: readability-identifier-naming.PrivateMemberSuffix,    value: _          }
+#   - { key: readability-identifier-naming.EnumCase,               value: CamelCase  }
+#   - { key: readability-identifier-naming.EnumConstantCase,       value: UPPER_CASE }
+#   - { key: readability-identifier-naming.GlobalConstantCase,     value: UPPER_CASE }
+#   - { key: readability-identifier-naming.StaticConstantCase,     value: UPPER_CASE }

--- a/include/modules/privacy/privacy.hpp
+++ b/include/modules/privacy/privacy.hpp
@@ -1,10 +1,7 @@
 #pragma once
 
-#include <iostream>
-#include <map>
 #include <string>
 
-#include "ALabel.hpp"
 #include "gtkmm/box.h"
 #include "modules/privacy/privacy_item.hpp"
 #include "util/pipewire/pipewire_backend.hpp"

--- a/include/modules/privacy/privacy_item.hpp
+++ b/include/modules/privacy/privacy_item.hpp
@@ -2,9 +2,6 @@
 
 #include <json/value.h>
 
-#include <iostream>
-#include <map>
-#include <mutex>
 #include <string>
 
 #include "gtkmm/box.h"

--- a/src/modules/privacy/privacy_item.cpp
+++ b/src/modules/privacy/privacy_item.cpp
@@ -1,14 +1,11 @@
 #include "modules/privacy/privacy_item.hpp"
 
 #include <string>
-#include <thread>
 
-#include "AModule.hpp"
 #include "glibmm/main.h"
 #include "gtkmm/label.h"
 #include "gtkmm/revealer.h"
 #include "gtkmm/tooltip.h"
-#include "sigc++/adaptors/bind.h"
 #include "util/pipewire/privacy_node_info.hpp"
 
 namespace waybar::modules::privacy {
@@ -89,7 +86,7 @@ PrivacyItem::PrivacyItem(const Json::Value &config_, enum PrivacyNodeType privac
 
 void PrivacyItem::update_tooltip() {
   // Removes all old nodes
-  for (auto child : tooltip_window.get_children()) {
+  for (auto *child : tooltip_window.get_children()) {
     delete child;
   }
 


### PR DESCRIPTION
Two commits: 

* Temporarily removed the case style hints from clang-tidy because otherwise the repo is full of warnings
* clang-tidy fixes in the privacy module code, also fixes a compilation warning I've seen often (line 120 in privacy.cpp: potential uninitialized use of booleans, as not all compilers will initialize booleans by default)