### PR TITLE
hyprland/backend: drop unnecessary getaddrinfo call

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -148,20 +148,10 @@ void IPC::unregisterForIPC(EventHandler* ev_handler) {
 std::string IPC::getSocket1Reply(const std::string& rq) {
   // basically hyprctl
 
-  struct addrinfo aiHints;
-  struct addrinfo* aiRes = nullptr;
   const auto serverSocket = socket(AF_UNIX, SOCK_STREAM, 0);
 
   if (serverSocket < 0) {
     throw std::runtime_error("Hyprland IPC: Couldn't open a socket (1)");
-  }
-
-  memset(&aiHints, 0, sizeof(struct addrinfo));
-  aiHints.ai_family = AF_UNSPEC;
-  aiHints.ai_socktype = SOCK_STREAM;
-
-  if (getaddrinfo("localhost", nullptr, &aiHints, &aiRes) != 0) {
-    throw std::runtime_error("Hyprland IPC: Couldn't get host (2)");
   }
 
   // get the instance signature


### PR DESCRIPTION
Hyprland hasn't been using TCP sockets for IPC since the first release, so this getaddrinfo call and its result was never needed.

Additionally, it leaks the `aiRes`, causing test failure under ASan.

Not tested on a real Hyprland, but see https://github.com/hyprwm/Hyprland/commit/39a9980fb116108807ee68def27a6348184f282c.

CC: @khaneliman 