### PR TITLE
Add cosmic/workspaces module

### DIFF
--- a/include/modules/cosmic/cosmic_workspace_manager.hpp
+++ b/include/modules/cosmic/cosmic_workspace_manager.hpp
@@ -1,0 +1,172 @@
+#pragma once
+
+#include <fmt/format.h>
+#include <gtkmm/button.h>
+#include <gtkmm/image.h>
+#include <gtkmm/label.h>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <vector>
+
+#include "AModule.hpp"
+#include "bar.hpp"
+#include "cosmic-workspace-unstable-v1-client-protocol.h"
+
+namespace waybar::modules::cosmic {
+
+class WorkspaceManager;
+class WorkspaceGroup;
+
+class Workspace {
+ public:
+  Workspace(const waybar::Bar &bar, const Json::Value &config, WorkspaceGroup &workspace_group,
+            zcosmic_workspace_handle_v1 *workspace, uint32_t id, std::string name);
+  ~Workspace();
+  auto update() -> void;
+
+  auto id() const -> uint32_t { return id_; }
+  auto is_active() const -> bool { return state_ & static_cast<uint32_t>(State::ACTIVE); }
+  auto is_urgent() const -> bool { return state_ & static_cast<uint32_t>(State::URGENT); }
+  auto is_hidden() const -> bool { return state_ & static_cast<uint32_t>(State::HIDDEN); }
+  auto is_empty() const -> bool { return state_ & static_cast<uint32_t>(State::EMPTY); }
+  auto is_persistent() const -> bool { return persistent_; }
+  // wlr stuff
+  auto handle_name(const std::string &name) -> void;
+  auto handle_coordinates(const std::vector<uint32_t> &coordinates) -> void;
+  auto handle_state(const std::vector<uint32_t> &state) -> void;
+  auto handle_remove() -> void;
+  auto make_persistent() -> void;
+  auto handle_duplicate() -> void;
+
+  auto handle_done() -> void;
+  auto handle_clicked(GdkEventButton *bt) -> bool;
+  auto show() -> void;
+  auto hide() -> void;
+  auto get_button_ref() -> Gtk::Button & { return button_; }
+  auto get_name() -> std::string & { return name_; }
+  auto get_coords() -> std::vector<uint32_t> & { return coordinates_; }
+
+  enum class State {
+    ACTIVE = (1 << 0),
+    URGENT = (1 << 1),
+    HIDDEN = (1 << 2),
+    EMPTY = (1 << 3),
+  };
+
+ private:
+  auto get_icon() -> std::string;
+
+  const Bar &bar_;
+  const Json::Value &config_;
+  WorkspaceGroup &workspace_group_;
+
+  // wlr stuff
+  zcosmic_workspace_handle_v1 *workspace_handle_;
+  uint32_t state_ = 0;
+
+  uint32_t id_;
+  std::string name_;
+  std::vector<uint32_t> coordinates_;
+  static std::map<std::string, std::string> icons_map_;
+  std::string format_;
+  bool with_icon_ = false;
+  bool persistent_ = false;
+
+  Gtk::Button button_;
+  Gtk::Box content_;
+  Gtk::Label label_;
+};
+
+class WorkspaceGroup {
+ public:
+  WorkspaceGroup(const waybar::Bar &bar, Gtk::Box &box, const Json::Value &config,
+                 WorkspaceManager &manager, zcosmic_workspace_group_handle_v1 *workspace_group_handle,
+                 uint32_t id);
+  ~WorkspaceGroup();
+  auto update() -> void;
+
+  auto id() const -> uint32_t { return id_; }
+  auto is_visible() const -> bool;
+  auto remove_workspace(uint32_t id_) -> void;
+  auto active_only() const -> bool;
+  auto creation_delayed() const -> bool;
+  auto workspaces() -> std::vector<std::unique_ptr<Workspace>> & { return workspaces_; }
+  auto persistent_workspaces() -> std::vector<std::string> & { return persistent_workspaces_; }
+
+  auto sort_workspaces() -> void;
+  auto set_need_to_sort() -> void { need_to_sort = true; }
+  auto add_button(Gtk::Button &button) -> void;
+  auto remove_button(Gtk::Button &button) -> void;
+  auto fill_persistent_workspaces() -> void;
+  auto create_persistent_workspaces() -> void;
+
+  // wlr stuff
+  auto handle_workspace_create(zcosmic_workspace_handle_v1 *workspace_handle) -> void;
+  auto handle_remove() -> void;
+  auto handle_output_enter(wl_output *output) -> void;
+  auto handle_output_leave() -> void;
+  auto handle_done() -> void;
+  auto commit() -> void;
+
+ private:
+  static uint32_t workspace_global_id;
+  const waybar::Bar &bar_;
+  Gtk::Box &box_;
+  const Json::Value &config_;
+  WorkspaceManager &workspace_manager_;
+
+  // wlr stuff
+  zcosmic_workspace_group_handle_v1 *workspace_group_handle_;
+  wl_output *output_ = nullptr;
+
+  uint32_t id_;
+  std::vector<std::unique_ptr<Workspace>> workspaces_;
+  bool need_to_sort = false;
+  std::vector<std::string> persistent_workspaces_;
+  bool persistent_created_ = false;
+};
+
+class WorkspaceManager : public AModule {
+ public:
+  WorkspaceManager(const std::string &id, const waybar::Bar &bar, const Json::Value &config);
+  ~WorkspaceManager() override;
+  auto update() -> void override;
+
+  auto all_outputs() const -> bool { return all_outputs_; }
+  auto active_only() const -> bool { return active_only_; }
+  auto workspace_comparator() const
+      -> std::function<bool(std::unique_ptr<Workspace> &, std::unique_ptr<Workspace> &)>;
+  auto creation_delayed() const -> bool { return creation_delayed_; }
+
+  auto sort_workspaces() -> void;
+  auto remove_workspace_group(uint32_t id_) -> void;
+
+  // wlr stuff
+  auto register_manager(wl_registry *registry, uint32_t name, uint32_t version) -> void;
+  auto handle_workspace_group_create(zcosmic_workspace_group_handle_v1 *workspace_group_handle)
+      -> void;
+  auto handle_done() -> void;
+  auto handle_finished() -> void;
+  auto commit() -> void;
+
+ private:
+  const waybar::Bar &bar_;
+  Gtk::Box box_;
+  std::vector<std::unique_ptr<WorkspaceGroup>> groups_;
+
+  // wlr stuff
+  zcosmic_workspace_manager_v1 *workspace_manager_ = nullptr;
+
+  static uint32_t group_global_id;
+
+  bool sort_by_name_ = true;
+  bool sort_by_coordinates_ = true;
+  bool sort_by_number_ = false;
+  bool all_outputs_ = false;
+  bool active_only_ = false;
+  bool creation_delayed_ = false;
+};
+
+}  // namespace waybar::modules::cosmic

--- a/include/modules/cosmic/cosmic_workspace_manager_binding.hpp
+++ b/include/modules/cosmic/cosmic_workspace_manager_binding.hpp
@@ -1,0 +1,10 @@
+#include "cosmic-workspace-unstable-v1-client-protocol.h"
+
+namespace waybar::modules::cosmic {
+void add_registry_listener(void *data);
+void add_workspace_listener(zcosmic_workspace_handle_v1 *workspace_handle, void *data);
+void add_workspace_group_listener(zcosmic_workspace_group_handle_v1 *workspace_group_handle,
+                                  void *data);
+zcosmic_workspace_manager_v1 *workspace_manager_bind(wl_registry *registry, uint32_t name,
+                                                  uint32_t version, void *data);
+}  // namespace waybar::modules::cosmic

--- a/man/waybar-cosmic-workspaces.5.scd
+++ b/man/waybar-cosmic-workspaces.5.scd
@@ -1,0 +1,93 @@
+waybar-cosmic-workspaces(5)
+
+# NAME
+
+waybar - cosmic workspaces module
+
+# DESCRIPTION
+
+The *workspaces* module displays the currently used workspaces in wayland compositor.
+
+# CONFIGURATION
+
+Addressed by *cosmic/workspaces*
+
+*format*: ++
+	typeof: string ++
+	default: {name} ++
+	The format, how information should be displayed.
+
+*format-icons*: ++
+	typeof: array ++
+	Based on the workspace name and state, the corresponding icon gets selected. See *icons*.
+
+*sort-by-name*: ++
+	typeof: bool ++
+	default: true ++
+	Should workspaces be sorted by name.
+
+*sort-by-coordinates*: ++
+	typeof: bool ++
+	default: true ++
+	Should workspaces be sorted by coordinates. ++
+	Note that if both  *sort-by-name* and *sort-by-coordinates* are true sort-by name will be first. If both are false - sort by id will be performed.
+
+*sort-by-number*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, workspace names will be sorted numerically. Takes precedence over any other sort-by option.
+
+*all-outputs*: ++
+	typeof: bool ++
+	default: false ++
+	If set to false workspaces group will be shown only in assigned output. Otherwise, all workspace groups are shown.
+
+*active-only*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true only active or urgent workspaces will be shown.
+
+# FORMAT REPLACEMENTS
+
+*{name}*: Name of workspace assigned by compositor
+
+*{icon}*: Icon, as defined in *format-icons*.
+
+# CLICK ACTIONS
+
+*activate*: Switch to workspace.
+
+*close*: Close the workspace.
+
+# ICONS
+
+In addition to workspace name matching, the following *format-icons* can be set.
+
+- *default*: Will be shown, when no string match is found.
+- *active*: Will be shown, when workspace is active
+
+# EXAMPLES
+
+```
+"cosmic/workspaces": {
+	"format": "{name}: {icon}",
+	"format-icons": {
+		"1": "",
+		"2": "",
+		"3": "",
+		"4": "",
+		"5": "",
+		"active": "",
+		"default": ""
+	},
+	"sort-by-number": true
+}
+```
+
+# Style
+
+- *#workspaces*
+- *#workspaces button*
+- *#workspaces button.active*
+- *#workspaces button.urgent*
+- *#workspaces button.hidden*

