### PR TITLE
Hyperland workspace windows to use system icons

### DIFF
--- a/include/AAppIconLabel.hpp
+++ b/include/AAppIconLabel.hpp
@@ -15,9 +15,10 @@ class AAppIconLabel : public AIconLabel {
   virtual ~AAppIconLabel() = default;
   auto update() -> void override;
 
- protected:
   void updateAppIconName(const std::string &app_identifier,
                          const std::string &alternative_app_identifier);
+
+ protected:
   void updateAppIcon();
   unsigned app_icon_size_{24};
   bool update_app_icon_{true};

--- a/include/modules/hyprland/windowcreationpayload.hpp
+++ b/include/modules/hyprland/windowcreationpayload.hpp
@@ -28,6 +28,8 @@ class Workspaces;
 
 class WindowCreationPayload {
  public:
+  using ClassAndTitle = std::pair<std::string, std::string>;
+
   WindowCreationPayload(std::string workspace_name, WindowAddress window_address,
                         std::string window_repr);
   WindowCreationPayload(std::string workspace_name, WindowAddress window_address,
@@ -37,8 +39,10 @@ class WindowCreationPayload {
   int incrementTimeSpentUncreated();
   bool isEmpty(Workspaces& workspace_manager);
   bool reprIsReady() const { return std::holds_alternative<Repr>(m_window); }
+  bool isClassReady() const { return std::holds_alternative<ClassAndTitle>(m_window); }
   std::string repr(Workspaces& workspace_manager);
 
+  ClassAndTitle getClassAndTitle() { return std::get<ClassAndTitle>(m_window); }
   std::string getWorkspaceName() const { return m_workspaceName; }
   WindowAddress getAddress() const { return m_windowAddress; }
 
@@ -49,7 +53,7 @@ class WindowCreationPayload {
   void clearWorkspaceName();
 
   using Repr = std::string;
-  using ClassAndTitle = std::pair<std::string, std::string>;
+
   std::variant<Repr, ClassAndTitle> m_window;
 
   WindowAddress m_windowAddress;

--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -14,6 +14,7 @@
 #include <variant>
 #include <vector>
 
+#include "AAppIconLabel.hpp"
 #include "AModule.hpp"
 #include "bar.hpp"
 #include "modules/hyprland/backend.hpp"
@@ -27,8 +28,11 @@ namespace waybar::modules::hyprland {
 
 class Workspaces;
 class Workspace {
+  using WindowDataRepr = std::variant<std::string, std::shared_ptr<AAppIconLabel>>;
+
  public:
   explicit Workspace(const Json::Value& workspace_data, Workspaces& workspace_manager,
+                     const Json::Value& config,
                      const Json::Value& clients_data = Json::Value::nullRef);
   std::string& selectIcon(std::map<std::string, std::string>& icons_map);
   Gtk::Button& button() { return m_button; };
@@ -77,8 +81,11 @@ class Workspace {
   bool m_isPersistentConfig = false;  // represents the persistent state in the Waybar config
   bool m_isUrgent = false;
   bool m_isVisible = false;
+  bool m_isUsingWindowSystemIcons = false;
 
-  std::map<WindowAddress, std::string> m_windowMap;
+  std::map<WindowAddress, WindowDataRepr> m_windowMap;
+
+  int m_labelFontSize = 10;
 
   Gtk::Button m_button;
   Gtk::Box m_content;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -145,6 +145,7 @@ class Workspaces : public AModule, public EventHandler {
   bool m_anyWindowRewriteRuleUsesTitle = false;
   std::string m_formatWindowSeparator;
 
+  bool m_systemDefaultWindowIcons = true;
   bool m_withIcon;
   uint64_t m_monitorId;
   int m_activeWorkspaceId;

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -42,7 +42,10 @@ Workspace::Workspace(const Json::Value &workspace_data, Workspaces &workspace_ma
     m_labelFontSize = config["windows-system-icon-size"].asInt();
   }
 
-  m_isUsingWindowSystemIcons = config["windows-system-icon"].asBool();
+  auto format = config["format"].asString();
+
+  m_isUsingWindowSystemIcons =
+      config["windows-system-icon"].asBool() && format.find("{windows}") != std::string::npos;
 
   m_button.add_events(Gdk::BUTTON_PRESS_MASK);
   m_button.signal_button_press_event().connect(sigc::mem_fun(*this, &Workspace::handleClicked),
@@ -257,11 +260,14 @@ void Workspace::update(const std::string &format, const std::string &icon) {
 
   bool isNotFirst = false;
 
-  for (auto &[_pid, window_repr] : m_windowMap) {
-    if (isNotFirst) {
-      // windows.append(windowSeparator);
+  if (!m_isUsingWindowSystemIcons) {
+    for (auto &[_pid, window_repr] : m_windowMap) {
+      if (isNotFirst) {
+        windows.append(windowSeparator);
+      }
+      isNotFirst = true;
+      windows.append(std::get<std::string>(window_repr));
     }
-    isNotFirst = true;
   }
 
   m_label.set_markup(fmt::format(fmt::runtime(format), fmt::arg("id", id()),

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -30,18 +30,7 @@ Workspace::Workspace(const Json::Value &workspace_data, Workspaces &workspace_ma
     m_isSpecial = true;
   }
 
-  m_isUsingWindowSystemIcons = config["windows-system-icon"].asBool();
-
-  m_button.add_events(Gdk::BUTTON_PRESS_MASK);
-  m_button.signal_button_press_event().connect(sigc::mem_fun(*this, &Workspace::handleClicked),
-                                               false);
-  m_button.set_relief(Gtk::RELIEF_NONE);
-  m_content.add(m_label);
-
-  initializeWindowMap(clients_data);
-  m_button.add(m_content);
-
-  if (!config["windows-system-icon-size"].isIntegral()) {
+  if (!config["windows-system-icon-size"].isInt()) {
     auto context = m_label.get_pango_context();
     auto font_desc = context->get_font_description();
 
@@ -52,6 +41,17 @@ Workspace::Workspace(const Json::Value &workspace_data, Workspaces &workspace_ma
   } else {
     m_labelFontSize = config["windows-system-icon-size"].asInt();
   }
+
+  m_isUsingWindowSystemIcons = config["windows-system-icon"].asBool();
+
+  m_button.add_events(Gdk::BUTTON_PRESS_MASK);
+  m_button.signal_button_press_event().connect(sigc::mem_fun(*this, &Workspace::handleClicked),
+                                               false);
+  m_button.set_relief(Gtk::RELIEF_NONE);
+  m_content.add(m_label);
+
+  initializeWindowMap(clients_data);
+  m_button.add(m_content);
 }
 
 void addOrRemoveClass(const Glib::RefPtr<Gtk::StyleContext> &context, bool condition,

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -96,7 +96,9 @@ void Workspaces::createWorkspace(Json::Value const &workspace_data,
   }
 
   // create new workspace
-  m_workspaces.emplace_back(std::make_unique<Workspace>(workspace_data, *this, clients_data));
+  m_workspaces.emplace_back(
+      std::make_unique<Workspace>(workspace_data, *this, config_, clients_data));
+
   Gtk::Button &newWorkspaceButton = m_workspaces.back()->button();
   m_box.pack_start(newWorkspaceButton, false, false);
   sortWorkspaces();


### PR DESCRIPTION
Added the option for the hyprland workspace module to use system icons instead of them having to be predefined.

Both options for rewrite and the system icons are available.

This also adds two new configuration options: 
"windows-system-icons": {Bool} // Sets the system icons to be used
"windows-system-icons-size": {Int} // Sets the size of the icons if not set defaults to the label's font size

