### PR TITLE
feat: add 'hide-empty' option to niri workspaces module

### DIFF
--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -41,6 +41,11 @@ Addressed by *niri/workspaces*
 	default: false ++
 	If set to true, only the active or focused workspace will be shown.
 
+*hide-empty*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, empty workspaces will be hidden.
+
 *on-update*: ++
 	typeof: string ++
 	Command to execute when the module is updated.

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -102,14 +102,17 @@ void Workspaces::doUpdate() {
       button.set_label(name);
     }
 
+    const auto *property = alloutputs ? "is_focused" : "is_active";
     if (config_["current-only"].asBool()) {
-      const auto *property = alloutputs ? "is_focused" : "is_active";
       if (ws[property].asBool())
         button.show();
       else
         button.hide();
     } else {
-      button.show();
+      if (config_["hide-empty"].asBool() && !ws[property].asBool() && ws["active_window_id"].isNull())
+        button.hide();
+      else
+        button.show();
     }
   }
 


### PR DESCRIPTION
This pr allows you to hide workspace buttons with a window count of 0.

https://github.com/user-attachments/assets/4d68f887-665c-47de-b49a-760229affd2a

