### PR TITLE
Fix build with fmt11

### DIFF
--- a/include/util/date.hpp
+++ b/include/util/date.hpp
@@ -64,7 +64,7 @@ struct fmt::formatter<date::zoned_time<Duration, TimeZonePtr>> {
   }
 
   template <typename FormatContext>
-  auto format(const date::zoned_time<Duration, TimeZonePtr>& ztime, FormatContext& ctx) {
+  auto format(const date::zoned_time<Duration, TimeZonePtr>& ztime, FormatContext& ctx) const {
     if (ctx.locale()) {
       const auto loc = ctx.locale().template get<std::locale>();
       return fmt::format_to(ctx.out(), "{}", date::format(loc, fmt::to_string(specs), ztime));

--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -45,7 +45,7 @@ struct formatter<pow_format> {
   }
 
   template <class FormatContext>
-  auto format(const pow_format& s, FormatContext& ctx) -> decltype(ctx.out()) {
+  auto format(const pow_format& s, FormatContext& ctx) const -> decltype(ctx.out()) {
     const char* units[] = {"", "k", "M", "G", "T", "P", nullptr};
 
     auto base = s.binary_ ? 1024ull : 1000ll;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -123,7 +123,7 @@ void waybar::Client::handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor) {
 }
 
 void waybar::Client::handleMonitorRemoved(Glib::RefPtr<Gdk::Monitor> monitor) {
-  spdlog::debug("Output removed: {} {}", monitor->get_manufacturer(), monitor->get_model());
+  spdlog::debug("Output removed: {} {}", monitor->get_manufacturer().c_str(), monitor->get_model().c_str());
   /* This event can be triggered from wl_display_roundtrip called by GTK or our code.
    * Defer destruction of bars for the output to the next iteration of the event loop to avoid
    * deleting objects referenced by currently executed code.


### PR DESCRIPTION
Since fmt 11.0.0, formatter:format() is required to be const.Mark affected functions as const to stay compatible with fmt 11.