### PR TITLE
Fixed one layout with multiple variant bug hyprland/language Fixes #3676

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -66,7 +66,11 @@ auto Language::update() -> void {
 void Language::onEvent(const std::string& ev) {
   std::lock_guard<std::mutex> lg(mutex_);
   std::string kbName(begin(ev) + ev.find_last_of('>') + 1, begin(ev) + ev.find_first_of(','));
-  auto layoutName = ev.substr(ev.find_first_of(',') + 1);
+  
+  // Last comma before variants parenthesis, eg:
+  // activelayout>>micro-star-int'l-co.,-ltd.-msi-gk50-elite-gaming-keyboard,English (US, intl., with dead keys)
+  std::string beforParenthesis(begin(ev), begin(ev) + ev.find_last_of('('));
+  auto layoutName = ev.substr(beforParenthesis.find_last_of(',') + 1);
 
   if (config_.isMember("keyboard-name") && kbName != config_["keyboard-name"].asString())
     return;  // ignore

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -66,7 +66,7 @@ auto Language::update() -> void {
 void Language::onEvent(const std::string& ev) {
   std::lock_guard<std::mutex> lg(mutex_);
   std::string kbName(begin(ev) + ev.find_last_of('>') + 1, begin(ev) + ev.find_first_of(','));
-  auto layoutName = ev.substr(ev.find_last_of(',') + 1);
+  auto layoutName = ev.substr(ev.find_first_of(',') + 1);
 
   if (config_.isMember("keyboard-name") && kbName != config_["keyboard-name"].asString())
     return;  // ignore


### PR DESCRIPTION
Hypr onfig:
```
kb_layout = us, us
kb_variant = basic, intl
```

Using find_last_of eg:
`ev = "activelayout>>kb-name-,English (US, intl., with dead keys)"`
So layout name will be = " with dead keys)" -> unknown layout !

Using find_first_of fixed it.