### PR TITLE
#2275  Backlight: Add minimum brightness

### DIFF
--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -81,6 +81,11 @@ The *backlight* module displays the current backlight level.
 	default: 1.0 ++
 	The speed at which to change the brightness when scrolling.
 
+*min-brightness*: ++
+	typeof: double ++
+	default: 10.0 ++
+	The minimum brightness of the backlight.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.

--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -83,7 +83,7 @@ The *backlight* module displays the current backlight level.
 
 *min-brightness*: ++
 	typeof: double ++
-	default: 10.0 ++
+	default: 0.0 ++
 	The minimum brightness of the backlight.
 
 *menu*: ++

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -112,7 +112,7 @@ bool waybar::modules::Backlight::handleScroll(GdkEventScroll *e) {
     step = config_["scroll-step"].asDouble();
   }
 
-  double min_brightness = 10;
+  double min_brightness = 0;
   if (config_["min-brightness"].isDouble()) {
     min_brightness = config_["min-brightness"].asDouble();
   }

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -112,6 +112,14 @@ bool waybar::modules::Backlight::handleScroll(GdkEventScroll *e) {
     step = config_["scroll-step"].asDouble();
   }
 
+  double min_brightness = 10;
+  if (config_["min-brightness"].isDouble()) {
+    min_brightness = config_["min-brightness"].asDouble();
+  }
+  if (backend.get_scaled_brightness(preferred_device_) <= min_brightness &&
+      ct == util::ChangeType::Decrease) {
+    return true;
+  }
   backend.set_brightness(preferred_device_, ct, step);
 
   return true;


### PR DESCRIPTION
As currently it is possible to turn the brightness to zero which may not be desirable, this patch add a configurable brightness check.