### PR TITLE
Escape tray tooltip text

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -124,7 +124,8 @@ ToolTip get_variant<ToolTip>(const Glib::VariantBase& value) {
   result.text = get_variant<Glib::ustring>(container.get_child(2));
   auto description = get_variant<Glib::ustring>(container.get_child(3));
   if (!description.empty()) {
-    result.text = fmt::format("<b>{}</b>\n{}", result.text, description);
+    auto escapedDescription = Glib::Markup::escape_text(description);
+    result.text = fmt::format("<b>{}</b>\n{}", result.text, escapedDescription);
   }
   return result;
 }


### PR DESCRIPTION
Fix errors when the tooltip set by a tray app contains markup characters.

For example, [CopyQ](https://github.com/hluk/CopyQ) sets its tooltip to the last copied text, which could contain arbitrary characters, some of which (like `< > &`) can cause an error when interpreted.