### PR TITLE
add hide-empty-text option to hide module whenever output is empty but format is not

### DIFF
--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -21,6 +21,10 @@ Addressed by *custom/<name>*
 	The path to a script, which determines if the script in *exec* should be executed. ++
 	*exec* will be executed if the exit code of *exec-if* equals 0.
 
+*hide-empty-text*: ++
+	typeof: bool ++
+	Disables the module when output is empty, but format might contain additional static content.
+
 *exec-on-event*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -162,7 +162,7 @@ auto waybar::modules::Custom::update() -> void {
     auto str = fmt::format(fmt::runtime(format_), text_, fmt::arg("alt", alt_),
                            fmt::arg("icon", getIcon(percentage_, alt_)),
                            fmt::arg("percentage", percentage_));
-    if (str.empty()) {
+    if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
       event_box_.hide();
     } else {
       label_.set_markup(str);


### PR DESCRIPTION
Resolves #3341

Custom module hides empty output, e.g. when a worker returns `{}` as json. But when using other content in the format, e.g. to add an icon before or after output, it's no longer possible to have the module hidden.

This PR addresses this by adding a config option `hide-empty-text`, when true, `text_` is checked for empty rather than `str`.

I realise I forgot the manpage, coming up in a second :P