### PR TITLE
fix: taskbar not applying empty class on empty

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -894,7 +894,7 @@ void Taskbar::move_button(Gtk::Button &bt, int pos) { box_.reorder_child(bt, pos
 
 void Taskbar::remove_button(Gtk::Button &bt) {
   box_.remove(bt);
-  if (tasks_.empty()) {
+  if (box_.get_children().empty()) {
     box_.get_style_context()->add_class("empty");
   }
 }


### PR DESCRIPTION
fixes taskbar `empty` class not being applied on taskbar empty when last not ignored application closes:

before: taskbar isn't transparent on empty (empty class is not applied when brave closes)

https://github.com/Alexays/Waybar/assets/66728045/9e21d3a5-2165-4410-bc30-39ca93c33a22





based on https://github.com/Alexays/Waybar/issues/2564






