### PR TITLE
Hide upower module when specified device disconnected

### DIFF
--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -358,10 +358,12 @@ void UPower::resetDevices() {
 void UPower::setDisplayDevice() {
   std::lock_guard<std::mutex> guard{mutex_};
 
-  if (nativePath_.empty() && model_.empty()) {
-    // Unref current upDevice
-    if (upDevice_.upDevice != NULL) g_object_unref(upDevice_.upDevice);
+  if (upDevice_.upDevice != NULL) {
+    g_object_unref(upDevice_.upDevice);
+    upDevice_.upDevice = NULL;
+  }
 
+  if (nativePath_.empty() && model_.empty()) {
     upDevice_.upDevice = up_client_get_display_device(upClient_);
     getUpDeviceInfo(upDevice_);
   } else {
@@ -386,7 +388,6 @@ void UPower::setDisplayDevice() {
           }
           // Unref current upDevice if it exists
           if (displayDevice.upDevice != NULL) {
-            if (thisPtr->upDevice_.upDevice != NULL) g_object_unref(thisPtr->upDevice_.upDevice);
             thisPtr->upDevice_ = displayDevice;
           }
         },


### PR DESCRIPTION
Fix https://github.com/Alexays/Waybar/issues/3027

Hide Upower module when specified by `native-path` or `model` device disconnected.