### PR TITLE
privacy: ignore some streams

### DIFF
--- a/include/modules/privacy/privacy.hpp
+++ b/include/modules/privacy/privacy.hpp
@@ -32,6 +32,7 @@ class Privacy : public AModule {
   uint iconSize = 20;
   uint transition_duration = 250;
   std::set<std::pair<PrivacyNodeType, std::string>> ignore;
+  bool ignore_monitor = true;
 
   std::shared_ptr<util::PipewireBackend::PipewireBackend> backend = nullptr;
 };

--- a/include/modules/privacy/privacy.hpp
+++ b/include/modules/privacy/privacy.hpp
@@ -31,6 +31,7 @@ class Privacy : public AModule {
   uint iconSpacing = 4;
   uint iconSize = 20;
   uint transition_duration = 250;
+  std::set<std::pair<PrivacyNodeType, std::string>> ignore;
 
   std::shared_ptr<util::PipewireBackend::PipewireBackend> backend = nullptr;
 };

--- a/include/util/pipewire/privacy_node_info.hpp
+++ b/include/util/pipewire/privacy_node_info.hpp
@@ -25,6 +25,7 @@ class PrivacyNodeInfo {
   std::string media_name;
   std::string node_name;
   std::string application_name;
+  bool is_monitor = false;
 
   std::string pipewire_access_portal_app_id;
   std::string application_icon_name;

--- a/man/waybar-privacy.5.scd
+++ b/man/waybar-privacy.5.scd
@@ -37,6 +37,17 @@ the screen or playing audio.
 	default: false ++
 	Enables this module to consume all left over space dynamically.
 
+*ignore-monitor* ++
+	typeof: bool ++
+	default: true ++
+	Ignore streams with *stream.monitor* property.
+
+*ignore* ++
+	typeof: array of objects ++
+	default: [] ++
+	Additional streams to be ignored. See *IGNORE CONFIGURATION* for++
+	more information.
+
 # MODULES CONFIGURATION
 
 *type*: ++
@@ -53,6 +64,14 @@ the screen or playing audio.
 	typeof: integer ++
 	default: 24 ++
 	The size of each icon in the tooltip.
+
+# IGNORE CONFIGURATION
+
+*type*: ++
+	typeof: string
+
+*name*: ++
+	typeof: string
 
 # EXAMPLES
 

--- a/src/modules/privacy/privacy.cpp
+++ b/src/modules/privacy/privacy.cpp
@@ -85,6 +85,10 @@ Privacy::Privacy(const std::string& id, const Json::Value& config, const std::st
     }
   }
 
+  if (config_["ignore-monitor"].isBool()) {
+    ignore_monitor = config_["ignore-monitor"].asBool();
+  }
+
   backend = util::PipewireBackend::PipewireBackend::getInstance();
   backend->privacy_nodes_changed_signal_event.connect(
       sigc::mem_fun(*this, &Privacy::onPrivacyNodesChanged));
@@ -99,6 +103,9 @@ void Privacy::onPrivacyNodesChanged() {
   nodes_screenshare.clear();
 
   for (auto& node : backend->privacy_nodes) {
+    if (ignore_monitor && node.second->is_monitor)
+      continue;
+
     auto iter = ignore.find(std::pair(node.second->type, node.second->node_name));
     if (iter != ignore.end())
       continue;

--- a/src/util/pipewire/privacy_node_info.cpp
+++ b/src/util/pipewire/privacy_node_info.cpp
@@ -49,6 +49,8 @@ void PrivacyNodeInfo::handleNodeEventInfo(const struct pw_node_info *info) {
       pipewire_access_portal_app_id = item->value;
     } else if (strcmp(item->key, PW_KEY_APP_ICON_NAME) == 0) {
       application_icon_name = item->value;
+    } else if (strcmp(item->key, "stream.monitor") == 0) {
+      is_monitor = strcmp(item->value, "true") == 0;
     }
   }
 }


### PR DESCRIPTION
This PR introduces an option `ignore` to exclude pipewire nodes from the privacy module.