### PR TITLE
feat: sway/window: provide {marks} format replacement

### DIFF
--- a/include/modules/sway/window.hpp
+++ b/include/modules/sway/window.hpp
@@ -19,10 +19,11 @@ class Window : public AAppIconLabel, public sigc::trackable {
   auto update() -> void override;
 
  private:
-  void setClass(std::string classname, bool enable);
+  void setClass(const std::string& classname, bool enable);
   void onEvent(const struct Ipc::ipc_response&);
   void onCmd(const struct Ipc::ipc_response&);
-  std::tuple<std::size_t, int, int, std::string, std::string, std::string, std::string, std::string>
+  std::tuple<std::size_t, int, int, std::string, std::string, std::string, std::string, std::string,
+             std::string>
   getFocusedNode(const Json::Value& nodes, std::string& output);
   void getTree();
 
@@ -35,6 +36,7 @@ class Window : public AAppIconLabel, public sigc::trackable {
   std::string old_app_id_;
   std::size_t app_nb_;
   std::string shell_;
+  std::string marks_;
   int floating_count_;
   util::JsonParser parser_;
   std::mutex mutex_;

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -89,6 +89,11 @@ Addressed by *sway/window*
 	default: false ++
 	If the workspace itself is focused and the workspace contains nodes or floating_nodes, show the workspace name. If not set, text remains empty but styles according to nodes in the workspace are still applied.
 
+*show-hidden-marks*: ++
+	typeof: bool ++
+	default: false ++
+	For the *{marks}* format replacement, include hidden marks that start with an underscore.
+
 *rewrite*: ++
 	typeof: object ++
 	Rules to rewrite the module format output. See *rewrite rules*.
@@ -116,6 +121,8 @@ Addressed by *sway/window*
 
 *{shell}*: The shell of the focused window. It's 'xwayland' when the window is
 running through xwayland, otherwise, it's 'xdg-shell'.
+
+*{marks}*: Marks of the window.
 
 # REWRITE RULES
 


### PR DESCRIPTION
if any check fails, that's still because of src/modules/sway/workspaces.cpp, i didn't touch that. see #4094 

EDIT: i did forget to format the header file though, should be fixed now.