### PR TITLE
add login-proxy option

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -333,6 +333,10 @@ if get_option('niri')
     )
 endif
 
+if get_option('login-proxy')
+    add_project_arguments('-DHAVE_LOGIN_PROXY', language: 'cpp')
+endif
+
 if libnl.found() and libnlgen.found()
     add_project_arguments('-DHAVE_LIBNL', language: 'cpp')
     src_files += files('src/modules/network.cpp')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,3 +20,4 @@ option('jack', type: 'feature', value: 'auto', description: 'Enable support for 
 option('wireplumber', type: 'feature', value: 'auto', description: 'Enable support for WirePlumber')
 option('cava', type: 'feature', value: 'auto', description: 'Enable support for Cava')
 option('niri', type: 'boolean', description: 'Enable support for niri')
+option('login-proxy', type: 'boolean', description: 'Enable interfacing with dbus login interface')

--- a/src/util/backlight_backend.cpp
+++ b/src/util/backlight_backend.cpp
@@ -150,6 +150,7 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
     throw std::runtime_error("No backlight found");
   }
 
+#ifdef HAVE_LOGIN_PROXY
   // Connect to the login interface
   login_proxy_ = Gio::DBus::Proxy::create_for_bus_sync(
       Gio::DBus::BusType::BUS_TYPE_SYSTEM, "org.freedesktop.login1",
@@ -160,6 +161,7 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
         Gio::DBus::BusType::BUS_TYPE_SYSTEM, "org.freedesktop.login1",
         "/org/freedesktop/login1/session/self", "org.freedesktop.login1.Session");
   }
+#endif
 
   udev_thread_ = [this] {
     std::unique_ptr<udev, UdevDeleter> udev{udev_new()};


### PR DESCRIPTION
There are cases where systemd-logind is not used/running. Result is that bcklight module will not run.

Add an option that, when set to false, allows backlight module to work without systemd-logind.