### PR TITLE
hyprland/workspaces: fixed urgent for special workspaces

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -863,7 +863,7 @@ void Workspaces::updateWorkspaceStates() {
   for (auto &workspace : m_workspaces) {
     workspace->setActive(workspace->name() == m_activeWorkspaceName ||
                          workspace->name() == m_activeSpecialWorkspaceName);
-    if (workspace->name() == m_activeWorkspaceName && workspace->isUrgent()) {
+    if (workspace->isActive() && workspace->isUrgent()) {
       workspace->setUrgent(false);
     }
     workspace->setVisible(std::find(visibleWorkspaces.begin(), visibleWorkspaces.end(),


### PR DESCRIPTION
Fixed handling of urgent state for special workspaces. Replaced unnecessary and incorrect second check of active workspace with result of previous check.