### PR TITLE
fix: never sleep cava when sleep_timer is 0

### DIFF
--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -139,7 +139,7 @@ auto waybar::modules::Cava::update() -> void {
     }
   }
 
-  if (silence_ && prm_.sleep_timer) {
+  if (silence_ && prm_.sleep_timer != 0) {
     if (sleep_counter_ <=
         (int)(std::chrono::milliseconds(prm_.sleep_timer * 1s) / frame_time_milsec_)) {
       ++sleep_counter_;
@@ -147,7 +147,7 @@ auto waybar::modules::Cava::update() -> void {
     }
   }
 
-  if (!silence_) {
+  if (!silence_ || prm_.sleep_timer == 0) {
     downThreadDelay(frame_time_milsec_, suspend_silence_delay_);
     // Process: execute cava
     pthread_mutex_lock(&audio_data_.lock);


### PR DESCRIPTION
Attempts to fix #3870. Makes Cava config behave according to the officially intended behavior.
```
# Seconds with no input before cava goes to sleep mode. Cava will not perform FFT or drawing and
# only check for input once per second. Cava will wake up once input is detected. 0 = disable.
; sleep_timer = 0
```

After some testing, this PR does indeed fix every problem observed in the original issue, including the glitchy freeze frame of cava upon playing sounds after silence.