### PR TITLE
fix example in manpage for pulseaudio/slider

### DIFF
--- a/man/waybar-pulseaudio-slider.5.scd
+++ b/man/waybar-pulseaudio-slider.5.scd
@@ -31,7 +31,7 @@ The volume can be controlled by dragging the slider across the bar or clicking o
 
 ```
 "modules-right": [
-    "pulseaudio-slider",
+    "pulseaudio/slider",
 ],
 "pulseaudio/slider": {
     "min": 0,


### PR DESCRIPTION
From #3373 : config example provided in man page does not work. This fixes it.