### PR TITLE
bar: fix setVisible

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -66,7 +66,7 @@ class Bar {
   ~Bar();
 
   void setMode(const std::string &mode);
-  void setVisible(bool visible);
+  void setVisible(bool value);
   void toggle();
   void handleSignal(int);
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -404,7 +404,8 @@ void waybar::Bar::onMap(GdkEventAny* /*unused*/) {
   setPassThrough(passthrough_);
 }
 
-void waybar::Bar::setVisible(bool visible) {
+void waybar::Bar::setVisible(bool value) {
+  visible = value;
   if (auto mode = config.get("mode", {}); mode.isString()) {
     setMode(visible ? config["mode"].asString() : MODE_INVISIBLE);
   } else {


### PR DESCRIPTION
Accidentally removed updating the visible variable
Resolves https://github.com/Alexays/Waybar/issues/3455

Verified sending signal works with this update, and previous version doesn't toggle.