### PR TITLE
fix: battery runtime estimation with negative sysfs values

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -273,14 +273,18 @@ waybar::modules::Battery::getInfos() {
       // Scale these by the voltage to get μW/μWh.
 
       uint32_t current_now = 0;
+      int32_t _current_now_int = 0;
       bool current_now_exists = false;
       if (fs::exists(bat / "current_now")) {
         current_now_exists = true;
-        std::ifstream(bat / "current_now") >> current_now;
+        std::ifstream(bat / "current_now") >> _current_now_int;
       } else if (fs::exists(bat / "current_avg")) {
         current_now_exists = true;
-        std::ifstream(bat / "current_avg") >> current_now;
+        std::ifstream(bat / "current_avg") >> _current_now_int;
       }
+      // Documentation ABI allows a negative value when discharging, positive
+      // value when charging.
+      current_now = std::abs(_current_now_int);
 
       if (fs::exists(bat / "time_to_empty_now")) {
         time_to_empty_now_exists = true;
@@ -324,11 +328,15 @@ waybar::modules::Battery::getInfos() {
       }
 
       uint32_t power_now = 0;
+      int32_t _power_now_int = 0;
       bool power_now_exists = false;
       if (fs::exists(bat / "power_now")) {
         power_now_exists = true;
-        std::ifstream(bat / "power_now") >> power_now;
+        std::ifstream(bat / "power_now") >> _power_now_int;
       }
+      // Some drivers (example: Qualcomm) exposes use a negative value when
+      // discharging, positive value when charging.
+      power_now = std::abs(_power_now_int);
 
       uint32_t energy_now = 0;
       bool energy_now_exists = false;


### PR DESCRIPTION
Some drivers (example: qualcomm-battmgr, present on Snapdragon X1 laptops) expose the current_now and power_now values in sysfs as negative int when the device is discharging, positive when charging.

This breaks the battery runtime estimation in Waybar, as it expects a uint32 for power_now.
Change the battery module to use the absolute values of current_now and power_now.

I discussed about it with the maintainer of qualcomm-battmgr, and the conclusion has been that it's better to fix the userland tools to respect the ABI documentation for current_now (which specifies negative values when discharging), and allows for negative values for power_now: https://lore.kernel.org/linux-arm-msm/20250213-patch-qcomm-bat-uint-power-v1-1-16e7e2a77a02@mailbox.org/

