### PR TITLE
Fix build with fmt11

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -92,7 +92,7 @@ struct formatter<pow_format> {
 template <>
 struct formatter<Glib::ustring> : formatter<std::string> {
   template <typename FormatContext>
-  auto format(const Glib::ustring& value, FormatContext& ctx) {
+  auto format(const Glib::ustring& value, FormatContext& ctx) const {
     return formatter<std::string>::format(static_cast<std::string>(value), ctx);
   }
 };

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -14,14 +14,14 @@
 
 template <>
 struct fmt::formatter<Glib::VariantBase> : formatter<std::string> {
-  bool is_printable(const Glib::VariantBase& value) {
+  bool is_printable(const Glib::VariantBase& value) const {
     auto type = value.get_type_string();
     /* Print only primitive (single character excluding 'v') and short complex types */
     return (type.length() == 1 && islower(type[0]) && type[0] != 'v') || value.get_size() <= 32;
   }
 
   template <typename FormatContext>
-  auto format(const Glib::VariantBase& value, FormatContext& ctx) {
+  auto format(const Glib::VariantBase& value, FormatContext& ctx) const {
     if (is_printable(value)) {
       return formatter<std::string>::format(static_cast<std::string>(value.print()), ctx);
     } else {


### PR DESCRIPTION
Since fmt 11.0.0, formatter:format() is required to be const. Mark all of the specializations as const to be compatible with fmt 11.

This change is implemented in the same spirit of 7725f6ed5a.