### PR TITLE
Features/systray custom icons

### DIFF
--- a/include/modules/sni/icon_manager.hpp
+++ b/include/modules/sni/icon_manager.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <json/json.h>
+#include <spdlog/spdlog.h>
+
+#include <string>
+#include <unordered_map>
+
+class IconManager {
+ public:
+  static IconManager& instance() {
+    static IconManager instance;
+    return instance;
+  }
+
+  void setIconsConfig(const Json::Value& icons_config) {
+    if (icons_config.isObject()) {
+      for (const auto& key : icons_config.getMemberNames()) {
+        std::string app_name = key;
+        const Json::Value& icon_value = icons_config[key];
+
+        if (icon_value.isString()) {
+          std::string icon_path = icon_value.asString();
+          icons_map_[app_name] = icon_path;
+        }
+      }
+    } else {
+      spdlog::warn("Invalid icon config format.");
+    }
+  }
+
+  std::string getIconForApp(const std::string& app_name) const {
+    auto it = icons_map_.find(app_name);
+    if (it != icons_map_.end()) {
+      return it->second;
+    }
+    return "";
+  }
+
+ private:
+  IconManager() = default;
+  std::unordered_map<std::string, std::string> icons_map_;
+};

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -62,6 +62,7 @@ class Item : public sigc::trackable {
   void proxyReady(Glib::RefPtr<Gio::AsyncResult>& result);
   void setProperty(const Glib::ustring& name, Glib::VariantBase& value);
   void setStatus(const Glib::ustring& value);
+  void setCustomIcon(const std::string& id);
   void getUpdatedProperties();
   void processUpdatedProperties(Glib::RefPtr<Gio::AsyncResult>& result);
   void onSignal(const Glib::ustring& sender_name, const Glib::ustring& signal_name,

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -47,7 +47,11 @@ Addressed by *tray*
 ```
 "tray": {
 	"icon-size": 21,
-	"spacing": 10
+	"spacing": 10,
+  "icons": {
+    "blueman": "bluetooth",
+    "TelegramDesktop": "$HOME/.local/share/icons/hicolor/16x16/apps/telegram.png"
+  }
 }
 
 ```

--- a/resources/config.jsonc
+++ b/resources/config.jsonc
@@ -104,7 +104,11 @@
     },
     "tray": {
         // "icon-size": 21,
-        "spacing": 10
+        "spacing": 10,
+        // "icons": {
+        //   "blueman": "bluetooth",
+        //   "TelegramDesktop": "$HOME/.local/share/icons/hicolor/16x16/apps/telegram.png"
+        // }
     },
     "clock": {
         // "timezone": "America/New_York",

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -1,4 +1,5 @@
 #include "modules/sni/item.hpp"
+#include "modules/sni/icon_manager.hpp"
 
 #include <gdkmm/general.h>
 #include <glibmm/main.h>
@@ -7,6 +8,7 @@
 
 #include <fstream>
 #include <map>
+#include <filesystem>
 
 #include "gdk/gdk.h"
 #include "util/format.hpp"
@@ -138,6 +140,7 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       category = get_variant<std::string>(value);
     } else if (name == "Id") {
       id = get_variant<std::string>(value);
+      setCustomIcon(id);
     } else if (name == "Title") {
       title = get_variant<std::string>(value);
       if (tooltip.text.empty()) {
@@ -197,6 +200,19 @@ void Item::setStatus(const Glib::ustring& value) {
     lower = "needs-attention";
   }
   style->add_class(lower);
+}
+
+void Item::setCustomIcon(const std::string& id) {
+  std::string custom_icon = IconManager::instance().getIconForApp(id);
+  if (!custom_icon.empty()) {
+    if (std::filesystem::exists(custom_icon)) {
+        Glib::RefPtr<Gdk::Pixbuf> custom_pixbuf = Gdk::Pixbuf::create_from_file(custom_icon);
+        icon_name = ""; // icon_name has priority over pixmap
+        icon_pixmap = custom_pixbuf;
+    } else { // if file doesn't exist it's most likely an icon_name
+      icon_name = custom_icon;
+    }
+  }
 }
 
 void Item::getUpdatedProperties() {

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -1,4 +1,5 @@
 #include "modules/sni/tray.hpp"
+#include "modules/sni/icon_manager.hpp"
 
 #include <spdlog/spdlog.h>
 
@@ -20,6 +21,9 @@ Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
     box_.set_spacing(config_["spacing"].asUInt());
   }
   nb_hosts_ += 1;
+  if (config_["icons"].isObject()) {
+    IconManager::instance().setIconsConfig(config_["icons"]);
+  }
   dp.emit();
 }
 


### PR DESCRIPTION
Hello o/

I really dislike having random-looking systray icons, and I saw that others were looking for a way to customize them—so I decided to take a stab at adding some (very rudimentary) support for this.

Related issue: [#1957](https://github.com/Alexays/Waybar/issues/1957)

This isn't the cleanest solution, but it does work—at least for non-Electron apps. (Electron seems to have its own issues: [electron/electron#40936](https://github.com/electron/electron/issues/40936)).

This implementation allows users to override tray icons through their config, following the suggestion in [#1400](https://github.com/Alexays/Waybar/issues/1400).

A couple of limitations:

- I could only make this work with actual image files, not font-based icons. The latter would likely require major changes to the current tray implementation.
- The icons are set before the item's ID is known, so I had to add the override (with a check to ensure it's applicable) when the ID is received via DBus.
- Users can match icons using either a system-wide recognized icon_name or by specifying a direct file path.

To avoid unnecessary config reloading, I also introduced a per-tray icon manager singleton, since there wasn't a good place where both the config and the item ID were accessible at the same time.

Maybe it'd be useful for someone :) Let me know if you have some suggestions