### PR TITLE
feat: add hide-vacant option to dwl/tags module

### DIFF
--- a/include/modules/dwl/tags.hpp
+++ b/include/modules/dwl/tags.hpp
@@ -20,6 +20,8 @@ class Tags : public waybar::AModule {
 
   void handle_primary_clicked(uint32_t tag);
   bool handle_button_press(GdkEventButton *event_button, uint32_t tag);
+  uint32_t get_label_position(std::string label);
+  void add_button(uint32_t tag);
 
   struct zdwl_ipc_manager_v2 *status_manager_;
   struct wl_seat *seat_;
@@ -28,6 +30,7 @@ class Tags : public waybar::AModule {
   const waybar::Bar &bar_;
   Gtk::Box box_;
   std::vector<Gtk::Button> buttons_;
+  bool hide_vacant_;
   struct zdwl_ipc_output_v2 *output_status_;
 };
 

--- a/man/waybar-dwl-tags.5.scd
+++ b/man/waybar-dwl-tags.5.scd
@@ -21,6 +21,11 @@ Addressed by *dwl/tags*
 	typeof: array ++
 	The label to display for each tag.
 
+*hide-vacant*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, tags without clients and that are not active will be hidden.
+
 *disable-click*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/dwl/tags.cpp
+++ b/src/modules/dwl/tags.cpp
@@ -19,7 +19,9 @@ namespace waybar::modules::dwl {
 /* dwl stuff */
 wl_array tags, layouts;
 
-static uint num_tags = 0;
+static uint32_t num_tags = 0;
+static uint32_t num_counts = 0;
+std::vector<std::string> tag_labels;
 
 static void toggle_visibility(void *data, zdwl_ipc_output_v2 *zdwl_output_v2) {
   // Intentionally empty
@@ -87,6 +89,47 @@ static void handle_global_remove(void *data, struct wl_registry *registry, uint3
 
 static const wl_registry_listener registry_listener_impl = {.global = handle_global,
                                                             .global_remove = handle_global_remove};
+uint32_t Tags::get_label_position(std::string label) {
+  uint32_t i;
+  for (i = 0; i < num_counts; i++) {
+    if (label == tag_labels[i]) {
+      return i;
+    }
+  }
+  return UINT32_MAX;
+}
+
+void Tags::add_button(uint32_t tag) {
+  uint32_t inser_pos = 0;
+  std::string label = tag_labels[tag];
+  std::string added_label;
+  uint32_t position = UINT32_MAX;
+
+  for (auto &added_button : buttons_) {
+    added_label = added_button.get_label();
+    position = get_label_position(added_label);
+    if (position != UINT32_MAX && position < (tag + 1)) {
+      inser_pos++;
+    }
+  }
+
+  buttons_.emplace(buttons_.begin() + (inser_pos), label);
+
+  auto &button = buttons_[inser_pos];
+
+  button.set_relief(Gtk::RELIEF_NONE);
+  box_.pack_start(button, false, false, 0);
+  for (size_t i = 0; i < buttons_.size(); ++i) {
+    box_.reorder_child(buttons_[i], i);
+  }
+
+  if (!config_["disable-click"].asBool()) {
+    button.signal_clicked().connect(
+        sigc::bind(sigc::mem_fun(*this, &Tags::handle_primary_clicked), 1 << tag));
+    button.signal_button_press_event().connect(
+        sigc::bind(sigc::mem_fun(*this, &Tags::handle_button_press), 1 << tag));
+  }
+}
 
 Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &config)
     : waybar::AModule(config, "tags", id, false, false),
@@ -94,7 +137,11 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
       seat_{nullptr},
       bar_(bar),
       box_{bar.orientation, 0},
+      hide_vacant_(false),
       output_status_{nullptr} {
+  if (config_["hide-vacant"].asBool()) {
+    hide_vacant_ = config_["hide-vacant"].asBool();
+  }
   struct wl_display *display = Client::inst()->wl_display;
   struct wl_registry *registry = wl_display_get_registry(display);
 
@@ -118,33 +165,27 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
   event_box_.add(box_);
 
   // Default to 9 tags, cap at 32
-  const uint32_t num_tags =
+  num_counts =
       config["num-tags"].isUInt() ? std::min<uint32_t>(32, config_["num-tags"].asUInt()) : 9;
 
-  std::vector<std::string> tag_labels(num_tags);
-  for (uint32_t tag = 0; tag < num_tags; ++tag) {
+  tag_labels.resize(num_counts);
+
+  for (uint32_t tag = 0; tag < num_counts; ++tag) {
     tag_labels[tag] = std::to_string(tag + 1);
   }
   const Json::Value custom_labels = config["tag-labels"];
   if (custom_labels.isArray() && !custom_labels.empty()) {
-    for (uint32_t tag = 0; tag < std::min(num_tags, custom_labels.size()); ++tag) {
+    for (uint32_t tag = 0; tag < std::min(num_counts, custom_labels.size()); ++tag) {
       tag_labels[tag] = custom_labels[tag].asString();
     }
   }
 
-  uint32_t i = 1;
-  for (const auto &tag_label : tag_labels) {
-    Gtk::Button &button = buttons_.emplace_back(tag_label);
-    button.set_relief(Gtk::RELIEF_NONE);
-    box_.pack_start(button, false, false, 0);
-    if (!config_["disable-click"].asBool()) {
-      button.signal_clicked().connect(
-          sigc::bind(sigc::mem_fun(*this, &Tags::handle_primary_clicked), i));
-      button.signal_button_press_event().connect(
-          sigc::bind(sigc::mem_fun(*this, &Tags::handle_button_press), i));
+  if (!hide_vacant_) {
+    uint32_t i = 1;
+    while (i <= num_counts) {
+      add_button(num_counts - i);
+      i++;
     }
-    button.show();
-    i <<= 1;
   }
 
   struct wl_output *output = gdk_wayland_monitor_get_wl_output(bar_.output->monitor->gobj());
@@ -179,24 +220,53 @@ bool Tags::handle_button_press(GdkEventButton *event_button, uint32_t tag) {
 }
 
 void Tags::handle_view_tags(uint32_t tag, uint32_t state, uint32_t clients, uint32_t focused) {
-  // First clear all occupied state
-  auto &button = buttons_[tag];
-  if (clients) {
-    button.get_style_context()->add_class("occupied");
-  } else {
-    button.get_style_context()->remove_class("occupied");
+  bool is_new_button = true;
+  std::string label;
+  uint32_t position = UINT32_MAX;
+
+  for (auto &added_button : buttons_) {
+    label = added_button.get_label();
+    position = get_label_position(label);
+    if (position != UINT32_MAX && position == tag) {
+      is_new_button = false;
+    }
   }
 
-  if (state & TAG_ACTIVE) {
-    button.get_style_context()->add_class("focused");
-  } else {
-    button.get_style_context()->remove_class("focused");
+  if (is_new_button && ((state & TAG_ACTIVE) || (state & TAG_URGENT) || clients)) {
+    add_button(tag);
   }
 
-  if (state & TAG_URGENT) {
-    button.get_style_context()->add_class("urgent");
-  } else {
-    button.get_style_context()->remove_class("urgent");
+  for (auto &button : buttons_) {
+    label = button.get_label();
+    position = get_label_position(label);
+    if (position == UINT32_MAX || position != tag) continue;
+
+    if (clients) {
+      button.get_style_context()->add_class("occupied");
+      button.set_visible(true);
+    } else {
+      button.get_style_context()->remove_class("occupied");
+    }
+
+    if (state & TAG_ACTIVE) {
+      button.get_style_context()->add_class("focused");
+      button.set_visible(true);
+    } else {
+      button.get_style_context()->remove_class("focused");
+    }
+
+    if (state & TAG_URGENT) {
+      button.get_style_context()->add_class("urgent");
+      button.set_visible(true);
+    } else {
+      button.get_style_context()->remove_class("urgent");
+    }
+
+    if (hide_vacant_ && !(state & TAG_ACTIVE) && !(state & TAG_URGENT) && !clients) {
+      button.set_visible(false);
+    } else {
+      button.set_visible(true);
+    }
   }
 }
 


### PR DESCRIPTION

https://github.com/user-attachments/assets/03cc7bea-76a3-4903-b7b4-e09dfab8781d

Allows the no-clients tag to be hidden, does not need to switch to hide  at startup.