--- a/meson.build
+++ b/meson.build
@@ -276,6 +276,15 @@ if true
 endif
 
 if true
+    add_project_arguments('-DHAVE_COSMIC_WORKSPACES', language: 'cpp')
+    src_files += files(
+        'src/modules/cosmic/cosmic_workspace_manager.cpp',
+        'src/modules/cosmic/cosmic_workspace_manager_binding.cpp',
+    )
+    man_files += files('man/waybar-cosmic-workspaces.5.scd')
+endif
+
+if true
     add_project_arguments('-DHAVE_RIVER', language: 'cpp')
     src_files += files(
         'src/modules/river/layout.cpp',

--- a/protocol/cosmic-workspace-unstable-v1.xml
+++ b/protocol/cosmic-workspace-unstable-v1.xml
@@ -1,0 +1,364 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="cosmic_workspace_unstable_v1">
+  <copyright>
+    Copyright © 2019 Christopher Billington
+    Copyright © 2020 Ilia Bozhinov
+    Copyright © 2022 Victoria Brekenfeld
+
+    Permission to use, copy, modify, distribute, and sell this
+    software and its documentation for any purpose is hereby granted
+    without fee, provided that the above copyright notice appear in
+    all copies and that both that copyright notice and this permission
+    notice appear in supporting documentation, and that the name of
+    the copyright holders not be used in advertising or publicity
+    pertaining to distribution of the software without specific,
+    written prior permission.  The copyright holders make no
+    representations about the suitability of this software for any
+    purpose.  It is provided "as is" without express or implied
+    warranty.
+
+    THE COPYRIGHT HOLDERS DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+    SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
+    FITNESS, IN NO EVENT SHALL THE COPYRIGHT HOLDERS BE LIABLE FOR ANY
+    SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+    AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+    ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
+    THIS SOFTWARE.
+  </copyright>
+
+  <interface name="zcosmic_workspace_manager_v1" version="1">
+    <description summary="list and control workspaces">
+      Workspaces, also called virtual desktops, are groups of surfaces. A
+      compositor with a concept of workspaces may only show some such groups of
+      surfaces (those of 'active' workspaces) at a time. 'Activating' a
+      workspace is a request for the compositor to display that workspace's
+      surfaces as normal, whereas the compositor may hide or otherwise
+      de-emphasise surfaces that are associated only with 'inactive' workspaces.
+      Workspaces are grouped by which sets of outputs they correspond to, and
+      may contain surfaces only from those outputs. In this way, it is possible
+      for each output to have its own set of workspaces, or for all outputs (or
+      any other arbitrary grouping) to share workspaces. Compositors may
+      optionally conceptually arrange each group of workspaces in an
+      N-dimensional grid.
+
+      The purpose of this protocol is to enable the creation of taskbars and
+      docks by providing them with a list of workspaces and their properties,
+      and allowing them to activate and deactivate workspaces.
+
+      After a client binds the zcosmic_workspace_manager_v1, each workspace will be
+      sent via the workspace event.
+    </description>
+
+    <event name="workspace_group">
+      <description summary="a workspace group has been created">
+        This event is emitted whenever a new workspace group has been created.
+
+        All initial details of the workspace group (workspaces, outputs) will be
+        sent immediately after this event via the corresponding events in
+        zcosmic_workspace_group_handle_v1.
+      </description>
+      <arg name="workspace_group" type="new_id" interface="zcosmic_workspace_group_handle_v1"/>
+    </event>
+
+    <request name="commit">
+      <description summary="all requests about the workspaces have been sent">
+        The client must send this request after it has finished sending other
+        requests. The compositor must process a series of requests preceding a
+        commit request atomically.
+
+        This allows changes to the workspace properties to be seen as atomic,
+        even if they happen via multiple events, and even if they involve
+        multiple zcosmic_workspace_handle_v1 objects, for example, deactivating one
+        workspace and activating another.
+      </description>
+    </request>
+
+    <event name="done">
+      <description summary="all information about the workspace groups has been sent">
+        This event is sent after all changes in all workspace groups have been
+        sent.
+
+        This allows changes to one or more zcosmic_workspace_group_handle_v1
+        properties and zcosmic_workspace_handle_v1 properties to be seen as atomic,
+        even if they happen via multiple events.
+        In particular, an output moving from one workspace group to
+        another sends an output_enter event and an output_leave event to the two
+        zcosmic_workspace_group_handle_v1 objects in question. The compositor sends
+        the done event only after updating the output information in both
+        workspace groups.
+      </description>
+    </event>
+
+    <event name="finished">
+      <description summary="the compositor has finished with the workspace_manager">
+        This event indicates that the compositor is done sending events to the
+        zcosmic_workspace_manager_v1. The server will destroy the object
+        immediately after sending this request, so it will become invalid and
+        the client should free any resources associated with it.
+      </description>
+    </event>
+
+    <request name="stop">
+      <description summary="stop sending events">
+        Indicates the client no longer wishes to receive events for new
+        workspace groups. However the compositor may emit further workspace
+        events, until the finished event is emitted.
+
+        The client must not send any more requests after this one.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zcosmic_workspace_group_handle_v1" version="1">
+    <description summary="a workspace group assigned to a set of outputs">
+      A zcosmic_workspace_group_handle_v1 object represents a a workspace group
+      that is assigned a set of outputs and contains a number of workspaces.
+
+      The set of outputs assigned to the workspace group is conveyed to the client via
+      output_enter and output_leave events, and its workspaces are conveyed with
+      workspace events.
+
+      For example, a compositor which has a set of workspaces for each output may
+      advertise a workspace group (and its workspaces) per output, whereas a compositor
+      where a workspace spans all outputs may advertise a single workspace group for all
+      outputs.
+    </description>
+
+    <enum name="zcosmic_workspace_group_capabilities_v1">
+      <entry name="create_workspace" value="1" summary="create_workspace request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for creating workspaces, a button
+        triggering the create_workspace request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for creating workspaces will ignore
+        create_workspace requests.
+
+        Compositors must send this event once after creation of an
+        zcosmic_workspace_group_handle_v1 . When the capabilities change, compositors
+        must send this event again.
+
+        The capabilities are sent as an array of 32-bit unsigned integers in
+        native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
+
+    <event name="output_enter">
+      <description summary="output assigned to workspace group">
+        This event is emitted whenever an output is assigned to the workspace
+        group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="output_leave">
+      <description summary="output removed from workspace group">
+        This event is emitted whenever an output is removed from the workspace
+        group.
+      </description>
+      <arg name="output" type="object" interface="wl_output"/>
+    </event>
+
+    <event name="workspace">
+      <description summary="workspace added to workspace group">
+        This event is emitted whenever a new workspace has been created.
+        A workspace can only be a member of a single workspace group and cannot
+        be re-assigned.
+
+        All initial details of the workspace (name, coordinates, state) will
+        be sent immediately after this event via the corresponding events in
+        zcosmic_workspace_handle_v1.
+      </description>
+      <arg name="workspace" type="new_id" interface="zcosmic_workspace_handle_v1"/>
+    </event>
+
+    <event name="remove">
+      <description summary="this workspace group has been destroyed">
+        This event means the zcosmic_workspace_group_handle_v1 has been destroyed.
+        It is guaranteed there won't be any more events for this
+        zcosmic_workspace_group_handle_v1. The zext_workspace_group_handle_v1 becomes
+        inert so any requests will be ignored except the destroy request.
+
+        The compositor must remove all workspaces belonging to a workspace group
+        before removing the workspace group.
+      </description>
+    </event>
+
+    <request name="create_workspace">
+      <description summary="create a new workspace">
+        Request that the compositor create a new workspace with the given name.
+
+        There is no guarantee that the compositor will create a new workspace,
+        or that the created workspace will have the provided name.
+      </description>
+      <arg name="workspace" type="string"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zcosmic_workspace_group_handle_v1 object">
+        Destroys the zcosmic_workspace_group_handle_v1 object.
+
+        This request should be called either when the client does not want to
+        use the workspace object any more or after the remove event to finalize
+        the destruction of the object.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zcosmic_workspace_handle_v1" version="1">
+    <description summary="a workspace handing a group of surfaces">
+      A zcosmic_workspace_handle_v1 object represents a a workspace that handles a
+      group of surfaces.
+
+      Each workspace has a name, conveyed to the client with the name event; a
+      list of states, conveyed to the client with the state event; and
+      optionally a set of coordinates, conveyed to the client with the
+      coordinates event. The client may request that the compositor activate or
+      deactivate the workspace.
+
+      Each workspace can belong to only a single workspace group.
+      Depepending on the compositor policy, there might be workspaces with
+      the same name in different workspace groups, but these workspaces are still
+      separate (e.g. one of them might be active while the other is not).
+    </description>
+
+    <event name="name">
+      <description summary="workspace name changed">
+        This event is emitted immediately after the zcosmic_workspace_handle_v1 is
+        created and whenever the name of the workspace changes.
+      </description>
+      <arg name="name" type="string"/>
+    </event>
+
+    <event name="coordinates">
+      <description summary="workspace coordinates changed">
+        This event is used to organize workspaces into an N-dimensional grid
+        within a workspace group, and if supported, is emitted immediately after
+        the zcosmic_workspace_handle_v1 is created and whenever the coordinates of
+        the workspace change. Compositors may not send this event if they do not
+        conceptually arrange workspaces in this way. If compositors simply
+        number workspaces, without any geometric interpretation, they may send
+        1D coordinates, which clients should not interpret as implying any
+        geometry. Sending an empty array means that the compositor no longer
+        orders the workspace geometrically.
+
+        Coordinates have an arbitrary number of dimensions N with an uint32
+        position along each dimension. By convention if N > 1, the first
+        dimension is X, the second Y, the third Z, and so on. The compositor may
+        chose to utilize these events for a more novel workspace layout
+        convention, however. No guarantee is made about the grid being filled or
+        bounded; there may be a workspace at coordinate 1 and another at
+        coordinate 1000 and none in between. Within a workspace group, however,
+        workspaces must have unique coordinates of equal dimensionality.
+      </description>
+      <arg name="coordinates" type="array"/>
+    </event>
+
+    <event name="state">
+      <description summary="the state of the workspace changed">
+        This event is emitted immediately after the zcosmic_workspace_handle_v1 is
+        created and each time the workspace state changes, either because of a
+        compositor action or because of a request in this protocol.
+      </description>
+      <arg name="state" type="array"/>
+    </event>
+
+    <enum name="state">
+      <description summary="types of states on the workspace">
+        The different states that a workspace can have.
+      </description>
+
+      <entry name="active" value="0" summary="the workspace is active"/>
+      <entry name="urgent" value="1" summary="the workspace requests attention"/>
+      <entry name="hidden" value="2">
+        <description summary="the workspace is not visible">
+          The workspace is not visible in its workspace group, and clients
+          attempting to visualize the compositor workspace state should not
+          display such workspaces.
+        </description>
+      </entry>
+    </enum>
+
+    <enum name="zcosmic_workspace_capabilities_v1">
+      <entry name="activate" value="1" summary="activate request is available"/>
+      <entry name="deactivate" value="2" summary="deactivate request is available"/>
+      <entry name="remove" value="3" summary="remove request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for removing workspaces, a button
+        triggering the remove request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for remove will ignore
+        remove requests.
+
+        Compositors must send this event once after creation of an
+        zcosmic_workspace_handle_v1 . When the capabilities change, compositors
+        must send this event again.
+
+        The capabilities are sent as an array of 32-bit unsigned integers in
+        native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
+
+    <event name="remove">
+      <description summary="this workspace has been destroyed">
+        This event means the zcosmic_workspace_handle_v1 has been destroyed. It is
+        guaranteed there won't be any more events for this
+        zcosmic_workspace_handle_v1. The zext_workspace_handle_v1 becomes inert so
+        any requests will be ignored except the destroy request.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the zcosmic_workspace_handle_v1 object">
+        Destroys the zcosmic_workspace_handle_v1 object.
+
+        This request should be called either when the client does not want to
+        use the workspace object any more or after the remove event to finalize
+        the destruction of the object.
+      </description>
+    </request>
+
+    <request name="activate">
+      <description summary="activate the workspace">
+        Request that this workspace be activated.
+
+        There is no guarantee the workspace will be actually activated, and
+        behaviour may be compositor-dependent. For example, activating a
+        workspace may or may not deactivate all other workspaces in the same
+        group.
+      </description>
+    </request>
+
+    <request name="deactivate">
+      <description summary="activate the workspace">
+        Request that this workspace be deactivated.
+
+        There is no guarantee the workspace will be actually deactivated.
+      </description>
+    </request>
+
+    <request name="remove">
+      <description summary="remove the workspace">
+        Request that this workspace be removed.
+
+        There is no guarantee the workspace will be actually removed.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/protocol/meson.build
+++ b/protocol/meson.build
@@ -26,6 +26,7 @@ client_protocols = [
 	[wl_protocol_dir, 'unstable/xdg-output/xdg-output-unstable-v1.xml'],
 	[wl_protocol_dir, 'unstable/idle-inhibit/idle-inhibit-unstable-v1.xml'],
 	['wlr-foreign-toplevel-management-unstable-v1.xml'],
+	['cosmic-workspace-unstable-v1.xml'],
 	['ext-workspace-unstable-v1.xml'],
 	['river-status-unstable-v1.xml'],
 	['river-control-unstable-v1.xml'],

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -20,6 +20,9 @@
 #ifdef HAVE_WLR_WORKSPACES
 #include "modules/wlr/workspace_manager.hpp"
 #endif
+#ifdef HAVE_COSMIC_WORKSPACES
+#include "modules/cosmic/cosmic_workspace_manager.hpp"
+#endif
 #ifdef HAVE_RIVER
 #include "modules/river/layout.hpp"
 #include "modules/river/mode.hpp"
@@ -163,6 +166,11 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
 #ifdef HAVE_WLR_TASKBAR
     if (ref == "wlr/taskbar") {
       return new waybar::modules::wlr::Taskbar(id, bar_, config_[name]);
+    }
+#endif
+#ifdef HAVE_COSMIC_WORKSPACES
+    if (ref == "cosmic/workspaces") {
+        return new waybar::modules::cosmic::WorkspaceManager(id, bar_, config_[name]);
     }
 #endif
 #ifdef HAVE_WLR_WORKSPACES

--- a/src/modules/cosmic/cosmic_workspace_manager.cpp
+++ b/src/modules/cosmic/cosmic_workspace_manager.cpp
@@ -1,0 +1,585 @@
+#include "modules/cosmic/cosmic_workspace_manager.hpp"
+
+#include <gdk/gdkwayland.h>
+#include <gtkmm.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+#include <iterator>
+#include <stdexcept>
+#include <vector>
+
+#include "client.hpp"
+#include "gtkmm/widget.h"
+#include "modules/cosmic/cosmic_workspace_manager_binding.hpp"
+
+namespace waybar::modules::cosmic {
+
+uint32_t WorkspaceGroup::workspace_global_id = 0;
+uint32_t WorkspaceManager::group_global_id = 0;
+std::map<std::string, std::string> Workspace::icons_map_;
+
+WorkspaceManager::WorkspaceManager(const std::string &id, const waybar::Bar &bar,
+                                   const Json::Value &config)
+    : waybar::AModule(config, "workspaces", id, false, false), bar_(bar), box_(bar.orientation, 0) {
+  auto config_sort_by_name = config_["sort-by-name"];
+  if (config_sort_by_name.isBool()) {
+    sort_by_name_ = config_sort_by_name.asBool();
+  }
+
+  auto config_sort_by_coordinates = config_["sort-by-coordinates"];
+  if (config_sort_by_coordinates.isBool()) {
+    sort_by_coordinates_ = config_sort_by_coordinates.asBool();
+  }
+
+  auto config_sort_by_number = config_["sort-by-number"];
+  if (config_sort_by_number.isBool()) {
+    sort_by_number_ = config_sort_by_number.asBool();
+  }
+
+  auto config_all_outputs = config_["all-outputs"];
+  if (config_all_outputs.isBool()) {
+    all_outputs_ = config_all_outputs.asBool();
+  }
+
+  auto config_active_only = config_["active-only"];
+  if (config_active_only.isBool()) {
+    active_only_ = config_active_only.asBool();
+    creation_delayed_ = active_only_;
+  }
+
+  box_.set_name("workspaces");
+  if (!id.empty()) {
+    box_.get_style_context()->add_class(id);
+  }
+  box_.get_style_context()->add_class(MODULE_CLASS);
+  event_box_.add(box_);
+
+  add_registry_listener(this);
+  if (!workspace_manager_) {
+    return;
+  }
+}
+
+auto WorkspaceManager::workspace_comparator() const
+    -> std::function<bool(std::unique_ptr<Workspace> &, std::unique_ptr<Workspace> &)> {
+  return [=, this](std::unique_ptr<Workspace> &lhs, std::unique_ptr<Workspace> &rhs) {
+    auto is_name_less = lhs->get_name() < rhs->get_name();
+    auto is_name_eq = lhs->get_name() == rhs->get_name();
+    auto is_coords_less = lhs->get_coords() < rhs->get_coords();
+
+    if (sort_by_number_) {
+      try {
+        auto is_number_less = std::stoi(lhs->get_name()) < std::stoi(rhs->get_name());
+        return is_number_less;
+      } catch (const std::invalid_argument &) {
+      }
+    }
+
+    if (sort_by_name_) {
+      if (sort_by_coordinates_) {
+        return is_name_eq ? is_coords_less : is_name_less;
+      } else {
+        return is_name_less;
+      }
+    }
+
+    if (sort_by_coordinates_) {
+      return is_coords_less;
+    }
+
+    return lhs->id() < rhs->id();
+  };
+}
+
+auto WorkspaceManager::sort_workspaces() -> void {
+  std::vector<std::reference_wrapper<std::unique_ptr<Workspace>>> all_workspaces;
+  for (auto &group : groups_) {
+    auto &group_workspaces = group->workspaces();
+    all_workspaces.reserve(all_workspaces.size() +
+                           std::distance(group_workspaces.begin(), group_workspaces.end()));
+    if (!active_only()) {
+      all_workspaces.insert(all_workspaces.end(), group_workspaces.begin(), group_workspaces.end());
+      continue;
+    }
+
+    for (auto &workspace : group_workspaces) {
+      if (!workspace->is_active()) {
+        continue;
+      }
+
+      all_workspaces.push_back(workspace);
+    }
+  }
+
+  std::sort(all_workspaces.begin(), all_workspaces.end(), workspace_comparator());
+  for (size_t i = 0; i < all_workspaces.size(); ++i) {
+    box_.reorder_child(all_workspaces[i].get()->get_button_ref(), i);
+  }
+}
+
+auto WorkspaceManager::register_manager(wl_registry *registry, uint32_t name, uint32_t version)
+    -> void {
+  if (workspace_manager_) {
+    spdlog::warn("Register workspace manager again although already registered!");
+    return;
+  }
+  if (version != 1) {
+    spdlog::warn("Using different workspace manager protocol version: {}", version);
+  }
+  workspace_manager_ = workspace_manager_bind(registry, name, version, this);
+}
+
+auto WorkspaceManager::handle_workspace_group_create(
+    zcosmic_workspace_group_handle_v1 *workspace_group_handle) -> void {
+  auto new_id = ++group_global_id;
+  groups_.push_back(
+      std::make_unique<WorkspaceGroup>(bar_, box_, config_, *this, workspace_group_handle, new_id));
+  spdlog::debug("Workspace group {} created", new_id);
+}
+
+auto WorkspaceManager::handle_finished() -> void {
+  zcosmic_workspace_manager_v1_destroy(workspace_manager_);
+  workspace_manager_ = nullptr;
+}
+
+auto WorkspaceManager::handle_done() -> void {
+  for (auto &group : groups_) {
+    group->handle_done();
+  }
+  dp.emit();
+}
+
+auto WorkspaceManager::update() -> void {
+  for (auto &group : groups_) {
+    group->update();
+  }
+  if (creation_delayed()) {
+    creation_delayed_ = false;
+    sort_workspaces();
+  }
+  AModule::update();
+}
+
+WorkspaceManager::~WorkspaceManager() {
+  if (!workspace_manager_) {
+    return;
+  }
+
+  wl_display *display = Client::inst()->wl_display;
+
+  // Send `stop` request and wait for one roundtrip. This is not quite correct as
+  // the protocol encourages us to wait for the .finished event, but it should work
+  // with wlroots workspace manager implementation.
+  zcosmic_workspace_manager_v1_stop(workspace_manager_);
+  wl_display_roundtrip(display);
+
+  // If the .finished handler is still not executed, destroy the workspace manager here.
+  if (workspace_manager_) {
+    spdlog::warn("Workspace manager destroyed before .finished event");
+    zcosmic_workspace_manager_v1_destroy(workspace_manager_);
+    workspace_manager_ = nullptr;
+  }
+}
+
+auto WorkspaceManager::remove_workspace_group(uint32_t id) -> void {
+  auto it = std::find_if(groups_.begin(), groups_.end(),
+                         [id](const std::unique_ptr<WorkspaceGroup> &g) { return g->id() == id; });
+
+  if (it == groups_.end()) {
+    spdlog::warn("Can't find group with id {}", id);
+    return;
+  }
+
+  groups_.erase(it);
+}
+auto WorkspaceManager::commit() -> void { zcosmic_workspace_manager_v1_commit(workspace_manager_); }
+
+WorkspaceGroup::WorkspaceGroup(const Bar &bar, Gtk::Box &box, const Json::Value &config,
+                               WorkspaceManager &manager,
+                               zcosmic_workspace_group_handle_v1 *workspace_group_handle, uint32_t id)
+    : bar_(bar),
+      box_(box),
+      config_(config),
+      workspace_manager_(manager),
+      workspace_group_handle_(workspace_group_handle),
+      id_(id) {
+  add_workspace_group_listener(workspace_group_handle, this);
+}
+
+auto WorkspaceGroup::fill_persistent_workspaces() -> void {
+  if (config_["persistent_workspaces"].isObject()) {
+    spdlog::warn(
+        "persistent_workspaces is deprecated. Please change config to use persistent-workspaces.");
+  }
+
+  if ((config_["persistent-workspaces"].isObject() ||
+       config_["persistent_workspaces"].isObject()) &&
+      !workspace_manager_.all_outputs()) {
+    const Json::Value &p_workspaces = config_["persistent-workspaces"].isObject()
+                                          ? config_["persistent-workspaces"]
+                                          : config_["persistent_workspaces"];
+    const std::vector<std::string> p_workspaces_names = p_workspaces.getMemberNames();
+
+    for (const std::string &p_w_name : p_workspaces_names) {
+      const Json::Value &p_w = p_workspaces[p_w_name];
+      if (p_w.isArray() && !p_w.empty()) {
+        // Adding to target outputs
+        for (const Json::Value &output : p_w) {
+          if (output.asString() == bar_.output->name) {
+            persistent_workspaces_.push_back(p_w_name);
+            break;
+          }
+        }
+      } else {
+        // Adding to all outputs
+        persistent_workspaces_.push_back(p_w_name);
+      }
+    }
+  }
+}
+
+auto WorkspaceGroup::create_persistent_workspaces() -> void {
+  for (const std::string &p_w_name : persistent_workspaces_) {
+    auto new_id = ++workspace_global_id;
+    workspaces_.push_back(
+        std::make_unique<Workspace>(bar_, config_, *this, nullptr, new_id, p_w_name));
+    spdlog::debug("Workspace {} created", new_id);
+  }
+}
+
+auto WorkspaceGroup::active_only() const -> bool { return workspace_manager_.active_only(); }
+auto WorkspaceGroup::creation_delayed() const -> bool {
+  return workspace_manager_.creation_delayed();
+}
+
+auto WorkspaceGroup::add_button(Gtk::Button &button) -> void {
+  box_.pack_start(button, false, false);
+}
+
+WorkspaceGroup::~WorkspaceGroup() {
+  if (!workspace_group_handle_) {
+    return;
+  }
+
+  zcosmic_workspace_group_handle_v1_destroy(workspace_group_handle_);
+  workspace_group_handle_ = nullptr;
+}
+
+auto WorkspaceGroup::handle_workspace_create(zcosmic_workspace_handle_v1 *workspace) -> void {
+  auto new_id = ++workspace_global_id;
+  workspaces_.push_back(std::make_unique<Workspace>(bar_, config_, *this, workspace, new_id, ""));
+  spdlog::debug("Workspace {} created", new_id);
+  if (!persistent_created_) {
+    fill_persistent_workspaces();
+    create_persistent_workspaces();
+    persistent_created_ = true;
+  }
+}
+
+auto WorkspaceGroup::handle_remove() -> void {
+  zcosmic_workspace_group_handle_v1_destroy(workspace_group_handle_);
+  workspace_group_handle_ = nullptr;
+  workspace_manager_.remove_workspace_group(id_);
+}
+
+auto WorkspaceGroup::handle_output_enter(wl_output *output) -> void {
+  spdlog::debug("Output {} assigned to {} group", (void *)output, id_);
+  output_ = output;
+
+  if (!is_visible() || workspace_manager_.creation_delayed()) {
+    return;
+  }
+
+  for (auto &workspace : workspaces_) {
+    add_button(workspace->get_button_ref());
+  }
+}
+
+auto WorkspaceGroup::is_visible() const -> bool {
+  return output_ != nullptr &&
+         (workspace_manager_.all_outputs() ||
+          output_ == gdk_wayland_monitor_get_wl_output(bar_.output->monitor->gobj()));
+}
+
+auto WorkspaceGroup::handle_output_leave() -> void {
+  spdlog::debug("Output {} remove from {} group", (void *)output_, id_);
+  output_ = nullptr;
+
+  if (output_ != gdk_wayland_monitor_get_wl_output(bar_.output->monitor->gobj())) {
+    return;
+  }
+
+  for (auto &workspace : workspaces_) {
+    remove_button(workspace->get_button_ref());
+  }
+}
+
+auto WorkspaceGroup::update() -> void {
+  for (auto &workspace : workspaces_) {
+    if (workspace_manager_.creation_delayed()) {
+      add_button(workspace->get_button_ref());
+      if (is_visible() && (workspace->is_active() || workspace->is_urgent())) {
+        workspace->show();
+      }
+    }
+
+    workspace->update();
+  }
+}
+
+auto WorkspaceGroup::remove_workspace(uint32_t id) -> void {
+  auto it = std::find_if(workspaces_.begin(), workspaces_.end(),
+                         [id](const std::unique_ptr<Workspace> &w) { return w->id() == id; });
+
+  if (it == workspaces_.end()) {
+    spdlog::warn("Can't find workspace with id {}", id);
+    return;
+  }
+
+  workspaces_.erase(it);
+}
+
+auto WorkspaceGroup::handle_done() -> void {
+  need_to_sort = false;
+  if (!is_visible()) {
+    return;
+  }
+
+  for (auto &workspace : workspaces_) {
+    workspace->handle_done();
+  }
+
+  if (creation_delayed()) {
+    return;
+  }
+
+  if (!workspace_manager_.all_outputs()) {
+    sort_workspaces();
+  } else {
+    workspace_manager_.sort_workspaces();
+  }
+}
+
+auto WorkspaceGroup::commit() -> void { workspace_manager_.commit(); }
+
+auto WorkspaceGroup::sort_workspaces() -> void {
+  std::sort(workspaces_.begin(), workspaces_.end(), workspace_manager_.workspace_comparator());
+  for (size_t i = 0; i < workspaces_.size(); ++i) {
+    box_.reorder_child(workspaces_[i]->get_button_ref(), i);
+  }
+}
+
+auto WorkspaceGroup::remove_button(Gtk::Button &button) -> void { box_.remove(button); }
+
+Workspace::Workspace(const Bar &bar, const Json::Value &config, WorkspaceGroup &workspace_group,
+                     zcosmic_workspace_handle_v1 *workspace, uint32_t id, std::string name)
+    : bar_(bar),
+      config_(config),
+      workspace_group_(workspace_group),
+      workspace_handle_(workspace),
+      id_(id),
+      name_(name) {
+  if (workspace) {
+    add_workspace_listener(workspace, this);
+  } else {
+    state_ = (uint32_t)State::EMPTY;
+  }
+
+  auto config_format = config["format"];
+
+  format_ = config_format.isString() ? config_format.asString() : "{name}";
+  with_icon_ = format_.find("{icon}") != std::string::npos;
+
+  if (with_icon_ && icons_map_.empty()) {
+    auto format_icons = config["format-icons"];
+    for (auto &name : format_icons.getMemberNames()) {
+      icons_map_.emplace(name, format_icons[name].asString());
+    }
+  }
+
+  /* Handle click events if configured */
+  if (config_["on-click"].isString() || config_["on-click-middle"].isString() ||
+      config_["on-click-right"].isString()) {
+    button_.add_events(Gdk::BUTTON_PRESS_MASK);
+    button_.signal_button_press_event().connect(sigc::mem_fun(*this, &Workspace::handle_clicked),
+                                                false);
+  }
+
+  button_.set_relief(Gtk::RELIEF_NONE);
+  content_.set_center_widget(label_);
+  button_.add(content_);
+
+  if (!workspace_group.is_visible()) {
+    return;
+  }
+
+  workspace_group.add_button(button_);
+  button_.show_all();
+}
+
+Workspace::~Workspace() {
+  workspace_group_.remove_button(button_);
+  if (!workspace_handle_) {
+    return;
+  }
+
+  zcosmic_workspace_handle_v1_destroy(workspace_handle_);
+  workspace_handle_ = nullptr;
+}
+
+auto Workspace::update() -> void {
+  label_.set_markup(fmt::format(fmt::runtime(format_), fmt::arg("name", name_),
+                                fmt::arg("icon", with_icon_ ? get_icon() : "")));
+}
+
+auto Workspace::handle_state(const std::vector<uint32_t> &state) -> void {
+  state_ = 0;
+  for (auto state_entry : state) {
+    switch (state_entry) {
+      case ZCOSMIC_WORKSPACE_HANDLE_V1_STATE_ACTIVE:
+        state_ |= (uint32_t)State::ACTIVE;
+        break;
+      case ZCOSMIC_WORKSPACE_HANDLE_V1_STATE_URGENT:
+        state_ |= (uint32_t)State::URGENT;
+        break;
+      case ZCOSMIC_WORKSPACE_HANDLE_V1_STATE_HIDDEN:
+        state_ |= (uint32_t)State::HIDDEN;
+        break;
+    }
+  }
+}
+
+auto Workspace::handle_remove() -> void {
+  if (workspace_handle_) {
+    zcosmic_workspace_handle_v1_destroy(workspace_handle_);
+    workspace_handle_ = nullptr;
+  }
+  if (!persistent_) {
+    workspace_group_.remove_workspace(id_);
+  } else {
+    state_ = (uint32_t)State::EMPTY;
+  }
+}
+
+auto add_or_remove_class(Glib::RefPtr<Gtk::StyleContext> context, bool condition,
+                         const std::string &class_name) {
+  if (condition) {
+    context->add_class(class_name);
+  } else {
+    context->remove_class(class_name);
+  }
+}
+
+auto Workspace::handle_done() -> void {
+  spdlog::debug("Workspace {} changed to state {}", id_, state_);
+  auto style_context = button_.get_style_context();
+  add_or_remove_class(style_context, is_active(), "active");
+  add_or_remove_class(style_context, is_urgent(), "urgent");
+  add_or_remove_class(style_context, is_hidden(), "hidden");
+  add_or_remove_class(style_context, is_empty(), "persistent");
+
+  if (workspace_group_.creation_delayed()) {
+    return;
+  }
+
+  if (workspace_group_.active_only() && (is_active() || is_urgent())) {
+    button_.show_all();
+  } else if (workspace_group_.active_only() && !(is_active() || is_urgent())) {
+    button_.hide();
+  }
+}
+
+auto Workspace::get_icon() -> std::string {
+  if (is_active()) {
+    auto active_icon_it = icons_map_.find("active");
+    if (active_icon_it != icons_map_.end()) {
+      return active_icon_it->second;
+    }
+  }
+
+  auto named_icon_it = icons_map_.find(name_);
+  if (named_icon_it != icons_map_.end()) {
+    return named_icon_it->second;
+  }
+
+  if (is_empty()) {
+    auto persistent_icon_it = icons_map_.find("persistent");
+    if (persistent_icon_it != icons_map_.end()) {
+      return persistent_icon_it->second;
+    }
+  }
+
+  auto default_icon_it = icons_map_.find("default");
+  if (default_icon_it != icons_map_.end()) {
+    return default_icon_it->second;
+  }
+
+  return name_;
+}
+
+auto Workspace::handle_clicked(GdkEventButton *bt) -> bool {
+  std::string action;
+  if (config_["on-click"].isString() && bt->button == 1) {
+    action = config_["on-click"].asString();
+  } else if (config_["on-click-middle"].isString() && bt->button == 2) {
+    action = config_["on-click-middle"].asString();
+  } else if (config_["on-click-right"].isString() && bt->button == 3) {
+    action = config_["on-click-right"].asString();
+  }
+
+  if (action.empty())
+    return true;
+  else if (action == "activate") {
+    zcosmic_workspace_handle_v1_activate(workspace_handle_);
+  } else if (action == "close") {
+    zcosmic_workspace_handle_v1_remove(workspace_handle_);
+  } else {
+    spdlog::warn("Unknown action {}", action);
+  }
+
+  workspace_group_.commit();
+
+  return true;
+}
+
+auto Workspace::show() -> void { button_.show_all(); }
+auto Workspace::hide() -> void { button_.hide(); }
+
+auto Workspace::handle_name(const std::string &name) -> void {
+  if (name_ != name) {
+    workspace_group_.set_need_to_sort();
+  }
+  name_ = name;
+  spdlog::debug("Workspace {} added to group {}", name, workspace_group_.id());
+
+  make_persistent();
+  handle_duplicate();
+}
+
+auto Workspace::make_persistent() -> void {
+  auto p_workspaces = workspace_group_.persistent_workspaces();
+
+  if (std::find(p_workspaces.begin(), p_workspaces.end(), name_) != p_workspaces.end()) {
+    persistent_ = true;
+  }
+}
+
+auto Workspace::handle_duplicate() -> void {
+  auto duplicate =
+      std::find_if(workspace_group_.workspaces().begin(), workspace_group_.workspaces().end(),
+                   [this](const std::unique_ptr<Workspace> &g) {
+                     return g->get_name() == name_ && g->id() != id_;
+                   });
+  if (duplicate != workspace_group_.workspaces().end()) {
+    workspace_group_.remove_workspace(duplicate->get()->id());
+  }
+}
+
+auto Workspace::handle_coordinates(const std::vector<uint32_t> &coordinates) -> void {
+  if (coordinates_ != coordinates) {
+    workspace_group_.set_need_to_sort();
+  }
+  coordinates_ = coordinates;
+}
+}  // namespace waybar::modules::cosmic

--- a/src/modules/cosmic/cosmic_workspace_manager_binding.cpp
+++ b/src/modules/cosmic/cosmic_workspace_manager_binding.cpp
@@ -1,0 +1,146 @@
+#include "modules/cosmic/cosmic_workspace_manager_binding.hpp"
+
+#include <spdlog/spdlog.h>
+
+#include <cstdint>
+
+#include "client.hpp"
+#include "modules/cosmic/cosmic_workspace_manager.hpp"
+
+namespace waybar::modules::cosmic {
+
+static void handle_global(void *data, wl_registry *registry, uint32_t name, const char *interface,
+                          uint32_t version) {
+  if (std::strcmp(interface, zcosmic_workspace_manager_v1_interface.name) == 0) {
+    static_cast<WorkspaceManager *>(data)->register_manager(registry, name, version);
+  }
+}
+
+static void handle_global_remove(void *data, wl_registry *registry, uint32_t name) {
+  /* Nothing to do here */
+}
+
+static const wl_registry_listener registry_listener_impl = {.global = handle_global,
+                                                            .global_remove = handle_global_remove};
+
+void add_registry_listener(void *data) {
+  wl_display *display = Client::inst()->wl_display;
+  wl_registry *registry = wl_display_get_registry(display);
+
+  wl_registry_add_listener(registry, &registry_listener_impl, data);
+  wl_display_roundtrip(display);
+  wl_display_roundtrip(display);
+}
+
+static void workspace_manager_handle_workspace_group(
+    void *data, zcosmic_workspace_manager_v1 *_, zcosmic_workspace_group_handle_v1 *workspace_group) {
+  static_cast<WorkspaceManager *>(data)->handle_workspace_group_create(workspace_group);
+}
+
+static void workspace_manager_handle_done(void *data, zcosmic_workspace_manager_v1 *_) {
+  static_cast<WorkspaceManager *>(data)->handle_done();
+}
+
+static void workspace_manager_handle_finished(void *data, zcosmic_workspace_manager_v1 *_) {
+  static_cast<WorkspaceManager *>(data)->handle_finished();
+}
+
+static const zcosmic_workspace_manager_v1_listener workspace_manager_impl = {
+    .workspace_group = workspace_manager_handle_workspace_group,
+    .done = workspace_manager_handle_done,
+    .finished = workspace_manager_handle_finished,
+};
+
+zcosmic_workspace_manager_v1 *workspace_manager_bind(wl_registry *registry, uint32_t name,
+                                                  uint32_t version, void *data) {
+  auto *workspace_manager = static_cast<zcosmic_workspace_manager_v1 *>(
+      wl_registry_bind(registry, name, &zcosmic_workspace_manager_v1_interface, version));
+
+  if (workspace_manager)
+    zcosmic_workspace_manager_v1_add_listener(workspace_manager, &workspace_manager_impl, data);
+  else
+    spdlog::error("Failed to register cosmic workspace manager");
+
+  return workspace_manager;
+}
+
+static void workspace_group_handle_capabilities(void *data, zcosmic_workspace_group_handle_v1 *_,
+                                                struct wl_array *capabilities) {
+}
+
+static void workspace_group_handle_output_enter(void *data, zcosmic_workspace_group_handle_v1 *_,
+                                                wl_output *output) {
+  static_cast<WorkspaceGroup *>(data)->handle_output_enter(output);
+}
+
+static void workspace_group_handle_output_leave(void *data, zcosmic_workspace_group_handle_v1 *_,
+                                                wl_output *output) {
+  static_cast<WorkspaceGroup *>(data)->handle_output_leave();
+}
+
+static void workspace_group_handle_workspace(void *data, zcosmic_workspace_group_handle_v1 *_,
+                                             zcosmic_workspace_handle_v1 *workspace) {
+  static_cast<WorkspaceGroup *>(data)->handle_workspace_create(workspace);
+}
+
+static void workspace_group_handle_remove(void *data, zcosmic_workspace_group_handle_v1 *_) {
+  static_cast<WorkspaceGroup *>(data)->handle_remove();
+}
+
+static const zcosmic_workspace_group_handle_v1_listener workspace_group_impl = {
+    .capabilities = workspace_group_handle_capabilities,
+    .output_enter = workspace_group_handle_output_enter,
+    .output_leave = workspace_group_handle_output_leave,
+    .workspace = workspace_group_handle_workspace,
+    .remove = workspace_group_handle_remove};
+
+void add_workspace_group_listener(zcosmic_workspace_group_handle_v1 *workspace_group_handle,
+                                  void *data) {
+  zcosmic_workspace_group_handle_v1_add_listener(workspace_group_handle, &workspace_group_impl, data);
+}
+
+void workspace_handle_capabilities(void *data, struct zcosmic_workspace_handle_v1 *_,
+                                   struct wl_array *capabilities) {
+}
+
+void workspace_handle_name(void *data, struct zcosmic_workspace_handle_v1 *_, const char *name) {
+  static_cast<Workspace *>(data)->handle_name(name);
+}
+
+void workspace_handle_coordinates(void *data, struct zcosmic_workspace_handle_v1 *_,
+                                  struct wl_array *coordinates) {
+  std::vector<uint32_t> coords_vec;
+  auto coords = static_cast<uint32_t *>(coordinates->data);
+  for (size_t i = 0; i < coordinates->size / sizeof(uint32_t); ++i) {
+    coords_vec.push_back(coords[i]);
+  }
+
+  static_cast<Workspace *>(data)->handle_coordinates(coords_vec);
+}
+
+void workspace_handle_state(void *data, struct zcosmic_workspace_handle_v1 *workspace_handle,
+                            struct wl_array *state) {
+  std::vector<uint32_t> state_vec;
+  auto states = static_cast<uint32_t *>(state->data);
+  for (size_t i = 0; i < state->size / sizeof(uint32_t); ++i) {
+    state_vec.push_back(states[i]);
+  }
+
+  static_cast<Workspace *>(data)->handle_state(state_vec);
+}
+
+void workspace_handle_remove(void *data, struct zcosmic_workspace_handle_v1 *_) {
+  static_cast<Workspace *>(data)->handle_remove();
+}
+
+static const zcosmic_workspace_handle_v1_listener workspace_impl = {
+    .name = workspace_handle_name,
+    .coordinates = workspace_handle_coordinates,
+    .state = workspace_handle_state,
+    .capabilities = workspace_handle_capabilities,
+    .remove = workspace_handle_remove};
+
+void add_workspace_listener(zcosmic_workspace_handle_v1 *workspace_handle, void *data) {
+  zcosmic_workspace_handle_v1_add_listener(workspace_handle, &workspace_impl, data);
+}
+}  // namespace waybar::modules::cosmic


### PR DESCRIPTION
[cosmic-workspace-unstable-v1](https://github.com/pop-os/cosmic-protocols/blob/9c41b6b0ece1672c335e59bf670f8671ce66ed33/unstable/cosmic-workspace-unstable-v1.xml) is a vendored version of the ext-workspace protocol and can be used without hiding the implementation behind feature flags. The only difference of version 1 in comparison to the ext-workspaces protocol implemented in Waybar is an added capability system.

---

This is essentially a straight up copy of wlr/workspaces with `s/zext_workspace/zcosmic_workspace/` and additional no-op listeners for the capability event. It can be tested against https://github.com/labwc/labwc/pull/2030 and should also work with the cosmic compositor itself but I never tested this. My hope is that other compositors and panels will implement support for version 1 of the protocol as well so it doesn't take another 3 years for users to be able to activate workspaces via panel.

Related PRs: 
- https://github.com/LBCrion/sfwbar/pull/212

<details><summary>Some diffs between the two protocols</summary>

```diff
--- protocol/ext-workspace-unstable-v1.xml	2022-06-06 12:54:51.225404838 +0200
+++ protocol/cosmic-workspace-unstable-v1.xml	2024-07-27 21:01:02.290416622 +0200
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<protocol name="ext_workspace_unstable_v1">
+<protocol name="cosmic_workspace_unstable_v1">
   <copyright>
     Copyright © 2019 Christopher Billington
     Copyright © 2020 Ilia Bozhinov
+    Copyright © 2022 Victoria Brekenfeld
 
     Permission to use, copy, modify, distribute, and sell this
     software and its documentation for any purpose is hereby granted
@@ -26,7 +27,7 @@
     THIS SOFTWARE.
   </copyright>
 
-  <interface name="zext_workspace_manager_v1" version="1">
+  <interface name="zcosmic_workspace_manager_v1" version="1">
     <description summary="list and control workspaces">
       Workspaces, also called virtual desktops, are groups of surfaces. A
       compositor with a concept of workspaces may only show some such groups of
@@ -45,7 +46,7 @@
       docks by providing them with a list of workspaces and their properties,
       and allowing them to activate and deactivate workspaces.
 
-      After a client binds the zext_workspace_manager_v1, each workspace will be
+      After a client binds the zcosmic_workspace_manager_v1, each workspace will be
       sent via the workspace event.
     </description>
 
@@ -55,9 +56,9 @@
 
         All initial details of the workspace group (workspaces, outputs) will be
         sent immediately after this event via the corresponding events in
-        zext_workspace_group_handle_v1.
+        zcosmic_workspace_group_handle_v1.
       </description>
-      <arg name="workspace_group" type="new_id" interface="zext_workspace_group_handle_v1"/>
+      <arg name="workspace_group" type="new_id" interface="zcosmic_workspace_group_handle_v1"/>
     </event>
 
     <request name="commit">
@@ -68,7 +69,7 @@
 
         This allows changes to the workspace properties to be seen as atomic,
         even if they happen via multiple events, and even if they involve
-        multiple zext_workspace_handle_v1 objects, for example, deactivating one
+        multiple zcosmic_workspace_handle_v1 objects, for example, deactivating one
         workspace and activating another.
       </description>
     </request>
@@ -78,11 +79,12 @@
         This event is sent after all changes in all workspace groups have been
         sent.
 
-        This allows changes to one or more zext_workspace_group_handle_v1
-        properties to be seen as atomic, even if they happen via multiple
-        events. In particular, an output moving from one workspace group to
+        This allows changes to one or more zcosmic_workspace_group_handle_v1
+        properties and zcosmic_workspace_handle_v1 properties to be seen as atomic,
+        even if they happen via multiple events.
+        In particular, an output moving from one workspace group to
         another sends an output_enter event and an output_leave event to the two
-        zext_workspace_group_handle_v1 objects in question. The compositor sends
+        zcosmic_workspace_group_handle_v1 objects in question. The compositor sends
         the done event only after updating the output information in both
         workspace groups.
       </description>
@@ -91,7 +93,7 @@
     <event name="finished">
       <description summary="the compositor has finished with the workspace_manager">
         This event indicates that the compositor is done sending events to the
-        zext_workspace_manager_v1. The server will destroy the object
+        zcosmic_workspace_manager_v1. The server will destroy the object
         immediately after sending this request, so it will become invalid and
         the client should free any resources associated with it.
       </description>
@@ -108,9 +110,9 @@
     </request>
   </interface>
 
-  <interface name="zext_workspace_group_handle_v1" version="1">
+  <interface name="zcosmic_workspace_group_handle_v1" version="1">
     <description summary="a workspace group assigned to a set of outputs">
-      A zext_workspace_group_handle_v1 object represents a a workspace group
+      A zcosmic_workspace_group_handle_v1 object represents a a workspace group
       that is assigned a set of outputs and contains a number of workspaces.
 
       The set of outputs assigned to the workspace group is conveyed to the client via
@@ -123,6 +125,32 @@
       outputs.
     </description>
 
+    <enum name="zcosmic_workspace_group_capabilities_v1">
+      <entry name="create_workspace" value="1" summary="create_workspace request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for creating workspaces, a button
+        triggering the create_workspace request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for creating workspaces will ignore
+        create_workspace requests.
+
+        Compositors must send this event once after creation of an
+        zcosmic_workspace_group_handle_v1 . When the capabilities change, compositors
+        must send this event again.
+
+        The capabilities are sent as an array of 32-bit unsigned integers in
+        native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
+
     <event name="output_enter">
       <description summary="output assigned to workspace group">
         This event is emitted whenever an output is assigned to the workspace
@@ -142,19 +170,21 @@
     <event name="workspace">
       <description summary="workspace added to workspace group">
         This event is emitted whenever a new workspace has been created.
+        A workspace can only be a member of a single workspace group and cannot
+        be re-assigned.
 
         All initial details of the workspace (name, coordinates, state) will
         be sent immediately after this event via the corresponding events in
-        zext_workspace_handle_v1.
+        zcosmic_workspace_handle_v1.
       </description>
-      <arg name="workspace" type="new_id" interface="zext_workspace_handle_v1"/>
+      <arg name="workspace" type="new_id" interface="zcosmic_workspace_handle_v1"/>
     </event>
 
     <event name="remove">
       <description summary="this workspace group has been destroyed">
-        This event means the zext_workspace_group_handle_v1 has been destroyed.
+        This event means the zcosmic_workspace_group_handle_v1 has been destroyed.
         It is guaranteed there won't be any more events for this
-        zext_workspace_group_handle_v1. The zext_workspace_group_handle_v1 becomes
+        zcosmic_workspace_group_handle_v1. The zext_workspace_group_handle_v1 becomes
         inert so any requests will be ignored except the destroy request.
 
         The compositor must remove all workspaces belonging to a workspace group
@@ -173,8 +203,8 @@
     </request>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy the zext_workspace_handle_v1 object">
-        Destroys the zext_workspace_handle_v1 object.
+      <description summary="destroy the zcosmic_workspace_group_handle_v1 object">
+        Destroys the zcosmic_workspace_group_handle_v1 object.
 
         This request should be called either when the client does not want to
         use the workspace object any more or after the remove event to finalize
@@ -183,9 +213,9 @@
     </request>
   </interface>
 
-  <interface name="zext_workspace_handle_v1" version="1">
+  <interface name="zcosmic_workspace_handle_v1" version="1">
     <description summary="a workspace handing a group of surfaces">
-      A zext_workspace_handle_v1 object represents a a workspace that handles a
+      A zcosmic_workspace_handle_v1 object represents a a workspace that handles a
       group of surfaces.
 
       Each workspace has a name, conveyed to the client with the name event; a
@@ -202,7 +232,7 @@
 
     <event name="name">
       <description summary="workspace name changed">
-        This event is emitted immediately after the zext_workspace_handle_v1 is
+        This event is emitted immediately after the zcosmic_workspace_handle_v1 is
         created and whenever the name of the workspace changes.
       </description>
       <arg name="name" type="string"/>
@@ -212,7 +242,7 @@
       <description summary="workspace coordinates changed">
         This event is used to organize workspaces into an N-dimensional grid
         within a workspace group, and if supported, is emitted immediately after
-        the zext_workspace_handle_v1 is created and whenever the coordinates of
+        the zcosmic_workspace_handle_v1 is created and whenever the coordinates of
         the workspace change. Compositors may not send this event if they do not
         conceptually arrange workspaces in this way. If compositors simply
         number workspaces, without any geometric interpretation, they may send
@@ -234,7 +264,7 @@
 
     <event name="state">
       <description summary="the state of the workspace changed">
-        This event is emitted immediately after the zext_workspace_handle_v1 is
+        This event is emitted immediately after the zcosmic_workspace_handle_v1 is
         created and each time the workspace state changes, either because of a
         compositor action or because of a request in this protocol.
       </description>
@@ -257,18 +287,46 @@
       </entry>
     </enum>
 
+    <enum name="zcosmic_workspace_capabilities_v1">
+      <entry name="activate" value="1" summary="activate request is available"/>
+      <entry name="deactivate" value="2" summary="deactivate request is available"/>
+      <entry name="remove" value="3" summary="remove request is available"/>
+    </enum>
+
+    <event name="capabilities">
+      <description summary="compositor capabilities">
+        This event advertises the capabilities supported by the compositor. If
+        a capability isn't supported, clients should hide or disable the UI
+        elements that expose this functionality. For instance, if the
+        compositor doesn't advertise support for removing workspaces, a button
+        triggering the remove request should not be displayed.
+
+        The compositor will ignore requests it doesn't support. For instance,
+        a compositor which doesn't advertise support for remove will ignore
+        remove requests.
+
+        Compositors must send this event once after creation of an
+        zcosmic_workspace_handle_v1 . When the capabilities change, compositors
+        must send this event again.
+
+        The capabilities are sent as an array of 32-bit unsigned integers in
+        native endianness.
+      </description>
+      <arg name="capabilities" type="array" summary="array of 32-bit capabilities"/>
+    </event>
+
     <event name="remove">
       <description summary="this workspace has been destroyed">
-        This event means the zext_workspace_handle_v1 has been destroyed. It is
+        This event means the zcosmic_workspace_handle_v1 has been destroyed. It is
         guaranteed there won't be any more events for this
-        zext_workspace_handle_v1. The zext_workspace_handle_v1 becomes inert so
+        zcosmic_workspace_handle_v1. The zext_workspace_handle_v1 becomes inert so
         any requests will be ignored except the destroy request.
       </description>
     </event>
 
     <request name="destroy" type="destructor">
-      <description summary="destroy the zext_workspace_handle_v1 object">
-        Destroys the zext_workspace_handle_v1 object.
+      <description summary="destroy the zcosmic_workspace_handle_v1 object">
+        Destroys the zcosmic_workspace_handle_v1 object.
 
         This request should be called either when the client does not want to
         use the workspace object any more or after the remove event to finalize
```

```diff
--- src/modules/wlr/workspace_manager_binding.cpp	2022-06-06 12:54:51.245405745 +0200
+++ src/modules/cosmic/cosmic_workspace_manager_binding.cpp	2024-07-27 21:03:18.840683727 +0200
@@ -1,17 +1,17 @@
-#include "modules/wlr/workspace_manager_binding.hpp"
+#include "modules/cosmic/cosmic_workspace_manager_binding.hpp"
 
 #include <spdlog/spdlog.h>
 
 #include <cstdint>
 
 #include "client.hpp"
-#include "modules/wlr/workspace_manager.hpp"
+#include "modules/cosmic/cosmic_workspace_manager.hpp"
 
-namespace waybar::modules::wlr {
+namespace waybar::modules::cosmic {
 
 static void handle_global(void *data, wl_registry *registry, uint32_t name, const char *interface,
                           uint32_t version) {
-  if (std::strcmp(interface, zext_workspace_manager_v1_interface.name) == 0) {
+  if (std::strcmp(interface, zcosmic_workspace_manager_v1_interface.name) == 0) {
     static_cast<WorkspaceManager *>(data)->register_manager(registry, name, version);
   }
 }
@@ -33,72 +33,81 @@
 }
 
 static void workspace_manager_handle_workspace_group(
-    void *data, zext_workspace_manager_v1 *_, zext_workspace_group_handle_v1 *workspace_group) {
+    void *data, zcosmic_workspace_manager_v1 *_, zcosmic_workspace_group_handle_v1 *workspace_group) {
   static_cast<WorkspaceManager *>(data)->handle_workspace_group_create(workspace_group);
 }
 
-static void workspace_manager_handle_done(void *data, zext_workspace_manager_v1 *_) {
+static void workspace_manager_handle_done(void *data, zcosmic_workspace_manager_v1 *_) {
   static_cast<WorkspaceManager *>(data)->handle_done();
 }
 
-static void workspace_manager_handle_finished(void *data, zext_workspace_manager_v1 *_) {
+static void workspace_manager_handle_finished(void *data, zcosmic_workspace_manager_v1 *_) {
   static_cast<WorkspaceManager *>(data)->handle_finished();
 }
 
-static const zext_workspace_manager_v1_listener workspace_manager_impl = {
+static const zcosmic_workspace_manager_v1_listener workspace_manager_impl = {
     .workspace_group = workspace_manager_handle_workspace_group,
     .done = workspace_manager_handle_done,
     .finished = workspace_manager_handle_finished,
 };
 
-zext_workspace_manager_v1 *workspace_manager_bind(wl_registry *registry, uint32_t name,
+zcosmic_workspace_manager_v1 *workspace_manager_bind(wl_registry *registry, uint32_t name,
                                                   uint32_t version, void *data) {
-  auto *workspace_manager = static_cast<zext_workspace_manager_v1 *>(
-      wl_registry_bind(registry, name, &zext_workspace_manager_v1_interface, version));
+  auto *workspace_manager = static_cast<zcosmic_workspace_manager_v1 *>(
+      wl_registry_bind(registry, name, &zcosmic_workspace_manager_v1_interface, version));
 
   if (workspace_manager)
-    zext_workspace_manager_v1_add_listener(workspace_manager, &workspace_manager_impl, data);
+    zcosmic_workspace_manager_v1_add_listener(workspace_manager, &workspace_manager_impl, data);
   else
-    spdlog::error("Failed to register manager");
+    spdlog::error("Failed to register cosmic workspace manager");
 
   return workspace_manager;
 }
 
-static void workspace_group_handle_output_enter(void *data, zext_workspace_group_handle_v1 *_,
+static void workspace_group_handle_capabilities(void *data, zcosmic_workspace_group_handle_v1 *_,
+                                                struct wl_array *capabilities) {
+}
+
+static void workspace_group_handle_output_enter(void *data, zcosmic_workspace_group_handle_v1 *_,
                                                 wl_output *output) {
   static_cast<WorkspaceGroup *>(data)->handle_output_enter(output);
 }
 
-static void workspace_group_handle_output_leave(void *data, zext_workspace_group_handle_v1 *_,
+static void workspace_group_handle_output_leave(void *data, zcosmic_workspace_group_handle_v1 *_,
                                                 wl_output *output) {
   static_cast<WorkspaceGroup *>(data)->handle_output_leave();
 }
 
-static void workspace_group_handle_workspace(void *data, zext_workspace_group_handle_v1 *_,
-                                             zext_workspace_handle_v1 *workspace) {
+static void workspace_group_handle_workspace(void *data, zcosmic_workspace_group_handle_v1 *_,
+                                             zcosmic_workspace_handle_v1 *workspace) {
   static_cast<WorkspaceGroup *>(data)->handle_workspace_create(workspace);
 }
 
-static void workspace_group_handle_remove(void *data, zext_workspace_group_handle_v1 *_) {
+static void workspace_group_handle_remove(void *data, zcosmic_workspace_group_handle_v1 *_) {
   static_cast<WorkspaceGroup *>(data)->handle_remove();
 }
 
-static const zext_workspace_group_handle_v1_listener workspace_group_impl = {
+static const zcosmic_workspace_group_handle_v1_listener workspace_group_impl = {
+    .capabilities = workspace_group_handle_capabilities,
     .output_enter = workspace_group_handle_output_enter,
     .output_leave = workspace_group_handle_output_leave,
     .workspace = workspace_group_handle_workspace,
     .remove = workspace_group_handle_remove};
 
-void add_workspace_group_listener(zext_workspace_group_handle_v1 *workspace_group_handle,
+void add_workspace_group_listener(zcosmic_workspace_group_handle_v1 *workspace_group_handle,
                                   void *data) {
-  zext_workspace_group_handle_v1_add_listener(workspace_group_handle, &workspace_group_impl, data);
+  zcosmic_workspace_group_handle_v1_add_listener(workspace_group_handle, &workspace_group_impl, data);
+}
+
+void workspace_handle_capabilities(void *data, struct zcosmic_workspace_handle_v1 *_,
+                                   struct wl_array *capabilities) {
 }
 
-void workspace_handle_name(void *data, struct zext_workspace_handle_v1 *_, const char *name) {
+void workspace_handle_name(void *data, struct zcosmic_workspace_handle_v1 *_, const char *name) {
   static_cast<Workspace *>(data)->handle_name(name);
 }
 
-void workspace_handle_coordinates(void *data, struct zext_workspace_handle_v1 *_,
+void workspace_handle_coordinates(void *data, struct zcosmic_workspace_handle_v1 *_,
                                   struct wl_array *coordinates) {
   std::vector<uint32_t> coords_vec;
   auto coords = static_cast<uint32_t *>(coordinates->data);
@@ -109,7 +118,7 @@
   static_cast<Workspace *>(data)->handle_coordinates(coords_vec);
 }
 
-void workspace_handle_state(void *data, struct zext_workspace_handle_v1 *workspace_handle,
+void workspace_handle_state(void *data, struct zcosmic_workspace_handle_v1 *workspace_handle,
                             struct wl_array *state) {
   std::vector<uint32_t> state_vec;
   auto states = static_cast<uint32_t *>(state->data);
@@ -120,17 +129,18 @@
   static_cast<Workspace *>(data)->handle_state(state_vec);
 }
 
-void workspace_handle_remove(void *data, struct zext_workspace_handle_v1 *_) {
+void workspace_handle_remove(void *data, struct zcosmic_workspace_handle_v1 *_) {
   static_cast<Workspace *>(data)->handle_remove();
 }
 
-static const zext_workspace_handle_v1_listener workspace_impl = {
+static const zcosmic_workspace_handle_v1_listener workspace_impl = {
     .name = workspace_handle_name,
     .coordinates = workspace_handle_coordinates,
     .state = workspace_handle_state,
+    .capabilities = workspace_handle_capabilities,
     .remove = workspace_handle_remove};
 
-void add_workspace_listener(zext_workspace_handle_v1 *workspace_handle, void *data) {
-  zext_workspace_handle_v1_add_listener(workspace_handle, &workspace_impl, data);
+void add_workspace_listener(zcosmic_workspace_handle_v1 *workspace_handle, void *data) {
+  zcosmic_workspace_handle_v1_add_listener(workspace_handle, &workspace_impl, data);
 }
-}  // namespace waybar::modules::wlr
+}  // namespace waybar::modules::cosmic
```

```diff
--- src/modules/wlr/workspace_manager.cpp	2024-07-27 00:55:00.613836114 +0200
+++ src/modules/cosmic/cosmic_workspace_manager.cpp	2024-07-27 21:03:18.844683910 +0200
@@ -1,4 +1,4 @@
-#include "modules/wlr/workspace_manager.hpp"
+#include "modules/cosmic/cosmic_workspace_manager.hpp"
 
 #include <gdk/gdkwayland.h>
 #include <gtkmm.h>
@@ -11,9 +11,9 @@
 
 #include "client.hpp"
 #include "gtkmm/widget.h"
-#include "modules/wlr/workspace_manager_binding.hpp"
+#include "modules/cosmic/cosmic_workspace_manager_binding.hpp"
 
-namespace waybar::modules::wlr {
+namespace waybar::modules::cosmic {
 
 uint32_t WorkspaceGroup::workspace_global_id = 0;
 uint32_t WorkspaceManager::group_global_id = 0;
@@ -131,7 +131,7 @@
 }
 
 auto WorkspaceManager::handle_workspace_group_create(
-    zext_workspace_group_handle_v1 *workspace_group_handle) -> void {
+    zcosmic_workspace_group_handle_v1 *workspace_group_handle) -> void {
   auto new_id = ++group_global_id;
   groups_.push_back(
       std::make_unique<WorkspaceGroup>(bar_, box_, config_, *this, workspace_group_handle, new_id));
@@ -139,7 +139,7 @@
 }
 
 auto WorkspaceManager::handle_finished() -> void {
-  zext_workspace_manager_v1_destroy(workspace_manager_);
+  zcosmic_workspace_manager_v1_destroy(workspace_manager_);
   workspace_manager_ = nullptr;
 }
 
@@ -171,13 +171,13 @@
   // Send `stop` request and wait for one roundtrip. This is not quite correct as
   // the protocol encourages us to wait for the .finished event, but it should work
   // with wlroots workspace manager implementation.
-  zext_workspace_manager_v1_stop(workspace_manager_);
+  zcosmic_workspace_manager_v1_stop(workspace_manager_);
   wl_display_roundtrip(display);
 
   // If the .finished handler is still not executed, destroy the workspace manager here.
   if (workspace_manager_) {
-    spdlog::warn("Foreign toplevel manager destroyed before .finished event");
-    zext_workspace_manager_v1_destroy(workspace_manager_);
+    spdlog::warn("Workspace manager destroyed before .finished event");
+    zcosmic_workspace_manager_v1_destroy(workspace_manager_);
     workspace_manager_ = nullptr;
   }
 }
@@ -193,11 +193,11 @@
 
   groups_.erase(it);
 }
-auto WorkspaceManager::commit() -> void { zext_workspace_manager_v1_commit(workspace_manager_); }
+auto WorkspaceManager::commit() -> void { zcosmic_workspace_manager_v1_commit(workspace_manager_); }
 
 WorkspaceGroup::WorkspaceGroup(const Bar &bar, Gtk::Box &box, const Json::Value &config,
                                WorkspaceManager &manager,
-                               zext_workspace_group_handle_v1 *workspace_group_handle, uint32_t id)
+                               zcosmic_workspace_group_handle_v1 *workspace_group_handle, uint32_t id)
     : bar_(bar),
       box_(box),
       config_(config),
@@ -262,11 +262,11 @@
     return;
   }
 
-  zext_workspace_group_handle_v1_destroy(workspace_group_handle_);
+  zcosmic_workspace_group_handle_v1_destroy(workspace_group_handle_);
   workspace_group_handle_ = nullptr;
 }
 
-auto WorkspaceGroup::handle_workspace_create(zext_workspace_handle_v1 *workspace) -> void {
+auto WorkspaceGroup::handle_workspace_create(zcosmic_workspace_handle_v1 *workspace) -> void {
   auto new_id = ++workspace_global_id;
   workspaces_.push_back(std::make_unique<Workspace>(bar_, config_, *this, workspace, new_id, ""));
   spdlog::debug("Workspace {} created", new_id);
@@ -278,7 +278,7 @@
 }
 
 auto WorkspaceGroup::handle_remove() -> void {
-  zext_workspace_group_handle_v1_destroy(workspace_group_handle_);
+  zcosmic_workspace_group_handle_v1_destroy(workspace_group_handle_);
   workspace_group_handle_ = nullptr;
   workspace_manager_.remove_workspace_group(id_);
 }
@@ -373,7 +373,7 @@
 auto WorkspaceGroup::remove_button(Gtk::Button &button) -> void { box_.remove(button); }
 
 Workspace::Workspace(const Bar &bar, const Json::Value &config, WorkspaceGroup &workspace_group,
-                     zext_workspace_handle_v1 *workspace, uint32_t id, std::string name)
+                     zcosmic_workspace_handle_v1 *workspace, uint32_t id, std::string name)
     : bar_(bar),
       config_(config),
       workspace_group_(workspace_group),
@@ -424,7 +424,7 @@
     return;
   }
 
-  zext_workspace_handle_v1_destroy(workspace_handle_);
+  zcosmic_workspace_handle_v1_destroy(workspace_handle_);
   workspace_handle_ = nullptr;
 }
 
@@ -437,13 +437,13 @@
   state_ = 0;
   for (auto state_entry : state) {
     switch (state_entry) {
-      case ZEXT_WORKSPACE_HANDLE_V1_STATE_ACTIVE:
+      case ZCOSMIC_WORKSPACE_HANDLE_V1_STATE_ACTIVE:
         state_ |= (uint32_t)State::ACTIVE;
         break;
-      case ZEXT_WORKSPACE_HANDLE_V1_STATE_URGENT:
+      case ZCOSMIC_WORKSPACE_HANDLE_V1_STATE_URGENT:
         state_ |= (uint32_t)State::URGENT;
         break;
-      case ZEXT_WORKSPACE_HANDLE_V1_STATE_HIDDEN:
+      case ZCOSMIC_WORKSPACE_HANDLE_V1_STATE_HIDDEN:
         state_ |= (uint32_t)State::HIDDEN;
         break;
     }
@@ -452,7 +452,7 @@
 
 auto Workspace::handle_remove() -> void {
   if (workspace_handle_) {
-    zext_workspace_handle_v1_destroy(workspace_handle_);
+    zcosmic_workspace_handle_v1_destroy(workspace_handle_);
     workspace_handle_ = nullptr;
   }
   if (!persistent_) {
@@ -531,9 +531,9 @@
   if (action.empty())
     return true;
   else if (action == "activate") {
-    zext_workspace_handle_v1_activate(workspace_handle_);
+    zcosmic_workspace_handle_v1_activate(workspace_handle_);
   } else if (action == "close") {
-    zext_workspace_handle_v1_remove(workspace_handle_);
+    zcosmic_workspace_handle_v1_remove(workspace_handle_);
   } else {
     spdlog::warn("Unknown action {}", action);
   }
@@ -582,4 +582,4 @@
   }
   coordinates_ = coordinates;
 }
-}  // namespace waybar::modules::wlr
+}  // namespace waybar::modules::cosmic
```

</details>
