### PR TITLE
Fix gentoo CI build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,8 +3,8 @@ name: Build and Push Docker Image
 on:
   workflow_dispatch:
   schedule:
-    # run every night at midnight
-    - cron: '0 0 * * *'
+    # run monthly
+    - cron: '0 0 1 * *'
 
 jobs:
   build-and-push:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Build and Push Docker Image
 
 on:
+  workflow_dispatch:
   schedule:
     # run every night at midnight
     - cron: '0 0 * * *'
@@ -8,7 +9,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    if: github.repository == 'Alexays/Waybar'
+    if: github.event_name != 'schedule' || github.repository == 'Alexays/Waybar'
     strategy:
       fail-fast: false # don't fail the other jobs if one of the images fails to build
       matrix:

--- a/Dockerfiles/gentoo
+++ b/Dockerfiles/gentoo
@@ -6,6 +6,6 @@ RUN export FEATURES="-ipc-sandbox -network-sandbox -pid-sandbox -sandbox -usersa
 		emerge --sync && \
 		eselect news read --quiet new 1>/dev/null 2>&1 && \
 		emerge --verbose --update --deep --with-bdeps=y --backtrack=30 --newuse @world && \
-		USE="wayland gtk3 gtk -doc X pulseaudio minimal" emerge dev-vcs/git dev-libs/wayland dev-libs/wayland-protocols =dev-cpp/gtkmm-3.24.6 x11-libs/libxkbcommon \
+		USE="wayland gtk3 gtk -doc X pulseaudio minimal" emerge dev-vcs/git dev-libs/wayland dev-libs/wayland-protocols dev-cpp/gtkmm:3.0 x11-libs/libxkbcommon \
 		x11-libs/gtk+:3 dev-libs/libdbusmenu dev-libs/libnl sys-power/upower media-libs/libpulse dev-libs/libevdev media-libs/libmpdclient \
 		media-sound/sndio gui-libs/gtk-layer-shell app-text/scdoc media-sound/playerctl dev-libs/iniparser sci-libs/fftw


### PR DESCRIPTION
The gentoo CI job started started failing on recent PRs. What caught my attention is that it's running a pretty old version of gcc (12.2.1). Turns out the docker image hasn't been updated in nearly 2 years (most likely because of the strict version requirement for `dev-cpp/gtkmm`).

I've reduced the frequency of the docker build workflow, as a daily rebuild of the gentoo image will most certainly bust through the free CI tier. I've also added a `workflow_dispatch` trigger, so it can be run manually if needed.