### PR TITLE
modules/hyprland/workspace: ignore empty window-rewrite

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -26,6 +26,7 @@ Addressed by *hyprland/workspaces*
 	Regex rules to map window class to an icon or preferred method of representation for a workspace's window.
 	Keys are the rules, while the values are the methods of representation. Values may use the placeholders {class} and {title} to use the window's original class and/or title respectively.
 	Rules may specify `class<...>`, `title<...>`, or both in order to fine-tune the matching.
+	You may assign an empty value to a rule to have it ignored from generating any representation in workspaces.
 
 *window-rewrite-default*:
 	typeof: string ++

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -92,7 +92,11 @@ void Workspace::initializeWindowMap(const Json::Value &clients_data) {
 
 void Workspace::insertWindow(WindowCreationPayload create_window_paylod) {
   if (!create_window_paylod.isEmpty(m_workspaceManager)) {
-    m_windowMap[create_window_paylod.getAddress()] = create_window_paylod.repr(m_workspaceManager);
+    auto repr = create_window_paylod.repr(m_workspaceManager);
+
+    if (!repr.empty()) {
+      m_windowMap[create_window_paylod.getAddress()] = repr;
+    }
   }
 };
 


### PR DESCRIPTION
I'd like to ignore some windows from having icons or empty space taken on the bar. By filtering out empty repr we can supply rewrite rules that will ignore them from being processed and showing an empty space or default icon.

![image](https://github.com/Alexays/Waybar/assets/1778670/f71eeeaf-9f8d-438b-a93f-c45221113dc1)
