### PR TITLE
Fixed a typo in power_menu.xml and reformat example

### DIFF
--- a/man/waybar-menu.5.scd
+++ b/man/waybar-menu.5.scd
@@ -91,8 +91,8 @@ Module config :
 		"menu": "on-click",
 		"menu-file": "~/.config/waybar/power_menu.xml",
 		"menu-actions": {
-			"shutdown": "shutdown",
-			"reboot": "reboot",
+			"shutdown": "systemctl poweroff",
+			"reboot": "systemctl reboot",
 			"suspend": "systemctl suspend",
 			"hibernate": "systemctl hibernate",
 		},
@@ -104,28 +104,28 @@ Module config :
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <object class="GtkMenu" id="menu">
-	<child>
-		<object class="GtkMenuItem" id="suspend">
-			<property name="label">Suspend</property>
-        </object>
-	</child>
-	<child>
-        <object class="GtkMenuItem" id="hibernat">
-			<property name="label">Hibernate</property>
-        </object>
-	</child>
     <child>
-        <object class="GtkMenuItem" id="shutdown">
-			<property name="label">Shutdown</property>
-        </object>
+      <object class="GtkMenuItem" id="suspend">
+	<property name="label">Suspend</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="hibernate">
+	<property name="label">Hibernate</property>
+      </object>
+    </child>
+    <child>
+      <object class="GtkMenuItem" id="shutdown">
+	<property name="label">Shutdown</property>
+      </object>
     </child>
     <child>
       <object class="GtkSeparatorMenuItem" id="delimiter1"/>
     </child>
     <child>
-		<object class="GtkMenuItem" id="reboot">
-			<property name="label">Reboot</property>
-		</object>
+      <object class="GtkMenuItem" id="reboot">
+	<property name="label">Reboot</property>
+      </object>
     </child>
   </object>
 </interface>

--- a/man/waybar-menu.5.scd
+++ b/man/waybar-menu.5.scd
@@ -91,8 +91,8 @@ Module config :
 		"menu": "on-click",
 		"menu-file": "~/.config/waybar/power_menu.xml",
 		"menu-actions": {
-			"shutdown": "systemctl poweroff",
-			"reboot": "systemctl reboot",
+			"shutdown": "shutdown",
+			"reboot": "reboot",
 			"suspend": "systemctl suspend",
 			"hibernate": "systemctl hibernate",
 		},


### PR DESCRIPTION
~Unified `shutdown` and `reboot` commands to use the modern systemd approach, replacing legacy SysVinit-style commands. This aligns the entire menu with the standard for contemporary distributions, enhancing consistency.~

Formatted indentation in `power_menu.xml` for readability, converting mixed spaces and tabs to 2-space indentation for better display on small screens.

Fixed a typo in `power_menu.xml` by correcting `id="hibernat"` to `id="hibernate"`.