### PR TITLE
Signal handling fixes

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -15,11 +15,16 @@ struct zwp_idle_inhibit_manager_v1;
 
 namespace waybar {
 
-class Client {
+class Client : public sigc::trackable {
  public:
   static Client *inst();
   int main(int argc, char *argv[]);
-  void reset();
+
+  /* signal handlers */
+  void handleSignal(int signum);
+  void reload(int signum = 0);
+  void toggle(int signum = 0);
+  void quit(int signum = 0);
 
   Glib::RefPtr<Gtk::Application> gtk_app;
   Glib::RefPtr<Gdk::Display> gdk_display;
@@ -54,8 +59,11 @@ class Client {
   Glib::RefPtr<Gtk::CssProvider> css_provider_;
   std::unique_ptr<Portal> portal;
   std::list<struct waybar_output> outputs_;
+  sigc::connection output_added_, output_removed_;
   std::unique_ptr<CssReloadHelper> m_cssReloadHelper;
   std::string m_cssFile;
+  std::string config_opt_;
+  std::string style_opt_;
 };
 
 }  // namespace waybar

--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -15,8 +15,7 @@
 
 #include <array>
 
-extern std::mutex reap_mtx;
-extern std::list<pid_t> reap;
+#include "util/unix_signal.hpp"
 
 namespace waybar::util::command {
 
@@ -160,9 +159,7 @@ inline int32_t forkExec(const std::string& cmd) {
     execl("/bin/sh", "sh", "-c", cmd.c_str(), (char*)0);
     exit(0);
   } else {
-    reap_mtx.lock();
-    reap.push_back(pid);
-    reap_mtx.unlock();
+    signal_handler.addChild(pid);
     spdlog::debug("Added child to reap list: {}", pid);
   }
 

--- a/include/util/unix_signal.hpp
+++ b/include/util/unix_signal.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <csignal>
+#include <list>
+#include <map>
+#include <mutex>
+#include <thread>
+
+#include "util/SafeSignal.hpp"
+
+namespace waybar {
+
+class UnixSignalHandler {
+ public:
+  class SignalProxy : private sigc::signal<void(int)> {
+   public:
+    friend class UnixSignalHandler;
+
+    using sigc::signal<void(int)>::connect;
+  };
+
+  UnixSignalHandler();
+  ~UnixSignalHandler();
+
+  void addChild(pid_t pid);
+  SignalProxy& signal(int signum);
+
+  void start();
+
+ private:
+  void run();
+
+  sigset_t mask_;
+  std::thread thread_;
+  std::mutex reap_mtx_;
+  std::list<pid_t> reap_;
+  std::atomic<bool> running_;
+
+  SafeSignal<int> signal_;
+  std::map<int, SignalProxy> handlers_;
+};
+
+}  // namespace waybar
+
+extern waybar::UnixSignalHandler signal_handler;

--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,8 @@ src_files = files(
     'src/util/rewrite_string.cpp',
     'src/util/gtk_icon.cpp',
     'src/util/regex_collection.cpp',
-    'src/util/css_reload_helper.cpp'
+    'src/util/css_reload_helper.cpp',
+    'src/util/unix_signal.cpp',
 )
 
 man_files = files(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,105 +1,41 @@
 #include <spdlog/spdlog.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-
-#include <csignal>
-#include <list>
-#include <mutex>
 
 #include "client.hpp"
+#include "util/unix_signal.hpp"
 
-std::mutex reap_mtx;
-std::list<pid_t> reap;
 volatile bool reload;
-
-void* signalThread(void* args) {
-  int err;
-  int signum;
-  sigset_t mask;
-  sigemptyset(&mask);
-  sigaddset(&mask, SIGCHLD);
-
-  while (true) {
-    err = sigwait(&mask, &signum);
-    if (err != 0) {
-      spdlog::error("sigwait failed: {}", strerror(errno));
-      continue;
-    }
-
-    switch (signum) {
-      case SIGCHLD:
-        spdlog::debug("Received SIGCHLD in signalThread");
-        if (!reap.empty()) {
-          reap_mtx.lock();
-          for (auto it = reap.begin(); it != reap.end(); ++it) {
-            if (waitpid(*it, nullptr, WNOHANG) == *it) {
-              spdlog::debug("Reaped child with PID: {}", *it);
-              it = reap.erase(it);
-            }
-          }
-          reap_mtx.unlock();
-        }
-        break;
-      default:
-        spdlog::debug("Received signal with number {}, but not handling", signum);
-        break;
-    }
-  }
-}
-
-void startSignalThread() {
-  int err;
-  sigset_t mask;
-  sigemptyset(&mask);
-  sigaddset(&mask, SIGCHLD);
-
-  // Block SIGCHLD so it can be handled by the signal thread
-  // Any threads created by this one (the main thread) should not
-  // modify their signal mask to unblock SIGCHLD
-  err = pthread_sigmask(SIG_BLOCK, &mask, nullptr);
-  if (err != 0) {
-    spdlog::error("pthread_sigmask failed in startSignalThread: {}", strerror(err));
-    exit(1);
-  }
-
-  pthread_t thread_id;
-  err = pthread_create(&thread_id, nullptr, signalThread, nullptr);
-  if (err != 0) {
-    spdlog::error("pthread_create failed in startSignalThread: {}", strerror(err));
-    exit(1);
-  }
-}
+waybar::UnixSignalHandler signal_handler;
 
 int main(int argc, char* argv[]) {
   try {
     auto* client = waybar::Client::inst();
 
-    std::signal(SIGUSR1, [](int /*signal*/) {
+    signal_handler.signal(SIGUSR1).connect([](int /*signal*/) {
       for (auto& bar : waybar::Client::inst()->bars) {
         bar->toggle();
       }
     });
 
-    std::signal(SIGUSR2, [](int /*signal*/) {
+    signal_handler.signal(SIGUSR2).connect([](int /*signal*/) {
       spdlog::info("Reloading...");
       reload = true;
       waybar::Client::inst()->reset();
     });
 
-    std::signal(SIGINT, [](int /*signal*/) {
+    signal_handler.signal(SIGINT).connect([](int /*signal*/) {
       spdlog::info("Quitting.");
       reload = false;
       waybar::Client::inst()->reset();
     });
 
     for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
-      std::signal(sig, [](int sig) {
+      signal_handler.signal(sig).connect([](int sig) {
         for (auto& bar : waybar::Client::inst()->bars) {
           bar->handleSignal(sig);
         }
       });
     }
-    startSignalThread();
+    signal_handler.start();
 
     auto ret = 0;
     do {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,46 +3,21 @@
 #include "client.hpp"
 #include "util/unix_signal.hpp"
 
-volatile bool reload;
 waybar::UnixSignalHandler signal_handler;
 
 int main(int argc, char* argv[]) {
   try {
     auto* client = waybar::Client::inst();
 
-    signal_handler.signal(SIGUSR1).connect([](int /*signal*/) {
-      for (auto& bar : waybar::Client::inst()->bars) {
-        bar->toggle();
-      }
-    });
-
-    signal_handler.signal(SIGUSR2).connect([](int /*signal*/) {
-      spdlog::info("Reloading...");
-      reload = true;
-      waybar::Client::inst()->reset();
-    });
-
-    signal_handler.signal(SIGINT).connect([](int /*signal*/) {
-      spdlog::info("Quitting.");
-      reload = false;
-      waybar::Client::inst()->reset();
-    });
-
+    signal_handler.signal(SIGUSR1).connect(sigc::mem_fun(*client, &waybar::Client::toggle));
+    signal_handler.signal(SIGUSR2).connect(sigc::mem_fun(*client, &waybar::Client::reload));
+    signal_handler.signal(SIGINT).connect(sigc::mem_fun(*client, &waybar::Client::quit));
     for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
-      signal_handler.signal(sig).connect([](int sig) {
-        for (auto& bar : waybar::Client::inst()->bars) {
-          bar->handleSignal(sig);
-        }
-      });
+      signal_handler.signal(sig).connect(sigc::mem_fun(*client, &waybar::Client::handleSignal));
     }
     signal_handler.start();
 
-    auto ret = 0;
-    do {
-      reload = false;
-      ret = client->main(argc, argv);
-    } while (reload);
-
+    auto ret = client->main(argc, argv);
     delete client;
     return ret;
   } catch (const std::exception& e) {

--- a/src/util/unix_signal.cpp
+++ b/src/util/unix_signal.cpp
@@ -1,0 +1,102 @@
+#include "util/unix_signal.hpp"
+
+#include <spdlog/spdlog.h>
+#include <sys/wait.h>
+
+#include <stdexcept>
+
+#include "util/format.hpp"
+
+namespace waybar {
+
+UnixSignalHandler::UnixSignalHandler() {
+  sigemptyset(&mask_);
+  /* Always handle SIGCHLD */
+  sigaddset(&mask_, SIGCHLD);
+
+  signal_.connect([this](int signum) {
+    try {
+      if (auto it = handlers_.find(signum); it != handlers_.end()) {
+        it->second(signum);
+      }
+    } catch (const std::exception& e) {
+      spdlog::error("Error handling signal {}: {}", signum, e.what());
+    } catch (const Glib::Exception& e) {
+      spdlog::error("Error handling signal {}: {}", signum, e.what());
+    }
+  });
+}
+
+void UnixSignalHandler::addChild(pid_t pid) {
+  std::unique_lock lock{reap_mtx_};
+  reap_.emplace_back(pid);
+}
+
+UnixSignalHandler::SignalProxy& UnixSignalHandler::signal(int signum) {
+  if (thread_.joinable() && (sigismember(&mask_, signum) == 0)) {
+    /*
+     * At this point we may have more threads running with the original sigmask,
+     * and it's too late to block new signals for them.
+     */
+    throw std::runtime_error("Cannot add signal to already running signal thread");
+  }
+
+  sigaddset(&mask_, signum);
+  return handlers_[signum];
+}
+
+void UnixSignalHandler::start() {
+  // Block signals so they can be handled by the signal thread
+  // Any threads created by this one (the main thread) should not
+  // modify their signal mask to unblock the handled signals
+  if (int err = pthread_sigmask(SIG_BLOCK, &mask_, nullptr); err != 0) {
+    spdlog::error("pthread_sigmask failed in UnixSignalHandler::start: {}", strerror(err));
+    exit(1);
+  }
+
+  running_ = true;
+  thread_ = std::thread([this]() { run(); });
+}
+
+UnixSignalHandler::~UnixSignalHandler() {
+  running_ = false;
+  if (thread_.joinable()) {
+    thread_.join();
+  }
+}
+
+void UnixSignalHandler::run() {
+  struct timespec timeout;
+  timeout.tv_sec = 0;
+  timeout.tv_nsec = 100 * 1000 * 1000;
+
+  while (running_) {
+    switch (int signum = sigtimedwait(&mask_, nullptr, &timeout)) {
+      case -1:
+        if (errno != EAGAIN && errno != EINTR) {
+          spdlog::error("sigtimedwait failed: {}", strerror(errno));
+        }
+        break;
+
+      case SIGCHLD: {
+        spdlog::debug("Received SIGCHLD in signal thread");
+
+        std::unique_lock lock{reap_mtx_};
+        for (auto it = reap_.begin(); it != reap_.end();) {
+          if (waitpid(*it, nullptr, WNOHANG) == *it) {
+            spdlog::debug("Reaped child with PID: {}", *it);
+            it = reap_.erase(it);
+          } else {
+            ++it;
+          }
+        }
+        break;
+      }
+      default:
+        signal_(signum);
+        break;
+    }
+  }
+}
+
+}  // namespace waybar


### PR DESCRIPTION
First draft. Tested on Linux with glibc only.

See individual commit descriptions for details.

TODOs:
- It should not be necessary to recreate the outputs. But the whole thing has so many races and weird things happen if I keep using the existing output list.
  Time to dig out my old work on reducing the number of `wl_display_roundtrip`s in the code.
- `CssReloadHelper` does not handle appearance changes and `.reset()` on reloads can be optimized.

Fixes: #3344 