### PR TITLE
Fix parsing issue in hyprland language module with layouts containing commas

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -69,8 +69,14 @@ auto Language::update() -> void {
 
 void Language::onEvent(const std::string& ev) {
   std::lock_guard<std::mutex> lg(mutex_);
-  std::string kbName(begin(ev) + ev.find_last_of('>') + 1, begin(ev) + ev.find_first_of(','));
-  auto layoutName = ev.substr(ev.find_last_of(',') + 1);
+
+  auto separatorPos = ev.find_last_of('>');
+  std::string kbAndLayoutName = ev.substr(separatorPos + 1);
+
+  auto firstComma = kbAndLayoutName.find(',');
+
+  std::string kbName = kbAndLayoutName.substr(0, firstComma);
+  std::string layoutName = kbAndLayoutName.substr(firstComma + 1);
 
   if (config_.isMember("keyboard-name") && kbName != config_["keyboard-name"].asString())
     return;  // ignore


### PR DESCRIPTION
Problem: Since version 10.4, the hyprland language module had an issue with parsing keyboard layout names that contain commas. For example, the layout "English (intl., with AltGr dead keys)" would not be parsed correctly when switching layouts.

Issue: The IPC event string for a layout like "English (intl., with AltGr dead keys)" received in the onEvent function contains two commas—one separating the keyboard name from the layout name and another within the layout name. However, the function currently splits the string after the last comma, which leads to incorrect parsing.

Solution: This pull request modifies the onEvent function to split the event string at the first comma instead of the last one, allowing for accurate parsing of both the keyboard name and layout name.