### PR TITLE
treewide: meson deprecation and freebsd fixes

### DIFF
--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -31,6 +31,6 @@ jobs:
               libdbusmenu libevdev libfmt libmpdclient libudev-devd meson \
               pkgconf pipewire pulseaudio scdoc sndio spdlog wayland-protocols upower \
               libinotify
-            meson build -Dman-pages=enabled
+            meson setup build -Dman-pages=enabled
             ninja -C build
             meson test -C build --no-rebuild --print-errorlogs --suite waybar

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: configure
-        run: meson -Dman-pages=enabled -Dcpp_std=${{matrix.cpp_std}} build
+        run: meson setup -Dman-pages=enabled -Dcpp_std=${{matrix.cpp_std}} build
       - name: build
         run: ninja -C build
       - name: test

--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@
 default: build
 
 build:
-	meson build
+	meson setup build
 	ninja -C build
 
 build-debug:
-	meson build --buildtype=debug
+	meson setup build --buildtype=debug
 	ninja -C build
 
 install: build

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -1,7 +1,5 @@
 #include "modules/temperature.hpp"
 
-#include <bits/ranges_algo.h>
-
 #include <filesystem>
 #include <string>
 


### PR DESCRIPTION
- [x] Clean up deprecations
- [x] Fix freebsd build
  - Looks like we reference std::ranges and dont need this. It's breaking freebsd build. 

Documentation seemed a little confusing on the temperature paths thing... took some trial and error to figure out what it needed to be parsed properly.

Tested with 
```json
"hwmon-path-abs": [
        "/sys/devices/pci0000:00/0000:00:18.3/hwmon/"
      ],
"input-filename": "temp3_input",
```
and 
```json
"hwmon-path-abs": "/sys/devices/pci0000:00/0000:00:18.3/hwmon",
"input-filename": "temp3_input",
```