### PR TITLE
modules: memory: Add swapState format argument

### DIFF
--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -120,6 +120,8 @@ Addressed by *memory*
 
 *{swapAvail}*: Amount of available swap in GiB.
 
+*{swapState}*: Signals if swap is activated or not
+
 # EXAMPLES
 
 ```

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -60,6 +60,7 @@ auto waybar::modules::Memory::update() -> void {
           fmt::arg("icon", getIcon(used_ram_percentage, icons)),
           fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
           fmt::arg("percentage", used_ram_percentage),
+          fmt::arg("swapState", swaptotal == 0 ? "Off" : "On"),
           fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram_gigabytes),
           fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
           fmt::arg("swapAvail", available_swap_gigabytes)));
@@ -72,6 +73,7 @@ auto waybar::modules::Memory::update() -> void {
             fmt::runtime(tooltip_format), used_ram_percentage,
             fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
             fmt::arg("percentage", used_ram_percentage),
+            fmt::arg("swapState", swaptotal == 0 ? "Off" : "On"),
             fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram_gigabytes),
             fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
             fmt::arg("swapAvail", available_swap_gigabytes)));


### PR DESCRIPTION
Add an argument to the memory module which displays the state of the swap configuration of the local system.

Usage of swap does not necessarily indicate if swap is on or off.