### PR TITLE
fix: don't use c++20 chrono literals

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -25,7 +25,7 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
       m_tooltip_{new Gtk::Label()},
       cldInTooltip_{m_tlpFmt_.find("{" + kCldPlaceholder + "}") != std::string::npos},
       cldYearShift_{January / 1 / 1900},
-      cldMonShift_{1900y / January},
+      cldMonShift_{year(1900) / January},
       tzInTooltip_{m_tlpFmt_.find("{" + kTZPlaceholder + "}") != std::string::npos},
       tzCurrIdx_{0},
       ordInTooltip_{m_tlpFmt_.find("{" + kOrdPlaceholder + "}") != std::string::npos} {


### PR DESCRIPTION
Unfortunately we can't use these yet because the freebsd build (clang) still uses HowardHinnant/date, which doesn't provide literal suffixes.

This should fix building on FreeBSD.