### PR TITLE
group: fix revealer hover regression

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -30,6 +30,7 @@ class Group : public AModule {
   bool handleMouseEnter(GdkEventCrossing *const &ev) override;
   bool handleMouseLeave(GdkEventCrossing *const &ev) override;
   bool handleToggle(GdkEventButton *const &ev) override;
+  void addHoverHandlerTo(Gtk::Widget &widget);
   void show_group();
   void hide_group();
 };

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -30,7 +30,6 @@ class Group : public AModule {
   bool handleMouseEnter(GdkEventCrossing *const &ev) override;
   bool handleMouseLeave(GdkEventCrossing *const &ev) override;
   bool handleToggle(GdkEventButton *const &ev) override;
-  void addHoverHandlerTo(Gtk::Widget &widget);
   void show_group();
   void hide_group();
 };

--- a/include/group.hpp
+++ b/include/group.hpp
@@ -12,7 +12,7 @@ namespace waybar {
 class Group : public AModule {
  public:
   Group(const std::string &, const std::string &, const Json::Value &, bool);
-  virtual ~Group() = default;
+  ~Group() override = default;
   auto update() -> void override;
   operator Gtk::Widget &() override;
 

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -9,7 +9,7 @@
 
 namespace waybar {
 
-const Gtk::RevealerTransitionType getPreferredTransitionType(bool is_vertical) {
+Gtk::RevealerTransitionType getPreferredTransitionType(bool is_vertical) {
   /* The transition direction of a drawer is not actually determined by the transition type,
    * but rather by the order of 'box' and 'revealer_box':
    *   'REVEALER_TRANSITION_TYPE_SLIDE_LEFT' and 'REVEALER_TRANSITION_TYPE_SLIDE_RIGHT'
@@ -112,7 +112,7 @@ bool Group::handleToggle(GdkEventButton* const& e) {
   if (!click_to_reveal || e->button != 1) {
     return false;
   }
-  if (box.get_state_flags() & Gtk::StateFlags::STATE_FLAG_PRELIGHT) {
+  if ((box.get_state_flags() & Gtk::StateFlags::STATE_FLAG_PRELIGHT) != 0U) {
     hide_group();
   } else {
     show_group();

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -81,14 +81,7 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     }
   }
 
-  addHoverHandlerTo(revealer);
   event_box_.add(box);
-}
-
-void Group::addHoverHandlerTo(Gtk::Widget& widget) {
-  widget.add_events(Gdk::EventMask::ENTER_NOTIFY_MASK | Gdk::EventMask::LEAVE_NOTIFY_MASK);
-  widget.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Group::handleMouseEnter));
-  widget.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Group::handleMouseLeave));
 }
 
 void Group::show_group() {
@@ -109,7 +102,7 @@ bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
 }
 
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
-  if (!click_to_reveal) {
+  if (!click_to_reveal && e->detail != GDK_NOTIFY_INFERIOR) {
     hide_group();
   }
   return false;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -81,7 +81,14 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     }
   }
 
+  addHoverHandlerTo(revealer);
   event_box_.add(box);
+}
+
+void Group::addHoverHandlerTo(Gtk::Widget& widget) {
+  widget.add_events(Gdk::EventMask::ENTER_NOTIFY_MASK | Gdk::EventMask::LEAVE_NOTIFY_MASK);
+  widget.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Group::handleMouseEnter));
+  widget.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Group::handleMouseLeave));
 }
 
 void Group::show_group() {

--- a/src/util/css_reload_helper.cpp
+++ b/src/util/css_reload_helper.cpp
@@ -44,7 +44,7 @@ std::string waybar::CssReloadHelper::findPath(const std::string& filename) {
 
   // File monitor does not work with symlinks, so resolve them
   std::string original = result;
-  while(std::filesystem::is_symlink(result)) {
+  while (std::filesystem::is_symlink(result)) {
     result = std::filesystem::read_symlink(result);
 
     // prevent infinite cycle


### PR DESCRIPTION
Resolves https://github.com/Alexays/Waybar/issues/3391 . 

Finally spent some time on this. This changes the handleMouseLeave event to only fire when we leave the entire event_box__ and are not just going to a child element. 