### PR TITLE
mpd: add uri and filename format arguments

### DIFF
--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -204,6 +204,10 @@ Addressed by *mpd*
 
 *{queueLength}*: The length of the current queue.
 
+*{uri}*: The URI of the song relative to the MPD music directory.
+
+*{filename}* The last part of the URI.
+
 *{stateIcon}*: The icon corresponding to the playing or paused status of the player (see *state-icons* option)
 
 *{consumeIcon}*: The icon corresponding the "consume" option (see *consume-icons* option)

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -118,7 +118,7 @@ void waybar::modules::MPD::setLabel() {
 
   auto format = format_;
   Glib::ustring artist, album_artist, album, title;
-  std::string date, filename;
+  std::string date, filename, uri;
   int song_pos = 0, queue_length = 0, volume = 0;
   std::chrono::seconds elapsedTime, totalTime;
 
@@ -151,6 +151,7 @@ void waybar::modules::MPD::setLabel() {
     title = sanitize_string(getTag(MPD_TAG_TITLE));
     date = sanitize_string(getTag(MPD_TAG_DATE));
     filename = sanitize_string(getFilename());
+    uri = mpd_song_get_uri(song_.get());
     song_pos = mpd_status_get_song_pos(status_.get()) + 1;
     volume = mpd_status_get_volume(status_.get());
     if (volume < 0) {
@@ -184,7 +185,8 @@ void waybar::modules::MPD::setLabel() {
         fmt::arg("songPosition", song_pos), fmt::arg("queueLength", queue_length),
         fmt::arg("stateIcon", stateIcon), fmt::arg("consumeIcon", consumeIcon),
         fmt::arg("randomIcon", randomIcon), fmt::arg("repeatIcon", repeatIcon),
-        fmt::arg("singleIcon", singleIcon), fmt::arg("filename", filename));
+        fmt::arg("singleIcon", singleIcon), fmt::arg("filename", filename),
+        fmt::arg("uri", uri));
     if (text.empty()) {
       label_.hide();
     } else {
@@ -208,7 +210,8 @@ void waybar::modules::MPD::setLabel() {
                       fmt::arg("totalTime", totalTime), fmt::arg("songPosition", song_pos),
                       fmt::arg("queueLength", queue_length), fmt::arg("stateIcon", stateIcon),
                       fmt::arg("consumeIcon", consumeIcon), fmt::arg("randomIcon", randomIcon),
-                      fmt::arg("repeatIcon", repeatIcon), fmt::arg("singleIcon", singleIcon));
+                      fmt::arg("repeatIcon", repeatIcon), fmt::arg("singleIcon", singleIcon),
+                      fmt::arg("filename", filename), fmt::arg("uri", uri));
       label_.set_tooltip_text(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpd: format error (tooltip): {}", e.what());


### PR DESCRIPTION
Many people have files in their music library that are not properly tagged and for such files `{title}` and `{album}` cannot be displayed by the mpd module. As a fallback the user might want to display filename or the full URI of this file instead ( see https://github.com/Alexays/Waybar/issues/3631 ).

This PR
* enables the `{filename}` format replacement to be used in tooltips (previously only available in the label, for some reason)
* documents the `{filename}` format replacement in the man page
* adds an `{uri}` format replacement which takes the value of [`mpd_song_get_uri`](https://www.musicpd.org/doc/libmpdclient/song_8h.html#a969dbd00e70ee44b573eb2feb0fb71b3)

While this does not allow to display the filename conditionally on the title being empty (format strings like `{title|filename}` don't seem to be allowed), at least one can now display the URI of the file in the tooltip and get a hint which file is missing proper tagging.