### PR TITLE
cava bump

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -482,7 +482,7 @@ if get_option('experimental')
 endif
 
 cava = dependency('cava',
-                  version : '>=0.10.2',
+                  version : '>=0.10.3',
                   required: get_option('cava'),
                   fallback : ['cava', 'cava_dep'],
                   not_found_message: 'cava is not found. Building waybar without cava')

--- a/subprojects/cava.wrap
+++ b/subprojects/cava.wrap
@@ -1,7 +1,7 @@
 [wrap-file]
-directory = cava-0.10.2
-source_url = https://github.com/LukashonakV/cava/archive/0.10.2.tar.gz
-source_filename = cava-0.10.2.tar.gz
-source_hash = dff78c4787c9843583086408a0a6e5bde7a5dee1fa17ae526847366846cb19c3
+directory = cava-0.10.3
+source_url = https://github.com/LukashonakV/cava/archive/0.10.3.tar.gz
+source_filename = cava-0.10.3.tar.gz
+source_hash = aab0a4ed3f999e8461ad9de63ef8a77f28b6b2011f7dd0c69ba81819d442f6f9
 [provide]
 cava = cava_dep


### PR DESCRIPTION
Hi @Alexays 
1. libcava is synced with upstream. Some critical things are fixed.
2. The problem with loading of the cava config rigth from waybar config is solved.
```json
"cava": {
        "cava_config": "$XDG_CONFIG_HOME/cava/waybar_cava.conf",
        "format-icons" : ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" ],
        "actions": {
                   "on-click-right": "mode"
                   }
    },
```
Such configuration now on my machine works well
So it should solve issues like: #3314, #3276 