### PR TITLE
Revert "Uses user-defined mode when toggling visibility rather than r…

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -406,11 +406,7 @@ void waybar::Bar::onMap(GdkEventAny* /*unused*/) {
 
 void waybar::Bar::setVisible(bool value) {
   visible = value;
-  if (auto mode = config.get("mode", {}); mode.isString()) {
-    setMode(visible ? config["mode"].asString() : MODE_INVISIBLE);
-  } else {
-    setMode(visible ? MODE_DEFAULT : MODE_INVISIBLE);
-  }
+  setMode(visible ? MODE_DEFAULT : MODE_INVISIBLE);
 }
 
 void waybar::Bar::toggle() { setVisible(!visible); }


### PR DESCRIPTION
…esetting to default mode"

But uses the invisible mode once it's set invisible.

This reverts commit f4c6dfcddc032a008f4b119edfc519fc4b38f64e.

This should fix #3578