### PR TITLE
fix(#3239): cursor change config flag (+ improved feature + code fix)

### DIFF
--- a/man/waybar-styles.5.scd.in
+++ b/man/waybar-styles.5.scd.in
@@ -45,10 +45,10 @@ Most, if not all, module types support setting the `cursor` option. This is
 configured in your `config.jsonc`. If set to `true`, when hovering the module a
 "pointer"(as commonly known from web CSS styling `cursor: pointer`) style cursor
 will be shown.
-There are more cursor types to choose frome by setting the `cursor` option to
+There are more cursor types to choose from by setting the `cursor` option to
 a number, see Gdk3 official docs for all possible cursor types:
 https://docs.gtk.org/gdk3/enum.CursorType.html.
-However, note that not all cursor options listed there may not be available on
+However, note that not all cursor options listed may be available on
 your system. If you attempt to use a cursor which is not available, the
 application will crash.
 

--- a/man/waybar-styles.5.scd.in
+++ b/man/waybar-styles.5.scd.in
@@ -39,6 +39,35 @@ You can apply special styling to any module for when the cursor hovers it.
 }
 ```
 
+## Setting cursor style
+
+Most, if not all, module types support setting the `cursor` option. This is
+configured in your `config.jsonc`. If set to `true`, when hovering the module a
+"pointer"(as commonly known from web CSS styling `cursor: pointer`) style cursor
+will be shown.
+There are more cursor types to choose frome by setting the `cursor` option to
+a number, see Gdk3 official docs for all possible cursor types:
+https://docs.gtk.org/gdk3/enum.CursorType.html.
+
+Example of enabling pointer(`Gdk::Hand2`) cursor type on a custom module:
+
+```
+"custom/my-custom-module": {
+    ...
+    "cursor": true,
+}
+```
+
+Example of setting cursor type to `Gdk::Boat`(according to
+https://docs.gtk.org/gdk3/enum.CursorType.html#boat):
+
+```
+"custom/my-custom-module": {
+    ...
+    "cursor": 8,
+}
+```
+
 # SEE ALSO
 
 - *waybar(5)*

--- a/man/waybar-styles.5.scd.in
+++ b/man/waybar-styles.5.scd.in
@@ -48,6 +48,9 @@ will be shown.
 There are more cursor types to choose frome by setting the `cursor` option to
 a number, see Gdk3 official docs for all possible cursor types:
 https://docs.gtk.org/gdk3/enum.CursorType.html.
+However, note that not all cursor options listed there may not be available on
+your system. If you attempt to use a cursor which is not available, the
+application will crash.
 
 Example of enabling pointer(`Gdk::Hand2`) cursor type on a custom module:
 

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -301,14 +301,6 @@ A group may hide all but one element, showing them only on mouse hover. In order
 },
 ```
 
-## Setting cursor style
-
-Most, if not all, module types support setting the `cursor` option. If set to
-`true`, when hovering the module a "pointer"(as known from web CSS styling `cursor: pointer;`) style cursor will be shown.
-There are more cursor types to choose from by setting the `cursor` option to a number,
-see Gdk3 offical docs for all possible cursor types:
-https://docs.gtk.org/gdk3/enum.CursorType.html.
-
 # SUPPORTED MODULES
 
 - *waybar-backlight(5)*

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -305,6 +305,10 @@ A group may hide all but one element, showing them only on mouse hover. In order
 
 Most, if not all, module types support setting the `cursor` option. If set to
 `true`, when hovering the module a "pointer"(as known from web CSS styling `cursor: pointer;`) style cursor will be shown.
+There are more cursor types to choose from by setting the `cursor` option to a number,
+see Gdk3 offical docs for all possible cursor types:
+https://docs.gtk.org/gdk3/enum.CursorType.html.
+
 # SUPPORTED MODULES
 
 - *waybar-backlight(5)*

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -301,6 +301,10 @@ A group may hide all but one element, showing them only on mouse hover. In order
 },
 ```
 
+## Setting cursor style
+
+Most, if not all, module types support setting the `cursor` option. If set to
+`true`, when hovering the module a "pointer"(as known from web CSS styling `cursor: pointer;`) style cursor will be shown.
 # SUPPORTED MODULES
 
 - *waybar-backlight(5)*

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -1,8 +1,11 @@
 #include "AModule.hpp"
 
 #include <fmt/format.h>
+#include <spdlog/spdlog.h>
 
 #include <util/command.hpp>
+
+#include "gdkmm/cursor.h"
 
 namespace waybar {
 
@@ -67,6 +70,12 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
   if (hasUserEvents_ && config_.isMember("cursor")) {
     if (config_["cursor"].isBool() && config_["cursor"].asBool()) {
       setCursor(Gdk::HAND2);
+    } else if (config_["cursor"].isInt()) {
+      auto cursor_type = static_cast<Gdk::CursorType>(config_["cursor"].asInt());
+      setCursor(cursor_type);  // Don't care what happens if the cast was unsuccesful, blame GTK
+                               // about what the default is
+    } else {
+      spdlog::warn("unknown cursor option configured on module %s", name_);
     }
   }
 }

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -105,9 +105,9 @@ auto AModule::doAction(const std::string& name) -> void {
 }
 
 void AModule::setCursor(Gdk::CursorType c) {
-  auto cursor = Gdk::Cursor::create(c);
   auto gdk_window = event_box_.get_window();
   if (gdk_window) {
+    auto cursor = Gdk::Cursor::create(c);
     gdk_window->set_cursor(cursor);
   } else {
     // window may not be accessible yet, in this case,

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -64,6 +64,11 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
     event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     event_box_.signal_scroll_event().connect(sigc::mem_fun(*this, &AModule::handleScroll));
   }
+  if (hasUserEvents_ && config_.isMember("cursor")) {
+    if (config_["cursor"].isBool() && config_["cursor"].asBool()) {
+      setCursor(Gdk::HAND2);
+    }
+  }
 }
 
 AModule::~AModule() {
@@ -100,20 +105,12 @@ bool AModule::handleMouseEnter(GdkEventCrossing* const& e) {
   if (auto* module = event_box_.get_child(); module != nullptr) {
     module->set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   }
-
-  if (hasUserEvents_) {
-    setCursor(Gdk::HAND2);
-  }
   return false;
 }
 
 bool AModule::handleMouseLeave(GdkEventCrossing* const& e) {
   if (auto* module = event_box_.get_child(); module != nullptr) {
     module->unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
-  }
-
-  if (hasUserEvents_) {
-    setCursor(Gdk::ARROW);
   }
   return false;
 }

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -67,7 +67,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
     event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     event_box_.signal_scroll_event().connect(sigc::mem_fun(*this, &AModule::handleScroll));
   }
-  if (hasUserEvents_ && config_.isMember("cursor")) {
+  if (config_.isMember("cursor")) {
     if (config_["cursor"].isBool() && config_["cursor"].asBool()) {
       setCursor(Gdk::HAND2);
     } else if (config_["cursor"].isInt()) {


### PR DESCRIPTION
- **fix(#3239): hide cursor type change behind config flag**
- **feat: also, no reason to block the user, expose all possible cursor types**

Resolves #3239.