### PR TITLE
fix issue: Client::handleOutputDone() is called multiple times for same monitor

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -4,6 +4,7 @@
 #include <gdk/gdk.h>
 #include <gdk/gdkwayland.h>
 #include <wayland-client.h>
+#include <unordered_set>
 
 #include "bar.hpp"
 #include "config.hpp"
@@ -56,6 +57,7 @@ class Client {
   std::list<struct waybar_output> outputs_;
   std::unique_ptr<CssReloadHelper> m_cssReloadHelper;
   std::string m_cssFile;
+  std::unordered_set<std::string> m_monitors_inprocess;
 };
 
 }  // namespace waybar

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -78,11 +78,18 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
       output.xdg_output.reset();
       spdlog::debug("Output detection done: {} ({})", output.name, output.identifier);
 
-      auto configs = client->getOutputConfigs(output);
-      if (!configs.empty()) {
-        for (const auto &config : configs) {
-          client->bars.emplace_back(std::make_unique<Bar>(&output, config));
+      if (client->m_monitors_inprocess.contains(output.name)) {
+        spdlog::debug("Ignore output detection done event: {} ({})", output.name,
+                      output.identifier);
+      } else {
+        client->m_monitors_inprocess.emplace(output.name);
+        auto configs = client->getOutputConfigs(output);
+        if (!configs.empty()) {
+          for (const auto &config : configs) {
+            client->bars.emplace_back(std::make_unique<Bar>(&output, config));
+          }
         }
+        client->m_monitors_inprocess.erase(output.name);
       }
     }
   } catch (const std::exception &e) {


### PR DESCRIPTION
I have a notebook connected to an external monitor. Sometimes when the lid is open, there are multiple bars
on the built-in screen (named "eDP-1").

After some investigation, it seems that it creates a bar instance for the same monitor multiple times: one for the `.done` event, and another when trying to display the window of the bar that was previously created:

``` text
Thread 1 "waybar" hit Breakpoint 7, waybar::Client::handleOutputDone (data=0x55e156d19f70)
    at /usr/src/debug/gui-apps/waybar-9999-r1/waybar-9999/src/client.cpp:77
/usr/src/debug/gui-apps/waybar-9999-r1/waybar-9999/src/client.cpp:77:3281:beg:0x55e11615b543
(peda)$ bt
=> #  0 0x000055e11615b543 waybar::Client::handleOutputDone --> second time
   #  1 0x00007fed91a1075e ?? ()
   #  2 0x00007fed91a0fa62 ?? ()
   #  3 0x00007fed91a10243 ffi_call
   #  4 0x00007fed9250e131 ?? ()
   #  5 0x00007fed9250a0bf ?? ()
   #  6 0x00007fed9250b3c3 wl_display_dispatch_queue_pending
   #  7 0x00007fed9250c13f wl_display_roundtrip_queue
   #  8 0x00007fed90ef0e00 g_closure_invoke
   #  9 0x00007fed90f0470e ?? ()
   # 10 0x00007fed90f06121 ?? ()
   # 11 0x00007fed90f0bdc6 g_signal_emit_valist
   # 12 0x00007fed90f0be8b g_signal_emit
   # 13 0x00007fed9134af7a gtk_widget_map [inlined]
   # 14 0x00007fed9134af7a gtk_widget_map
   # 15 0x00007fed913595a2 gtk_window_show
   # 16 0x00007fed90ef0e00 g_closure_invoke
   # 17 0x00007fed90f0482f ?? ()
   # 18 0x00007fed90f06121 ?? ()
   # 19 0x00007fed90f0bdc6 g_signal_emit_valist
   # 20 0x00007fed90f0be8b g_signal_emit
   # 21 0x00007fed91344d6a gtk_widget_show [inlined]
   # 22 0x00007fed91344d6a gtk_widget_show
   # 23 0x000055e116154460 waybar::Bar::Bar
   # 24 0x000055e11615b608 std::make_unique<waybar::Bar, waybar::waybar_output*, Json::Value const&> [inlined]
   # 25 0x000055e11615b608 waybar::Client::handleOutputDone  ---> first time a bar is created
   # 26 0x00007fed91a1075e ?? ()
   # 27 0x00007fed91a0fa62 ?? ()
   # 28 0x00007fed91a10243 ffi_call
   # 29 0x00007fed9250e131 ?? ()
   # 30 0x00007fed9250a0bf ?? ()
   # 31 0x00007fed9250b3c3 wl_display_dispatch_queue_pending
   # 32 0x00007fed922c26c8 _gdk_wayland_display_queue_events
   # 33 0x00007fed92291fb4 gdk_display_get_event
   # 34 0x00007fed922c23d6 gdk_event_source_dispatch
   # 35 0x00007fed90def834 ?? ()
   # 36 0x00007fed90df2977 ?? ()
   # 37 0x00007fed90df2fa0 g_main_context_iteration
   # 38 0x00007fed91af6b7d g_application_run
   # 39 0x000055e11615e7bd waybar::Client::main
   # 40 0x000055e1161524c4 main
   # 41 0x00007fed9065f2e0 ?? ()
   # 42 0x00007fed9065f399 __libc_start_main
   # 43 0x000055e116105415 _start
(peda)$ f 23
#23 0x000055e116154460 in waybar::Bar::Bar (this=0x55e156afdd30, w_output=<optimized out>, w_config=...)
    at /usr/src/debug/gui-apps/waybar-9999-r1/waybar-9999/src/bar.cpp:280
/usr/src/debug/gui-apps/waybar-9999-r1/waybar-9999/src/bar.cpp:280:9305:beg:0x55e116154460
(peda)$ f 6
#6  0x00007fed9250b3c3 in wl_display_dispatch_queue_pending () from /usr/lib64/libwayland-client.so.0
(peda)$ f 0
#0  waybar::Client::handleOutputDone (data=0x55e156d19f70)
    at /usr/src/debug/gui-apps/waybar-9999-r1/waybar-9999/src/client.cpp:77
/usr/src/debug/gui-apps/waybar-9999-r1/waybar-9999/src/client.cpp:77:3281:beg:0x55e11615b543
(peda)$ p output
$9 = (waybar::waybar_output &) @0x55e156d19f70: {
  monitor = {
    pCppObject_ = 0x55e156a57c40
  },
  name = "eDP-1",
  identifier = "AU Optronics 0x713C ",
  xdg_output = std::unique_ptr<zxdg_output_v1> = {
    get() = 0x55e156727ba0
  }
}
```

I'm not sure what the best way is to fix this issue, but I think it can be avoided by not recursively creating bar instances for the same monitor...

Please review this carefully before merging.


Thanks.