### PR TITLE
feat/issue 3256: Toggle drawer state

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -25,9 +25,13 @@ class Group : public AModule {
   Gtk::Revealer revealer;
   bool is_first_widget = true;
   bool is_drawer = false;
+  bool click_to_reveal = false;
   std::string add_class_to_drawer_children;
   bool handleMouseEnter(GdkEventCrossing *const &ev) override;
   bool handleMouseLeave(GdkEventCrossing *const &ev) override;
+  bool handleToggle(GdkEventButton *const &ev) override;
+  void show_group();
+  void hide_group();
 };
 
 }  // namespace waybar

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -278,6 +278,11 @@ A group may hide all but one element, showing them only on mouse hover. In order
 	default: "hidden" ++
 	Defines the CSS class to be applied to the hidden elements.
 
+*click-to-reveal*: ++
+	typeof: bool ++
+	default: false ++
+	Whether left click should reveal the content rather than mouse over. Note that grouped modules may still process their own on-click events.
+
 *transition-left-to-right*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -62,6 +62,7 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     const bool left_to_right = (drawer_config["transition-left-to-right"].isBool()
                                     ? drawer_config["transition-left-to-right"].asBool()
                                     : true);
+    click_to_reveal = drawer_config["click-to-reveal"].asBool();
 
     auto transition_type = getPreferredTransitionType(vertical);
 
@@ -83,16 +84,40 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
   event_box_.add(box);
 }
 
-bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
+void Group::show_group() {
   box.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   revealer.set_reveal_child(true);
+}
+
+void Group::hide_group() {
+  box.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+  revealer.set_reveal_child(false);
+}
+
+bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
+  if (!click_to_reveal) {
+    show_group();
+  }
   return false;
 }
 
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
-  box.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
-  revealer.set_reveal_child(false);
+  if (!click_to_reveal) {
+    hide_group();
+  }
   return false;
+}
+
+bool Group::handleToggle(GdkEventButton* const& e) {
+  if (!click_to_reveal || e->button != 1) {
+    return false;
+  }
+  if (box.get_state_flags() & Gtk::StateFlags::STATE_FLAG_PRELIGHT) {
+    hide_group();
+  } else {
+    show_group();
+  }
+  return true;
 }
 
 auto Group::update() -> void {


### PR DESCRIPTION
resolves #3256 

Adds a config to groups revealer "click-to-reveal", which allows to reveal the hidden modules by clicking rather than mouse over.
