### PR TITLE
Allow using wildcards in config include paths

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -20,8 +20,8 @@ class Config {
   static std::optional<std::string> findConfigPath(
       const std::vector<std::string> &names, const std::vector<std::string> &dirs = CONFIG_DIRS);
 
-  static std::optional<std::string> tryExpandPath(const std::string &base,
-                                                  const std::string &filename);
+  static std::vector<std::string> tryExpandPath(const std::string &base,
+                                                const std::string &filename);
 
   Config() = default;
 

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -68,11 +68,11 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
 
       // there might be "~" or "$HOME" in original path, try to expand it.
       auto result = Config::tryExpandPath(menuFile, "");
-      if (!result.has_value()) {
+      if (result.empty()) {
         throw std::runtime_error("Failed to expand file: " + menuFile);
       }
 
-      menuFile = result.value();
+      menuFile = result.front();
       // Read the menu descriptor file
       std::ifstream file(menuFile);
       if (!file.is_open()) {


### PR DESCRIPTION
Since Waybar supports including additional configuration files using the `"include"` key, I expected to be able to use wildcards in the paths passed in. For example, a drop-in config directory:

```jsonc
{
  "include": "/etc/waybar/config.d/*.jsonc"
}
```

Currently, this *almost* works. `Config::tryExpandPath()` already expands wildcards using `wordexp()`, but only takes the first result and discards the rest.

This PR updates `Config::tryExpandPath()` to return a vector of expanded path matches instead of a single path wrapped in an optional, with an empty vector indicating no matches.

`Config::resolveConfigIncludes()` iterates over all of these matches, while other instances of path expansion (such as finding the base config path) retain their existing behavior and only use the first match.