### PR TITLE
hyprland/window: fix crash when no return from socket

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1719506693,
-        "narHash": "sha256-C8e9S7RzshSdHB7L+v9I51af1gDM5unhJ2xO1ywxNH8=",
+        "lastModified": 1720957393,
+        "narHash": "sha256-oedh2RwpjEa+TNxhg5Je9Ch6d3W1NKi7DbRO1ziHemA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b2852eb9365c6de48ffb0dc2c9562591f652242a",
+        "rev": "693bc46d169f5af9c992095736e82c3488bf7dbb",
         "type": "github"
       },
       "original": {

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -123,7 +123,8 @@ void waybar::Client::handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor) {
 }
 
 void waybar::Client::handleMonitorRemoved(Glib::RefPtr<Gdk::Monitor> monitor) {
-  spdlog::debug("Output removed: {} {}", monitor->get_manufacturer().c_str(), monitor->get_model().c_str());
+  spdlog::debug("Output removed: {} {}", monitor->get_manufacturer().c_str(),
+                monitor->get_model().c_str());
   /* This event can be triggered from wl_display_roundtrip called by GTK or our code.
    * Defer destruction of bars for the output to the next iteration of the event loop to avoid
    * deleting objects referenced by currently executed code.

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -845,7 +845,7 @@ void waybar::modules::Network::parseBssid(struct nlattr **bss) {
     auto bssid = static_cast<uint8_t *>(nla_data(bss[NL80211_BSS_BSSID]));
     auto bssid_len = nla_len(bss[NL80211_BSS_BSSID]);
     if (bssid_len == 6) {
-      bssid_ = std::format("{:x}:{:x}:{:x}:{:x}:{:x}:{:x}", bssid[0], bssid[1], bssid[2], bssid[3],
+      bssid_ = fmt::format("{:x}:{:x}:{:x}:{:x}:{:x}:{:x}", bssid[0], bssid[1], bssid[2], bssid[3],
                            bssid[4], bssid[5]);
     }
   }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -845,11 +845,8 @@ void waybar::modules::Network::parseBssid(struct nlattr **bss) {
     auto bssid = static_cast<uint8_t *>(nla_data(bss[NL80211_BSS_BSSID]));
     auto bssid_len = nla_len(bss[NL80211_BSS_BSSID]);
     if (bssid_len == 6) {
-      bssid_ = std::format(
-        "{:x}:{:x}:{:x}:{:x}:{:x}:{:x}",
-        bssid[0], bssid[1], bssid[2],
-        bssid[3], bssid[4], bssid[5]
-      );
+      bssid_ = std::format("{:x}:{:x}:{:x}:{:x}:{:x}:{:x}", bssid[0], bssid[1], bssid[2], bssid[3],
+                           bssid[4], bssid[5]);
     }
   }
 }


### PR DESCRIPTION
Gracefully handle lack of response from the IPC. If socket isn't available, we already log the IPC isn't running. We dont need to crash program just because we couldn't get responses. We can just return an empty object.

Tested this running on sway and Hyprland. No longer crashes on sway and appears to work the same on Hyprland. 

Also added some clang format and build fixes. 