### PR TITLE
.github/workflows: allow forks to manually run flake lock update

### DIFF
--- a/.github/workflows/nix-update-flake-lock.yml
+++ b/.github/workflows/nix-update-flake-lock.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   lockfile:
     runs-on: ubuntu-latest
-    if: github.repository == 'Alexays/Waybar'
+    if: github.event_name != 'schedule' || github.repository == 'Alexays/Waybar'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Follow up to https://github.com/Alexays/Waybar/pull/3651 since it sounded like https://github.com/Alexays/Waybar/pull/3651#discussion_r1779728761 some contributors find it useful to run it in their forks