### PR TITLE
Add signals section to manpage

### DIFF
--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -181,6 +181,19 @@ A minimal *config* file could look like this:
 }
 ```
 
+# SIGNALS
+
+Waybar accepts the following signals:
+
+*SIGUSR1*
+	Toggles the bar visibility (hides if shown, shows if hidden)
+*SIGUSR2*
+	Reloads (resets) the bar
+*SIGINT*
+	Quits the bar
+
+For example, to toggle the bar programmatically, you can invoke `killall -SIGUSR1 waybar`.
+
 # MULTI OUTPUT CONFIGURATION
 
 ## Limit a configuration to some outputs


### PR DESCRIPTION
I could only find information on how to toggle the bar in a GitHub issue/discussion, so I added the signals that Waybar accepts in the manpage