### PR TITLE
nix/default: cava bump

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -5,12 +5,12 @@
 }:
 let
   libcava = rec {
-    version = "0.10.2";
+    version = "0.10.3";
     src = pkgs.fetchFromGitHub {
       owner = "LukashonakV";
       repo = "cava";
       rev = version;
-      hash = "sha256-jU7RQV2txruu/nUUl0TzjK4nai7G38J1rcTjO7UXumY=";
+      hash = "sha256-ZDFbI69ECsUTjbhlw2kHRufZbQMu+FQSMmncCJ5pagg=";
     };
   };
 in


### PR DESCRIPTION
Follow up to https://github.com/Alexays/Waybar/pull/3646, fixes the nix flake build.