### PR TITLE
Issue #3375/#3363/mpris: enable tooltip markup/systemd-failed-units: enable tooltip

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -35,6 +35,7 @@ class AModule : public IModule {
 
   SCROLL_DIR getScrollDir(GdkEventScroll* e);
   bool tooltipEnabled() const;
+  bool tooltipMarkupEnabled() const;
 
   std::vector<int> pid_children_;
   const std::string name_;
@@ -54,6 +55,7 @@ class AModule : public IModule {
   bool handleUserEvent(GdkEventButton* const& ev);
   const bool isTooltip;
   const bool isExpand;
+  const bool isMarkupTooltip;
   bool hasUserEvents_;
   gdouble distance_scrolled_y_;
   gdouble distance_scrolled_x_;

--- a/include/modules/systemd_failed_units.hpp
+++ b/include/modules/systemd_failed_units.hpp
@@ -17,6 +17,7 @@ class SystemdFailedUnits : public ALabel {
  private:
   bool hide_on_ok;
   std::string format_ok;
+  std::string tooltip_format_;
 
   bool update_pending;
   std::string system_state, user_state, overall_state;

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -47,6 +47,11 @@ The *mpris* module displays currently playing media via libplayerctl.
 	typeof: string ++
 	The status-specific tooltip format.
 
+*tooltip-with-markup*: ++
+	typeof: bool ++
+	default: true ++
+	Whether to accept pango markup in the tooltip.
+
 *artist-len*: ++
 	typeof: integer ++
 	Maximum length of the Artist tag (Wide/Fullwidth Unicode characters count as two). Set to zero to hide the artist in `{dynamic}` tag.

--- a/man/waybar-systemd-failed-units.5.scd
+++ b/man/waybar-systemd-failed-units.5.scd
@@ -53,6 +53,15 @@ Addressed by *systemd-failed-units*
 	typeof: bool ++
 	default: false ++
 	Enables this module to consume all left over space dynamically.
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Whether to display a tooltip.
+
+*tooltip-format* ++
+	typeof: string ++
+	default: content of *format* ++
+	The format for the tooltip.
 
 # FORMAT REPLACEMENTS
 

--- a/man/waybar-systemd-failed-units.5.scd
+++ b/man/waybar-systemd-failed-units.5.scd
@@ -63,6 +63,11 @@ Addressed by *systemd-failed-units*
 	default: content of *format* ++
 	The format for the tooltip.
 
+*tooltip-with-markup* ++
+	typeof: bool ++
+	default: true ++
+	Whether to accept pango markup in the tooltip.
+
 # FORMAT REPLACEMENTS
 
 *{nr_failed_system}*: Number of failed units from systemwide (PID=1) systemd.

--- a/man/waybar-systemd-failed-units.5.scd
+++ b/man/waybar-systemd-failed-units.5.scd
@@ -53,6 +53,7 @@ Addressed by *systemd-failed-units*
 	typeof: bool ++
 	default: false ++
 	Enables this module to consume all left over space dynamically.
+
 *tooltip*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -16,6 +16,9 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
       config_(config),
       isTooltip{config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true},
       isExpand{config_["expand"].isBool() ? config_["expand"].asBool() : false},
+      isMarkupTooltip{isTooltip && config_["tooltip-with-markup"].isBool()
+                          ? config_["tooltip-with-markup"].asBool()
+                          : true},
       distance_scrolled_y_(0.0),
       distance_scrolled_x_(0.0) {
   // Configure module action Map
@@ -279,6 +282,8 @@ bool AModule::handleScroll(GdkEventScroll* e) {
 
 bool AModule::tooltipEnabled() const { return isTooltip; }
 bool AModule::expandEnabled() const { return isExpand; }
+
+bool AModule::tooltipMarkupEnabled() const { return isMarkupTooltip; }
 
 AModule::operator Gtk::Widget&() { return event_box_; }
 

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -734,7 +734,11 @@ auto Mpris::update() -> void {
           fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
           fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
 
-      label_.set_tooltip_text(tooltip_text);
+      if (tooltipMarkupEnabled()) {
+        label_.set_tooltip_markup(tooltip_text);
+      } else {
+        label_.set_tooltip_text(tooltip_text);
+      }
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpris: format error (tooltip): {}", e.what());
     }

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -723,20 +723,33 @@ auto Mpris::update() -> void {
 
   if (tooltipEnabled()) {
     try {
-      auto tooltip_text = fmt::format(
-          fmt::runtime(tooltipstr), fmt::arg("player", info.name),
-          fmt::arg("status", info.status_string),
-          fmt::arg("artist", getArtistStr(info, tooltip_len_limits_)),
-          fmt::arg("title", getTitleStr(info, tooltip_len_limits_)),
-          fmt::arg("album", getAlbumStr(info, tooltip_len_limits_)),
-          fmt::arg("length", tooltipLength), fmt::arg("position", tooltipPosition),
-          fmt::arg("dynamic", getDynamicStr(info, tooltip_len_limits_, false)),
-          fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
-          fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
-
       if (tooltipMarkupEnabled()) {
+        auto tooltip_text = fmt::format(
+            fmt::runtime(tooltipstr),
+            fmt::arg("player", std::string(Glib::Markup::escape_text(info.name))),
+            fmt::arg("status", info.status_string),
+            fmt::arg("artist", std::string(Glib::Markup::escape_text(
+                                   getArtistStr(info, tooltip_len_limits_)))),
+            fmt::arg("title", std::string(Glib::Markup::escape_text(
+                                  getTitleStr(info, tooltip_len_limits_)))),
+            fmt::arg("album", std::string(Glib::Markup::escape_text(
+                                  getAlbumStr(info, tooltip_len_limits_)))),
+            fmt::arg("length", tooltipLength), fmt::arg("position", tooltipPosition),
+            fmt::arg("dynamic", getDynamicStr(info, tooltip_len_limits_, false)),
+            fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
+            fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
         label_.set_tooltip_markup(tooltip_text);
       } else {
+        auto tooltip_text = fmt::format(
+            fmt::runtime(tooltipstr), fmt::arg("player", info.name),
+            fmt::arg("status", info.status_string),
+            fmt::arg("artist", getArtistStr(info, tooltip_len_limits_)),
+            fmt::arg("title", getTitleStr(info, tooltip_len_limits_)),
+            fmt::arg("album", getAlbumStr(info, tooltip_len_limits_)),
+            fmt::arg("length", tooltipLength), fmt::arg("position", tooltipPosition),
+            fmt::arg("dynamic", getDynamicStr(info, tooltip_len_limits_, false)),
+            fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
+            fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
         label_.set_tooltip_text(tooltip_text);
       }
     } catch (fmt::format_error const& e) {

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -47,6 +47,12 @@ SystemdFailedUnits::SystemdFailedUnits(const std::string& id, const Json::Value&
     user_proxy->signal_signal().connect(sigc::mem_fun(*this, &SystemdFailedUnits::notify_cb));
   }
 
+  if (tooltipEnabled() && config["tooltip-format"].isString()) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  } else if (tooltipEnabled()) {
+    tooltip_format_ = format_;
+  }
+
   updateData();
   /* Always update for the first time. */
   dp.emit();
@@ -156,6 +162,21 @@ auto SystemdFailedUnits::update() -> void {
       fmt::arg("nr_failed_system", nr_failed_system), fmt::arg("nr_failed_user", nr_failed_user),
       fmt::arg("system_state", system_state), fmt::arg("user_state", user_state),
       fmt::arg("overall_state", overall_state)));
+
+  if (tooltipEnabled()) {
+    if (tooltipMarkupEnabled()) {
+      label_.set_tooltip_markup(fmt::format(fmt::runtime(tooltip_format_),
+                                            fmt::arg("nr_failed", nr_failed),
+                                            fmt::arg("nr_failed_system", nr_failed_system),
+                                            fmt::arg("nr_failed_user", nr_failed_user)));
+    } else {
+      label_.set_tooltip_text(fmt::format(fmt::runtime(tooltip_format_),
+                                          fmt::arg("nr_failed", nr_failed),
+                                          fmt::arg("nr_failed_system", nr_failed_system),
+                                          fmt::arg("nr_failed_user", nr_failed_user)));
+    }
+  }
+
   ALabel::update();
 }
 


### PR DESCRIPTION
Closes #3363
Closes #3375
Closes #2357

EDIT: includes former PR #3458 

- Adds tooltip-with-markup config option to AModule (default true). Modules can use this through the method tooltipMarkupEnabled(), but don't have to
- adds usage of this method to mpris for its tooltip
- also for systemd-failed-units
