### PR TITLE
feat: css query for first, last, and solo niri workspace(s)

### DIFF
--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -70,14 +70,22 @@ void Workspaces::doUpdate() {
     if (ws["idx"].asUInt() == workspaces.size() && workspaces.size() > 1) { 
       style_context->add_class("last");
       style_context->remove_class("solo");
+      style_context->remove_class("first");
     }
     else {
       if (workspaces.size() == 1) {
         style_context->remove_class("last");
+        style_context->remove_class("first");
         style_context->add_class("solo");
+      }
+      else if (ws["idx"].asUInt() == 1) {
+        style_context->remove_class("last");
+        style_context->add_class("first");
+        style_context->remove_class("solo");
       }
       else {
         style_context->remove_class("last");
+        style_context->remove_class("first");
         style_context->remove_class("solo");
       }
     }

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -72,7 +72,7 @@ void Workspaces::doUpdate() {
       style_context->remove_class("solo");
     }
     else {
-      if (ws["idx"].asUInt() == workspaces.size() && workspaces.size() == 1) {
+      if (workspaces.size() == 1) {
         style_context->remove_class("last");
         style_context->add_class("solo");
       }

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -67,6 +67,20 @@ void Workspaces::doUpdate() {
     else
       style_context->remove_class("active");
 
+    if (ws["idx"].asUInt() == workspaces.size() && workspaces.size() > 1) { 
+      style_context->add_class("last");
+      style_context->remove_class("solo");
+    }
+    else {
+      if (ws["idx"].asUInt() == workspaces.size() && workspaces.size() == 1) {
+        style_context->remove_class("last");
+        style_context->add_class("solo");
+      }
+      else {
+        style_context->remove_class("last");
+        style_context->remove_class("solo");
+      }
+    }
     if (ws["output"]) {
       if (ws["output"].asString() == bar_.output->name)
         style_context->add_class("current_output");


### PR DESCRIPTION
Closes #3610

Was able to achieve this effect with

```css
#workspaces button {
	margin-top: 4px;
	margin-bottom: 0px;
	padding: 0 7px;
	border-radius: 0;
	background: #1f1d2e;
	color: #6e6a86;
	transition: color 0.2s ease-in-out;
}

#workspaces button.first {
	padding-left: 12px;
	border-radius: 10px 0 0 10px;
	margin-left: 8px;
}

#workspaces button.last {
	padding-right: 12px;
	border-radius: 0 10px 10px 0;
}

#workspaces button.solo {
	border-radius: 10px;
	padding: 0 12px;
	margin-left: 8px;
	border-radius: 10px;
}

#workspaces button.active {
	color: #e0def4;
	background: #1f1d2e;
}
```

![image](https://github.com/user-attachments/assets/c730acfd-cebd-4ee5-9184-38bb60c32587)

[Video_2024-09-15_17-10-02.webm](https://github.com/user-attachments/assets/828ee418-613c-4c44-9a75-1e5b3ebd6dff)
