### PR TITLE
fix(custom): stop mixing manual and automatic arg indexing

### DIFF
--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -55,8 +55,8 @@ Addressed by *custom/<name>*
 
 *format*: ++
 	typeof: string ++
-	default: {} ++
-	The format, how information should be displayed. On {} data gets inserted.
+	default: {text} ++
+	The format, how information should be displayed. On {text} data gets inserted.
 
 *format-icons*: ++
 	typeof: array ++
@@ -160,7 +160,7 @@ $text\\n$tooltip\\n$class*
 
 # FORMAT REPLACEMENTS
 
-*{}*: Output of the script.
+*{text}*: Output of the script.
 
 *{percentage}* Percentage which can be set via a json return type.
 
@@ -172,7 +172,7 @@ $text\\n$tooltip\\n$class*
 
 ```
 "custom/spotify": {
-	"format": " {}",
+	"format": " {text}",
 	"max-length": 40,
 	"interval": 30, // Remove this if your script is endless and write in loop
 	"exec": "$HOME/.config/waybar/mediaplayer.sh 2> /dev/null", // Script in resources folder
@@ -185,7 +185,7 @@ $text\\n$tooltip\\n$class*
 
 ```
 "custom/mpd": {
-	"format": "♪ {}",
+	"format": "♪ {text}",
 	//"max-length": 15,
 	"interval": 10,
 	"exec": "mpc current",
@@ -199,7 +199,7 @@ $text\\n$tooltip\\n$class*
 
 ```
 "custom/cmus": {
-	"format": "♪ {}",
+	"format": "♪ {text}",
 	//"max-length": 15,
 	"interval": 10,
 	"exec": "cmus-remote -C \"format_print '%a - %t'\"", // artist - title
@@ -214,7 +214,7 @@ $text\\n$tooltip\\n$class*
 ```
 
 "custom/pacman": {
-	"format": "{}  ",
+	"format": "{text}  ",
 	"interval": "once",
 	"exec": "pacman_packages",
 	"on-click": "update-system",
@@ -226,7 +226,7 @@ $text\\n$tooltip\\n$class*
 
 ```
 "custom/pacman": {
-	"format": "{}  ",
+	"format": "{text}  ",
 	"interval": 3600,                     // every hour
 	"exec": "checkupdates | wc -l",       // # of updates
 	"exec-if": "exit 0",                  // always run; consider advanced run conditions

--- a/resources/config.jsonc
+++ b/resources/config.jsonc
@@ -189,7 +189,7 @@
         "on-click": "pavucontrol"
     },
     "custom/media": {
-        "format": "{icon} {}",
+        "format": "{icon} {text}",
         "return-type": "json",
         "max-length": 40,
         "format-icons": {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -170,9 +170,9 @@ auto waybar::modules::Custom::update() -> void {
         if (tooltipEnabled()) {
           if (tooltip_format_enabled_) {
             auto tooltip = config_["tooltip-format"].asString();
-            tooltip = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
-                                  fmt::arg("alt", alt_), fmt::arg("icon", getIcon(percentage_, alt_)),
-                                  fmt::arg("percentage", percentage_));
+            tooltip = fmt::format(
+                fmt::runtime(tooltip), fmt::arg("text", text_), fmt::arg("alt", alt_),
+                fmt::arg("icon", getIcon(percentage_, alt_)), fmt::arg("percentage", percentage_));
             label_.set_tooltip_markup(tooltip);
           } else if (text_ == tooltip_) {
             if (label_.get_tooltip_markup() != str) {
@@ -202,8 +202,9 @@ auto waybar::modules::Custom::update() -> void {
       if (std::strcmp(e.what(), "cannot switch from manual to automatic argument indexing") != 0)
         throw;
 
-      throw fmt::format_error("mixing manual and automatic argument indexing is no longer supported; "
-                               "try replacing \"{}\" with \"{text}\" in your format specifier");
+      throw fmt::format_error(
+          "mixing manual and automatic argument indexing is no longer supported; "
+          "try replacing \"{}\" with \"{text}\" in your format specifier");
     }
   }
   // Call parent update

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -159,43 +159,51 @@ auto waybar::modules::Custom::update() -> void {
       parseOutputRaw();
     }
 
-    auto str = fmt::format(fmt::runtime(format_), fmt::arg("text", text_), fmt::arg("alt", alt_),
-                           fmt::arg("icon", getIcon(percentage_, alt_)),
-                           fmt::arg("percentage", percentage_));
-    if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
-      event_box_.hide();
-    } else {
-      label_.set_markup(str);
-      if (tooltipEnabled()) {
-        if (tooltip_format_enabled_) {
-          auto tooltip = config_["tooltip-format"].asString();
-          tooltip = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
-                                fmt::arg("alt", alt_), fmt::arg("icon", getIcon(percentage_, alt_)),
-                                fmt::arg("percentage", percentage_));
-          label_.set_tooltip_markup(tooltip);
-        } else if (text_ == tooltip_) {
-          if (label_.get_tooltip_markup() != str) {
-            label_.set_tooltip_markup(str);
-          }
-        } else {
-          if (label_.get_tooltip_markup() != tooltip_) {
-            label_.set_tooltip_markup(tooltip_);
+    try {
+      auto str = fmt::format(fmt::runtime(format_), fmt::arg("text", text_), fmt::arg("alt", alt_),
+                             fmt::arg("icon", getIcon(percentage_, alt_)),
+                             fmt::arg("percentage", percentage_));
+      if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
+        event_box_.hide();
+      } else {
+        label_.set_markup(str);
+        if (tooltipEnabled()) {
+          if (tooltip_format_enabled_) {
+            auto tooltip = config_["tooltip-format"].asString();
+            tooltip = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
+                                  fmt::arg("alt", alt_), fmt::arg("icon", getIcon(percentage_, alt_)),
+                                  fmt::arg("percentage", percentage_));
+            label_.set_tooltip_markup(tooltip);
+          } else if (text_ == tooltip_) {
+            if (label_.get_tooltip_markup() != str) {
+              label_.set_tooltip_markup(str);
+            }
+          } else {
+            if (label_.get_tooltip_markup() != tooltip_) {
+              label_.set_tooltip_markup(tooltip_);
+            }
           }
         }
+        auto style = label_.get_style_context();
+        auto classes = style->list_classes();
+        for (auto const& c : classes) {
+          if (c == id_) continue;
+          style->remove_class(c);
+        }
+        for (auto const& c : class_) {
+          style->add_class(c);
+        }
+        style->add_class("flat");
+        style->add_class("text-button");
+        style->add_class(MODULE_CLASS);
+        event_box_.show();
       }
-      auto style = label_.get_style_context();
-      auto classes = style->list_classes();
-      for (auto const& c : classes) {
-        if (c == id_) continue;
-        style->remove_class(c);
-      }
-      for (auto const& c : class_) {
-        style->add_class(c);
-      }
-      style->add_class("flat");
-      style->add_class("text-button");
-      style->add_class(MODULE_CLASS);
-      event_box_.show();
+    } catch (const fmt::format_error& e) {
+      if (std::strcmp(e.what(), "cannot switch from manual to automatic argument indexing") != 0)
+        throw;
+
+      throw fmt::format_error("mixing manual and automatic argument indexing is no longer supported; "
+                               "try replacing \"{}\" with \"{text}\" in your format specifier");
     }
   }
   // Call parent update

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -159,7 +159,9 @@ auto waybar::modules::Custom::update() -> void {
       parseOutputRaw();
     }
 
-    auto str = fmt::format(fmt::runtime(format_), text_, fmt::arg("alt", alt_),
+    auto str = fmt::format(fmt::runtime(format_),
+                           fmt::arg("text", text_),
+                           fmt::arg("alt", alt_),
                            fmt::arg("icon", getIcon(percentage_, alt_)),
                            fmt::arg("percentage", percentage_));
     if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
@@ -169,7 +171,9 @@ auto waybar::modules::Custom::update() -> void {
       if (tooltipEnabled()) {
         if (tooltip_format_enabled_) {
           auto tooltip = config_["tooltip-format"].asString();
-          tooltip = fmt::format(fmt::runtime(tooltip), text_, fmt::arg("alt", alt_),
+          tooltip = fmt::format(fmt::runtime(tooltip),
+                                fmt::arg("text", text_),
+                                fmt::arg("alt", alt_),
                                 fmt::arg("icon", getIcon(percentage_, alt_)),
                                 fmt::arg("percentage", percentage_));
           label_.set_tooltip_markup(tooltip);

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -159,9 +159,7 @@ auto waybar::modules::Custom::update() -> void {
       parseOutputRaw();
     }
 
-    auto str = fmt::format(fmt::runtime(format_),
-                           fmt::arg("text", text_),
-                           fmt::arg("alt", alt_),
+    auto str = fmt::format(fmt::runtime(format_), fmt::arg("text", text_), fmt::arg("alt", alt_),
                            fmt::arg("icon", getIcon(percentage_, alt_)),
                            fmt::arg("percentage", percentage_));
     if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
@@ -171,10 +169,8 @@ auto waybar::modules::Custom::update() -> void {
       if (tooltipEnabled()) {
         if (tooltip_format_enabled_) {
           auto tooltip = config_["tooltip-format"].asString();
-          tooltip = fmt::format(fmt::runtime(tooltip),
-                                fmt::arg("text", text_),
-                                fmt::arg("alt", alt_),
-                                fmt::arg("icon", getIcon(percentage_, alt_)),
+          tooltip = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
+                                fmt::arg("alt", alt_), fmt::arg("icon", getIcon(percentage_, alt_)),
                                 fmt::arg("percentage", percentage_));
           label_.set_tooltip_markup(tooltip);
         } else if (text_ == tooltip_) {


### PR DESCRIPTION
The current documentation for the custom module suggests mixing manual (`{icon}`) and automatic (`{}`) indexing of format args. Newer versions of the fmt library seem to not support this anymore (see issue #3605).

This commit introduces a name for the `text` output of the script, so that `{text}` can now be used instead of `{}` in the configuration. The documentation in the wiki should be updated upon rolling out this change.

An alternative way would be to just replace `{}` with `{0}` in the documentation, then this pull request wouldn’t be required.