### PR TITLE
turn off ellipsize for niri/language module

### DIFF
--- a/src/modules/niri/language.cpp
+++ b/src/modules/niri/language.cpp
@@ -9,7 +9,7 @@
 namespace waybar::modules::niri {
 
 Language::Language(const std::string &id, const Bar &bar, const Json::Value &config)
-    : ALabel(config, "language", id, "{}", 0, true), bar_(bar) {
+    : ALabel(config, "language", id, "{}", 0, false), bar_(bar) {
   label_.hide();
 
   if (!gIPC) gIPC = std::make_unique<IPC>();


### PR DESCRIPTION
Ellipsize (converting the content of the widget to triple dots `...`) leads to the module displaying no information and therefore becoming useless. Since other modules don't have this behavior, I think it should be off for this one too. 