### PR TITLE
Make battery module update on plugging/unplugging again (refs #2519)

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -5,7 +5,10 @@
 #include <filesystem>
 #if defined(__linux__)
 #include <sys/inotify.h>
+#include "util/udev_deleter.hpp"
 #endif
+
+#include <sys/poll.h>
 
 #include <algorithm>
 #include <fstream>
@@ -36,11 +39,12 @@ class Battery : public ALabel {
   const std::string formatTimeRemaining(float hoursRemaining);
   void setBarClass(std::string&);
 
-  int global_watch;
   std::map<fs::path, int> batteries_;
+  std::unique_ptr<udev, util::UdevDeleter> udev_;
+  std::array<pollfd, 1> poll_fds_;
+  std::unique_ptr<udev_monitor, util::UdevMonitorDeleter> mon_;
   fs::path adapter_;
   int battery_watch_fd_;
-  int global_watch_fd_;
   std::mutex battery_list_mutex_;
   std::string old_status_;
   bool warnFirstTime_{true};

--- a/include/util/udev_deleter.hpp
+++ b/include/util/udev_deleter.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <libudev.h>
+
+namespace waybar::util {
+struct UdevDeleter {
+  void operator()(udev *ptr) const { udev_unref(ptr); }
+};
+
+struct UdevDeviceDeleter {
+  void operator()(udev_device *ptr) const { udev_device_unref(ptr); }
+};
+
+struct UdevEnumerateDeleter {
+  void operator()(udev_enumerate *ptr) const { udev_enumerate_unref(ptr); }
+};
+
+struct UdevMonitorDeleter {
+  void operator()(udev_monitor *ptr) const { udev_monitor_unref(ptr); }
+};
+}  // namespace waybar::util

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -5,6 +5,9 @@
 #include <sys/sysctl.h>
 #endif
 #include <spdlog/spdlog.h>
+#include <libudev.h>
+#include <poll.h>
+#include <sys/signalfd.h>
 
 #include <iostream>
 waybar::modules::Battery::Battery(const std::string& id, const Bar& bar, const Json::Value& config)
@@ -14,17 +17,18 @@ waybar::modules::Battery::Battery(const std::string& id, const Bar& bar, const J
   if (battery_watch_fd_ == -1) {
     throw std::runtime_error("Unable to listen batteries.");
   }
-
-  global_watch_fd_ = inotify_init1(IN_CLOEXEC);
-  if (global_watch_fd_ == -1) {
-    throw std::runtime_error("Unable to listen batteries.");
+  udev_ = std::unique_ptr<udev, util::UdevDeleter>(udev_new());
+  if (udev_ == nullptr) {
+    throw std::runtime_error("udev_new failed");
   }
-
-  // Watch the directory for any added or removed batteries
-  global_watch = inotify_add_watch(global_watch_fd_, data_dir_.c_str(), IN_CREATE | IN_DELETE);
-  if (global_watch < 0) {
-    throw std::runtime_error("Could not watch for battery plug/unplug");
+  mon_ = std::unique_ptr<udev_monitor, util::UdevMonitorDeleter>(udev_monitor_new_from_netlink(udev_.get(), "kernel"));
+  if (mon_ == nullptr) {
+    throw std::runtime_error("udev monitor new failed");
   }
+  if (udev_monitor_filter_add_match_subsystem_devtype(mon_.get(), "power_supply", nullptr) < 0) {
+    throw std::runtime_error("udev failed to add monitor filter");
+  }
+  udev_monitor_enable_receiving(mon_.get());
 #endif
   worker();
 }
@@ -32,11 +36,6 @@ waybar::modules::Battery::Battery(const std::string& id, const Bar& bar, const J
 waybar::modules::Battery::~Battery() {
 #if defined(__linux__)
   std::lock_guard<std::mutex> guard(battery_list_mutex_);
-
-  if (global_watch >= 0) {
-    inotify_rm_watch(global_watch_fd_, global_watch);
-  }
-  close(global_watch_fd_);
 
   for (auto it = batteries_.cbegin(), next_it = it; it != batteries_.cend(); it = next_it) {
     ++next_it;
@@ -74,11 +73,17 @@ void waybar::modules::Battery::worker() {
     dp.emit();
   };
   thread_battery_update_ = [this] {
-    struct inotify_event event = {0};
-    int nbytes = read(global_watch_fd_, &event, sizeof(event));
-    if (nbytes != sizeof(event) || event.mask & IN_IGNORED) {
+    poll_fds_[0].revents = 0;
+    poll_fds_[0].events = POLLIN;
+    poll_fds_[0].fd = udev_monitor_get_fd(mon_.get());
+    int ret = poll(poll_fds_.data(), poll_fds_.size(), -1);
+    if (ret < 0) {
       thread_.stop();
       return;
+    }
+    if ((poll_fds_[0].revents & POLLIN) != 0) {
+      signalfd_siginfo signal_info;
+      read(poll_fds_[0].fd, &signal_info, sizeof(signal_info));
     }
     refreshBatteries();
     dp.emit();
@@ -668,6 +673,7 @@ auto waybar::modules::Battery::update() -> void {
     status = getAdapterStatus(capacity);
   }
   auto status_pretty = status;
+  puts(status.c_str());
   // Transform to lowercase  and replace space with dash
   std::transform(status.begin(), status.end(), status.begin(),
                  [](char ch) { return ch == ' ' ? '-' : std::tolower(ch); });

--- a/src/util/backlight_backend.cpp
+++ b/src/util/backlight_backend.cpp
@@ -1,4 +1,5 @@
 #include "util/backlight_backend.hpp"
+#include "util/udev_deleter.hpp"
 
 #include <fmt/core.h>
 #include <spdlog/spdlog.h>
@@ -27,22 +28,6 @@ class FileDescriptor {
 
  private:
   int fd_;
-};
-
-struct UdevDeleter {
-  void operator()(udev *ptr) { udev_unref(ptr); }
-};
-
-struct UdevDeviceDeleter {
-  void operator()(udev_device *ptr) { udev_device_unref(ptr); }
-};
-
-struct UdevEnumerateDeleter {
-  void operator()(udev_enumerate *ptr) { udev_enumerate_unref(ptr); }
-};
-
-struct UdevMonitorDeleter {
-  void operator()(udev_monitor *ptr) { udev_monitor_unref(ptr); }
 };
 
 void check_eq(int rc, int expected, const char *message = "eq, rc was: ") {


### PR DESCRIPTION
When switching how you listen for battery plugging status events, the battery status will instantly update again!
Instead of inotify events on the /sys/class/.../ files, it is recommended to listen to udev netlink kernel events.

Closes #2444 
Closes #2519 

I need aid implementing this, because I'm new to this project.
I will try to make this code look more like the backlight_backend, which also uses the udev netlink interfaces.