### PR TITLE
sway/workspaces: Made the focused check in "current-only" fully recursive

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -494,14 +494,18 @@ std::string Workspaces::trimWorkspaceName(std::string name) {
   return name;
 }
 
+bool checkFocused(const Json::Value &node) {
+  return node["focused"].asBool() ||
+         std::any_of(node["nodes"].begin(), node["nodes"].end(),
+                     [](const auto &child) { return checkFocused(child); });
+}
+
 void Workspaces::onButtonReady(const Json::Value &node, Gtk::Button &button) {
   if (config_["current-only"].asBool()) {
     // If a workspace has a focused container then get_tree will say
     // that the workspace itself isn't focused.  Therefore we need to
     // check if any of its nodes are focused as well.
-    bool focused = node["focused"].asBool() ||
-                   std::any_of(node["nodes"].begin(), node["nodes"].end(),
-                               [](const auto &child) { return child["focused"].asBool(); });
+    bool focused = checkFocused(node);
 
     if (focused) {
       button.show();


### PR DESCRIPTION
I was experiencing a similar version of issue #3369. However, in my case, the issue only kicked in when a tabbed container was in use. I noticed that PR #3336 attempted to address the issues with current-only by not only checking whether the workspace itself is focused, but also whether any window within it is focused.

However, it did not check recursively. This meant that if the focused window was at the top level, it would be detected. Or if it was in a container that sway decided to also indicate as focused. (It's really not clear to me how Sway decides when to indicate a container as focused.) But if the window is in a container not indicated as focused, it will be missed. This seems to happen often with tabbed containers. Changing this check to be recursive seems to fix it.