### PR TITLE
 Fix namespace pollution

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -38,39 +38,39 @@ class Clock final : public ALabel {
     5 - tooltip-format
    */
   std::map<int, std::string const> fmtMap_;
-  uint cldMonCols_{3};           // calendar count month columns
-  int cldWnLen_{3};              // calendar week number length
-  const int cldMonColLen_{20};   // calendar month column length
-  WS cldWPos_{WS::HIDDEN};       // calendar week side to print
-  months cldCurrShift_{0};       // calendar months shift
-  int cldShift_{1};              // calendar months shift factor
-  year_month_day cldYearShift_;  // calendar Year mode. Cached ymd
-  std::string cldYearCached_;    // calendar Year mode. Cached calendar
-  year_month cldMonShift_;       // calendar Month mode. Cached ym
-  std::string cldMonCached_;     // calendar Month mode. Cached calendar
-  day cldBaseDay_{0};            // calendar Cached day. Is used when today is changing(midnight)
-  std::string cldText_{""};      // calendar text to print
+  uint cldMonCols_{3};                 // calendar count month columns
+  int cldWnLen_{3};                    // calendar week number length
+  const int cldMonColLen_{20};         // calendar month column length
+  WS cldWPos_{WS::HIDDEN};             // calendar week side to print
+  date::months cldCurrShift_{0};       // calendar months shift
+  int cldShift_{1};                    // calendar months shift factor
+  date::year_month_day cldYearShift_;  // calendar Year mode. Cached ymd
+  std::string cldYearCached_;          // calendar Year mode. Cached calendar
+  date::year_month cldMonShift_;       // calendar Month mode. Cached ym
+  std::string cldMonCached_;           // calendar Month mode. Cached calendar
+  date::day cldBaseDay_{0};  // calendar Cached day. Is used when today is changing(midnight)
+  std::string cldText_{""};  // calendar text to print
   CldMode cldMode_{CldMode::MONTH};
-  auto get_calendar(const year_month_day& today, const year_month_day& ymd, const time_zone* tz)
-      -> const std::string;
+  auto get_calendar(const date::year_month_day& today, const date::year_month_day& ymd,
+                    const date::time_zone* tz) -> const std::string;
 
   // get local time zone
-  auto local_zone() -> const time_zone*;
+  auto local_zone() -> const date::time_zone*;
 
   // time zoned time in tooltip
-  const bool tzInTooltip_;                // if need to print time zones text
-  std::vector<const time_zone*> tzList_;  // time zones list
-  int tzCurrIdx_;                         // current time zone index for tzList_
-  std::string tzText_{""};                // time zones text to print
+  const bool tzInTooltip_;                      // if need to print time zones text
+  std::vector<const date::time_zone*> tzList_;  // time zones list
+  int tzCurrIdx_;                               // current time zone index for tzList_
+  std::string tzText_{""};                      // time zones text to print
   util::SleeperThread thread_;
 
   // ordinal date in tooltip
   const bool ordInTooltip_;
   std::string ordText_{""};
-  auto get_ordinal_date(const year_month_day& today) -> std::string;
+  auto get_ordinal_date(const date::year_month_day& today) -> std::string;
 
-  auto getTZtext(sys_seconds now) -> std::string;
-  auto first_day_of_week() -> weekday;
+  auto getTZtext(date::sys_seconds now) -> std::string;
+  auto first_day_of_week() -> date::weekday;
   // Module actions
   void cldModeSwitch();
   void cldShift_up();

--- a/include/util/date.hpp
+++ b/include/util/date.hpp
@@ -15,7 +15,7 @@
 namespace date {
 #if HAVE_CHRONO_TIMEZONES
 using namespace std::chrono;
-using namespace std;
+using std::format;
 #else
 
 using system_clock = std::chrono::system_clock;
@@ -73,5 +73,3 @@ struct fmt::formatter<date::zoned_time<Duration, TimeZonePtr>> {
   }
 };
 #endif
-
-using namespace date;

--- a/include/util/portal.hpp
+++ b/include/util/portal.hpp
@@ -6,14 +6,12 @@
 
 namespace waybar {
 
-using namespace Gio;
-
 enum class Appearance {
   UNKNOWN = 0,
   DARK = 1,
   LIGHT = 2,
 };
-class Portal : private DBus::Proxy {
+class Portal : private Gio::DBus::Proxy {
  public:
   Portal();
   void refreshAppearance();

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -16,6 +16,7 @@
 #include <clocale>
 #endif
 
+using namespace date;
 namespace fmt_lib = waybar::util::date::format;
 
 waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
@@ -349,9 +350,9 @@ auto waybar::modules::Clock::get_calendar(const year_month_day& today, const yea
                           m_locale_, fmtMap_[4],
                           fmt_lib::make_format_args(
                               (line == 2)
-                                  ? static_cast<const date::zoned_seconds&&>(
+                                  ? static_cast<const zoned_seconds&&>(
                                         zoned_seconds{tz, local_days{ymTmp / 1}})
-                                  : static_cast<const date::zoned_seconds&&>(zoned_seconds{
+                                  : static_cast<const zoned_seconds&&>(zoned_seconds{
                                         tz, local_days{cldGetWeekForLine(ymTmp, firstdow, line)}})))
                    << ' ';
               } else
@@ -372,9 +373,9 @@ auto waybar::modules::Clock::get_calendar(const year_month_day& today, const yea
                    << fmt_lib::vformat(
                           m_locale_, fmtMap_[4],
                           fmt_lib::make_format_args(
-                              (line == 2) ? static_cast<const date::zoned_seconds&&>(
+                              (line == 2) ? static_cast<const zoned_seconds&&>(
                                                 zoned_seconds{tz, local_days{ymTmp / 1}})
-                                          : static_cast<const date::zoned_seconds&&>(
+                                          : static_cast<const zoned_seconds&&>(
                                                 zoned_seconds{tz, local_days{cldGetWeekForLine(
                                                                       ymTmp, firstdow, line)}})));
               else

--- a/src/util/portal.cpp
+++ b/src/util/portal.cpp
@@ -17,8 +17,6 @@ static constexpr const char* PORTAL_NAMESPACE = "org.freedesktop.appearance";
 static constexpr const char* PORTAL_KEY = "color-scheme";
 }  // namespace waybar
 
-using namespace Gio;
-
 auto fmt::formatter<waybar::Appearance>::format(waybar::Appearance c, format_context& ctx) const {
   string_view name;
   switch (c) {
@@ -36,8 +34,8 @@ auto fmt::formatter<waybar::Appearance>::format(waybar::Appearance c, format_con
 }
 
 waybar::Portal::Portal()
-    : DBus::Proxy(DBus::Connection::get_sync(DBus::BusType::BUS_TYPE_SESSION), PORTAL_BUS_NAME,
-                  PORTAL_OBJ_PATH, PORTAL_INTERFACE),
+    : Gio::DBus::Proxy(Gio::DBus::Connection::get_sync(Gio::DBus::BusType::BUS_TYPE_SESSION),
+                       PORTAL_BUS_NAME, PORTAL_OBJ_PATH, PORTAL_INTERFACE),
       currentMode(Appearance::UNKNOWN) {
   refreshAppearance();
 };

--- a/test/utils/date.cpp
+++ b/test/utils/date.cpp
@@ -18,8 +18,10 @@
   return
 #endif
 
+using namespace date;
 using namespace std::literals::chrono_literals;
 namespace fmt_lib = waybar::util::date::format;
+
 /*
  * Check that the date/time formatter with locale and timezone support is working as expected.
  */


### PR DESCRIPTION
A few tweaks to keep `using namespace`  statements out of header files and avoid polluting other namespaces.