### PR TITLE
sway/workspaces: use X11 class for XWayland windows

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -88,6 +88,7 @@ warp-on-scroll: ++
 	Keys are the rules, while the values are the methods of representation.
 	Rules may specify `class<...>`, `title<...>`, or both in order to fine-tune the matching.
 	You may assign an empty value to a rule to have it ignored from generating any representation in workspaces.
+	For Wayland windows `class` is matched against the `app_id`, and for X11 windows against the `class` property.
 
 *window-rewrite-default*:
 	typeof: string ++

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -260,7 +260,9 @@ void Workspaces::updateWindows(const Json::Value &node, std::string &windows) {
   if ((node["type"].asString() == "con" || node["type"].asString() == "floating_con") &&
       node["name"].isString()) {
     std::string title = g_markup_escape_text(node["name"].asString().c_str(), -1);
-    std::string windowClass = node["app_id"].asString();
+    std::string windowClass = node["app_id"].isString()
+                                  ? node["app_id"].asString()
+                                  : node["window_properties"]["class"].asString();
 
     // Only add window rewrites that can be looked up
     if (!windowClass.empty()) {


### PR DESCRIPTION
When using `window-rewrite`, the `class<>` rule would previously only match against the `app_id` of a window. However, XWayland windows don't have an app ID, resulting in an empty string for the rewritten name.

This change falls back to checking the `class` window property if there is no app ID to support matching against XWayland windows.

Closes: #3020 