### PR TITLE
Issue 3981: try and fix memory leak in privacy module

### DIFF
--- a/src/modules/privacy/privacy_item.cpp
+++ b/src/modules/privacy/privacy_item.cpp
@@ -1,5 +1,7 @@
 #include "modules/privacy/privacy_item.hpp"
 
+#include <spdlog/spdlog.h>
+
 #include <string>
 
 #include "glibmm/main.h"
@@ -94,22 +96,22 @@ PrivacyItem::PrivacyItem(const Json::Value &config_, enum PrivacyNodeType privac
 }
 
 void PrivacyItem::update_tooltip() {
+  spdlog::trace("update privacy tooltip");
   // Removes all old nodes
   for (auto *child : tooltip_window.get_children()) {
-    delete child;
+    tooltip_window.remove(*child);
   }
-
   for (auto *node : *nodes) {
     Gtk::Box *box = new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 4);
 
     // Set device icon
-    Gtk::Image *node_icon = new Gtk::Image();
+    Gtk::Image *node_icon = Gtk::make_managed<Gtk::Image>();
     node_icon->set_pixel_size(tooltipIconSize);
     node_icon->set_from_icon_name(node->getIconName(), Gtk::ICON_SIZE_INVALID);
     box->add(*node_icon);
 
     // Set model
-    auto *nodeName = new Gtk::Label(node->getName());
+    auto *nodeName = Gtk::make_managed<Gtk::Label>(node->getName());
     box->add(*nodeName);
 
     tooltip_window.add(*box);

--- a/src/modules/privacy/privacy_item.cpp
+++ b/src/modules/privacy/privacy_item.cpp
@@ -100,12 +100,15 @@ void PrivacyItem::update_tooltip() {
   // Removes all old nodes
   for (auto *child : tooltip_window.get_children()) {
     tooltip_window.remove(*child);
+    // despite the remove, still needs a delete to prevent memory leak. Speculating that this might
+    // work differently in GTK4.
+    delete child;
   }
   for (auto *node : *nodes) {
-    Gtk::Box *box = new Gtk::Box(Gtk::ORIENTATION_HORIZONTAL, 4);
+    auto *box = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL, 4);
 
     // Set device icon
-    Gtk::Image *node_icon = Gtk::make_managed<Gtk::Image>();
+    auto *node_icon = Gtk::make_managed<Gtk::Image>();
     node_icon->set_pixel_size(tooltipIconSize);
     node_icon->set_from_icon_name(node->getIconName(), Gtk::ICON_SIZE_INVALID);
     box->add(*node_icon);

--- a/src/modules/privacy/privacy_item.cpp
+++ b/src/modules/privacy/privacy_item.cpp
@@ -96,7 +96,6 @@ PrivacyItem::PrivacyItem(const Json::Value &config_, enum PrivacyNodeType privac
 }
 
 void PrivacyItem::update_tooltip() {
-  spdlog::trace("update privacy tooltip");
   // Removes all old nodes
   for (auto *child : tooltip_window.get_children()) {
     tooltip_window.remove(*child);


### PR DESCRIPTION
Closes #3981

As I'm mostly dealing with languages with automatic memory management, I'm not an expert on this. :p But I think `update_tooltip` creates objects with every update and at least doesn't get rid of the childrens' children.

Attempt to address this by using `make_managed` instead of new objects.

I've tested it and at least with my limited test it worked, can't see the reported memory leak with heaptrack anymore, either.