### PR TITLE
Add stretching of modules and  modules-center toggling

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -23,6 +23,8 @@ class AModule : public IModule {
   /// Emitting on this dispatcher triggers a update() call
   Glib::Dispatcher dp;
 
+  bool expandEnabled() const;
+
  protected:
   // Don't need to make an object directly
   // Derived classes are able to use it
@@ -50,6 +52,7 @@ class AModule : public IModule {
  private:
   bool handleUserEvent(GdkEventButton *const &ev);
   const bool isTooltip;
+  const bool isExpand;
   bool hasUserEvents_;
   std::vector<int> pid_;
   gdouble distance_scrolled_y_;

--- a/man/waybar-backlight-slider.5.scd
+++ b/man/waybar-backlight-slider.5.scd
@@ -31,6 +31,11 @@ The brightness can be controlled by dragging the slider across the bar or clicki
     typeof: string ++
     The name of the preferred device to control. If left empty, a device will be chosen automatically.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLES
 
 ```

--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -99,6 +99,11 @@ The *backlight* module displays the current backlight level.
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLE:
 
 ```

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -122,6 +122,11 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{capacity}*: Capacity in percentage

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -142,6 +142,11 @@ Addressed by *bluetooth*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{status}*: Status of the bluetooth device.

--- a/man/waybar-cffi.5.scd
+++ b/man/waybar-cffi.5.scd
@@ -15,6 +15,11 @@ Addressed by *cffi/<name>*
 	typeof: string ++
 	The path to the dynamic library to load to control the widget.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 Some additional configuration may be required depending on the cffi dynamic library being used.
 
 

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -96,6 +96,10 @@ $XDG_CONFIG_HOME/waybar/config ++
 :[ array
 :[
 :[ The actions corresponding to the buttons of the menu.
+|[ *expand*:
+:[ bool
+:[ false
+:[ Enables this module to consume all left over space dynamically.
 
 View all valid format options in *strftime(3)* or have a look https://en.cppreference.com/w/cpp/chrono/duration/formatter
 

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -82,6 +82,11 @@ The *cpu* module displays the current CPU utilization.
 	default: true ++
 	Option to disable tooltip on hover.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{load}*: Current CPU load.

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -138,6 +138,11 @@ Addressed by *custom/<name>*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # RETURN-TYPE
 
 When *return-type* is set to *json*, Waybar expects the *exec*-script  to output its data in JSON format.

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -106,6 +106,11 @@ Addressed by *disk*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{percentage_used}*: Percentage of disk in use.

--- a/man/waybar-dwl-tags.5.scd
+++ b/man/waybar-dwl-tags.5.scd
@@ -26,6 +26,11 @@ Addressed by *dwl/tags*
 	default: false ++
 	If set to false, you can left-click to set focused tag. Right-click to toggle tag focus. If set to true this behaviour is disabled.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLE
 
 ```

--- a/man/waybar-dwl-window.5.scd
+++ b/man/waybar-dwl-window.5.scd
@@ -84,6 +84,11 @@ Addressed by *dwl/window*
 	default: 24 ++
 	Option to change the size of the application icon.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{title}*: The title of the focused window.

--- a/man/waybar-gamemode.5.scd
+++ b/man/waybar-gamemode.5.scd
@@ -61,6 +61,11 @@ Feral Gamemode optimizations.
 	default: 4 ++
 	Defines the spacing between the icon and the text.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{glyph}*: The string icon glyph to use instead.

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -38,6 +38,11 @@ Addressed by *hyprland/language*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 
 # FORMAT REPLACEMENTS
 

--- a/man/waybar-hyprland-submap.5.scd
+++ b/man/waybar-hyprland-submap.5.scd
@@ -93,6 +93,11 @@ Addressed by *hyprland/submap*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 
 # EXAMPLES
 

--- a/man/waybar-hyprland-window.5.scd
+++ b/man/waybar-hyprland-window.5.scd
@@ -35,6 +35,11 @@ Addressed by *hyprland/window*
 	default: 24 ++
 	Option to change the size of the application icon.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 See the output of "hyprctl clients" for examples
 

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -78,6 +78,11 @@ Addressed by *hyprland/workspaces*
 	If set to id, workspaces will sort by id.
 	If none of those, workspaces will sort with default behavior.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{id}*: id of workspace assigned by compositor

--- a/man/waybar-idle-inhibitor.5.scd
+++ b/man/waybar-idle-inhibitor.5.scd
@@ -102,6 +102,11 @@ screensaver, also known as "presentation mode".
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{status}*: status (*activated* or *deactivated*)

--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -64,6 +64,11 @@ The *image* module displays an image from a path.
 	default: true ++
 	Option to enable tooltip on hover.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # SCRIPT OUTPUT
 
 Similar to the *custom* module, output values of the script are *newline* separated.

--- a/man/waybar-inhibitor.5.scd
+++ b/man/waybar-inhibitor.5.scd
@@ -89,6 +89,11 @@ See *systemd-inhibit*(1) for more information.
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{status}*: status (*activated* or *deactivated*)

--- a/man/waybar-jack.5.scd
+++ b/man/waybar-jack.5.scd
@@ -98,6 +98,11 @@ Addressed by *jack*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{load}*: The current CPU load estimated by JACK.

--- a/man/waybar-keyboard-state.5.scd
+++ b/man/waybar-keyboard-state.5.scd
@@ -53,6 +53,11 @@ You must be a member of the input group to use this module.
 	default: [58, 69, 70] ++
 	Customize the key to trigger this module, the key number can be found in /usr/include/linux/input-event-codes.h or running sudo libinput debug-events --show-keycodes.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{name}*: Caps, Num, or Scroll.

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -97,6 +97,11 @@ Addressed by *memory*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{percentage}*: Percentage of memory in use.

--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -175,6 +175,11 @@ Addressed by *mpd*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 ## WHEN PLAYING/PAUSED

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -148,6 +148,11 @@ The *mpris* module displays currently playing media via libplayerctl.
 	typeof: map[string]string ++
 	Allows setting _{status_icon}_ based on player status (playing, paused, stopped).
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 
 # FORMAT REPLACEMENTS
 

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -142,6 +142,11 @@ Addressed by *network*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{ifname}*: Name of the network interface.

--- a/man/waybar-niri-language.5.scd
+++ b/man/waybar-niri-language.5.scd
@@ -33,6 +33,11 @@ Addressed by *niri/language*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{short}*: Short name of layout (e.g. "us"). Equals to {}.

--- a/man/waybar-niri-window.5.scd
+++ b/man/waybar-niri-window.5.scd
@@ -35,6 +35,11 @@ Addressed by *niri/window*
 	default: 24 ++
 	Option to change the size of the application icon.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 See the output of "niri msg windows" for examples

--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -45,6 +45,11 @@ Addressed by *niri/workspaces*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{value}*: Name of the workspace, or index for unnamed workspaces,

--- a/man/waybar-power-profiles-daemon.5.scd
+++ b/man/waybar-power-profiles-daemon.5.scd
@@ -35,6 +35,13 @@ $XDG_CONFIG_HOME/waybar/config
 :[ object
 :[ See default value in the example below.
 :[ Icons used to represent the various power-profile. *Note*: the default configuration uses the font-awesome icons. You may want to override it if you don't have this font installed on your system.
+|[ *expand*:
+:[ bool
+:[ false
+:[ Enables this module to consume all left over space dynamically.
+
+
+
 
 
 # CONFIGURATION EXAMPLES

--- a/man/waybar-privacy.5.scd
+++ b/man/waybar-privacy.5.scd
@@ -32,6 +32,11 @@ the screen or playing audio.
 	Which privacy modules to monitor. See *MODULES CONFIGURATION* for++
 	more information.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # MODULES CONFIGURATION
 
 *type*: ++

--- a/man/waybar-pulseaudio-slider.5.scd
+++ b/man/waybar-pulseaudio-slider.5.scd
@@ -27,6 +27,11 @@ The volume can be controlled by dragging the slider across the bar or clicking o
     default: horizontal ++
     The orientation of the slider. Can be either `horizontal` or `vertical`.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLES
 
 ```

--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -126,6 +126,11 @@ Additionally, you can control the volume by scrolling *up* or *down* while the c
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{desc}*: Pulseaudio port's description, for bluetooth it'll be the device name.

--- a/man/waybar-river-layout.5.scd
+++ b/man/waybar-river-layout.5.scd
@@ -64,6 +64,11 @@ Addressed by *river/layout*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLE
 
 ```

--- a/man/waybar-river-mode.5.scd
+++ b/man/waybar-river-mode.5.scd
@@ -78,6 +78,11 @@ Addressed by *river/mode*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLES
 
 ```

--- a/man/waybar-river-tags.5.scd
+++ b/man/waybar-river-tags.5.scd
@@ -26,6 +26,11 @@ Addressed by *river/tags*
 	default: false ++
 	If set to false, you can left-click to set focused tag. Right-click to toggle tag focus. If set to true this behaviour is disabled.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLE
 
 ```

--- a/man/waybar-river-window.5.scd
+++ b/man/waybar-river-window.5.scd
@@ -62,6 +62,11 @@ Addressed by *river/window*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLES
 
 ```

--- a/man/waybar-sndio.5.scd
+++ b/man/waybar-sndio.5.scd
@@ -87,6 +87,11 @@ cursor is over the module, and clicking on the module toggles mute.
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{volume}*: Volume in percentage.

--- a/man/waybar-sway-language.5.scd
+++ b/man/waybar-sway-language.5.scd
@@ -45,6 +45,11 @@ Addressed by *sway/language*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{short}*: Short name of layout (e.g. "us"). Equals to {}.

--- a/man/waybar-sway-mode.5.scd
+++ b/man/waybar-sway-mode.5.scd
@@ -83,6 +83,11 @@ Addressed by *sway/mode*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLES
 
 ```

--- a/man/waybar-sway-scratchpad.5.scd
+++ b/man/waybar-sway-scratchpad.5.scd
@@ -49,6 +49,11 @@ Addressed by *sway/scratchpad*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{icon}*: Icon, as defined in *format-icons*.

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -103,6 +103,11 @@ Addressed by *sway/window*
 	default: 24 ++
 	Option to change the size of the application icon.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{title}*: The title of the focused window.

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -99,6 +99,11 @@ warp-on-scroll: ++
 	default: " " ++
 	The separator to be used between windows in a workspace.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 
 # FORMAT REPLACEMENTS
 

--- a/man/waybar-systemd-failed-units.5.scd
+++ b/man/waybar-systemd-failed-units.5.scd
@@ -49,6 +49,11 @@ Addressed by *systemd-failed-units*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{nr_failed_system}*: Number of failed units from systemwide (PID=1) systemd.

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -132,6 +132,11 @@ Addressed by *temperature*
 	typeof: array ++
 	The actions corresponding to the buttons of the menu.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # FORMAT REPLACEMENTS
 
 *{temperatureC}*: Temperature in Celsius.

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -37,6 +37,11 @@ Addressed by *tray*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Enables this module to consume all left over space dynamically.
+
 # EXAMPLES
 
 ```

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -23,6 +23,21 @@ The visual display elements for waybar use a CSS stylesheet, see *waybar-styles(
 
 # BAR CONFIGURATION
 
+*expand-center* ++
+	typeof: bool ++
+	default: false ++
+	Enables the modules-center to consume all left over space dynamically.
+
+*expand-left* ++
+	typeof: bool ++
+	default: false ++
+	Enables the modules-left to consume all left over space dynamically.
+
+*expand-right* ++
+	typeof: bool ++
+	default: false ++
+	Enables the modules-left to consume all left over space dynamically.
+
 *layer* ++
 	typeof: string ++
 	default: bottom ++
@@ -67,6 +82,11 @@ The visual display elements for waybar use a CSS stylesheet, see *waybar-styles(
 *margin-<top\|left\|bottom\|right>* ++
 	typeof: integer ++
 	Margins value without units.
+
+*no-center* ++
+	typeof: bool ++
+	default: false ++
+	Option to disable the center modules fully usefull together with expand-\*.
 
 *spacing* ++
 	typeof: integer ++

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -15,6 +15,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
     : name_(name),
       config_(config),
       isTooltip{config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true},
+      isExpand{config_["expand"].isBool() ? config_["expand"].asBool() : false},
       distance_scrolled_y_(0.0),
       distance_scrolled_x_(0.0) {
   // Configure module action Map
@@ -273,6 +274,7 @@ bool AModule::handleScroll(GdkEventScroll* e) {
 }
 
 bool AModule::tooltipEnabled() const { return isTooltip; }
+bool AModule::expandEnabled() const { return isExpand; }
 
 AModule::operator Gtk::Widget&() { return event_box_; }
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -534,13 +534,22 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
 
 auto waybar::Bar::setupWidgets() -> void {
   window.add(box_);
-  box_.pack_start(left_, false, false);
-  if (config["fixed-center"].isBool() ? config["fixed-center"].asBool() : true) {
-    box_.set_center_widget(center_);
-  } else {
-    box_.pack_start(center_, true, false);
+
+  bool expand_left = config["expand-left"].isBool() ? config["expand-left"].asBool() : false;
+  bool expand_center = config["expand-center"].isBool() ? config["expand-center"].asBool() : false;
+  bool expand_right = config["expand-right"].isBool() ? config["expand-right"].asBool() : false;
+  bool no_center = config["no-center"].isBool() ? config["no-center"].asBool() : false;
+
+  box_.pack_start(left_, expand_left, expand_left);
+  if (!no_center) {
+    if (config["fixed-center"].isBool() ? config["fixed-center"].asBool() : true) {
+      box_.set_center_widget(center_);
+    } else {
+      spdlog::error("No fixed center_");
+      box_.pack_start(center_, true, expand_center);
+    }
   }
-  box_.pack_end(right_, false, false);
+  box_.pack_end(right_, expand_right, expand_right);
 
   // Convert to button code for every module that is used.
   setupAltFormatKeyForModuleList("modules-left");
@@ -549,14 +558,21 @@ auto waybar::Bar::setupWidgets() -> void {
 
   Factory factory(*this, config);
   getModules(factory, "modules-left");
-  getModules(factory, "modules-center");
+  if (!no_center) {
+    getModules(factory, "modules-center");
+  }
   getModules(factory, "modules-right");
+
   for (auto const& module : modules_left_) {
-    left_.pack_start(*module, false, false);
+    left_.pack_start(*module, module->expandEnabled(), module->expandEnabled());
   }
-  for (auto const& module : modules_center_) {
-    center_.pack_start(*module, false, false);
+
+  if (!no_center) {
+    for (auto const& module : modules_center_) {
+      center_.pack_start(*module, false, false);
+    }
   }
+
   std::reverse(modules_right_.begin(), modules_right_.end());
   for (auto const& module : modules_right_) {
     right_.pack_end(*module, false, false);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char* argv[]) {
 
     std::signal(SIGUSR1, SIG_IGN);
     std::signal(SIGUSR2, SIG_IGN);
-    std::signal(SIGINT,  SIG_IGN);
+    std::signal(SIGINT, SIG_IGN);
 
     delete client;
     return ret;

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -77,7 +77,7 @@ auto waybar::modules::Temperature::update() -> void {
   } else if (warning) {
     format = config_["format-warning"].isString() ? config_["format-warning"].asString() : format;
     label_.get_style_context()->add_class("warning");
-  } else        {
+  } else {
     label_.get_style_context()->remove_class("critical");
     label_.get_style_context()->remove_class("warning");
   }


### PR DESCRIPTION
This Patch allows the stretching of modules-{left,center,right} as well add a "expand" flag to AModule. This allows one module to consume the leftover space.
To allow the left or right modules to fully consume the center, the changes also include a way to remove the center box (center_) altogether.

This is useful for use-cases like: https://github.com/Alexays/Waybar/issues/1561