### PR TITLE
Enable using capture groups in window-rewrite

### DIFF
--- a/include/util/regex_collection.hpp
+++ b/include/util/regex_collection.hpp
@@ -36,7 +36,7 @@ class RegexCollection {
   std::map<std::string, std::string> regex_cache;
   std::string default_repr;
 
-  std::string& find_match(std::string& value, bool& matched_any);
+  std::string find_match(std::string& value, bool& matched_any);
 
  public:
   RegexCollection() = default;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -147,6 +147,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 		"class<firefox> title<.*github.*>": "", // Windows whose class is "firefox" and title contains "github". Note that "class" always comes first.
 		"foot": "", // Windows that contain "foot" in either class or title. For optimization reasons, it will only match against a title if at least one other window explicitly matches against a title.
 		"code": "󰨞",
+		"title<.* - (.*) - VSCodium>": "codium $1"  // captures part of the window title and formats it into output
 	}
 }
 ```

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -171,6 +171,7 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
   "window-rewrite": {
     "class<firefox>": "",
     "class<kitty>": "k",
+	"title<.* - (.*) - VSCodium>": "codium $1"  // captures part of the window title and formats it into output
   }
 }
 ```

--- a/src/util/regex_collection.cpp
+++ b/src/util/regex_collection.cpp
@@ -31,11 +31,12 @@ RegexCollection::RegexCollection(const Json::Value& map, std::string default_rep
   std::sort(rules.begin(), rules.end(), [](Rule& a, Rule& b) { return a.priority > b.priority; });
 }
 
-std::string& RegexCollection::find_match(std::string& value, bool& matched_any) {
+std::string RegexCollection::find_match(std::string& value, bool& matched_any) {
   for (auto& rule : rules) {
-    if (std::regex_search(value, rule.rule)) {
+    std::smatch match;
+    if (std::regex_search(value, match, rule.rule)) {
       matched_any = true;
-      return rule.repr;
+      return match.format(rule.repr.data());
     }
   }
 


### PR DESCRIPTION
This uses `std::match_results::format` to format the output of `get` in `RegexCollection` using the match results.

The effect of this is that you can now use capture groups in the regexes in `window-rewrite` in the sway and hyprland workspaces modules, similarly to the window module, e.g. like this:

```json
"window-rewrite": {
    "title<.* - (.*) - VSCodium>": "codium $1"  // captures part of the window title and formats it into output
}
```

This example would rewrite a window titled `foo.cpp - Waybar - VSCodium` to `codium Waybar`. This is quite useful to rewrite long window titles, but keeping relevant parts of the original title, in this example the workpsace of the VSCodium window.

I have only tested this with sway. Note that I don't know C++ very well so I hope I haven't accidentally introduced a memory leak or something like that.