### PR TITLE
Fix Description= in systemd service file

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -1,5 +1,5 @@
 [Unit]
-Description=Highly customizable Wayland bar for Sway and Wlroots based compositors.
+Description=Highly customizable Wayland bar for Sway and Wlroots based compositors
 Documentation=https://github.com/Alexays/Waybar/wiki/
 PartOf=graphical-session.target
 After=graphical-session.target


### PR DESCRIPTION
Description= should be a noun phrase, and not a full sentence, according
to man 5 systemd.unit.

In particular, using a dot at the end result in messages like this in
journalctl when running as a user service (note the superfluous dot at
the end):

May 31 16:03:38 framework systemd[1180]: Started Highly customizable Wayland bar for Sway and Wlroots based compositors..
May 31 16:20:39 framework systemd[1180]: Stopping Highly customizable Wayland bar for Sway and Wlroots based compositors....
May 31 16:20:39 framework systemd[1180]: Stopped Highly customizable Wayland bar for Sway and Wlroots based compositors..
