### PR TITLE
dwl/window: add .active styling class for active windows

### DIFF
--- a/include/modules/dwl/window.hpp
+++ b/include/modules/dwl/window.hpp
@@ -19,6 +19,7 @@ class Window : public AAppIconLabel, public sigc::trackable {
   void handle_layout(const uint32_t layout);
   void handle_title(const char *title);
   void handle_appid(const char *ppid);
+  void handle_active(const uint32_t active);
   void handle_layout_symbol(const char *layout_symbol);
   void handle_frame();
 
@@ -30,6 +31,7 @@ class Window : public AAppIconLabel, public sigc::trackable {
   std::string title_;
   std::string appid_;
   std::string layout_symbol_;
+  bool active_;
   uint32_t layout_;
 
   struct zdwl_ipc_output_v2 *output_status_;

--- a/man/waybar-dwl-window.5.scd
+++ b/man/waybar-dwl-window.5.scd
@@ -109,6 +109,10 @@ If no expression matches, the format output is left unchanged.
 
 Invalid expressions (e.g., mismatched parentheses) are skipped.
 
+# STYLE
+
+- *#window.active*
+
 # EXAMPLES
 
 ```

--- a/src/modules/dwl/window.cpp
+++ b/src/modules/dwl/window.cpp
@@ -19,7 +19,7 @@ static void toggle_visibility(void *data, zdwl_ipc_output_v2 *zdwl_output_v2) {
 }
 
 static void active(void *data, zdwl_ipc_output_v2 *zdwl_output_v2, uint32_t active) {
-  // Intentionally empty
+  static_cast<Window *>(data)->handle_active(active);
 }
 
 static void set_tag(void *data, zdwl_ipc_output_v2 *zdwl_output_v2, uint32_t tag, uint32_t state,
@@ -74,7 +74,9 @@ static const wl_registry_listener registry_listener_impl = {.global = handle_glo
                                                             .global_remove = handle_global_remove};
 
 Window::Window(const std::string &id, const Bar &bar, const Json::Value &config)
-    : AAppIconLabel(config, "window", id, "{}", 0, true), bar_(bar) {
+    : AAppIconLabel(config, "window", id, "{}", 0, true),
+      bar_(bar),
+      active_(false) {
   struct wl_display *display = Client::inst()->wl_display;
   struct wl_registry *registry = wl_display_get_registry(display);
 
@@ -102,6 +104,8 @@ void Window::handle_title(const char *title) { title_ = Glib::Markup::escape_tex
 
 void Window::handle_appid(const char *appid) { appid_ = Glib::Markup::escape_text(appid); }
 
+void Window::handle_active(const uint32_t active) { active_ = active != 0; }
+
 void Window::handle_layout_symbol(const char *layout_symbol) {
   layout_symbol_ = Glib::Markup::escape_text(layout_symbol);
 }
@@ -117,6 +121,11 @@ void Window::handle_frame() {
   updateAppIcon();
   if (tooltipEnabled()) {
     label_.set_tooltip_text(title_);
+  }
+  if (active_) {
+    box_.get_style_context()->add_class("active");
+  } else {
+    box_.get_style_context()->remove_class("active");
   }
 }
 


### PR DESCRIPTION
This allows equivalent styling as of dwm's status bar when a output is highlighted, making it possible to distinguish which output is selected without the need of borders (which may be hidden by specific patches.)