### PR TITLE
Dockerfiles: Use debian-slim for container

### DIFF
--- a/Dockerfiles/debian
+++ b/Dockerfiles/debian
@@ -1,6 +1,6 @@
 # vim: ft=Dockerfile
 
-FROM debian:sid
+FROM debian:sid-slim
 
 RUN apt update && \
     apt install --no-install-recommends --no-install-suggests -y \


### PR DESCRIPTION
Slim images of Debian tend to be smaller even during development. Hence replace the full-fledged variant with the slim one.