### PR TITLE
fix: network module not displaying rfkill state

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -223,8 +223,8 @@ void waybar::modules::Network::worker() {
       std::lock_guard<std::mutex> lock(mutex_);
       if (ifid_ > 0) {
         getInfo();
-        dp.emit();
       }
+      dp.emit();
     }
     thread_timer_.sleep_for(interval_);
   };
@@ -271,10 +271,10 @@ void waybar::modules::Network::worker() {
 }
 
 const std::string waybar::modules::Network::getNetworkState() const {
-  if (ifid_ == -1) {
 #ifdef WANT_RFKILL
     if (rfkill_.getState()) return "disabled";
 #endif
+  if (ifid_ == -1) {
     return "disconnected";
   }
   if (!carrier_) return "disconnected";


### PR DESCRIPTION
`clearIface` resets `ifid_` to `-1`, but it does so before the rfkill state can be displayed.
This results in the module never switching to the `disabled` state (unless rfkill was already active prior to launching waybar).