### PR TITLE
cffi: always return config values as JSON

### DIFF
--- a/resources/custom_modules/cffi_example/main.c
+++ b/resources/custom_modules/cffi_example/main.c
@@ -17,7 +17,7 @@ void onclicked(GtkButton* button) {
 }
 
 // You must
-const size_t wbcffi_version = 1;
+const size_t wbcffi_version = 2;
 
 void* wbcffi_init(const wbcffi_init_info* init_info, const wbcffi_config_entry* config_entries,
                   size_t config_entries_len) {

--- a/resources/custom_modules/cffi_example/waybar_cffi_module.h
+++ b/resources/custom_modules/cffi_example/waybar_cffi_module.h
@@ -7,7 +7,7 @@
 extern "C" {
 #endif
 
-/// Waybar ABI version. 1 is the latest version
+/// Waybar ABI version. 2 is the latest version
 extern const size_t wbcffi_version;
 
 /// Private Waybar CFFI module
@@ -35,7 +35,13 @@ typedef struct {
 typedef struct {
   /// Entry key
   const char* key;
-  /// Entry value as string. JSON object and arrays are serialized.
+  /// Entry value
+  ///
+  /// In ABI version 1, this may be either a bare string if the value is a
+  /// string, or the JSON representation of any other JSON object as a string.
+  ///
+  /// From ABI version 2 onwards, this is always the JSON representation of the
+  /// value as a string.
   const char* value;
 } wbcffi_config_entry;
 

--- a/src/modules/cffi.cpp
+++ b/src/modules/cffi.cpp
@@ -28,7 +28,7 @@ CFFI::CFFI(const std::string& name, const std::string& id, const Json::Value& co
   }
 
   // Fetch functions
-  if (*wbcffi_version == 1) {
+  if (*wbcffi_version == 1 || *wbcffi_version == 2) {
     // Mandatory functions
     hooks_.init = reinterpret_cast<InitFn*>(dlsym(handle, "wbcffi_init"));
     if (!hooks_.init) {
@@ -58,10 +58,14 @@ CFFI::CFFI(const std::string& name, const std::string& id, const Json::Value& co
   const auto& keys = config.getMemberNames();
   for (size_t i = 0; i < keys.size(); i++) {
     const auto& value = config[keys[i]];
-    if (value.isConvertibleTo(Json::ValueType::stringValue)) {
-      config_entries_stringstor.push_back(config[keys[i]].asString());
+    if (*wbcffi_version == 1) {
+      if (value.isConvertibleTo(Json::ValueType::stringValue)) {
+        config_entries_stringstor.push_back(value.asString());
+      } else {
+        config_entries_stringstor.push_back(value.toStyledString());
+      }
     } else {
-      config_entries_stringstor.push_back(config[keys[i]].toStyledString());
+      config_entries_stringstor.push_back(value.toStyledString());
     }
   }
 


### PR DESCRIPTION
Previously, string JSON values were special cased to be provided as bare strings, which means that CFFI modules have to either know what type each value is expected to be, or use a heuristic such as trying to decode and then treating the value as a string on failure.

Instead, we can always return JSON, and let the downstream consumer handle deserialising the value into whatever type is expected.

The new behaviour is gated on a new ABI version 2: modules built against version 1 will continue to get the old behaviour.