### PR TITLE
Hide vacant tags config option on River

### DIFF
--- a/man/waybar-river-tags.5.scd
+++ b/man/waybar-river-tags.5.scd
@@ -31,6 +31,11 @@ Addressed by *river/tags*
 	default: false ++
 	Enables this module to consume all left over space dynamically.
 
+*hide-vacant*: ++
+	typeof: bool ++
+	default: false ++
+	Only show relevant tags: tags that are either focused or have a window on them.
+
 # EXAMPLE
 
 ```

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -220,7 +220,7 @@ void Tags::handle_view_tags(struct wl_array *view_tags) {
       }
       buttons_[i].get_style_context()->add_class("occupied");
     } else {
-      if (hide_vacant) {
+      if (hide_vacant && !buttons_[i].get_style_context()->has_class("focused")) {
         buttons_[i].set_visible(false);
       }
       buttons_[i].get_style_context()->remove_class("occupied");

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -189,11 +189,18 @@ bool Tags::handle_button_press(GdkEventButton *event_button, uint32_t tag) {
 }
 
 void Tags::handle_focused_tags(uint32_t tags) {
+  auto hide_vacant = config_["hide-vacant"].asBool();
   for (size_t i = 0; i < buttons_.size(); ++i) {
     if ((1 << i) & tags) {
+      if (hide_vacant) {
+        buttons_[i].set_visible(true);
+      }
       buttons_[i].get_style_context()->add_class("focused");
     } else {
       buttons_[i].get_style_context()->remove_class("focused");
+      if (hide_vacant && !buttons_[i].get_style_context()->has_class("occupied")) {
+        buttons_[i].set_visible(false);
+      }
     }
   }
 }
@@ -205,10 +212,17 @@ void Tags::handle_view_tags(struct wl_array *view_tags) {
   for (; view_tag < end; ++view_tag) {
     tags |= *view_tag;
   }
+  auto hide_vacant = config_["hide-vacant"].asBool();
   for (size_t i = 0; i < buttons_.size(); ++i) {
     if ((1 << i) & tags) {
+      if (hide_vacant) {
+        buttons_[i].set_visible(true);
+      }
       buttons_[i].get_style_context()->add_class("occupied");
     } else {
+      if (hide_vacant) {
+        buttons_[i].set_visible(false);
+      }
       buttons_[i].get_style_context()->remove_class("occupied");
     }
   }

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -191,16 +191,19 @@ bool Tags::handle_button_press(GdkEventButton *event_button, uint32_t tag) {
 void Tags::handle_focused_tags(uint32_t tags) {
   auto hide_vacant = config_["hide-vacant"].asBool();
   for (size_t i = 0; i < buttons_.size(); ++i) {
+    bool visible = buttons_[i].is_visible();
+    bool occupied = buttons_[i].get_style_context()->has_class("occupied");
+    bool urgent = buttons_[i].get_style_context()->has_class("urgent");
     if ((1 << i) & tags) {
-      if (hide_vacant) {
+      if (hide_vacant && !visible) {
         buttons_[i].set_visible(true);
       }
       buttons_[i].get_style_context()->add_class("focused");
     } else {
-      buttons_[i].get_style_context()->remove_class("focused");
-      if (hide_vacant && !buttons_[i].get_style_context()->has_class("occupied")) {
+      if (hide_vacant && !(occupied || urgent)) {
         buttons_[i].set_visible(false);
       }
+      buttons_[i].get_style_context()->remove_class("focused");
     }
   }
 }
@@ -214,13 +217,16 @@ void Tags::handle_view_tags(struct wl_array *view_tags) {
   }
   auto hide_vacant = config_["hide-vacant"].asBool();
   for (size_t i = 0; i < buttons_.size(); ++i) {
+    bool visible = buttons_[i].is_visible();
+    bool focused = buttons_[i].get_style_context()->has_class("focused");
+    bool urgent = buttons_[i].get_style_context()->has_class("urgent");
     if ((1 << i) & tags) {
-      if (hide_vacant) {
+      if (hide_vacant && !visible) {
         buttons_[i].set_visible(true);
       }
       buttons_[i].get_style_context()->add_class("occupied");
     } else {
-      if (hide_vacant && !buttons_[i].get_style_context()->has_class("focused")) {
+      if (hide_vacant && !(focused || urgent)) {
         buttons_[i].set_visible(false);
       }
       buttons_[i].get_style_context()->remove_class("occupied");
@@ -229,10 +235,20 @@ void Tags::handle_view_tags(struct wl_array *view_tags) {
 }
 
 void Tags::handle_urgent_tags(uint32_t tags) {
+  auto hide_vacant = config_["hide-vacant"].asBool();
   for (size_t i = 0; i < buttons_.size(); ++i) {
+    bool visible = buttons_[i].is_visible();
+    bool occupied = buttons_[i].get_style_context()->has_class("occupied");
+    bool focused = buttons_[i].get_style_context()->has_class("focused");
     if ((1 << i) & tags) {
+      if (hide_vacant && !visible) {
+        buttons_[i].set_visible(true);
+      }
       buttons_[i].get_style_context()->add_class("urgent");
     } else {
+      if (hide_vacant && !(occupied || focused)) {
+        buttons_[i].set_visible(false);
+      }
       buttons_[i].get_style_context()->remove_class("urgent");
     }
   }


### PR DESCRIPTION
Adds the ability to hide vacant tags on river. Vacant means not occupied and not focused.
![image](https://github.com/user-attachments/assets/31e4045b-2632-43e0-924b-592306f2877c)
![image](https://github.com/user-attachments/assets/d313b180-efcd-4c17-af2f-826bb7fbbf8c)

Addresses:
https://github.com/Alexays/Waybar/issues/3790
https://github.com/Alexays/Waybar/issues/2537
