### PR TITLE
hyprland/submap: allow pango markup.

### DIFF
--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -68,8 +68,6 @@ void Submap::onEvent(const std::string& ev) {
     return;
   }
 
-  //auto submapName = ev.substr(ev.find_last_of('>') + 1);
-  //submapName = waybar::util::sanitize_string(submapName);
   auto submapName = ev.substr(ev.find_first_of('>') + 2 );
 
   if (!submap_.empty()) {

--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -68,8 +68,9 @@ void Submap::onEvent(const std::string& ev) {
     return;
   }
 
-  auto submapName = ev.substr(ev.find_last_of('>') + 1);
-  submapName = waybar::util::sanitize_string(submapName);
+  //auto submapName = ev.substr(ev.find_last_of('>') + 1);
+  //submapName = waybar::util::sanitize_string(submapName);
+  auto submapName = ev.substr(ev.find_first_of('>') + 2 );
 
   if (!submap_.empty()) {
     label_.get_style_context()->remove_class(submap_);


### PR DESCRIPTION
It would be nice to allow simple pango markup in `"format": "{}",` of the `"hyprland/submap"` module from the `hyprland.conf` file.

Example `hyprland.conf`:

```conf
...
$submapName = Note:  <b>S</b> <i>some app</i> <b>O</b> <i>other app</i>
bind = $mainMod, A, submap, $submapName
submap = $submapName
bind = , s, exec, someapp
bind = , o, exec, otherapp
bind = , escape, submap, reset
submap = reset
...
```


I was able to get this to work by editing the code in `src/modules/hyprland/submap.cpp` and changing lines `71-72` from

```cpp
auto submapName = ev.substr(ev.find_last_of('>') + 1);
submapName = waybar::util::sanitize_string(submapName);
```
to
```cpp
auto submapName = ev.substr(ev.find_first_of('>') + 2 );
```

Without these edits or something similar the original code cuts/removes everything from before the last `>` plus one character. This works without the pango markup due to the submap string starting with `submap >> `. With the pango markup it jumps to the last `>` in the string. 

Also the `sanitize_string` function converts the `>` and `<` to entities. There may be a better way to escape the string than using the `sanitize_string` function. Removing the line worked for me for now.

Tested on `0.12.0`
