### PR TITLE
AIconLabel.cpp: honour "rotation" property and add "swap-icon-label" propery

### DIFF
--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -272,6 +272,17 @@ When positioning Waybar on the left or right side of the screen, sometimes it's 
 
 Valid options for the "rotate" property are: 0, 90, 180, and 270.
 
+## Swapping icon and label
+
+If a module displays both a label and an icon, it might be desirable to swap them (for instance, for panels on the left or right of the screen, or for user adopting a right-to-left script). This can be achieved with the "swap-icon-label" property, taking a boolean. Example:
+```
+{
+	"sway/window": {
+		"swap-icon-label": true
+	}
+}
+```
+
 ## Grouping modules
 
 Module groups allow stacking modules in any direction. By default, when the bar is positioned on the top or bottom of the screen, modules in a group are stacked vertically. Likewise, when positioned on the left or right, modules in a group are stacked horizontally. This can be changed with the "orientation" property.

--- a/src/AIconLabel.cpp
+++ b/src/AIconLabel.cpp
@@ -1,6 +1,7 @@
 #include "AIconLabel.hpp"
 
 #include <gdkmm/pixbuf.h>
+#include <spdlog/spdlog.h>
 
 namespace waybar {
 
@@ -17,14 +18,37 @@ AIconLabel::AIconLabel(const Json::Value &config, const std::string &name, const
     box_.get_style_context()->add_class(id);
   }
 
-  box_.set_orientation(Gtk::Orientation::ORIENTATION_HORIZONTAL);
+  int rot = 0;
+
+  if (config_["rotate"].isUInt()) {
+    rot = config["rotate"].asUInt() % 360;
+    if ((rot % 90) != 00)
+      rot = 0;
+    rot /= 90;
+  }
+
+  if ((rot % 2) == 0)
+    box_.set_orientation(Gtk::Orientation::ORIENTATION_HORIZONTAL);
+  else
+    box_.set_orientation(Gtk::Orientation::ORIENTATION_VERTICAL);
   box_.set_name(name);
 
   int spacing = config_["icon-spacing"].isInt() ? config_["icon-spacing"].asInt() : 8;
   box_.set_spacing(spacing);
 
-  box_.add(image_);
-  box_.add(label_);
+  bool swap_icon_label = false;
+  if (not config_["swap-icon-label"].isBool())
+    spdlog::warn("'swap-icon-label' must be a bool.");
+  else
+    swap_icon_label = config_["swap-icon-label"].asBool();
+
+  if ( (rot == 0 || rot == 3) ^ swap_icon_label ) {
+    box_.add(image_);
+    box_.add(label_);
+  } else {
+    box_.add(label_);
+    box_.add(image_);
+  }
 
   event_box_.add(box_);
 }


### PR DESCRIPTION
The current behaviour for modules employing `AIconLabel` is that the icon is show on the left of the label.  This is not desirable for for vertical bars and for users with a right-to-left script.  

This PR solves this issue by:

 * making `AIconLabel` honour the `rotation` property
 * adding a `swap-icon-label` property