### PR TITLE
wireplumber: fix potential nullpointer deref

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -299,7 +299,7 @@ void waybar::modules::Wireplumber::onMixerApiLoaded(WpObject* p, GAsyncResult* r
   gboolean success = FALSE;
   g_autoptr(GError) error = nullptr;
 
-  success = wp_core_load_component_finish(self->wp_core_, res, nullptr);
+  success = wp_core_load_component_finish(self->wp_core_, res, &error);
 
   if (success == FALSE) {
     spdlog::error("[{}]: mixer API load failed", self->name_);


### PR DESCRIPTION
From #3974 

I don't know how to reproduce the error, would be great if somebody could test this who can.

EDIT: While I think this was sensible to fix, there seem to be more problems on the back of the reported issue. Perhaps a short lived wireplumber device, but since I don't know the repro that's very speculative.