### PR TITLE
nix: remove patches from downstream

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,9 @@ in
 
     mesonFlags = lib.remove "-Dgtk-layer-shell=enabled" oldAttrs.mesonFlags;
 
+    # downstream patch should not affect upstream
+    patches = [];
+
     buildInputs = (builtins.filter (p: p.pname != "wireplumber") oldAttrs.buildInputs) ++ [
         pkgs.wireplumber
     ];


### PR DESCRIPTION
Tested by add it to my nixos config.

The patches is the modification of downstream, it should not affect upstream. Any changes of upstream would caused patch fail. 

There are few person to maintain nix here I guess since the conflict has been existed for 1 week(from last time the flake.lock update), so I keep use overrideAttrs from nixpkgs in order to reduce the need of maintain.

Close #3639.