### PR TITLE
Fix length error output description

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -86,7 +86,7 @@ void waybar::Client::handleOutputDone(void *data, struct zxdg_output_v1 * /*xdg_
       }
     }
   } catch (const std::exception &e) {
-    std::cerr << e.what() << '\n';
+    spdlog::warn("caught exception in zxdg_output_v1_listener::done: {}", e.what());
   }
 }
 
@@ -97,7 +97,7 @@ void waybar::Client::handleOutputName(void *data, struct zxdg_output_v1 * /*xdg_
     auto &output = client->getOutput(data);
     output.name = name;
   } catch (const std::exception &e) {
-    std::cerr << e.what() << '\n';
+    spdlog::warn("caught exception in zxdg_output_v1_listener::name: {}", e.what());
   }
 }
 
@@ -112,7 +112,7 @@ void waybar::Client::handleOutputDescription(void *data, struct zxdg_output_v1 *
     auto pos = s.find(" (");
     output.identifier = pos != std::string::npos ? s.substr(0, pos) : s;
   } catch (const std::exception &e) {
-    std::cerr << e.what() << '\n';
+    spdlog::warn("caught exception in zxdg_output_v1_listener::description: {}", e.what());
   }
 }
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -106,11 +106,11 @@ void waybar::Client::handleOutputDescription(void *data, struct zxdg_output_v1 *
   auto *client = waybar::Client::inst();
   try {
     auto &output = client->getOutput(data);
-    const char *open_paren = strrchr(description, '(');
 
     // Description format: "identifier (name)"
-    size_t identifier_length = open_paren - description;
-    output.identifier = std::string(description, identifier_length - 1);
+    auto s = std::string(description);
+    auto pos = s.find(" (");
+    output.identifier = pos != std::string::npos ? s.substr(0, pos) : s;
   } catch (const std::exception &e) {
     std::cerr << e.what() << '\n';
   }


### PR DESCRIPTION
I was seeing this weird `basic_string::_M_create` log coming form waybar. Turns out it's caused by a `std::length_error`, which gets thrown because `strchr` returns null when there's no parentheses in the output description.
```
systemd[1525]: Started Highly customizable Wayland bar for Sway and Wlroots based compositors..
waybar[14684]: [2025-06-13 22:49:52.286] [info] Using configuration file /home/peelz/.config/waybar/config.jsonc
waybar[14684]: [2025-06-13 22:49:52.293] [info] Discovered appearance 'dark'
waybar[14684]: [2025-06-13 22:49:52.293] [info] Using CSS file /home/peelz/.config/waybar/style.css
waybar[14684]: basic_string::_M_create
waybar[14684]: [2025-06-13 22:49:52.304] [info] Niri IPC starting
waybar[14684]: [2025-06-13 22:49:52.377] [info] Bar configured (width: 1707, height: 31) for output: eDP-1
```