### PR TITLE
workflows: add nix workflows

### DIFF
--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -1,0 +1,17 @@
+name: "Nix-Tests"
+on:
+  pull_request:
+  push:
+jobs:
+  nix-flake-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: cachix/install-nix-action@v27
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - run: nix flake show
+    - run: nix flake check --print-build-logs
+    - run: nix build --print-build-logs

--- a/.github/workflows/nix-update-flake-lock.yml
+++ b/.github/workflows/nix-update-flake-lock.yml
@@ -1,0 +1,21 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 1 * *' # Run monthly
+  push:
+      paths:
+        - 'flake.nix'
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v21


### PR DESCRIPTION
## Changes

This PR adds two workflows:
1. `nix-tests` - checks nix files, builds the package, on every push and PR
2. `nix-update-flake-lock` - update dependencies of nix flake, runs once a month

`nix-update-flake-lock` creates a pull request updating flake.lock file when run.

Samples:-  [Nix-tests](https://github.com/Alexays/Waybar/actions/runs/9265649908/job/25488188870?pr=3306), [Update-flake-lock](https://github.com/JohnRTitor/Waybar/actions/runs/9265625759)