### PR TITLE
cava: Add format_silent option and css triggers

### DIFF
--- a/include/modules/cava.hpp
+++ b/include/modules/cava.hpp
@@ -39,6 +39,7 @@ class Cava final : public ALabel {
   std::chrono::seconds suspend_silence_delay_{0};
   bool silence_{false};
   bool hide_on_silence_{false};
+  std::string format_silent_{""};
   int sleep_counter_{0};
   // Cava method
   void pause_resume();

--- a/man/waybar-cava.5.scd
+++ b/man/waybar-cava.5.scd
@@ -64,6 +64,10 @@ libcava lives in:
 :[ bool
 :[ false
 :[ Hides the widget if no input (after sleep_timer elapsed)
+|[ *format_silent*
+:[ string
+:[
+:[ Widget's text after sleep_timer elapsed (hide_on_silence has to be false)
 |[ *method*
 :[ string
 :[ pulse
@@ -196,3 +200,8 @@ In case when cava releases new version and you're wanna get it, it should be rai
 	}
 },
 ```
+# STYLE
+
+- *#cava*
+- *#cava.silent* Applied after no sound has been detected for sleep_timer seconds
+- *#cava.updated* Applied when a new frame is shown

--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -173,17 +173,17 @@ auto waybar::modules::Cava::update() -> void {
       label_.set_markup(text_);
       label_.show();
       ALabel::update();
-      label_.get_style_context()->add_class("update");
+      label_.get_style_context()->add_class("updated");
     }
     
-    label_.get_style_context()->remove_class("silence");
+    label_.get_style_context()->remove_class("silent");
   } else {
     upThreadDelay(frame_time_milsec_, suspend_silence_delay_);
     if (hide_on_silence_) label_.hide();
     else if (config_["format_silent"].isString()) label_.set_markup(format_silent_);
 
-    label_.get_style_context()->add_class("silence");
-    label_.get_style_context()->remove_class("update");
+    label_.get_style_context()->add_class("silent");
+    label_.get_style_context()->remove_class("updated");
   }
 }
 

--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -173,6 +173,7 @@ auto waybar::modules::Cava::update() -> void {
       label_.set_markup(text_);
       label_.show();
       ALabel::update();
+      label_.get_style_context()->add_class("update");
     }
     
     label_.get_style_context()->remove_class("silence");
@@ -182,6 +183,7 @@ auto waybar::modules::Cava::update() -> void {
     else if (config_["format_silent"].isString()) label_.set_markup(format_silent_);
 
     label_.get_style_context()->add_class("silence");
+    label_.get_style_context()->remove_class("update");
   }
 }
 

--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -59,6 +59,7 @@ waybar::modules::Cava::Cava(const std::string& id, const Json::Value& config)
   if (config_["input_delay"].isInt())
     fetch_input_delay_ = std::chrono::seconds(config_["input_delay"].asInt());
   if (config_["hide_on_silence"].isBool()) hide_on_silence_ = config_["hide_on_silence"].asBool();
+  if (config_["format_silent"].isString()) format_silent_ = config_["format_silent"].asString();
   // Make cava parameters configuration
   plan_ = new cava::cava_plan{};
 
@@ -176,6 +177,7 @@ auto waybar::modules::Cava::update() -> void {
   } else {
     upThreadDelay(frame_time_milsec_, suspend_silence_delay_);
     if (hide_on_silence_) label_.hide();
+    else if (config_["format_silent"].isString()) label_.set_markup(format_silent_);
   }
 }
 

--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -174,10 +174,14 @@ auto waybar::modules::Cava::update() -> void {
       label_.show();
       ALabel::update();
     }
+    
+    label_.get_style_context()->remove_class("silence");
   } else {
     upThreadDelay(frame_time_milsec_, suspend_silence_delay_);
     if (hide_on_silence_) label_.hide();
     else if (config_["format_silent"].isString()) label_.set_markup(format_silent_);
+
+    label_.get_style_context()->add_class("silence");
   }
 }
 


### PR DESCRIPTION
This PR adds `format_silent` config option; `updated` and `silent` css triggers.

### Explanation:
 - If `format_silent` is set and `hide_on_silence` is set to false and audio has not been playing for `sleep_timer` seconds, then cava module will be showing `format_silent` string until audio starts playing.
 - `#cava.updated` triggers when a new frame is shown
 - `#cava.silent` triggers when there has been no audio for `sleep_timer` seconds

When this PR gets merged, I will write documentation for these options

@Alexays if there is anything wrong with this PR, please point it out