### PR TITLE
Add keyboard debug info to hyprland language module

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -36,6 +36,11 @@ Language::~Language() {
 auto Language::update() -> void {
   std::lock_guard<std::mutex> lg(mutex_);
 
+  spdlog::debug("hyprland language update with full name {}", layout_.full_name);
+  spdlog::debug("hyprland language update with short name {}", layout_.short_name);
+  spdlog::debug("hyprland language update with short description {}", layout_.short_description);
+  spdlog::debug("hyprland language update with variant {}", layout_.variant);
+
   std::string layoutName = std::string{};
   if (config_.isMember("format-" + layout_.short_description + "-" + layout_.variant)) {
     const auto propName = "format-" + layout_.short_description + "-" + layout_.variant;
@@ -49,6 +54,8 @@ auto Language::update() -> void {
                                   fmt::arg("shortDescription", layout_.short_description),
                                   fmt::arg("variant", layout_.variant)));
   }
+
+  spdlog::debug("hyprland language formatted layout name {}", layoutName);
 
   if (!format_.empty()) {
     label_.show();


### PR DESCRIPTION
As I found out myself in #2072 and others have noted is baffling to figure out why some things are not matching or what to enter in a config to match the right keyboard language/layout/variant combo. This debug information helped clarify what was going wrong for my case (not fix it, just point to the problem) after being baffled for a long time and having tried a lot of stabbing in the dark.
