### PR TITLE
fix/upower: upower module selection with multiple devices

### DIFF
--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -384,10 +384,11 @@ void UPower::setDisplayDevice() {
               displayDevice = upDevice;
             }
           }
-          // Unref current upDevice
-          if (displayDevice.upDevice != NULL) g_object_unref(thisPtr->upDevice_.upDevice);
-          // Reassign new upDevice
-          thisPtr->upDevice_ = displayDevice;
+          // Unref current upDevice if it exists
+          if (displayDevice.upDevice != NULL) {
+            if (thisPtr->upDevice_.upDevice != NULL) g_object_unref(thisPtr->upDevice_.upDevice);
+            thisPtr->upDevice_ = displayDevice;
+          }
         },
         this);
   }


### PR DESCRIPTION
While looping over all the upower devices, the currently set device that will be rendered in the waybar, is overridden. Since the loop doesn't end when the device is found, the upDevice_ is overridden with NULL in the iteration for the next device.

Now we only override upDevice_ if the current device matches the constraints.

Fixes d2a719d67c5427dffc3e431c41b96b60399576e6 ("Redo to minimize code duplication.") 
Fixes #3267