### PR TITLE
Memory Fix for continuous scripts in custom module

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -62,7 +62,7 @@ void waybar::modules::Custom::continuousWorker() {
   }
   thread_ = [this, cmd] {
     char* buff = nullptr;
-    waybar::util::ScopeGuard buff_deleter([buff]() {
+    waybar::util::ScopeGuard buff_deleter([&buff]() {
       if (buff) {
         free(buff);
       }


### PR DESCRIPTION
I noticed that waybar was continually allocating more memory after I added a custom module that invoked a continuous script. After looking at it for a while, I think it is because the `ScopeGuard`—meant to clear the buffer—was capturing `buff` by value, so it would continually try and free `nullptr`.

Here's a change that should capture `buff` by reference and hopefully fix the issue (it seemed to fix it for at least my use case). 

I'm pretty rusty at C++, and newish to github in general, so feedback is appreciated.