### PR TITLE
modules/battery: Deprioritize `capacity` /sys value for battery calculation if other methods are available

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -272,13 +272,6 @@ waybar::modules::Battery::getInfos() {
       // Some battery will report current and charge in μA/μAh.
       // Scale these by the voltage to get μW/μWh.
 
-      uint32_t capacity = 0;
-      bool capacity_exists = false;
-      if (fs::exists(bat / "capacity")) {
-        capacity_exists = true;
-        std::ifstream(bat / "capacity") >> capacity;
-      }
-
       uint32_t current_now = 0;
       bool current_now_exists = false;
       if (fs::exists(bat / "current_now")) {
@@ -382,6 +375,19 @@ waybar::modules::Battery::getInfos() {
         }
       }
 
+      uint32_t capacity = 0;
+      bool capacity_exists = false;
+      if (charge_now_exists && charge_full_exists && charge_full != 0) {
+        capacity_exists = true;
+        capacity = 100 * (uint64_t)charge_now / (uint64_t)charge_full;
+      } else if (energy_now_exists && energy_full_exists && energy_full != 0) {
+        capacity_exists = true;
+        capacity = 100 * (uint64_t)energy_now / (uint64_t)energy_full;
+      } else if (fs::exists(bat / "capacity")) {
+        capacity_exists = true;
+        std::ifstream(bat / "capacity") >> capacity;
+      }
+
       if (!voltage_now_exists) {
         if (power_now_exists && current_now_exists && current_now != 0) {
           voltage_now_exists = true;
@@ -422,13 +428,7 @@ waybar::modules::Battery::getInfos() {
       }
 
       if (!capacity_exists) {
-        if (charge_now_exists && charge_full_exists && charge_full != 0) {
-          capacity_exists = true;
-          capacity = 100 * (uint64_t)charge_now / (uint64_t)charge_full;
-        } else if (energy_now_exists && energy_full_exists && energy_full != 0) {
-          capacity_exists = true;
-          capacity = 100 * (uint64_t)energy_now / (uint64_t)energy_full;
-        } else if (charge_now_exists && energy_full_exists && voltage_now_exists) {
+        if (charge_now_exists && energy_full_exists && voltage_now_exists) {
           if (!charge_full_exists && voltage_now != 0) {
             charge_full_exists = true;
             charge_full = 1000000 * (uint64_t)energy_full / (uint64_t)voltage_now;


### PR DESCRIPTION
Closes #3293

The current code for battery calculation seems to assume that the `capacity` value returns the non-design battery capacity. This is not the case, and it instead returns the design capacity of the battery.

Currently, the `capacity` value is used above all other methods if it is present in the /sys directory of the battery. This means that the design capacity of the battery will always be displayed regardless of the `design-capacity` configuration option.

To remedy this issue, I have restructured the code so that the `capacity` value is only used if the other possible options for calculation have been exhausted beforehand.

This screenshot shows two instances Waybar while the battery is plugged in at full capacity. The top instance is the current release version, and the bottom instance is the code present in this pull request:
![image](https://github.com/Alexays/Waybar/assets/48618519/ca622b5a-b7fc-45e2-af28-354a70981a42)

This pull request maintains the functionality of the `design-capacity` configuration option. Here is the previous screenshot taken again with `design-capacity` set to `true`:
![image](https://github.com/Alexays/Waybar/assets/48618519/27779f8c-5a46-4fa2-913e-12a5fc0e2967)

Please correct me if I have done anything incorrectly in this pull request, as I am not very familiar with the codebase.