### PR TITLE
taskbar: Send minimize geometry hints

### DIFF
--- a/include/modules/wlr/taskbar.hpp
+++ b/include/modules/wlr/taskbar.hpp
@@ -24,6 +24,10 @@
 
 namespace waybar::modules::wlr {
 
+struct widget_geometry {
+    int x, y, w, h;
+};
+
 class Taskbar;
 
 class Task {
@@ -42,6 +46,7 @@ class Task {
   };
   // made public so TaskBar can reorder based on configuration.
   Gtk::Button button;
+  struct widget_geometry minimize_hint;
 
  private:
   static uint32_t global_id;
@@ -82,6 +87,8 @@ class Task {
  private:
   std::string repr() const;
   std::string state_string(bool = false) const;
+  void set_minimize_hint();
+  void on_button_size_allocated(Gtk::Allocation &alloc);
   void set_app_info_from_app_id_list(const std::string &app_id_list);
   bool image_load_icon(Gtk::Image &image, const Glib::RefPtr<Gtk::IconTheme> &icon_theme,
                        Glib::RefPtr<Gio::DesktopAppInfo> app_info, int size);

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -387,6 +387,10 @@ void Task::handle_title(const char *title) {
   hide_if_ignored();
 }
 
+void Task::set_minimize_hint() {
+    zwlr_foreign_toplevel_handle_v1_set_rectangle(handle_, bar_.surface, minimize_hint.x, minimize_hint.y, minimize_hint.w, minimize_hint.h);
+}
+
 void Task::hide_if_ignored() {
   if (tbar_->ignore_list().count(app_id_) || tbar_->ignore_list().count(title_)) {
     ignored_ = true;
@@ -447,6 +451,12 @@ void Task::handle_app_id(const char *app_id) {
     spdlog::debug("Couldn't find icon for {}", app_id_);
 }
 
+void Task::on_button_size_allocated(Gtk::Allocation &alloc) {
+    gtk_widget_translate_coordinates(GTK_WIDGET(button.gobj()), GTK_WIDGET(bar_.window.gobj()), 0, 0, &minimize_hint.x, &minimize_hint.y);
+    minimize_hint.w = button.get_width();
+    minimize_hint.h = button.get_height();
+}
+
 void Task::handle_output_enter(struct wl_output *output) {
   if (ignored_) {
     spdlog::debug("{} is ignored", repr());
@@ -457,6 +467,7 @@ void Task::handle_output_enter(struct wl_output *output) {
 
   if (!button_visible_ && (tbar_->all_outputs() || tbar_->show_output(output))) {
     /* The task entered the output of the current bar make the button visible */
+    button.signal_size_allocate().connect_notify(sigc::mem_fun(this, &Task::on_button_size_allocated));
     tbar_->add_button(button);
     button.show();
     button_visible_ = true;
@@ -553,9 +564,11 @@ bool Task::handle_clicked(GdkEventButton *bt) {
     return true;
   else if (action == "activate")
     activate();
-  else if (action == "minimize")
+  else if (action == "minimize") {
+    set_minimize_hint();
     minimize(!minimized());
-  else if (action == "minimize-raise") {
+  } else if (action == "minimize-raise") {
+    set_minimize_hint();
     if (minimized())
       minimize(false);
     else if (active())


### PR DESCRIPTION
This allows compositors to know the minimize widget geometry so that minimize animations work properly.