### PR TITLE
mpris: keep button visible for stopped state

### DIFF
--- a/include/modules/mpris/mpris.hpp
+++ b/include/modules/mpris/mpris.hpp
@@ -74,6 +74,7 @@ class Mpris : public ALabel {
   std::string ellipsis_;
 
   std::string player_;
+  int player_count;
   std::vector<std::string> ignored_players_;
 
   PlayerctlPlayerManager* manager;


### PR DESCRIPTION
This allows to use the button for players that don't pause but stop. An example is shortwave for listening to radio streams.
Hide the button finally when all mpris players have vanished.

This works much better for the way I'm using the mpris module, but really not sure if this covers all situations/configurations.