### PR TITLE
fix: return app_identifier as itself in AAppIconLabel if it's an absolute path

### DIFF
--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -154,6 +154,16 @@ void AAppIconLabel::updateAppIcon() {
     update_app_icon_ = false;
     if (app_icon_name_.empty()) {
       image_.set_visible(false);
+    }
+    else if (app_icon_name_.front() == '/') {
+      auto pixbuf = Gdk::Pixbuf::create_from_file(app_icon_name_);
+      int scaled_icon_size = app_icon_size_ * image_.get_scale_factor();
+      pixbuf = Gdk::Pixbuf::create_from_file(app_icon_name_, scaled_icon_size, scaled_icon_size);
+
+      auto surface = Gdk::Cairo::create_surface_from_pixbuf(pixbuf, image_.get_scale_factor(),
+                                                            image_.get_window());
+      image_.set(surface);
+      image_.set_visible(true);
     } else {
       image_.set_from_icon_name(app_icon_name_, Gtk::ICON_SIZE_INVALID);
       image_.set_visible(true);


### PR DESCRIPTION
If an app's identifier is an absolute path, return said path. This is for apps like `tidal-hifi` that identify itself as `/usr/share/icons/tidal-hifi/tidal-hifi.png`. Closes #3612