### PR TITLE
Update mediaplayer.py - Fix artist name display in mediaplayer.py

### DIFF
--- a/resources/custom_modules/mediaplayer.py
+++ b/resources/custom_modules/mediaplayer.py
@@ -112,6 +112,7 @@ class PlayerManager:
         logger.debug(f"Metadata changed for player {player.props.player_name}")
         player_name = player.props.player_name
         artist = player.get_artist()
+        artist = artist.replace("&", "&amp;")
         title = player.get_title()
         title = title.replace("&", "&amp;")
 


### PR DESCRIPTION
Fixed an issue where artist names like "Earth, Wind & Fire" were not displayed correctly. The change ensures that artist names containing "&" are now shown properly.