### PR TITLE
Fix docker image build github action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false # don't fail the other jobs if one of the images fails to build
       matrix:
         os: [ 'alpine', 'archlinux', 'debian', 'fedora', 'gentoo', 'opensuse' ]
 

--- a/Dockerfiles/fedora
+++ b/Dockerfiles/fedora
@@ -29,6 +29,6 @@ RUN dnf install -y @c-development \
     'pkgconfig(wayland-client)' \
     'pkgconfig(wayland-cursor)' \
     'pkgconfig(wayland-protocols)' \
-    'pkgconfig(wireplumber-0.4)' \
+    'pkgconfig(wireplumber-0.5)' \
     'pkgconfig(xkbregistry)' && \
     dnf clean all -y


### PR DESCRIPTION
* Fix fedora image (https://github.com/Alexays/Waybar/actions/runs/9294824170/job/25580709676#step:4:197)
* Fix docker build failing when another build fails

I haven't been able to fix the opensuse build yet, here's the error:

```
╰─ docker build -f opensuse .
[+] Building 13.0s (5/5) FINISHED                                                                                                                                             docker:default
 => [internal] load build definition from opensuse                                                                                                                                      0.0s
 => => transferring dockerfile: 647B                                                                                                                                                    0.0s
 => [internal] load metadata for docker.io/opensuse/tumbleweed:latest                                                                                                                   0.0s
 => [internal] load .dockerignore                                                                                                                                                       0.0s
 => => transferring context: 2B                                                                                                                                                         0.0s
 => CACHED [1/2] FROM docker.io/opensuse/tumbleweed:latest                                                                                                                              0.0s
 => ERROR [2/2] RUN zypper -n up &&     zypper addrepo https://download.opensuse.org/repositories/X11:Wayland/openSUSE_Tumbleweed/X11:Wayland.repo | echo 'a' &&     zypper -n refres  12.9s
------                                                                                                                                                                                       
 > [2/2] RUN zypper -n up &&     zypper addrepo https://download.opensuse.org/repositories/X11:Wayland/openSUSE_Tumbleweed/X11:Wayland.repo | echo 'a' &&     zypper -n refresh &&     zypper -n install -t pattern devel_C_C++ &&     zypper -n install git meson clang libinput10 libinput-devel pugixml-devel libwayland-client0 libwayland-cursor0 wayland-protocols-devel wayland-devel Mesa-libEGL-devel Mesa-libGLESv2-devel libgbm-devel libxkbcommon-devel libudev-devel libpixman-1-0-devel gtkmm3-devel jsoncpp-devel libxkbregistry-devel scdoc playerctl-devel:           
0.438 Retrieving repository 'openSUSE-Tumbleweed-Non-Oss' metadata [...............done]                                                                                                     
1.487 Building repository 'openSUSE-Tumbleweed-Non-Oss' cache [...done]                                                                                                                      
1.495 Retrieving repository 'Open H.264 Codec (openSUSE Tumbleweed)' metadata [.......done]
1.986 Building repository 'Open H.264 Codec (openSUSE Tumbleweed)' cache [...done]
1.993 Retrieving repository 'openSUSE-Tumbleweed-Oss' metadata [......................................................done]
7.226 Building repository 'openSUSE-Tumbleweed-Oss' cache [....done]
9.879 Retrieving repository 'openSUSE-Tumbleweed-Update' metadata [.........done]
10.68 Building repository 'openSUSE-Tumbleweed-Update' cache [...done]
10.69 Loading repository data...
10.85 Reading installed packages...
11.15 Nothing to do.
11.16 a
11.55 Retrieving repository 'Wayland Project (openSUSE_Tumbleweed)' metadata [.......
12.23 
12.23 New repository or package signing key received:
12.23 
12.23   Repository:       Wayland Project (openSUSE_Tumbleweed)
12.23   Key Fingerprint:  18CF C763 92ED 4351 07A7 6F36 8B23 A9A7 7805 04E9
12.23   Key Name:         X11 OBS Project <X11@build.opensuse.org>
12.23   Key Algorithm:    RSA 2048
12.23   Key Created:      Fri May 13 17:22:39 2022
12.23   Key Expires:      Sun Jul 21 17:22:39 2024 (expires in 51 days)
12.23   Rpm Name:         gpg-pubkey-780504e9-627e93df
12.23 
12.23 
12.23 
12.23     Note: Signing data enables the recipient to verify that no modifications occurred after the data
12.23     were signed. Accepting data with no, wrong or unknown signature can lead to a corrupted system
12.23     and in extreme cases even to a system compromise.
12.23 
12.23     Note: A GPG pubkey is clearly identified by its fingerprint. Do not rely on the key's name. If
12.23     you are not sure whether the presented key is authentic, ask the repository provider or check
12.23     their web site. Many providers maintain a web page showing the fingerprints of the GPG keys they
12.23     are using.
12.23 
12.23 Do you want to reject the key, trust temporarily, or trust always? [r/t/a/?] (r): r
12.23 error]
12.23 Repository 'Wayland Project (openSUSE_Tumbleweed)' is invalid.
12.23 [X11_Wayland|https://download.opensuse.org/repositories/X11:/Wayland/openSUSE_Tumbleweed/] Valid metadata not found at specified URL
12.23 History:
12.23  - Signature verification failed for repomd.xml
12.23 
12.23 Please check if the URIs defined for this repository are pointing to a valid repository.
12.23 Skipping repository 'Wayland Project (openSUSE_Tumbleweed)' because of the above error.
12.32 Repository 'openSUSE-Tumbleweed-Non-Oss' is up to date.
12.38 Repository 'Open H.264 Codec (openSUSE Tumbleweed)' is up to date.
12.48 Repository 'openSUSE-Tumbleweed-Oss' is up to date.
12.73 Repository 'openSUSE-Tumbleweed-Update' is up to date.
12.73 Some of the repositories have not been refreshed because of an error.
------
opensuse:5
--------------------
   4 |     
   5 | >>> RUN zypper -n up && \
   6 | >>>     zypper addrepo https://download.opensuse.org/repositories/X11:Wayland/openSUSE_Tumbleweed/X11:Wayland.repo | echo 'a' && \
   7 | >>>     zypper -n refresh && \
   8 | >>>     zypper -n install -t pattern devel_C_C++ && \
   9 | >>>     zypper -n install git meson clang libinput10 libinput-devel pugixml-devel libwayland-client0 libwayland-cursor0 wayland-protocols-devel wayland-devel Mesa-libEGL-devel Mesa-libGLESv2-devel libgbm-devel libxkbcommon-devel libudev-devel libpixman-1-0-devel gtkmm3-devel jsoncpp-devel libxkbregistry-devel scdoc playerctl-devel
  10 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c zypper -n up &&     zypper addrepo https://download.opensuse.org/repositories/X11:Wayland/openSUSE_Tumbleweed/X11:Wayland.repo | echo 'a' &&     zypper -n refresh &&     zypper -n install -t pattern devel_C_C++ &&     zypper -n install git meson clang libinput10 libinput-devel pugixml-devel libwayland-client0 libwayland-cursor0 wayland-protocols-devel wayland-devel Mesa-libEGL-devel Mesa-libGLESv2-devel libgbm-devel libxkbcommon-devel libudev-devel libpixman-1-0-devel gtkmm3-devel jsoncpp-devel libxkbregistry-devel scdoc playerctl-devel" did not complete successfully: exit code: 4
```