### PR TITLE
Migrate Hyprland workspace events to v2

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#include <optional>
 #include <regex>
 #include <string>
 #include <vector>
@@ -55,7 +56,7 @@ class Workspaces : public AModule, public EventHandler {
 
   static Json::Value createMonitorWorkspaceData(std::string const& name,
                                                 std::string const& monitor);
-  void removeWorkspace(std::string const& name);
+  void removeWorkspace(std::string const& workspaceString);
   void setUrgentWorkspace(std::string const& windowaddress);
 
   // Config
@@ -74,10 +75,11 @@ class Workspaces : public AModule, public EventHandler {
   void onWorkspaceActivated(std::string const& payload);
   void onSpecialWorkspaceActivated(std::string const& payload);
   void onWorkspaceDestroyed(std::string const& payload);
-  void onWorkspaceCreated(std::string const& workspaceName,
+  void onWorkspaceCreated(std::string const& payload,
                           Json::Value const& clientsData = Json::Value::nullRef);
   void onWorkspaceMoved(std::string const& payload);
   void onWorkspaceRenamed(std::string const& payload);
+  static std::optional<int> parseWorkspaceId(std::string const& workspaceIdStr);
 
   // monitor events
   void onMonitorFocused(std::string const& payload);
@@ -93,11 +95,18 @@ class Workspaces : public AModule, public EventHandler {
 
   int windowRewritePriorityFunction(std::string const& window_rule);
 
+  // event payload management
+  template <typename... Args>
+  static std::string makePayload(Args const&... args);
+  static std::pair<std::string, std::string> splitDoublePayload(std::string const& payload);
+  static std::tuple<std::string, std::string, std::string> splitTriplePayload(
+      std::string const& payload);
+
   // Update methods
   void doUpdate();
   void removeWorkspacesToRemove();
   void createWorkspacesToCreate();
-  static std::vector<std::string> getVisibleWorkspaces();
+  static std::vector<int> getVisibleWorkspaces();
   void updateWorkspaceStates();
   bool updateWindowsToCreate();
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -138,7 +138,7 @@ class Workspaces : public AModule, public EventHandler {
 
   bool m_withIcon;
   uint64_t m_monitorId;
-  std::string m_activeWorkspaceName;
+  int m_activeWorkspaceId;
   std::string m_activeSpecialWorkspaceName;
   std::vector<std::unique_ptr<Workspace>> m_workspaces;
   std::vector<std::pair<Json::Value, Json::Value>> m_workspacesToCreate;


### PR DESCRIPTION
The Hyprland [v2 workspace events](https://github.com/hyprwm/Hyprland/pull/5022) add the workspace ID to the event payload.

Currently Waybar relies on workspace names because that was the best the old events provided. By transitioning to IDs instead of names, Waybar can provide a more robust experience, avoid hairy issues like https://github.com/Alexays/Waybar/issues/3830.

At some point I'd like to follow up with a similar change in special workspaces, but `activespecialv2` doesn't exist yet in Hyprland.