### PR TITLE
fix: hide tray when there are no non-passive icons

### DIFF
--- a/include/modules/sni/tray.hpp
+++ b/include/modules/sni/tray.hpp
@@ -21,6 +21,7 @@ class Tray : public AModule {
   void onRemove(std::unique_ptr<Item>& item);
 
   static inline std::size_t nb_hosts_ = 0;
+  bool show_passive_ = false;
   Gtk::Box box_;
   SNI::Watcher::singleton watcher_;
   SNI::Host host_;

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -2,6 +2,8 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+
 namespace waybar::modules::SNI {
 
 Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
@@ -39,7 +41,9 @@ void Tray::onRemove(std::unique_ptr<Item>& item) {
 
 auto Tray::update() -> void {
   // Show tray only when items are available
-  event_box_.set_visible(!box_.get_children().empty());
+  std::vector<Gtk::Widget*> children = box_.get_children();
+  event_box_.set_visible(std::any_of(children.begin(), children.end(),
+                                     [](Gtk::Widget* child) { return child->get_visible(); }));
   // Call parent update
   AModule::update();
 }


### PR DESCRIPTION
Currently, the tray module automatically hides when there are no tray icons. However, this behavior is not consistent with the "show-passive-items" config property. If there are passive tray items (e.g. Spotify) and "show-passive-items" is false (as it is by default), the tray will still be visible.

This PR fixes this by only hiding the tray if there are no visible tray icons.