### PR TITLE
modules/river/tags: use toggle-tags to determine focused/occupied/urgent status

### DIFF
--- a/include/modules/river/tags.hpp
+++ b/include/modules/river/tags.hpp
@@ -29,6 +29,8 @@ class Tags : public waybar::AModule {
   struct wl_seat *seat_;
 
  private:
+  bool check_tags(uint32_t tags, size_t i);
+ 
   const waybar::Bar &bar_;
   Gtk::Box box_;
   std::vector<Gtk::Button> buttons_;

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -188,9 +188,15 @@ bool Tags::handle_button_press(GdkEventButton *event_button, uint32_t tag) {
   return true;
 }
 
+bool Tags::check_tags(uint32_t tags, size_t i) {
+  const auto toggle_tags = config_["toggle-tags"];
+  auto tag = toggle_tags.isArray() && !toggle_tags.empty() ? toggle_tags[(int) i].asUInt() : 1 << i;
+  return (bool) (tag & tags);
+}
+
 void Tags::handle_focused_tags(uint32_t tags) {
   for (size_t i = 0; i < buttons_.size(); ++i) {
-    if ((1 << i) & tags) {
+    if (check_tags(tags, i)) {
       buttons_[i].get_style_context()->add_class("focused");
     } else {
       buttons_[i].get_style_context()->remove_class("focused");
@@ -206,7 +212,7 @@ void Tags::handle_view_tags(struct wl_array *view_tags) {
     tags |= *view_tag;
   }
   for (size_t i = 0; i < buttons_.size(); ++i) {
-    if ((1 << i) & tags) {
+    if (check_tags(tags, i)) {
       buttons_[i].get_style_context()->add_class("occupied");
     } else {
       buttons_[i].get_style_context()->remove_class("occupied");
@@ -216,7 +222,7 @@ void Tags::handle_view_tags(struct wl_array *view_tags) {
 
 void Tags::handle_urgent_tags(uint32_t tags) {
   for (size_t i = 0; i < buttons_.size(); ++i) {
-    if ((1 << i) & tags) {
+    if (check_tags(tags, i)) {
       buttons_[i].get_style_context()->add_class("urgent");
     } else {
       buttons_[i].get_style_context()->remove_class("urgent");


### PR DESCRIPTION
Currently, the `river/tags` module uses the index of each button to determine the tag to use when determining focused/occupied/urgent status, rather than using the `set-tags` or `toggle-tags` value in the config. In my config, I have tags counting down from 30 for certain applications (the characters after 9 in `tag-labels` are Nerd Fonts icons for Firefox, Discord, KeePass and Thunderbird respectively):

```json
    "river/tags": {
        "num-tags": 13,
        "tag-labels": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "󰈹", "", "", ""],
        "set-tags": [
            1,
            2,
            4,
            8,
            16,
            32,
            64,
            128,
            256,
            1073741824,
            536870912,
            268435456,
            134217728
        ],
        "toggle-tags": [
            1,
            2,
            4,
            8,
            16,
            32,
            64,
            128,
            256,
            1073741824,
            536870912,
            268435456,
            134217728
        ]
    },
```

The current implementation means that tag 10 (512) is used for the Firefox button when determining focused/occupied/urgent status, even though the `set-tags` and `toggle-tags` values are both 30 (1073741824). In other words, the button appears occupied when tag 10 is activated, even though the button actually controls tag 30.

This PR changes this behaviour to use the `toggle-tags` value, falling back to the previous behaviour if `toggle-tags` is not specified. `toggle-tags` is used instead of `set-tags` to support "sticky tag" configurations (as in the [wiki example](https://github.com/Alexays/Waybar/wiki/Module:-River#example-1)).