### PR TITLE
feat(river): set layout name as class

### DIFF
--- a/include/modules/river/layout.hpp
+++ b/include/modules/river/layout.hpp
@@ -24,6 +24,7 @@ class Layout : public waybar::ALabel {
 
  private:
   const waybar::Bar &bar_;
+  std::string name_;
   struct wl_output *output_;          // stores the output this module belongs to
   struct wl_output *focused_output_;  // stores the currently focused output
   struct zriver_output_status_v1 *output_status_;

--- a/man/waybar-river-layout.5.scd
+++ b/man/waybar-river-layout.5.scd
@@ -83,6 +83,7 @@ Addressed by *river/layout*
 
 - *#layout*
 - *#layout.focused* Applied when the output this module's bar belongs to is focused.
+- *#layout.<layout>* Applied when the output this module's bar belongs uses this layout.
 
 # SEE ALSO
 

--- a/src/modules/river/layout.cpp
+++ b/src/modules/river/layout.cpp
@@ -145,9 +145,16 @@ void Layout::handle_name(const char *name) {
   if (std::strcmp(name, "") == 0 || format_.empty()) {
     label_.hide();  // hide empty labels or labels with empty format
   } else {
-    label_.show();
+    if (!name_.empty()) {
+      label_.get_style_context()->remove_class(name_);
+    }
+
+    label_.get_style_context()->add_class(name);
     label_.set_markup(fmt::format(fmt::runtime(format_), Glib::Markup::escape_text(name).raw()));
+    label_.show();
+
   }
+  name_ = name;
   ALabel::update();
 }
 


### PR DESCRIPTION
This allows for custom styling for specific river layouts (such as monocle). It follows the same pattern as used in river/mode for making custom per-mode styling possible.