### PR TITLE
Add support for vertical orientation in privacy module

### DIFF
--- a/include/modules/privacy/privacy.hpp
+++ b/include/modules/privacy/privacy.hpp
@@ -13,7 +13,7 @@ namespace waybar::modules::privacy {
 
 class Privacy : public AModule {
  public:
-  Privacy(const std::string &, const Json::Value &, const std::string &pos);
+  Privacy(const std::string &, const Json::Value &, Gtk::Orientation, const std::string &pos);
   auto update() -> void override;
 
   void onPrivacyNodesChanged();

--- a/include/modules/privacy/privacy_item.hpp
+++ b/include/modules/privacy/privacy_item.hpp
@@ -17,8 +17,8 @@ namespace waybar::modules::privacy {
 class PrivacyItem : public Gtk::Revealer {
  public:
   PrivacyItem(const Json::Value &config_, enum PrivacyNodeType privacy_type_,
-              std::list<PrivacyNodeInfo *> *nodes, const std::string &pos, const uint icon_size,
-              const uint transition_duration);
+              std::list<PrivacyNodeInfo *> *nodes, Gtk::Orientation orientation,
+              const std::string &pos, const uint icon_size, const uint transition_duration);
 
   enum PrivacyNodeType privacy_type;
 

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -140,7 +140,7 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
 #endif
 #ifdef HAVE_PIPEWIRE
     if (ref == "privacy") {
-      return new waybar::modules::privacy::Privacy(id, config_[name], pos);
+      return new waybar::modules::privacy::Privacy(id, config_[name], bar_.orientation, pos);
     }
 #endif
 #ifdef HAVE_MPRIS

--- a/src/modules/privacy/privacy.cpp
+++ b/src/modules/privacy/privacy.cpp
@@ -15,13 +15,14 @@ using util::PipewireBackend::PRIVACY_NODE_TYPE_AUDIO_OUTPUT;
 using util::PipewireBackend::PRIVACY_NODE_TYPE_NONE;
 using util::PipewireBackend::PRIVACY_NODE_TYPE_VIDEO_INPUT;
 
-Privacy::Privacy(const std::string& id, const Json::Value& config, const std::string& pos)
+Privacy::Privacy(const std::string& id, const Json::Value& config, Gtk::Orientation orientation,
+                 const std::string& pos)
     : AModule(config, "privacy", id),
       nodes_screenshare(),
       nodes_audio_in(),
       nodes_audio_out(),
       visibility_conn(),
-      box_(Gtk::ORIENTATION_HORIZONTAL, 0) {
+      box_(orientation, 0) {
   box_.set_name(name_);
 
   event_box_.add(box_);
@@ -67,8 +68,8 @@ Privacy::Privacy(const std::string& id, const Json::Value& config, const std::st
     auto iter = typeMap.find(type);
     if (iter != typeMap.end()) {
       auto& [nodePtr, nodeType] = iter->second;
-      auto* item = Gtk::make_managed<PrivacyItem>(module, nodeType, nodePtr, pos, iconSize,
-                                                  transition_duration);
+      auto* item = Gtk::make_managed<PrivacyItem>(module, nodeType, nodePtr, orientation, pos,
+                                                  iconSize, transition_duration);
       box_.add(*item);
     }
   }

--- a/src/modules/privacy/privacy_item.cpp
+++ b/src/modules/privacy/privacy_item.cpp
@@ -11,8 +11,9 @@
 namespace waybar::modules::privacy {
 
 PrivacyItem::PrivacyItem(const Json::Value &config_, enum PrivacyNodeType privacy_type_,
-                         std::list<PrivacyNodeInfo *> *nodes_, const std::string &pos,
-                         const uint icon_size, const uint transition_duration)
+                         std::list<PrivacyNodeInfo *> *nodes_, Gtk::Orientation orientation,
+                         const std::string &pos, const uint icon_size,
+                         const uint transition_duration)
     : Gtk::Revealer(),
       privacy_type(privacy_type_),
       nodes(nodes_),
@@ -40,16 +41,24 @@ PrivacyItem::PrivacyItem(const Json::Value &config_, enum PrivacyNodeType privac
 
   // Set the reveal transition to not look weird when sliding in
   if (pos == "modules-left") {
-    set_transition_type(Gtk::REVEALER_TRANSITION_TYPE_SLIDE_RIGHT);
+    set_transition_type(orientation == Gtk::ORIENTATION_HORIZONTAL
+                            ? Gtk::REVEALER_TRANSITION_TYPE_SLIDE_RIGHT
+                            : Gtk::REVEALER_TRANSITION_TYPE_SLIDE_DOWN);
   } else if (pos == "modules-center") {
     set_transition_type(Gtk::REVEALER_TRANSITION_TYPE_CROSSFADE);
   } else if (pos == "modules-right") {
-    set_transition_type(Gtk::REVEALER_TRANSITION_TYPE_SLIDE_LEFT);
+    set_transition_type(orientation == Gtk::ORIENTATION_HORIZONTAL
+                            ? Gtk::REVEALER_TRANSITION_TYPE_SLIDE_LEFT
+                            : Gtk::REVEALER_TRANSITION_TYPE_SLIDE_UP);
   }
   set_transition_duration(transition_duration);
 
   box_.set_name("privacy-item");
-  box_.add(icon_);
+
+  // We use `set_center_widget` instead of `add` to make sure the icon is
+  // centered even if the orientation is vertical
+  box_.set_center_widget(icon_);
+
   icon_.set_pixel_size(icon_size);
   add(box_);
 


### PR DESCRIPTION
This PR changes the privacy module to stack icons vertically when the bar orientation is vertical. Closes #2657.