### PR TITLE
sway/workspaces: Implement reverse-scroll

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -31,6 +31,11 @@ Addressed by *sway/workspaces*
 	default: false ++
 	If set to false, you can scroll to cycle through workspaces. If set to true this behaviour is disabled.
 
+*reverse-scroll*: ++
+	typeof: bool ++
+	default: false ++
+	If set to false, scrolling up will switch to the previous workspace and scrolling down will switch to the next workspace. If set to true, the behavior will be reversed.
+
 *disable-click*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -443,10 +443,11 @@ bool Workspaces::handleScroll(GdkEventScroll *e) {
     if (it == workspaces_.end()) {
       return true;
     }
+    bool reverse_scroll = config_["reverse-scroll"].isBool() && config_["reverse-scroll"].asBool();
     if (dir == SCROLL_DIR::DOWN || dir == SCROLL_DIR::RIGHT) {
-      name = getCycleWorkspace(it, false);
+      name = getCycleWorkspace(it, reverse_scroll ? true : false);
     } else if (dir == SCROLL_DIR::UP || dir == SCROLL_DIR::LEFT) {
-      name = getCycleWorkspace(it, true);
+      name = getCycleWorkspace(it, reverse_scroll ? false : true);
     } else {
       return true;
     }


### PR DESCRIPTION
Scroll direction by default is kinda counterintuitive, especially for people who migrating from i3/polybar to sway/waybar.
The code now checks for "reverse-scroll" property and switches workspaces in different direction if it's true