### PR TITLE
add only-populated option to niri/workspaces module

### DIFF
--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -41,6 +41,11 @@ Addressed by *niri/workspaces*
 	default: false ++
 	If set to true, only the active or focused workspace will be shown.
 
+*only-populated*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, only workspaces that contain windows will be shown.
+
 *on-update*: ++
 	typeof: string ++
 	Command to execute when the module is updated.

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -32,10 +32,12 @@ void Workspaces::doUpdate() {
   auto ipcLock = gIPC->lockData();
 
   const auto alloutputs = config_["all-outputs"].asBool();
+  const auto onlypop= config_["only-populated"].asBool();
   std::vector<Json::Value> my_workspaces;
   const auto &workspaces = gIPC->workspaces();
   std::copy_if(workspaces.cbegin(), workspaces.cend(), std::back_inserter(my_workspaces),
                [&](const auto &ws) {
+                 if (onlypop && ws["active_window_id"].isNull() && !ws["is_active"].asBool()) return false;
                  if (alloutputs) return true;
                  return ws["output"].asString() == bar_.output->name;
                });


### PR DESCRIPTION
When set to true, only workspaces which contain windows will be drawn. (the active one will always be drawn)

