### PR TITLE
Do not try to strcmp a variable that may be a null-pointer

### DIFF
--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -370,6 +370,8 @@ void UPower::setDisplayDevice() {
           auto thisPtr{static_cast<UPower *>(user_data)};
           upDevice.upDevice = static_cast<UpDevice *>(data);
           thisPtr->getUpDeviceInfo(upDevice);
+          if (upDevice.nativePath == nullptr)
+            return;
           if (0 == std::strcmp(upDevice.nativePath, thisPtr->nativePath_.c_str())) {
             // Unref current upDevice
             if (thisPtr->upDevice_.upDevice != NULL) g_object_unref(thisPtr->upDevice_.upDevice);

--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -370,8 +370,7 @@ void UPower::setDisplayDevice() {
           auto thisPtr{static_cast<UPower *>(user_data)};
           upDevice.upDevice = static_cast<UpDevice *>(data);
           thisPtr->getUpDeviceInfo(upDevice);
-          if (upDevice.nativePath == nullptr)
-            return;
+          if (upDevice.nativePath == nullptr) return;
           if (0 == std::strcmp(upDevice.nativePath, thisPtr->nativePath_.c_str())) {
             // Unref current upDevice
             if (thisPtr->upDevice_.upDevice != NULL) g_object_unref(thisPtr->upDevice_.upDevice);


### PR DESCRIPTION
If a UPower device (such as a wireless mouse/keyboard) is removed `UPower::getUpDeviceInfo()` will succeeded, but the struct will be filled with null values, and then the `std::strcmp` will fail! A simple nullptr check will avoid this.