### PR TITLE
hyprland: disable modules instead of rendering empty

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -153,8 +153,7 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
   const auto serverSocket = socket(AF_UNIX, SOCK_STREAM, 0);
 
   if (serverSocket < 0) {
-    spdlog::error("Hyprland IPC: Couldn't open a socket (1)");
-    return "";
+    throw std::runtime_error("Hyprland IPC: Couldn't open a socket (1)");
   }
 
   memset(&aiHints, 0, sizeof(struct addrinfo));
@@ -162,16 +161,15 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
   aiHints.ai_socktype = SOCK_STREAM;
 
   if (getaddrinfo("localhost", nullptr, &aiHints, &aiRes) != 0) {
-    spdlog::error("Hyprland IPC: Couldn't get host (2)");
-    return "";
+    throw std::runtime_error("Hyprland IPC: Couldn't get host (2)");
   }
 
   // get the instance signature
   auto* instanceSig = getenv("HYPRLAND_INSTANCE_SIGNATURE");
 
   if (instanceSig == nullptr) {
-    spdlog::error("Hyprland IPC: HYPRLAND_INSTANCE_SIGNATURE was not set! (Is Hyprland running?)");
-    return "";
+    throw std::runtime_error(
+        "Hyprland IPC: HYPRLAND_INSTANCE_SIGNATURE was not set! (Is Hyprland running?)");
   }
 
   sockaddr_un serverAddress = {0};
@@ -182,14 +180,12 @@ std::string IPC::getSocket1Reply(const std::string& rq) {
   // Use snprintf to copy the socketPath string into serverAddress.sun_path
   if (snprintf(serverAddress.sun_path, sizeof(serverAddress.sun_path), "%s", socketPath.c_str()) <
       0) {
-    spdlog::error("Hyprland IPC: Couldn't copy socket path (6)");
-    return "";
+    throw std::runtime_error("Hyprland IPC: Couldn't copy socket path (6)");
   }
 
   if (connect(serverSocket, reinterpret_cast<sockaddr*>(&serverAddress), sizeof(serverAddress)) <
       0) {
-    spdlog::error("Hyprland IPC: Couldn't connect to " + socketPath + ". (3)");
-    return "";
+    throw std::runtime_error("Hyprland IPC: Couldn't connect to " + socketPath + ". (3)");
   }
 
   auto sizeWritten = write(serverSocket, rq.c_str(), rq.length());

--- a/test/hyprland/backend.cpp
+++ b/test/hyprland/backend.cpp
@@ -52,10 +52,8 @@ TEST_CASE_METHOD(IPCTestFixture, "XDGRuntimeDirExistsNoHyprDir", "[getSocketFold
   REQUIRE(actualPath == expectedPath);
 }
 
-TEST_CASE_METHOD(IPCMock, "getSocket1JsonReply handles empty response", "[getSocket1JsonReply]") {
+TEST_CASE_METHOD(IPCTestFixture, "getSocket1Reply throws on no socket", "[getSocket1Reply]") {
   std::string request = "test_request";
 
-  Json::Value jsonResponse = getSocket1JsonReply(request);
-
-  REQUIRE(jsonResponse.isNull());
+  CHECK_THROWS(getSocket1Reply(request));
 }

--- a/test/hyprland/fixtures/IPCTestFixture.hpp
+++ b/test/hyprland/fixtures/IPCTestFixture.hpp
@@ -19,4 +19,7 @@ class IPCMock : public IPCTestFixture {
  public:
   // Mock getSocket1Reply to return an empty string
   static std::string getSocket1Reply(const std::string& rq) { return ""; }
+
+ protected:
+  const char* instanceSig = "instance_sig";
 };


### PR DESCRIPTION
Allows us to disable modules entirely when socket connection isn't working. This is similar to how sway handles their socket connections disabling modules. This supports a single waybar config for multiple IPCs.

Previously, my waybar config would crash when Hyprland modules were in the same config when I was running under sway. In a recent PR I allowed empty responses to not crash the program. Now, I'm throwing runtime_errors when socket doesn't exist so the factory can disable the module in a similar way to the sway module. Now, a single config works properly when you have both hyprland and sway modules declared. 