### PR TITLE
niri/workspaces: Add empty icon

### DIFF
--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -70,6 +70,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *default*: Will be shown, when no string matches are found.
 - *focused*: Will be shown, when workspace is focused.
 - *active*: Will be shown, when workspace is active on its output.
+- *empty*: Will be shown, when workspace is empty.
 
 # EXAMPLES
 

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -166,6 +166,8 @@ std::string Workspaces::getIcon(const std::string &value, const Json::Value &ws)
   const auto &icons = config_["format-icons"];
   if (!icons) return value;
 
+  if (ws["active_window_id"].isNull() && icons["empty"]) return icons["empty"].asString();
+
   if (ws["is_focused"].asBool() && icons["focused"]) return icons["focused"].asString();
 
   if (ws["is_active"].asBool() && icons["active"]) return icons["active"].asString();


### PR DESCRIPTION
This adds another icon to `format-icons` of `niri/workspaces`: `empty`, which will be used for workspaces that contain no windows.

Example usage:
![image](https://github.com/user-attachments/assets/0d7bff1a-6c25-4eef-b70a-11853215b927)

```json
"niri/workspaces": {
  "format": "{icon}",
  "format-icons": {
    "empty": "○",
    "default": "●"
  },
},
```