### PR TITLE
chore: update meson build command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ An Ubuntu PPA with more recent versions is available
 ```bash
 $ git clone https://github.com/Alexays/Waybar
 $ cd Waybar
-$ meson build
+$ meson setup build
 $ ninja -C build
 $ ./build/waybar
 # If you want to install it


### PR DESCRIPTION
Receiving this warning when following the instructions from the readme to build from scratch:

```txt
❯ meson build
WARNING: Running the setup command as `meson [options]` instead of `meson setup [options]` is ambiguous and deprecated.
```

Would it be better to just specify `make build` instead of `meson setup build` & `ninja -C build`?