### PR TITLE
niri: add support for urgency indicators to workspaces

### DIFF
--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -70,6 +70,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *default*: Will be shown, when no string matches are found.
 - *focused*: Will be shown, when workspace is focused.
 - *active*: Will be shown, when workspace is active on its output.
+- *urgent*: Will be shown, when workspace has urgent windows.
 
 # EXAMPLES
 
@@ -95,6 +96,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces button*
 - *#workspaces button.focused*: The single focused workspace.
 - *#workspaces button.active*: The workspace is active (visible) on its output.
+- *#workspaces button.urgent*: The workspace has one or more urgent windows.
 - *#workspaces button.empty*: The workspace is empty.
 - *#workspaces button.current_output*: The workspace is from the same output as
   the bar that it is displayed on.

--- a/src/modules/niri/backend.cpp
+++ b/src/modules/niri/backend.cpp
@@ -147,6 +147,17 @@ void IPC::parseIPC(const std::string &line) {
       } else {
         spdlog::error("Active window changed on unknown workspace");
       }
+    } else if (const auto &payload = ev["WorkspaceUrgencyChanged"]) {
+      const auto id = payload["id"].asUInt64();
+      const auto urgent = payload["urgent"].asBool();
+      auto it = std::find_if(workspaces_.begin(), workspaces_.end(),
+                             [id](const auto &ws) { return ws["id"].asUInt64() == id; });
+      if (it != workspaces_.end()) {
+        auto &ws = *it;
+        ws["is_urgent"] = urgent;
+      } else {
+        spdlog::error("Urgency changed for unknown workspace");
+      }
     } else if (const auto &payload = ev["KeyboardLayoutsChanged"]) {
       const auto &layouts = payload["keyboard_layouts"];
       const auto &names = layouts["names"];

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -20,6 +20,7 @@ Workspaces::Workspaces(const std::string &id, const Bar &bar, const Json::Value 
   gIPC->registerForIPC("WorkspacesChanged", this);
   gIPC->registerForIPC("WorkspaceActivated", this);
   gIPC->registerForIPC("WorkspaceActiveWindowChanged", this);
+  gIPC->registerForIPC("WorkspaceUrgencyChanged", this);
 
   dp.emit();
 }
@@ -66,6 +67,11 @@ void Workspaces::doUpdate() {
       style_context->add_class("active");
     else
       style_context->remove_class("active");
+
+    if (ws["is_urgent"].asBool())
+      style_context->add_class("urgent");
+    else
+      style_context->remove_class("urgent");
 
     if (ws["output"]) {
       if (ws["output"].asString() == bar_.output->name)
@@ -165,6 +171,8 @@ Gtk::Button &Workspaces::addButton(const Json::Value &ws) {
 std::string Workspaces::getIcon(const std::string &value, const Json::Value &ws) {
   const auto &icons = config_["format-icons"];
   if (!icons) return value;
+
+  if (ws["is_urgent"].asBool() && icons["urgent"]) return icons["urgent"].asString();
 
   if (ws["is_focused"].asBool() && icons["focused"]) return icons["focused"].asString();
 


### PR DESCRIPTION
This adds support for the [newly added urgency feature in niri](https://github.com/YaLTeR/niri/pull/1319) to niri-workspaces, matching other modules like sway-workspaces.