### PR TITLE
nix/default: disable version check

### DIFF
--- a/nix/default.nix
+++ b/nix/default.nix
@@ -27,6 +27,8 @@ in
 
     # downstream patch should not affect upstream
     patches = [];
+    # nixpkgs checks version, no need when building locally
+    nativeInstallCheckInputs = [];
 
     buildInputs = (builtins.filter (p: p.pname != "wireplumber") oldAttrs.buildInputs) ++ [
         pkgs.wireplumber


### PR DESCRIPTION
Downstream added version check, causes this flake to fail building.

With latest nixpkgs:
```bash
 > Executing versionCheckPhase
       > Did not find version 0.12.0+date=2025-03-06_dirty in the output of the command /nix/store/zpb7x04yv9d1z2mrm5wml644v4kgfr6k-waybar-0.12.0+date=2025-03-06_dirty/bin/waybar --version
       > env: '--version': No such file or directory
```