### PR TITLE
Fix build error on Ubuntu 22.04

### DIFF
--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -10,6 +10,10 @@ namespace waybar::modules {
 struct Profile {
   std::string name;
   std::string driver;
+
+  Profile(std::string n, std::string d)
+    : name(std::move(n)), driver(std::move(d)){
+  }
 };
 
 class PowerProfilesDaemon : public ALabel {

--- a/include/modules/power_profiles_daemon.hpp
+++ b/include/modules/power_profiles_daemon.hpp
@@ -11,9 +11,7 @@ struct Profile {
   std::string name;
   std::string driver;
 
-  Profile(std::string n, std::string d)
-    : name(std::move(n)), driver(std::move(d)){
-  }
+  Profile(std::string n, std::string d) : name(std::move(n)), driver(std::move(d)) {}
 };
 
 class PowerProfilesDaemon : public ALabel {


### PR DESCRIPTION
When building the master branch on Ubuntu 22.04 I encountered a build error both with g++ 11 and clang 14. Essentially the compiler can not find a constructor for the `Profile` class in `src/modules/power_profiles_daemon`. I think c++ 20 should create a default constructor with a parameter list but that seems to not have happened even though g++11 and clang 14 should be (at least partially) c++20-capable. The error is as follows:
```
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/alloc_traits.h:518:4: error: no matching function for call to 'construct_at'
          std::construct_at(__p, std::forward<_Args>(__args)...);
          ^~~~~~~~~~~~~~~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/vector.tcc:117:21: note: in instantiation of function template specialization 'std::allocator_traits<std::allocator<waybar::modules::Profile>>::construct<waybar::modules::Profile, Glib::ustring, Glib::ustring>' requested here
            _Alloc_traits::construct(this->_M_impl, this->_M_impl._M_finish,
                           ^
../src/modules/power_profiles_daemon.cpp:106:26: note: in instantiation of function template specialization 'std::vector<waybar::modules::Profile>::emplace_back<Glib::ustring, Glib::ustring>' requested here
      availableProfiles_.emplace_back(std::move(name), std::move(driver));
                         ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/12/../../../../include/c++/12/bits/stl_construct.h:94:5: note: candidate template ignored: substitution failure [with _Tp = waybar::modules::Profile, _Args = <Glib::ustring, Glib::ustring>]: no matching constructor for initialization of 'waybar::modules::Profile'
    construct_at(_Tp* __location, _Args&&... __args)
    ^
```