### PR TITLE
(hyprland) fix crash when failed to parse IPC message

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -86,7 +86,14 @@ void IPC::startIPC() {
       std::string messageReceived(buffer.data());
       messageReceived = messageReceived.substr(0, messageReceived.find_first_of('\n'));
       spdlog::debug("hyprland IPC received {}", messageReceived);
-      parseIPC(messageReceived);
+
+      try {
+        parseIPC(messageReceived);
+      } catch (std::exception& e) {
+        spdlog::warn("Failed to parse IPC message: {}, reason: {}", messageReceived, e.what());
+      } catch (...) {
+        throw;
+      }
 
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
     }


### PR DESCRIPTION
IPC messages are parsed in a dedicated thread, and the thread terminates when an exception is not caught, which causes the waybar process to crash with SIGABORT.

While this issue might be related to Hyprland, it is really annoying to see waybar crash. It would be better to catch those exceptions and report errors instead of crashing.
