### PR TITLE
Walk up Symlink Chain

### DIFF
--- a/src/util/css_reload_helper.cpp
+++ b/src/util/css_reload_helper.cpp
@@ -43,8 +43,14 @@ std::string waybar::CssReloadHelper::findPath(const std::string& filename) {
   }
 
   // File monitor does not work with symlinks, so resolve them
-  if (std::filesystem::is_symlink(result)) {
+  std::string original = result;
+  while(std::filesystem::is_symlink(result)) {
     result = std::filesystem::read_symlink(result);
+
+    // prevent infinite cycle
+    if (result == original) {
+      break;
+    }
   }
 
   return result;


### PR DESCRIPTION
"reload_style_on_change" would check if the target file is a symlink, but only resolves the first link. If the symlink is acutally a chain of symlinks, such as what happens with NixOS's `mkOutOfStoreSymlink,` we will not find the actual file style file.

Updated the symlink resolution logic to walk down the symlink chain until it finds a non-symlink. Also check against a the original filename (which may be a symlink) to guard against infinitely looping on a circular symlink chain.