### PR TITLE
Let network module handle ipv4 and ipv6 simultaneously

### DIFF
--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -50,7 +50,6 @@ class Network : public ALabel {
   std::optional<std::pair<unsigned long long, unsigned long long>> readBandwidthUsage();
 
   int ifid_;
-  sa_family_t family_;
   struct sockaddr_nl nladdr_ = {0};
   struct nl_sock* sock_ = nullptr;
   struct nl_sock* ev_sock_ = nullptr;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -80,7 +80,6 @@ waybar::modules::Network::readBandwidthUsage() {
 waybar::modules::Network::Network(const std::string &id, const Json::Value &config)
     : ALabel(config, "network", id, DEFAULT_FORMAT, 60),
       ifid_(-1),
-      family_(config["family"] == "ipv6" ? AF_INET6 : AF_INET),
       efd_(-1),
       ev_fd_(-1),
       want_route_dump_(false),
@@ -141,12 +140,7 @@ waybar::modules::Network::~Network() {
     close(efd_);
   }
   if (ev_sock_ != nullptr) {
-    nl_socket_drop_membership(ev_sock_, RTNLGRP_LINK);
-    if (family_ == AF_INET) {
-      nl_socket_drop_membership(ev_sock_, RTNLGRP_IPV4_IFADDR);
-    } else {
-      nl_socket_drop_membership(ev_sock_, RTNLGRP_IPV6_IFADDR);
-    }
+    nl_socket_drop_memberships(ev_sock_, RTNLGRP_LINK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR);
     nl_close(ev_sock_);
     nl_socket_free(ev_sock_);
   }
@@ -161,7 +155,7 @@ void waybar::modules::Network::createEventSocket() {
   nl_socket_disable_seq_check(ev_sock_);
   nl_socket_modify_cb(ev_sock_, NL_CB_VALID, NL_CB_CUSTOM, handleEvents, this);
   nl_socket_modify_cb(ev_sock_, NL_CB_FINISH, NL_CB_CUSTOM, handleEventsDone, this);
-  auto groups = RTMGRP_LINK | (family_ == AF_INET ? RTMGRP_IPV4_IFADDR : RTMGRP_IPV6_IFADDR);
+  auto groups = RTMGRP_LINK | RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR;
   nl_join_groups(ev_sock_, groups);  // Deprecated
   if (nl_connect(ev_sock_, NETLINK_ROUTE) != 0) {
     throw std::runtime_error("Can't connect network socket");
@@ -169,18 +163,9 @@ void waybar::modules::Network::createEventSocket() {
   if (nl_socket_set_nonblocking(ev_sock_)) {
     throw std::runtime_error("Can't set non-blocking on network socket");
   }
-  nl_socket_add_membership(ev_sock_, RTNLGRP_LINK);
-  if (family_ == AF_INET) {
-    nl_socket_add_membership(ev_sock_, RTNLGRP_IPV4_IFADDR);
-  } else {
-    nl_socket_add_membership(ev_sock_, RTNLGRP_IPV6_IFADDR);
-  }
+  nl_socket_add_memberships(ev_sock_, RTNLGRP_LINK, RTNLGRP_IPV4_IFADDR, RTNLGRP_IPV6_IFADDR, 0);
   if (!config_["interface"].isString()) {
-    if (family_ == AF_INET) {
-      nl_socket_add_membership(ev_sock_, RTNLGRP_IPV4_ROUTE);
-    } else {
-      nl_socket_add_membership(ev_sock_, RTNLGRP_IPV6_ROUTE);
-    }
+    nl_socket_add_memberships(ev_sock_, RTNLGRP_IPV4_ROUTE, RTNLGRP_IPV6_ROUTE, 0);
   }
 
   efd_ = epoll_create1(EPOLL_CLOEXEC);
@@ -531,10 +516,6 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
         return NL_OK;
       }
 
-      if (ifa->ifa_family != net->family_) {
-        return NL_OK;
-      }
-
       // We ignore address mark as scope for the link or host,
       // which should leave scope global addresses.
       if (ifa->ifa_scope >= RT_SCOPE_LINK) {
@@ -591,6 +572,7 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
       // to find the interface used to reach the outside world
 
       struct rtmsg *rtm = static_cast<struct rtmsg *>(NLMSG_DATA(nh));
+      int family = rtm->rtm_family;
       ssize_t attrlen = RTM_PAYLOAD(nh);
       struct rtattr *attr = RTM_RTA(rtm);
       bool has_gateway = false;
@@ -618,14 +600,14 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
              * If someone ever needs to figure out the gateway address as well,
              * it's here as the attribute payload.
              */
-            inet_ntop(net->family_, RTA_DATA(attr), temp_gw_addr, sizeof(temp_gw_addr));
+            inet_ntop(family, RTA_DATA(attr), temp_gw_addr, sizeof(temp_gw_addr));
             has_gateway = true;
             break;
           case RTA_DST: {
             /* The destination address.
              * Should be either missing, or maybe all 0s.  Accept both.
              */
-            const uint32_t nr_zeroes = (net->family_ == AF_INET) ? 4 : 16;
+            const uint32_t nr_zeroes = (family == AF_INET) ? 4 : 16;
             unsigned char c = 0;
             size_t dstlen = RTA_PAYLOAD(attr);
             if (dstlen != nr_zeroes) {
@@ -717,7 +699,6 @@ void waybar::modules::Network::askForStateDump(void) {
   };
 
   if (want_route_dump_) {
-    rt_hdr.rtgen_family = family_;
     nl_send_simple(ev_sock_, RTM_GETROUTE, NLM_F_DUMP, &rt_hdr, sizeof(rt_hdr));
     want_route_dump_ = false;
     dump_in_progress_ = true;
@@ -728,7 +709,6 @@ void waybar::modules::Network::askForStateDump(void) {
     dump_in_progress_ = true;
 
   } else if (want_addr_dump_) {
-    rt_hdr.rtgen_family = family_;
     nl_send_simple(ev_sock_, RTM_GETADDR, NLM_F_DUMP, &rt_hdr, sizeof(rt_hdr));
     want_addr_dump_ = false;
     dump_in_progress_ = true;


### PR DESCRIPTION
I often switch between networks that use either IPv4 or IPv6.

As the network module supports IPv4 _or_ IPv6 (but not both at the same time) I currently need to add two instances of the network module to my config and explicitly set the family to "ipv6" for one of them.

This PR makes the network module able to handle both IPv4 and IPv6 simultaneously. It is enough to have a single instance of the network module that handle both protocols and the family doesn't have to be specified. This is a bit simpler and probably what most users would expect.