### PR TITLE
Using 'auto' instead of 'self' in backlight module

### DIFF
--- a/src/util/backlight_backend.cpp
+++ b/src/util/backlight_backend.cpp
@@ -153,7 +153,13 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
   // Connect to the login interface
   login_proxy_ = Gio::DBus::Proxy::create_for_bus_sync(
       Gio::DBus::BusType::BUS_TYPE_SYSTEM, "org.freedesktop.login1",
-      "/org/freedesktop/login1/session/self", "org.freedesktop.login1.Session");
+      "/org/freedesktop/login1/session/auto", "org.freedesktop.login1.Session");
+
+  if (!login_proxy_) {
+    login_proxy_ = Gio::DBus::Proxy::create_for_bus_sync(
+        Gio::DBus::BusType::BUS_TYPE_SYSTEM, "org.freedesktop.login1",
+        "/org/freedesktop/login1/session/self", "org.freedesktop.login1.Session");
+  }
 
   udev_thread_ = [this] {
     std::unique_ptr<udev, UdevDeleter> udev{udev_new()};


### PR DESCRIPTION
re-implementation of #3519 
fix #3302 

It works on my Arch Linux but I didn't test it comprehensively.