### PR TITLE
fix(FreeBSD): Use dev.cpu temperature sysctl

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -114,13 +114,17 @@ float waybar::modules::Temperature::getTemperature() {
 
   auto zone = config_["thermal-zone"].isInt() ? config_["thermal-zone"].asInt() : 0;
 
-  if (sysctlbyname(fmt::format("hw.acpi.thermal.tz{}.temperature", zone).c_str(), &temp, &size,
-                   NULL, 0) != 0) {
-    throw std::runtime_error(fmt::format(
-        "sysctl hw.acpi.thermal.tz{}.temperature or dev.cpu.{}.temperature failed", zone, zone));
+  // First, try with dev.cpu
+  if ( (sysctlbyname(fmt::format("dev.cpu.{}.temperature", zone).c_str(), &temp, &size,
+                     NULL, 0) == 0) ||
+       (sysctlbyname(fmt::format("hw.acpi.thermal.tz{}.temperature", zone).c_str(), &temp, &size,
+                     NULL, 0) == 0) ) {
+    auto temperature_c = ((float)temp - 2732) / 10;
+    return temperature_c;
   }
-  auto temperature_c = ((float)temp - 2732) / 10;
-  return temperature_c;
+
+  throw std::runtime_error(fmt::format(
+      "sysctl hw.acpi.thermal.tz{}.temperature and dev.cpu.{}.temperature failed", zone, zone));
 
 #else  // Linux
   std::ifstream temp(file_path_);


### PR DESCRIPTION
dev.cpu is mentionned but not used. Moreover, you can have dev.cpu... but no hw.acpi, so include a test on dev.cpu first