### PR TITLE
fix: network frequency is reported in GHz

### DIFF
--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -171,7 +171,7 @@ Addressed by *network*
 
 *{signaldBm}*: Signal strength of the wireless network in dBm.
 
-*{frequency}*: Frequency of the wireless network in MHz.
+*{frequency}*: Frequency of the wireless network in GHz.
 
 *{bandwidthUpBits}*: Instant up speed in bits/seconds.
 


### PR DESCRIPTION
Fixed a small inconsistency in the man page. Personally I would prefer to see the frequency in MHz but it's not that important.