### PR TITLE
Add signal to hide/show group

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -30,6 +30,7 @@ class Group : public AModule {
   bool handleMouseEnter(GdkEventCrossing *const &ev) override;
   bool handleMouseLeave(GdkEventCrossing *const &ev) override;
   bool handleToggle(GdkEventButton *const &ev) override;
+  void refresh(int sig) override;
   void show_group();
   void hide_group();
 };

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -120,6 +120,18 @@ bool Group::handleToggle(GdkEventButton* const& e) {
   return true;
 }
 
+void Group::refresh(int sig) {
+  if (click_to_reveal) {
+    if (sig == SIGRTMIN + config_["signal"].asInt()) {
+      if ((box.get_state_flags() & Gtk::StateFlags::STATE_FLAG_PRELIGHT) != 0U) {
+        hide_group();
+      } else {
+        show_group();
+      }
+    }
+  }
+}
+
 auto Group::update() -> void {
   // noop
 }


### PR DESCRIPTION
Added the "signal" field in the group class to toggle the visibility of the group without requiring a mouse click if "click-to-reveal" is set to true.