### PR TITLE
.github/workflows: don't run on forks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    if: github.repository == 'Alexays/Waybar'
     strategy:
       fail-fast: false # don't fail the other jobs if one of the images fails to build
       matrix:

--- a/.github/workflows/nix-update-flake-lock.yml
+++ b/.github/workflows/nix-update-flake-lock.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   lockfile:
     runs-on: ubuntu-latest
+    if: github.repository == 'Alexays/Waybar'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Limits the scheduled build and push and flake update CI to not run on forks since they just create failure noise. 