### PR TITLE
Issue #3375: Allow markup in mpris tooltip

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -33,6 +33,7 @@ class AModule : public IModule {
 
   SCROLL_DIR getScrollDir(GdkEventScroll *e);
   bool tooltipEnabled() const;
+  bool tooltipMarkupEnabled() const;
 
   const std::string name_;
   const Json::Value &config_;
@@ -50,6 +51,7 @@ class AModule : public IModule {
  private:
   bool handleUserEvent(GdkEventButton *const &ev);
   const bool isTooltip;
+  const bool isMarkupTooltip;
   bool hasUserEvents_;
   std::vector<int> pid_;
   gdouble distance_scrolled_y_;

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -47,6 +47,11 @@ The *mpris* module displays currently playing media via libplayerctl.
 	typeof: string ++
 	The status-specific tooltip format.
 
+*tooltip-with-markup*: ++
+	typeof: bool ++
+	default: true ++
+	Whether to accept pango markup in the tooltip.
+
 *artist-len*: ++
 	typeof: integer ++
 	Maximum length of the Artist tag (Wide/Fullwidth Unicode characters count as two). Set to zero to hide the artist in `{dynamic}` tag.

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -15,6 +15,9 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
     : name_(name),
       config_(config),
       isTooltip{config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true},
+      isMarkupTooltip{isTooltip && config_["tooltip-with-markup"].isBool()
+                          ? config_["tooltip-with-markup"].asBool()
+                          : true},
       distance_scrolled_y_(0.0),
       distance_scrolled_x_(0.0) {
   // Configure module action Map
@@ -273,6 +276,8 @@ bool AModule::handleScroll(GdkEventScroll* e) {
 }
 
 bool AModule::tooltipEnabled() const { return isTooltip; }
+
+bool AModule::tooltipMarkupEnabled() const { return isMarkupTooltip; }
 
 AModule::operator Gtk::Widget&() { return event_box_; }
 

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -723,7 +723,11 @@ auto Mpris::update() -> void {
           fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
           fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
 
-      label_.set_tooltip_text(tooltip_text);
+      if (tooltipMarkupEnabled()) {
+        label_.set_tooltip_markup(tooltip_text);
+      } else {
+        label_.set_tooltip_text(tooltip_text);
+      }
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpris: format error (tooltip): {}", e.what());
     }


### PR DESCRIPTION
Fixes #3375 

- Adds `tooltip-with-markup` config option to AModule (default true). Modules can use this through the method `tooltipMarkupEnabled()`, but don't have to.
- adds usage of this method to mpris for its tooltip

