### PR TITLE
Special behavior for special workspace(hyprland/workspaces) [WIP but works in its basic form lol]

### DIFF
--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -56,6 +56,7 @@ class Workspace {
   void setOutput(std::string const& value) { m_output = value; };
   bool containsWindow(WindowAddress const& addr) const { return m_windowMap.contains(addr); }
   void insertWindow(WindowCreationPayload create_window_paylod);
+
   std::string removeWindow(WindowAddress const& addr);
   void initializeWindowMap(const Json::Value& clients_data);
 

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -46,6 +46,8 @@ class Workspaces : public AModule, public EventHandler {
   bool isWorkspaceIgnored(std::string const& workspace_name);
 
   bool windowRewriteConfigUsesTitle() const { return m_anyWindowRewriteRuleUsesTitle; }
+  bool specialWorkspaceIsActive() const;
+
 
  private:
   void onEvent(const std::string& e) override;

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -124,6 +124,22 @@ std::string &Workspace::selectIcon(std::map<std::string, std::string> &icons_map
     }
   }
 
+    // Check if both isActive and isSpecial
+    if (isActive() && isSpecial()) {
+      auto specialActiveIconIt = icons_map.find("special-active");
+      if (specialActiveIconIt != icons_map.end()) {
+        return specialActiveIconIt->second;
+      }
+    }
+  
+    // Check if isActive but not isSpecial
+    if (isActive() && !isSpecial()) {
+      auto normalActiveIconIt = icons_map.find("normal-active");
+      if (normalActiveIconIt != icons_map.end()) {
+        return normalActiveIconIt->second;
+      }
+    }
+
   if (isActive()) {
     auto activeIconIt = icons_map.find("active");
     if (activeIconIt != icons_map.end()) {
@@ -192,6 +208,14 @@ void Workspace::update(const std::string &format, const std::string &icon) {
 
   auto styleContext = m_button.get_style_context();
   addOrRemoveClass(styleContext, isActive(), "active");
+//   // Only add 'active' class if:
+// // (1) This is the special workspace and it is active
+// // OR
+// // (2) No special workspace is active, and this is the normal active one
+//   bool specialIsActive = m_workspaceManager.specialWorkspaceIsActive();
+//   bool applyActive = isActive() && (!specialIsActive || isSpecial());
+//   addOrRemoveClass(styleContext, applyActive, "active");
+
   addOrRemoveClass(styleContext, isSpecial(), "special");
   addOrRemoveClass(styleContext, isEmpty(), "empty");
   addOrRemoveClass(styleContext, isPersistent(), "persistent");

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -46,6 +46,15 @@ void Workspaces::init() {
   dp.emit();
 }
 
+bool Workspaces::specialWorkspaceIsActive() const {
+  for (const auto &workspace : m_workspaces) {
+    if (workspace->isActive() && workspace->isSpecial()) {
+      return true;
+    }
+  }
+  return false;
+}
+
 Json::Value Workspaces::createMonitorWorkspaceData(std::string const &name,
                                                    std::string const &monitor) {
   spdlog::trace("Creating persistent workspace: {} on monitor {}", name, monitor);
@@ -60,6 +69,15 @@ Json::Value Workspaces::createMonitorWorkspaceData(std::string const &name,
   workspaceData["monitor"] = monitor;
   workspaceData["windows"] = 0;
   return workspaceData;
+}
+
+void addOrRemoveClassWorkspaces(const Glib::RefPtr<Gtk::StyleContext> &context, bool condition,
+                      const std::string &class_name) {
+  if (condition) {
+    context->add_class(class_name);
+  } else {
+    context->remove_class(class_name);
+  }
 }
 
 void Workspaces::createWorkspace(Json::Value const &workspace_data,
@@ -856,6 +874,11 @@ void Workspaces::setUrgentWorkspace(std::string const &windowaddress) {
 auto Workspaces::update() -> void {
   doUpdate();
   AModule::update();
+
+  //pol was here
+  bool specialActive = specialWorkspaceIsActive();
+  auto styleContext = m_box.get_style_context();
+  addOrRemoveClassWorkspaces(styleContext, specialActive, "has-special-active");
 }
 
 void Workspaces::updateWindowCount() {


### PR DESCRIPTION
This should not break anything. Just extended the functionality a bit. So I was tinkering with the workspaces buttons css and I wanted to have a **separate active indicator for my special workspace** as currently, you can only have one active indicator.

Also, it bothered me a lot that when my special workspace is turned on, the non-special active one is also colored and I want only the special one to be colored

### My implementation

- [x] added a check to see if it is a special and active, if so, find the "special-active" format-icon and if not special, checks for "normal-active" and as a fallback and support for the old "active" format-icon, it is not removed.


- [x] added a check for when a special workspace is active. if true, append a class "has-special-active" to the workspace so you can select it with css as an additional indicator or whatever you like to do with it.


#### Before: Same active icons for normal and special workspaces, two highlighted workspaces
![2025-04-05T04:02:40,774811781+08:00](https://github.com/user-attachments/assets/e11feb02-7d95-4bd9-af50-828ea13022e2)

#### After: Can have a separate active icon for special workspaces, can style workspace module and its elements if special is not active
![2025-04-05T03:56:15,192195304+08:00](https://github.com/user-attachments/assets/690bf492-81bb-42a6-9933-5b88a8d7f133)
![2025-04-05T03:53:21,477728137+08:00](https://github.com/user-attachments/assets/291b4d14-336a-426b-92ee-d31fbbbfffe9)

My styling use case
```css
#workspaces.has-special-active .active:not(.special) {
    background: none; /* Remove active highlight from normal workspaces */
    color: inherit;
}
```

How my configuration looks like
```conf
  "hyprland/workspaces": {
//truncated for simplicity
    "format-icons": {
    "special-active": "✨",
    "normal-active": "",
      "active": "", //for backwards compatibility
      "default": "",
      "special" : "",
      "empty" : ""
    },
```
Feel free to give any opinions. It's just for my personal satisfaction but I thought I might share it cause someone else might be itching a lot about it just like me.

Also, yay my first time ever contributing T.T

