### PR TITLE
Feat/display systemd system state

### DIFF
--- a/include/modules/systemd_failed_units.hpp
+++ b/include/modules/systemd_failed_units.hpp
@@ -25,6 +25,7 @@ class SystemdFailedUnits : public ALabel {
 
   void notify_cb(const Glib::ustring &sender_name, const Glib::ustring &signal_name,
                  const Glib::VariantContainerBase &arguments);
+  void RequestFailedUnits();
   void updateData();
 };
 

--- a/include/modules/systemd_failed_units.hpp
+++ b/include/modules/systemd_failed_units.hpp
@@ -19,6 +19,7 @@ class SystemdFailedUnits : public ALabel {
   std::string format_ok;
 
   bool update_pending;
+  std::string system_state, user_state, overall_state;
   uint32_t nr_failed_system, nr_failed_user, nr_failed;
   std::string last_status;
   Glib::RefPtr<Gio::DBus::Proxy> system_proxy, user_proxy;
@@ -26,6 +27,7 @@ class SystemdFailedUnits : public ALabel {
   void notify_cb(const Glib::ustring &sender_name, const Glib::ustring &signal_name,
                  const Glib::VariantContainerBase &arguments);
   void RequestFailedUnits();
+  void RequestSystemState();
   void updateData();
 };
 

--- a/include/modules/systemd_failed_units.hpp
+++ b/include/modules/systemd_failed_units.hpp
@@ -19,7 +19,7 @@ class SystemdFailedUnits : public ALabel {
   std::string format_ok;
 
   bool update_pending;
-  uint32_t nr_failed_system, nr_failed_user;
+  uint32_t nr_failed_system, nr_failed_user, nr_failed;
   std::string last_status;
   Glib::RefPtr<Gio::DBus::Proxy> system_proxy, user_proxy;
 

--- a/man/waybar-systemd-failed-units.5.scd
+++ b/man/waybar-systemd-failed-units.5.scd
@@ -62,6 +62,12 @@ Addressed by *systemd-failed-units*
 
 *{nr_failed}*: Number of total failed units.
 
+*{systemd_state}:* State of the systemd system session
+
+*{user_state}:* State of the systemd user session
+
+*{overall_state}:* Overall state of the systemd and user session. ("Ok" or "Degraded")
+
 # EXAMPLES
 
 ```

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -109,9 +109,8 @@ auto SystemdFailedUnits::update() -> void {
     event_box_.set_visible(false);
     return;
   }
-  if (!event_box_.get_visible()) {
-    event_box_.set_visible(true);
-  }
+
+  event_box_.set_visible(true);
 
   // Set state class.
   if (!last_status.empty() && label_.get_style_context()->has_class(last_status)) {

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -68,9 +68,7 @@ auto SystemdFailedUnits::notify_cb(const Glib::ustring& sender_name,
   }
 }
 
-void SystemdFailedUnits::updateData() {
-  update_pending = false;
-
+void SystemdFailedUnits::RequestFailedUnits() {
   auto load = [](const char* kind, Glib::RefPtr<Gio::DBus::Proxy>& proxy) -> uint32_t {
     try {
       if (!proxy) return 0;
@@ -93,6 +91,11 @@ void SystemdFailedUnits::updateData() {
   nr_failed_system = load("systemwide", system_proxy);
   nr_failed_user = load("user", user_proxy);
   nr_failed = nr_failed_system + nr_failed_user;
+}
+
+void SystemdFailedUnits::updateData() {
+  update_pending = false;
+  RequestFailedUnits();
   dp.emit();
 }
 

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -16,6 +16,7 @@ SystemdFailedUnits::SystemdFailedUnits(const std::string& id, const Json::Value&
       update_pending(false),
       nr_failed_system(0),
       nr_failed_user(0),
+      nr_failed(0),
       last_status() {
   if (config["hide-on-ok"].isBool()) {
     hide_on_ok = config["hide-on-ok"].asBool();
@@ -100,7 +101,7 @@ void SystemdFailedUnits::updateData() {
 }
 
 auto SystemdFailedUnits::update() -> void {
-  uint32_t nr_failed = nr_failed_system + nr_failed_user;
+  nr_failed = nr_failed_system + nr_failed_user;
 
   // Hide if needed.
   if (nr_failed == 0 && hide_on_ok) {

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -81,9 +81,7 @@ void SystemdFailedUnits::updateData() {
         Glib::VariantBase variant;
         g_variant_get(data.gobj_copy(), "(v)", &variant);
         if (variant && variant.is_of_type(Glib::VARIANT_TYPE_UINT32)) {
-          uint32_t value = 0;
-          g_variant_get(variant.gobj_copy(), "u", &value);
-          return value;
+          return g_variant_get_uint32(variant.gobj_copy());
         }
       }
     } catch (Glib::Error& e) {

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -103,6 +103,10 @@ void SystemdFailedUnits::updateData() {
 }
 
 auto SystemdFailedUnits::update() -> void {
+  const std::string status = nr_failed == 0 ? "ok" : "degraded";
+
+  if (last_status == status) return;
+
   // Hide if needed.
   if (nr_failed == 0 && hide_on_ok) {
     event_box_.set_visible(false);
@@ -113,7 +117,6 @@ auto SystemdFailedUnits::update() -> void {
   }
 
   // Set state class.
-  const std::string status = nr_failed == 0 ? "ok" : "degraded";
   if (!last_status.empty() && label_.get_style_context()->has_class(last_status)) {
     label_.get_style_context()->remove_class(last_status);
   }

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -97,12 +97,12 @@ void SystemdFailedUnits::updateData() {
   if (user_proxy) {
     nr_failed_user = load("user", user_proxy);
   }
+
+  nr_failed = nr_failed_system + nr_failed_user;
   dp.emit();
 }
 
 auto SystemdFailedUnits::update() -> void {
-  nr_failed = nr_failed_system + nr_failed_user;
-
   // Hide if needed.
   if (nr_failed == 0 && hide_on_ok) {
     event_box_.set_visible(false);

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -73,6 +73,7 @@ void SystemdFailedUnits::updateData() {
 
   auto load = [](const char* kind, Glib::RefPtr<Gio::DBus::Proxy>& proxy) -> uint32_t {
     try {
+      if (!proxy) return 0;
       auto parameters = Glib::VariantContainerBase(
           g_variant_new("(ss)", "org.freedesktop.systemd1.Manager", "NFailedUnits"));
       Glib::VariantContainerBase data = proxy->call_sync("Get", parameters);
@@ -91,13 +92,8 @@ void SystemdFailedUnits::updateData() {
     return 0;
   };
 
-  if (system_proxy) {
-    nr_failed_system = load("systemwide", system_proxy);
-  }
-  if (user_proxy) {
-    nr_failed_user = load("user", user_proxy);
-  }
-
+  nr_failed_system = load("systemwide", system_proxy);
+  nr_failed_user = load("user", user_proxy);
   nr_failed = nr_failed_system + nr_failed_user;
   dp.emit();
 }


### PR DESCRIPTION
First part of this pull-request refactors the code of the systemd_failed_units module for two reasons:

- eases readability of code
- prepares for introduction of system state displaying feature

Users, which are not interested in the number of failed units but in the general distinguishing of the state of systemd for the user and system session can now display this information too.