### PR TITLE
Accept "default-node-changed" signals from wireplumber, even if only the node ID is changed

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -163,7 +163,8 @@ void waybar::modules::Wireplumber::onDefaultNodesApiChanged(waybar::modules::Wir
       "[{}]: (onDefaultNodesApiChanged) - got the following default node: Node(name: {}, id: {})",
       self->name_, defaultNodeName, defaultNodeId);
 
-  if (g_strcmp0(self->default_node_name_, defaultNodeName) == 0) {
+  if (g_strcmp0(self->default_node_name_, defaultNodeName) == 0 &&
+      self->node_id_ == defaultNodeId) {
     spdlog::debug(
         "[{}]: (onDefaultNodesApiChanged) - Default node has not changed. Node(name: {}, id: {}). "
         "Ignoring.",


### PR DESCRIPTION
This fixes an issue on my system where for some reason the initial default node ID is incorrect and the initial node name is correct. Only afterwards there is a "default-node-changed" signal with the correct ID. However, this signal is discarded as the node name is unchanged.