### PR TITLE
niri/workspaces: Allow restricting the module to an output

### DIFF
--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -17,6 +17,10 @@ Addressed by *niri/workspaces*
 	default: false ++
 	If set to false, workspaces will only be shown on the output they are on. If set to true all workspaces will be shown on every output.
 
+*output*: ++
+	typeof: string ++
+	If set, only show workspaces for the output set.
+
 *format*: ++
 	typeof: string ++
 	default: {value} ++

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -37,6 +37,8 @@ void Workspaces::doUpdate() {
   std::copy_if(workspaces.cbegin(), workspaces.cend(), std::back_inserter(my_workspaces),
                [&](const auto &ws) {
                  if (alloutputs) return true;
+                 if (config_["output"].isString())
+                   return config_["output"].asString() == ws["output"].asString();
                  return ws["output"].asString() == bar_.output->name;
                });
 


### PR DESCRIPTION
To be able to show the workspaces for a given output only, which may be different from the output the bar is displayed on, allow restricting the niri/workspaces module to a single output.

The default - when the `output` option is unset - remains the same as before.

This lets me set up Waybar to do this:

![image](https://github.com/user-attachments/assets/39f85e6f-e917-43e6-b015-ff401fa954f6)

The "main" and "social" modules on the left are configured like this:

```json
    "niri/workspaces#left": {
        "current-only": true,
        "disable-click": true,
        "output": "DP-1",
        "format": "🄻 {value}"
    },
    "niri/workspaces#right": {
        "current-only": true,
        "disable-click": true,
        "output": "HDMI-A-1",
        "format": "🅁 {value}"
    },
```

In other words, this lets me show the active workspace on both my displays, on a single bar.