### PR TITLE
Add config option to select UPower device based on device model.

### DIFF
--- a/include/modules/upower.hpp
+++ b/include/modules/upower.hpp
@@ -45,6 +45,7 @@ class UPower final : public AIconLabel {
 
   // Technical variables
   std::string nativePath_;
+  std::string model_;
   std::string lastStatus_;
   Glib::ustring label_markup_;
   std::mutex mutex_;

--- a/man/waybar-upower.5.scd
+++ b/man/waybar-upower.5.scd
@@ -17,6 +17,12 @@ compatible devices in the tooltip.
 	The battery to monitor. Refer to the https://upower.freedesktop.org/docs/UpDevice.html#UpDevice--native-path ++
 	Can be obtained using `upower --dump`
 
+*model*: ++
+	typeof: string ++
+	default: ++
+	The battery to monitor, based on the model. (this option is ignored if *native-path* is given). ++
+	Can be obtained using `upower --dump`
+
 *icon-size*: ++
 	typeof: integer ++
 	default: 20 ++

--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -381,12 +381,12 @@ void UPower::setDisplayDevice() {
           }
         },
         this);
-  } else { // if `nativePath_` is empty, but `model_` is not.
+  } else {  // if `nativePath_` is empty, but `model_` is not.
     g_ptr_array_foreach(
         up_client_get_devices2(upClient_),
         [](gpointer data, gpointer user_data) {
           upDevice_output upDevice;
-          auto thisPtr {static_cast<UPower *>(user_data)};
+          auto thisPtr{static_cast<UPower *>(user_data)};
           upDevice.upDevice = static_cast<UpDevice *>(data);
           thisPtr->getUpDeviceInfo(upDevice);
           if (upDevice.model == nullptr) return;


### PR DESCRIPTION
This is useful for wireless HID devices, as they often do not have the same `native-path` when re-connected.