### PR TITLE
.github/workflows/clang-format: bump github action (fix clang-format check)

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: DoozyX/clang-format-lint-action@v0.16.2
+      # TODO: bump to clang 19 release
+      # - uses: DoozyX/clang-format-lint-action@v0.18.2
+      - uses: DoozyX/clang-format-lint-action@558090054b3f39e3d6af24f0cd73b319535da809
         name: clang-format
         with:
           source: "."

--- a/.github/workflows/clang-tidy.yml.bak
+++ b/.github/workflows/clang-tidy.yml.bak
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     container:
       image: alexays/waybar:debian

--- a/.github/workflows/freebsd.yml
+++ b/.github/workflows/freebsd.yml
@@ -7,7 +7,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  clang:
+  build:
     # Run actions in a FreeBSD VM on the ubuntu runner
     # https://github.com/actions/runner/issues/385 - for FreeBSD runner support
     runs-on: ubuntu-latest


### PR DESCRIPTION
Looks like the clangFormatVersion was bumped to an unreleased version of the github action, pinning to the commit that makes that version available until next release. 

Formatting should be handled in https://github.com/Alexays/Waybar/pull/4025