### PR TITLE
feat: Add ISO 8601 calendar to clock module

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -38,18 +38,19 @@ class Clock final : public ALabel {
     5 - tooltip-format
    */
   std::map<int, std::string const> fmtMap_;
-  uint cldMonCols_{3};                 // calendar count month columns
-  int cldWnLen_{3};                    // calendar week number length
-  const int cldMonColLen_{20};         // calendar month column length
-  WS cldWPos_{WS::HIDDEN};             // calendar week side to print
-  date::months cldCurrShift_{0};       // calendar months shift
-  int cldShift_{1};                    // calendar months shift factor
-  date::year_month_day cldYearShift_;  // calendar Year mode. Cached ymd
-  std::string cldYearCached_;          // calendar Year mode. Cached calendar
-  date::year_month cldMonShift_;       // calendar Month mode. Cached ym
-  std::string cldMonCached_;           // calendar Month mode. Cached calendar
-  date::day cldBaseDay_{0};  // calendar Cached day. Is used when today is changing(midnight)
-  std::string cldText_{""};  // calendar text to print
+  uint cldMonCols_{3};                       // calendar count month columns
+  int cldWnLen_{3};                          // calendar week number length
+  const int cldMonColLen_{20};               // calendar month column length
+  WS cldWPos_{WS::HIDDEN};                   // calendar week side to print
+  date::months cldCurrShift_{0};             // calendar months shift
+  int cldShift_{1};                          // calendar months shift factor
+  date::year_month_day cldYearShift_;        // calendar Year mode. Cached ymd
+  std::string cldYearCached_;                // calendar Year mode. Cached calendar
+  date::year_month cldMonShift_;             // calendar Month mode. Cached ym
+  std::string cldMonCached_;                 // calendar Month mode. Cached calendar
+  date::day cldBaseDay_{0};                  // calendar Cached day. Is used when today is changing(midnight)
+  std::string cldText_{""};                  // calendar text to print
+  bool iso8601Calendar_{false};              // whether the calendar is in ISO8601
   CldMode cldMode_{CldMode::MONTH};
   auto get_calendar(const date::year_month_day& today, const date::year_month_day& ymd,
                     const date::time_zone* tz) -> const std::string;

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -126,6 +126,12 @@ View all valid format options in *strftime(3)* or have a look https://en.cpprefe
 :[ 1
 :[ Value to scroll months/years forward/backward. Can be negative. Is
    configured under *on-scroll* option
+|[ *iso8601*
+:[ bool
+:[ false
+:[ When enabled, the calendar follows the ISO 8601 standard: weeks begin on
+   Monday, and the first week of the year is numbered 1. The default week format is
+   '{:%V}'.
 
 3. Addressed by *clock: calendar: format*
 [- *Option*


### PR DESCRIPTION
### Summary:
This PR adds ISO 8601 week formatting support for the calendar tooltip in Waybar's clock module. Users can now display weeks according to the ISO standard (Monday start, week 1 begins with the year's first Thursday) in the tooltip.

### Changes:
Introduced a new iso8601 configuration option to enable ISO-compliant week formatting in the tooltip.

When enabled, weeks follow {:%V} (e.g., "Week 42") per ISO 8601.

Backward-compatible—default behavior remains unchanged unless iso8601: true is set.

### Motivation:
ISO 8601 is widely used in scheduling, business, and international contexts. This change aligns Waybar with standard date/week representations (e.g., Linux’s %V), avoiding locale-specific inconsistencies.

### Example Configuration:

```jsonc
  "clock": {
    // "timezone": "America/New_York",
    "format": "W{:%V %a %b %d %I:%M %p}",
    "format-alt": "{:%Y-%m-%d}",
    "tooltip-format": "<tt><small>{calendar}</small></tt>",
    "calendar": {
      "mode": "year",
      "mode-mon-col": 3,
      "weeks-pos": "right",
      "on-scroll": 1,
      "iso": true,
      "format": {
        "months": "<span color='#ebdbb2'><b>{}</b></span>",
        "days": "<span color='#bdae93'><b>{}</b></span>",
        "weeks": "<span color='#458588'><b>W{}</b></span>",
        "weekdays": "<span color='#d79921'><b>{}</b></span>",
        "today": "<span color='#b16286'><b><u>{}</u></b></span>",
      },
    },
  },
```
