### PR TITLE
modules/hyprland/backend: handle empty socket response 

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -4,14 +4,11 @@
 #include <gtkmm/label.h>
 #include <json/value.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <memory>
-#include <optional>
 #include <regex>
 #include <string>
-#include <variant>
 #include <vector>
 
 #include "AModule.hpp"
@@ -53,17 +50,19 @@ class Workspaces : public AModule, public EventHandler {
   void onEvent(const std::string& e) override;
   void updateWindowCount();
   void sortWorkspaces();
-  void createWorkspace(Json::Value const& workspaceData,
-                       Json::Value const& clientsData = Json::Value::nullRef);
+  void createWorkspace(Json::Value const& workspace_data,
+                       Json::Value const& clients_data = Json::Value::nullRef);
 
-  Json::Value createMonitorWorkspaceData(std::string const& name, std::string const& monitor);
+  static Json::Value createMonitorWorkspaceData(std::string const& name,
+                                                std::string const& monitor);
   void removeWorkspace(std::string const& name);
   void setUrgentWorkspace(std::string const& windowaddress);
 
   // Config
   void parseConfig(const Json::Value& config);
   auto populateIconsMap(const Json::Value& formatIcons) -> void;
-  auto populateBoolConfig(const Json::Value& config, const std::string& key, bool& member) -> void;
+  static auto populateBoolConfig(const Json::Value& config, const std::string& key, bool& member)
+      -> void;
   auto populateSortByConfig(const Json::Value& config) -> void;
   auto populateIgnoreWorkspacesConfig(const Json::Value& config) -> void;
   auto populateFormatWindowSeparatorConfig(const Json::Value& config) -> void;
@@ -98,7 +97,7 @@ class Workspaces : public AModule, public EventHandler {
   void doUpdate();
   void removeWorkspacesToRemove();
   void createWorkspacesToCreate();
-  std::vector<std::string> getVisibleWorkspaces();
+  static std::vector<std::string> getVisibleWorkspaces();
   void updateWorkspaceStates();
   bool updateWindowsToCreate();
 

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -26,7 +26,7 @@ std::filesystem::path IPC::getSocketFolder(const char* instanceSig) {
   const char* xdgRuntimeDirEnv = std::getenv("XDG_RUNTIME_DIR");
   std::filesystem::path xdgRuntimeDir;
   // Only set path if env variable is set
-  if (xdgRuntimeDirEnv) {
+  if (xdgRuntimeDirEnv != nullptr) {
     xdgRuntimeDir = std::filesystem::path(xdgRuntimeDirEnv);
   }
 

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -218,7 +218,13 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
 }
 
 Json::Value IPC::getSocket1JsonReply(const std::string& rq) {
-  return parser_.parse(getSocket1Reply("j/" + rq));
+  std::string reply = getSocket1Reply("j/" + rq);
+
+  if (reply.empty()) {
+    return {};
+  }
+
+  return parser_.parse(reply);
 }
 
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -38,12 +38,12 @@ Submap::~Submap() {
 }
 
 auto Submap::parseConfig(const Json::Value& config) -> void {
-  auto const alwaysOn = config["always-on"];
+  auto const& alwaysOn = config["always-on"];
   if (alwaysOn.isBool()) {
     always_on_ = alwaysOn.asBool();
   }
 
-  auto const defaultSubmap = config["default-submap"];
+  auto const& defaultSubmap = config["default-submap"];
   if (defaultSubmap.isString()) {
     default_submap_ = defaultSubmap.asString();
   }

--- a/src/modules/hyprland/windowcreationpayload.cpp
+++ b/src/modules/hyprland/windowcreationpayload.cpp
@@ -3,14 +3,11 @@
 #include <json/value.h>
 #include <spdlog/spdlog.h>
 
-#include <algorithm>
-#include <memory>
 #include <string>
 #include <utility>
 #include <variant>
 
 #include "modules/hyprland/workspaces.hpp"
-#include "util/regex_collection.hpp"
 
 namespace waybar::modules::hyprland {
 

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -1,14 +1,11 @@
 #include <json/value.h>
 #include <spdlog/spdlog.h>
 
-#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>
-#include <variant>
 
 #include "modules/hyprland/workspaces.hpp"
-#include "util/regex_collection.hpp"
 
 namespace waybar::modules::hyprland {
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -7,7 +7,6 @@
 #include <memory>
 #include <string>
 #include <utility>
-#include <variant>
 
 #include "util/regex_collection.hpp"
 
@@ -593,14 +592,14 @@ auto Workspaces::populateIconsMap(const Json::Value &formatIcons) -> void {
 
 auto Workspaces::populateBoolConfig(const Json::Value &config, const std::string &key, bool &member)
     -> void {
-  auto configValue = config[key];
+  const auto &configValue = config[key];
   if (configValue.isBool()) {
     member = configValue.asBool();
   }
 }
 
 auto Workspaces::populateSortByConfig(const Json::Value &config) -> void {
-  auto configSortBy = config["sort-by"];
+  const auto &configSortBy = config["sort-by"];
   if (configSortBy.isString()) {
     auto sortByStr = configSortBy.asString();
     try {
@@ -633,7 +632,7 @@ auto Workspaces::populateIgnoreWorkspacesConfig(const Json::Value &config) -> vo
 }
 
 auto Workspaces::populateFormatWindowSeparatorConfig(const Json::Value &config) -> void {
-  auto formatWindowSeparator = config["format-window-separator"];
+  const auto &formatWindowSeparator = config["format-window-separator"];
   m_formatWindowSeparator =
       formatWindowSeparator.isString() ? formatWindowSeparator.asString() : " ";
 }

--- a/test/hyprland/backend.cpp
+++ b/test/hyprland/backend.cpp
@@ -1,4 +1,3 @@
-#include <cstdlib>
 #if __has_include(<catch2/catch_test_macros.hpp>)
 #include <catch2/catch_test_macros.hpp>
 #else
@@ -6,7 +5,6 @@
 #endif
 
 #include "fixtures/IPCTestFixture.hpp"
-#include "modules/hyprland/backend.hpp"
 
 namespace fs = std::filesystem;
 namespace hyprland = waybar::modules::hyprland;
@@ -52,4 +50,12 @@ TEST_CASE_METHOD(IPCTestFixture, "XDGRuntimeDirExistsNoHyprDir", "[getSocketFold
 
   // Assert expected result
   REQUIRE(actualPath == expectedPath);
+}
+
+TEST_CASE_METHOD(IPCMock, "getSocket1JsonReply handles empty response", "[getSocket1JsonReply]") {
+  std::string request = "test_request";
+
+  Json::Value jsonResponse = getSocket1JsonReply(request);
+
+  REQUIRE(jsonResponse.isNull());
 }

--- a/test/hyprland/fixtures/IPCTestFixture.hpp
+++ b/test/hyprland/fixtures/IPCTestFixture.hpp
@@ -14,3 +14,9 @@ class IPCTestFixture : public hyprland::IPC {
 
  private:
 };
+
+class IPCMock : public IPCTestFixture {
+ public:
+  // Mock getSocket1Reply to return an empty string
+  static std::string getSocket1Reply(const std::string& rq) { return ""; }
+};


### PR DESCRIPTION
Issues:
- Resolves https://github.com/Alexays/Waybar/issues/3388 
- Resolves https://github.com/Alexays/Waybar/issues/3365

This PR: 
- We will check for an empty response from getSocketReply before trying to parse JSON. Before the empty response check we get the JSON parse error from the JSON module. After the change, we wont try and parse the message that will cause the crash.
- Also includes some clangd cleanup. 
- Added test to verify we dont crash when we receive an empty socket response. 