### PR TITLE
sway/workspaces: Correct behavior when "current-only" is set

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -501,7 +501,16 @@ std::string Workspaces::trimWorkspaceName(std::string name) {
 
 void Workspaces::onButtonReady(const Json::Value &node, Gtk::Button &button) {
   if (config_["current-only"].asBool()) {
-    if (node["focused"].asBool()) {
+    // If a workspace has a focused container then get_tree will say
+    // that the workspace itself isn't focused.  Therefore we need to
+    // check if any of its nodes are focused as well.
+    bool focused = node["focused"].asBool() ||
+      std::any_of(node["nodes"].begin(), node["nodes"].end(),
+                  [](const auto &child) {
+                    return child["focused"].asBool();
+                  });
+
+    if (focused) {
       button.show();
     } else {
       button.hide();


### PR DESCRIPTION
The `current-only` workspace setting should display only the active workspace name as determined by its `focused` attribute.  However, according to the `get_tree` output, workspaces that contain a focused window will report `"focused": false` and the window will report `"focused": true.` In this case, Waybar will not display a workspace name at all.

This change updates the logic for determining if a workspace is focused by also looking for a focused window.