### PR TITLE
fix null-deref due to unconstructed PrivacyNodeInfo

### DIFF
--- a/src/util/pipewire/pipewire_backend.cpp
+++ b/src/util/pipewire/pipewire_backend.cpp
@@ -126,6 +126,7 @@ void PipewireBackend::handleRegistryEventGlobal(uint32_t id, uint32_t permission
   if (proxy == nullptr) return;
 
   auto *pNodeInfo = (PrivacyNodeInfo *)pw_proxy_get_user_data(proxy);
+  new(pNodeInfo) PrivacyNodeInfo{};
   pNodeInfo->id = id;
   pNodeInfo->data = this;
   pNodeInfo->type = mediaType;
@@ -142,6 +143,7 @@ void PipewireBackend::handleRegistryEventGlobalRemove(uint32_t id) {
   mutex_.lock();
   auto iter = privacy_nodes.find(id);
   if (iter != privacy_nodes.end()) {
+    privacy_nodes[id]->~PrivacyNodeInfo();
     privacy_nodes.erase(id);
   }
   mutex_.unlock();


### PR DESCRIPTION
This would cause Waybar to crash if the privacy module ever got e.g. a empty (but properly null-terminated) string for the application_name.