### PR TITLE
workaround for icons not rendered for apps existing before waybar launch

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -788,6 +788,10 @@ Taskbar::Taskbar(const std::string &id, const waybar::Bar &bar, const Json::Valu
   }
 
   icon_themes_.push_back(Gtk::IconTheme::get_default());
+
+  for (auto &t : tasks_) {
+    t->handle_app_id(t->app_id().c_str());
+  }
 }
 
 Taskbar::~Taskbar() {


### PR DESCRIPTION
This is a workaround for #3366 .

Using gdb, I can see that `handle_app_id` can sometimes run when `tbar_->icon_themes()` has 0 elements. This happens in multi output settings and can result in empty icons for apps that have been started before waybar.

It looks to me that the Tasks can be present before `Taskbar::Taskbar` has run, I could also confirm this by temporarily setting a bool flag in the constructor. If anyone can, I would appreciate any more detailed explanation why that is even possible, because I don't understand it at all.

With an explanation there's probably better ways to do this. :) But the code in this PR addresses this by setting the app_ids for all of the taskbar's tasks again at the end of Taskbar's constructor, leading to another icon lookup with `icon_themes()` available for `handle_app_id`. 