### PR TITLE
Support for muted icons for pulseaudio devices/ports

### DIFF
--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -142,6 +142,8 @@ If they are found in the current PulseAudio port name, the corresponding icons w
 - *hifi*
 - *phone*
 
+Additionally, suffixing a device name or port with *-muted* will cause the icon
+to be selected when the corresponding audio device is muted. This applies to *default* as well.
 
 # EXAMPLES
 
@@ -152,10 +154,12 @@ If they are found in the current PulseAudio port name, the corresponding icons w
 	"format-muted": "",
 	"format-icons": {
 		"alsa_output.pci-0000_00_1f.3.analog-stereo": "",
+		"alsa_output.pci-0000_00_1f.3.analog-stereo-muted": "",
 		"headphones": "",
 		"handsfree": "",
 		"headset": "",
 		"phone": "",
+		"phone-muted": "",
 		"portable": "",
 		"car": "",
 		"default": ["", ""]

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -42,14 +42,26 @@ static const std::array<std::string, 9> ports = {
 };
 
 const std::vector<std::string> waybar::modules::Pulseaudio::getPulseIcon() const {
-  std::vector<std::string> res = {backend->getCurrentSinkName(), backend->getDefaultSourceName()};
+  std::vector<std::string> res;
+  auto sink_muted = backend->getSinkMuted();
+  if (sink_muted) {
+    res.emplace_back(backend->getCurrentSinkName() + "-muted");
+  }
+  res.push_back(backend->getCurrentSinkName());
+  res.push_back(backend->getDefaultSourceName());
   std::string nameLC = backend->getSinkPortName() + backend->getFormFactor();
   std::transform(nameLC.begin(), nameLC.end(), nameLC.begin(), ::tolower);
   for (auto const &port : ports) {
     if (nameLC.find(port) != std::string::npos) {
+      if (sink_muted) {
+        res.emplace_back(port + "-muted");
+      }
       res.push_back(port);
-      return res;
+      break;
     }
+  }
+  if (sink_muted) {
+    res.emplace_back("default-muted");
   }
   return res;
 }


### PR DESCRIPTION
This PR enables users to specify alternate pulseaudio icons for when a sink is muted. 
For example, adding a `headphone-muted` entry into a `format-icons` object will use the corresponding icon when the current sink is a headphone port and is muted.
Users can also specify `[current_sink_name]-muted`, `[port]-muted` or `default-muted` icons

When not muted, behavior is unchanged.
When muted, icons are searched for in the following order:
- `[current_sink_name]-muted`
- `[current_sink_name]` _(Existing behavior)_
- `[default_source_name]` _(Existing behavior)_
- `[port]-muted`
- `[port]` _(Existing behavior)_
- `default-muted`
- `default` _(Existing behavior)_

Feedback welcome, this is the least intrusive way I thought of to include this feature that I wanted personally.
 
## Example config
```
  "pulseaudio": {
      "format": "{icon} {volume}%",
      "format-muted": "{icon} Muted",

      "format-icons": {
          "headphone":        "󰋋",
          "headphone-muted":  "󰟎",
          "portable":         "󰏲",
          "portable-muted":   "󰷯",
          "car":              "󰄋",
          "car-muted":        "󰸜",
          "default": ["", "", ""],
          "default-muted":    "󰸈"
      }
  }
```
## Example results
![20240612_18h11m18s_grim](https://github.com/Alexays/Waybar/assets/36212485/74d4d152-847d-4082-9257-baa7b143b135)
![20240612_18h11m15s_grim](https://github.com/Alexays/Waybar/assets/36212485/376a79fe-8465-46b2-93fd-30e10f0c8429)
![20240612_18h11m02s_grim](https://github.com/Alexays/Waybar/assets/36212485/6299eea7-1af8-480e-bb87-c69c83b7de11)
![20240612_18h10m58s_grim](https://github.com/Alexays/Waybar/assets/36212485/84ca8c85-fe65-401b-bf37-7a55b7a1a3dd)

