### PR TITLE
fix mpd module hang after suspend

### DIFF
--- a/include/util/command.hpp
+++ b/include/util/command.hpp
@@ -50,7 +50,7 @@ inline int close(FILE* fp, pid_t pid) {
     ret = waitpid(pid, &stat, WCONTINUED | WUNTRACED);
 
     if (WIFEXITED(stat)) {
-      spdlog::debug("Cmd exited with code {}", WEXITSTATUS(stat));
+      spdlog::trace("Cmd exited with code {}", WEXITSTATUS(stat));
     } else if (WIFSIGNALED(stat)) {
       spdlog::debug("Cmd killed by {}", WTERMSIG(stat));
     } else if (WIFSTOPPED(stat)) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,7 @@ void* signalThread(void* args) {
 
     switch (signum) {
       case SIGCHLD:
-        spdlog::debug("Received SIGCHLD in signalThread");
+        spdlog::trace("Received SIGCHLD in signalThread");
         if (!reap.empty()) {
           reap_mtx.lock();
           for (auto it = reap.begin(); it != reap.end(); ++it) {

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -80,7 +80,15 @@ void Idle::exit() noexcept {
   }
 }
 
-bool Idle::on_io(Glib::IOCondition const&) {
+bool Idle::on_io(Glib::IOCondition const& condition) {
+  if (condition & Glib::IO_HUP || condition & Glib::IO_ERR) {
+    spdlog::debug("mpd: Idle: Error (IO_HUP or IO_ERR ), restarting connection");
+    idle_connection_.disconnect();
+    ctx_->connection().reset();
+    ctx_->setState(std::make_unique<Disconnected>(ctx_));
+    return false;
+  }
+
   auto conn = ctx_->connection().get();
 
   // callback should do this:


### PR DESCRIPTION
I've been having this annoying issue for a while, in which after waking up from a _long_ suspend the MPD module is not updating anymore.

Clicking the MPD module icon does trigger play/pause events but it does not show the active song anymore.

I think I finally manage to track it down to a broken idle connection, and this PR fixes the issue.

# How to reproduce

Run:

```bash
systemctl suspend
```

go get a beer, come back after a lot of time, and the MPD module will not update anymore.

If you don't have a lot of time, I managed to reproduce similar symptoms by killing the socket(s) using `ss`:

```bash
export MPD_HOST=<mpd host>
export MPD_PORT=<mpd port>
sudo ss -k "dst $MPD_HOST and dport $MPD_PORT" # WARNING: this will kill ALL connections to MPD_HOST:MPD_PORT
```

The mpd module will not update anymore, even though it responds to clicks.
