### PR TITLE
Add support for mouse side buttons (back/forward) to control track navigation in mpris module

### DIFF
--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -14,7 +14,6 @@ extern "C" {
 
 #include <glib.h>
 #include <spdlog/spdlog.h>
-
 namespace waybar::modules::mpris {
 
 const std::string DEFAULT_FORMAT = "{player} ({status}): {dynamic}";
@@ -584,38 +583,45 @@ errorexit:
 }
 
 bool Mpris::handleToggle(GdkEventButton* const& e) {
+  if (!e || e->type != GdkEventType::GDK_BUTTON_PRESS) {
+    return false;
+  }
+
+  auto info = getPlayerInfo();
+  if (!info) return false;
+
+  struct ButtonAction {
+    guint button;
+    const char* config_key;
+    std::function<void()> builtin_action;
+  };
+
   GError* error = nullptr;
-  waybar::util::ScopeGuard error_deleter([error]() {
+  waybar::util::ScopeGuard error_deleter([&error]() {
     if (error) {
       g_error_free(error);
     }
   });
 
-  auto info = getPlayerInfo();
-  if (!info) return false;
+  // Command pattern: encapsulate each button's action
+  const ButtonAction actions[] = {
+    {1, "on-click",          [&]() { playerctl_player_play_pause(player, &error); }},
+    {2, "on-click-middle",   [&]() { playerctl_player_previous(player, &error); }},
+    {3, "on-click-right",    [&]() { playerctl_player_next(player, &error); }},
+    {8, "on-click-backward", [&]() { playerctl_player_previous(player, &error); }},
+    {9, "on-click-forward",  [&]() { playerctl_player_next(player, &error); }},
+  };
 
-  if (e->type == GdkEventType::GDK_BUTTON_PRESS) {
-    switch (e->button) {
-      case 1:  // left-click
-        if (config_["on-click"].isString()) {
-          return ALabel::handleToggle(e);
-        }
-        playerctl_player_play_pause(player, &error);
-        break;
-      case 2:  // middle-click
-        if (config_["on-click-middle"].isString()) {
-          return ALabel::handleToggle(e);
-        }
-        playerctl_player_previous(player, &error);
-        break;
-      case 3:  // right-click
-        if (config_["on-click-right"].isString()) {
-          return ALabel::handleToggle(e);
-        }
-        playerctl_player_next(player, &error);
-        break;
+  for (const auto& action : actions) {
+    if (e->button == action.button) {
+      if (config_[action.config_key].isString()) {
+        return ALabel::handleToggle(e);
+      }
+      action.builtin_action();
+      break;
     }
   }
+
   if (error) {
     spdlog::error("mpris[{}]: error running builtin on-click action: {}", (*info).name,
                   error->message);


### PR DESCRIPTION
**Summary:**  
This PR adds support for using mouse side buttons (typically buttons 8 and 9, often mapped as "back" and "forward" on high-end mice) to control previous/next track actions in the Waybar mpris module. This allows users to quickly skip tracks using their mouse's extra buttons.

**Context:**  
Related to #1160, which requested support for additional mouse buttons (beyond 0–5) for actions like next/previous track. This PR implements `on-click-backward` (button 8) and `on-click-forward` (button 9) as built-in actions, making it easier to control playback with modern mice.

**Testing:**  
Tested on Arch Linux (Wayland) with a Razer mouse.  
Please note: Other platforms and mice may need further testing.

**Notes:**  
- No breaking changes; existing button actions remain unchanged.
- Custom hooks for these buttons can still be set via config if desired.