### PR TITLE
Fix compilation with libc++

### DIFF
--- a/src/util/regex_collection.cpp
+++ b/src/util/regex_collection.cpp
@@ -3,6 +3,7 @@
 #include <json/value.h>
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <utility>
 
 namespace waybar::util {


### PR DESCRIPTION
`regex_collection.cpp` uses `std::sort` and does not import correct header.
Compilation with libstdc++ worked due to some indirect import, but compilation with LLVM libc++ fails.