### PR TITLE
pulseaudio: Consider ignored sinks never running

### DIFF
--- a/src/util/audio_backend.cpp
+++ b/src/util/audio_backend.cpp
@@ -144,6 +144,12 @@ void AudioBackend::sinkInfoCb(pa_context * /*context*/, const pa_sink_info *i, i
   if (!backend->ignored_sinks_.empty()) {
     for (const auto &ignored_sink : backend->ignored_sinks_) {
       if (ignored_sink == i->description) {
+        if (i->name == backend->current_sink_name_) {
+          // If the current sink happens to be ignored it is never considered running
+          // so it will be replaced with another sink.
+          backend->current_sink_running_ = false;
+        }
+
         return;
       }
     }


### PR DESCRIPTION
If the current sink happens to be ignored it is never considered running so it will be replaced with another sink.

Otherwise if an ignored sink was set as the default sink for some reason during startup it might never get replaced even though it's supposed to be ignored.