### PR TITLE
fix: 'ethernet' network state should have precedence over 'disabled'

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -272,11 +272,9 @@ void waybar::modules::Network::worker() {
 
 const std::string waybar::modules::Network::getNetworkState() const {
 #ifdef WANT_RFKILL
-  if (rfkill_.getState()) return "disabled";
+  if (rfkill_.getState() && ifid_ == -1) return "disabled";
 #endif
-  if (ifid_ == -1) {
-    return "disconnected";
-  }
+  if (ifid_ == -1) return "disconnected";
   if (!carrier_) return "disconnected";
   if (ipaddr_.empty() && ipaddr6_.empty()) return "linked";
   if (essid_.empty()) return "ethernet";


### PR DESCRIPTION
Fixes #4221
Fixes #4250