### PR TITLE
UI module

### DIFF
--- a/include/modules/ui.hpp
+++ b/include/modules/ui.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "AModule.hpp"
+
+namespace waybar::modules {
+
+class UI final : public AModule {
+ public:
+  UI(const std::string&, const std::string&, const Json::Value&);
+  virtual ~UI() = default;
+};
+
+}  // namespace waybar::modules

--- a/meson.build
+++ b/meson.build
@@ -183,7 +183,8 @@ src_files = files(
     'src/util/rewrite_string.cpp',
     'src/util/gtk_icon.cpp',
     'src/util/regex_collection.cpp',
-    'src/util/css_reload_helper.cpp'
+    'src/util/css_reload_helper.cpp',
+    'src/modules/ui.cpp'
 )
 
 man_files = files(
@@ -541,6 +542,11 @@ install_data(
     'resources/config.jsonc',
     'resources/style.css',
     install_dir: sysconfdir / 'xdg/waybar'
+)
+
+install_subdir(
+    'resources/ui',
+     install_dir: sysconfdir / 'xdg/waybar'
 )
 
 scdoc = dependency('scdoc', version: '>=1.9.2', native: true, required: get_option('man-pages'))

--- a/resources/ui/ui-power.xml
+++ b/resources/ui/ui-power.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+    <requires lib="gtk+" version="3.22"/>
+    <menu id='waybar-power-menu'>
+        <section>
+            <item>
+                <attribute name='label' translatable='yes'>Suspend</attribute>
+                <attribute name='action'>ui-power.doAction</attribute>
+                <attribute name='target'>Suspend</attribute>
+            </item>
+            <item>
+                <attribute name='label' translatable='yes'>Hibernate</attribute>
+                <attribute name='action'>ui-power.doAction</attribute>
+                <attribute name='target'>Hibernate</attribute>
+            </item>
+            <item>
+                <attribute name='label' translatable='yes'>Shutdown</attribute>
+                <attribute name='action'>ui-power.doAction</attribute>
+                <attribute name='target'>Shutdown</attribute>
+            </item>
+        </section>
+        <section>
+            <item>
+                <attribute name='label' translatable='yes'>Reboot</attribute>
+                <attribute name='action'>ui-power.doAction</attribute>
+                <attribute name='target'>Reboot</attribute>
+            </item>
+        </section>
+    </menu>
+
+    <object class="GtkMenuButton" id="ui-power">
+        <property name="menu-model">waybar-power-menu</property>
+        <property name="tooltip-text" translatable="yes">Power menu</property>
+        <property name="label">⏻</property>
+        <property name="visible">true</property>
+        <property name="direction">GTK_ARROW_NONE</property>
+        <property name="use-popover">false</property>
+    </object>
+</interface>

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -113,6 +113,7 @@
 #include "modules/custom.hpp"
 #include "modules/image.hpp"
 #include "modules/temperature.hpp"
+#include "modules/ui.hpp"
 #include "modules/user.hpp"
 
 waybar::Factory::Factory(const Bar& bar, const Json::Value& config) : bar_(bar), config_(config) {}
@@ -340,6 +341,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
     }
     if (ref.compare(0, 5, "cffi/") == 0 && ref.size() > 5) {
       return new waybar::modules::CFFI(ref.substr(5), id, config_[name]);
+    }
+    if (ref.compare(0, 3, "ui/") == 0 && ref.size() > 3) {
+      return new waybar::modules::UI(ref.substr(3), id, config_[name]);
     }
   } catch (const std::exception& e) {
     auto err = fmt::format("Disabling module \"{}\", {}", name, e.what());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
 
     std::signal(SIGUSR1, SIG_IGN);
     std::signal(SIGUSR2, SIG_IGN);
-    std::signal(SIGINT,  SIG_IGN);
+    std::signal(SIGINT, SIG_IGN);
 
     delete client;
     return ret;

--- a/src/modules/ui.cpp
+++ b/src/modules/ui.cpp
@@ -1,0 +1,38 @@
+#include "modules/ui.hpp"
+
+#include <gtkmm/builder.h>
+#include <spdlog/spdlog.h>
+
+#include <util/command.hpp>
+
+waybar::modules::UI::UI(const std::string& name, const std::string& id, const Json::Value& config)
+    : AModule(config, "ui-" + name, id, false, false) {
+  if (config_["file-path"].isString()) {
+    Glib::RefPtr<Gtk::Builder> builder{
+        Gtk::Builder::create_from_file(config_["file-path"].asString())};
+    Glib::RefPtr<Gtk::Widget> uiWg{
+        Glib::RefPtr<Gtk::Widget>::cast_dynamic(builder->get_object(name_))};
+
+    if (uiWg) {
+      uiWg->set_name(name_);
+      if (!id.empty()) {
+        uiWg->get_style_context()->add_class(id);
+      }
+      uiWg->get_style_context()->add_class(MODULE_CLASS);
+
+      Glib::RefPtr<Gio::SimpleActionGroup> actionGroup{Gio::SimpleActionGroup::create()};
+      Glib::RefPtr<Gio::SimpleAction> action{actionGroup->add_action_with_parameter(
+          "doAction", Glib::VARIANT_TYPE_STRING, [this](const Glib::VariantBase& param) {
+            assert(param.is_of_type(Glib::VARIANT_TYPE_STRING));
+            waybar::util::command::res res = waybar::util::command::exec(
+                Glib::VariantBase::cast_dynamic<Glib::Variant<Glib::ustring>>(param).get(), "TLP");
+          })};
+
+      uiWg->insert_action_group(name_, actionGroup);
+      event_box_.add(*uiWg.get());
+    } else {
+      spdlog::error("UI: object id \"{}\" is not found at \"{}\"", name_,
+                    config_["file-path"].asString());
+    }
+  }
+}


### PR DESCRIPTION
Hi @Alexays , during routine on migration waybar from gtk3 to gtk4 and doing merging commits are left  I found a commit [884b909e](https://github.com/Alexays/Waybar/commit/884b909e7d4c8f670785ba3fac80ec931922ab50) whuch brings an opportunity to have a user defined menu. It looks a little bit strange to extend base AModule for that purpose. In gtk4 branch I realized another concept - separate UI module which brings an opportunity to construct UI elements is based on provided gtk builder xml specification. So in GTK4 branch I removed AModule extension and replaced it with the UI module. In current master branch I decided do not drop current implementation but just provide new functionality with the UI module. 