### PR TITLE
fix hyprland's grouped window flags

### DIFF
--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -191,12 +191,6 @@ void Window::queryActiveWorkspace() {
         solo_ = true;
       }
 
-      // Grouped windows have a tab bar and therefore don't look fullscreen or solo
-      if (windowData_.grouped) {
-        fullscreen_ = false;
-        solo_ = false;
-      }
-
       if (solo_) {
         soloClass_ = windowData_.class_name;
       } else {


### PR DESCRIPTION
Both flags are wrong, because:
- the active group member can be fullscreened.
- technically, a grouped window can be solo as well, because only the active group member is shown, the other members are hidden. Also, you can have a group consisting of only one member.

Fixes https://github.com/Alexays/Waybar/issues/3746