### PR TITLE
fix: display titles with '&' correctly 

### DIFF
--- a/resources/custom_modules/mediaplayer.py
+++ b/resources/custom_modules/mediaplayer.py
@@ -113,6 +113,7 @@ class PlayerManager:
         player_name = player.props.player_name
         artist = player.get_artist()
         title = player.get_title()
+        title = title.replace("&", "&amp;")
 
         track_info = ""
         if player_name == "spotify" and "mpris:trackid" in metadata.keys() and ":ad:" in player.props.metadata["mpris:trackid"]:


### PR DESCRIPTION
if title has a & in the name then the program will fail to set text due to error parsing markup, this fixes this