### PR TITLE
Fix signal safety deadlock

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include <fcntl.h>
 #include <spdlog/spdlog.h>
 #include <sys/types.h>
 #include <sys/wait.h>
@@ -7,6 +8,7 @@
 #include <mutex>
 
 #include "client.hpp"
+#include "util/SafeSignal.hpp"
 
 std::mutex reap_mtx;
 std::list<pid_t> reap;
@@ -70,36 +72,114 @@ void startSignalThread() {
   }
 }
 
+static int signal_pipe_write_fd;
+
+// Write a single signal to `signal_pipe_write_fd`.
+// This function is set as a signal handler, so it must be async-signal-safe.
+static void writeSignalToPipe(int signum) {
+  ssize_t amt = write(signal_pipe_write_fd, &signum, sizeof(int));
+
+  // There's not much we can safely do inside of a signal handler.
+  // Let's just ignore any errors.
+  (void) amt;
+}
+
+// This initializes `signal_pipe_write_fd`, and sets up signal handlers.
+//
+// This function will run forever, emitting every `SIGUSR1`, `SIGUSR2`,
+// `SIGINT`, and `SIGRTMIN + 1`...`SIGRTMAX` signal received to
+// `signal_handler`.
+static void catchSignals(waybar::SafeSignal<int> &signal_handler) {
+  int fd[2];
+  pipe(fd);
+
+  int signal_pipe_read_fd = fd[0];
+  signal_pipe_write_fd = fd[1];
+
+  // This pipe should be able to buffer ~thousands of signals. If it fills up,
+  // we'll drop signals instead of blocking.
+
+  // We can't allow the write end to block because we'll be writing to it in a
+  // signal handler, which could interrupt the loop that's reading from it and
+  // deadlock.
+
+  fcntl(signal_pipe_write_fd, F_SETFL, O_NONBLOCK);
+
+  std::signal(SIGUSR1, writeSignalToPipe);
+  std::signal(SIGUSR2, writeSignalToPipe);
+  std::signal(SIGINT, writeSignalToPipe);
+
+  for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
+    std::signal(sig, writeSignalToPipe);
+  }
+
+  while (true) {
+    int signum;
+    ssize_t amt = read(signal_pipe_read_fd, &signum, sizeof(int));
+    if (amt < 0) {
+      spdlog::error("read from signal pipe failed with error {}, closing thread", strerror(errno));
+      break;
+    }
+
+    if (amt != sizeof(int)) {
+      continue;
+    }
+
+    signal_handler.emit(signum);
+  }
+}
+
+// Must be called on the main thread.
+static void handleSignalMainThread(int signum) {
+  if (signum >= SIGRTMIN + 1 && signum <= SIGRTMAX) {
+    for (auto& bar : waybar::Client::inst()->bars) {
+      bar->handleSignal(signum);
+    }
+
+    return;
+  }
+
+  switch (signum) {
+    case SIGUSR1:
+      spdlog::debug("Visibility toggled");
+      for (auto& bar : waybar::Client::inst()->bars) {
+        bar->toggle();
+      }
+      break;
+    case SIGUSR2:
+      spdlog::info("Reloading...");
+      reload = true;
+      waybar::Client::inst()->reset();
+      break;
+    case SIGINT:
+      spdlog::info("Quitting.");
+      reload = false;
+      waybar::Client::inst()->reset();
+      break;
+   default:
+      spdlog::debug("Received signal with number {}, but not handling", signum);
+      break;
+  }
+}
+
 int main(int argc, char* argv[]) {
   try {
     auto* client = waybar::Client::inst();
 
-    std::signal(SIGUSR1, [](int /*signal*/) {
-      for (auto& bar : waybar::Client::inst()->bars) {
-        bar->toggle();
-      }
-    });
-
-    std::signal(SIGUSR2, [](int /*signal*/) {
-      spdlog::info("Reloading...");
-      reload = true;
-      waybar::Client::inst()->reset();
-    });
-
-    std::signal(SIGINT, [](int /*signal*/) {
-      spdlog::info("Quitting.");
-      reload = false;
-      waybar::Client::inst()->reset();
-    });
-
-    for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
-      std::signal(sig, [](int sig) {
-        for (auto& bar : waybar::Client::inst()->bars) {
-          bar->handleSignal(sig);
-        }
-      });
-    }
     startSignalThread();
+
+    waybar::SafeSignal<int> posix_signal_received;
+    posix_signal_received.connect([&](int signum) {
+      handleSignalMainThread(signum);
+    });
+
+    std::thread signal_thread([&]() {
+      catchSignals(posix_signal_received);
+    });
+
+    // Every `std::thread` must be joined or detached.
+    // This thread should run forever, so detach it.
+    signal_thread.detach();
 
     auto ret = 0;
     do {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@ static void writeSignalToPipe(int signum) {
 
   // There's not much we can safely do inside of a signal handler.
   // Let's just ignore any errors.
-  (void) amt;
+  (void)amt;
 }
 
 // This initializes `signal_pipe_write_fd`, and sets up signal handlers.
@@ -30,7 +30,7 @@ static void writeSignalToPipe(int signum) {
 // This function will run forever, emitting every `SIGUSR1`, `SIGUSR2`,
 // `SIGINT`, `SIGCHLD`, and `SIGRTMIN + 1`...`SIGRTMAX` signal received
 // to `signal_handler`.
-static void catchSignals(waybar::SafeSignal<int> &signal_handler) {
+static void catchSignals(waybar::SafeSignal<int>& signal_handler) {
   int fd[2];
   pipe(fd);
 
@@ -72,10 +72,10 @@ static void catchSignals(waybar::SafeSignal<int> &signal_handler) {
 }
 
 // Must be called on the main thread.
-// 
+//
 // If this signal should restart or close the bar, this function will write
 // `true` or `false`, respectively, into `reload`.
-static void handleSignalMainThread(int signum, bool &reload) {
+static void handleSignalMainThread(int signum, bool& reload) {
   if (signum >= SIGRTMIN + 1 && signum <= SIGRTMAX) {
     for (auto& bar : waybar::Client::inst()->bars) {
       bar->handleSignal(signum);
@@ -114,7 +114,7 @@ static void handleSignalMainThread(int signum, bool &reload) {
         reap_mtx.unlock();
       }
       break;
-   default:
+    default:
       spdlog::debug("Received signal with number {}, but not handling", signum);
       break;
   }
@@ -127,13 +127,9 @@ int main(int argc, char* argv[]) {
     bool reload;
 
     waybar::SafeSignal<int> posix_signal_received;
-    posix_signal_received.connect([&](int signum) {
-      handleSignalMainThread(signum, reload);
-    });
+    posix_signal_received.connect([&](int signum) { handleSignalMainThread(signum, reload); });
 
-    std::thread signal_thread([&]() {
-      catchSignals(posix_signal_received);
-    });
+    std::thread signal_thread([&]() { catchSignals(posix_signal_received); });
 
     // Every `std::thread` must be joined or detached.
     // This thread should run forever, so detach it.


### PR DESCRIPTION
Fixes #4047.

This creates a separate thread to watch for signals. I used a `pipe` to send signals to the signal thread, as pipes are one of the few signal-safe messaging options.

Because GTK isn't thread safe, I couldn't handle signals in the signal thread either, so I used a `SafeSignal` which is thread-safe (but probably not signal-safe!) so that signals were handled on the main thread.

I also moved the `SIGCHLD` handling code into the new thread. I'm unsure about this change, as it will longer mask `SIGCHLD` in the main thread. From a cursory test it seems to work and children are still being reaped correctly, but I separated this change into its own commit so it can be reverted separately.

(Incidentally, all of `reload`'s accesses were on the same thread, so I changed it from a global to a local.)