### PR TITLE
feat: add rfkill network setting

### DIFF
--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -27,8 +27,8 @@ class Network : public ALabel {
   auto update() -> void override;
 
  private:
-  static const uint8_t MAX_RETRY = 5;
-  static const uint8_t EPOLL_MAX = 200;
+  static const uint8_t MAX_RETRY{5};
+  static const uint8_t EPOLL_MAX{200};
 
   static int handleEvents(struct nl_msg*, void*);
   static int handleEventsDone(struct nl_msg*, void*);
@@ -51,37 +51,37 @@ class Network : public ALabel {
   bool wildcardMatch(const std::string& pattern, const std::string& text) const;
   std::optional<std::pair<unsigned long long, unsigned long long>> readBandwidthUsage();
 
-  int ifid_;
-  ip_addr_pref addr_pref_;
-  struct sockaddr_nl nladdr_ = {0};
-  struct nl_sock* sock_ = nullptr;
-  struct nl_sock* ev_sock_ = nullptr;
-  int efd_;
-  int ev_fd_;
-  int nl80211_id_;
+  int ifid_{-1};
+  ip_addr_pref addr_pref_{ip_addr_pref::IPV4};
+  struct sockaddr_nl nladdr_{0};
+  struct nl_sock* sock_{nullptr};
+  struct nl_sock* ev_sock_{nullptr};
+  int efd_{-1};
+  int ev_fd_{-1};
+  int nl80211_id_{-1};
   std::mutex mutex_;
 
-  bool want_route_dump_;
-  bool want_link_dump_;
-  bool want_addr_dump_;
-  bool dump_in_progress_;
-  bool is_p2p_;
+  bool want_route_dump_{false};
+  bool want_link_dump_{false};
+  bool want_addr_dump_{false};
+  bool dump_in_progress_{false};
+  bool is_p2p_{false};
 
-  unsigned long long bandwidth_down_total_;
-  unsigned long long bandwidth_up_total_;
+  unsigned long long bandwidth_down_total_{0};
+  unsigned long long bandwidth_up_total_{0};
 
   std::string state_;
   std::string essid_;
   std::string bssid_;
-  bool carrier_;
+  bool carrier_{false};
   std::string ifname_;
   std::string ipaddr_;
   std::string ipaddr6_;
   std::string gwaddr_;
   std::string netmask_;
   std::string netmask6_;
-  int cidr_;
-  int cidr6_;
+  int cidr_{0};
+  int cidr6_{0};
   int32_t signal_strength_dbm_;
   uint8_t signal_strength_;
   std::string signal_strength_app_;
@@ -90,9 +90,9 @@ class Network : public ALabel {
   util::SleeperThread thread_;
   util::SleeperThread thread_timer_;
 #ifdef WANT_RFKILL
-  util::Rfkill rfkill_;
+  util::Rfkill rfkill_{RFKILL_TYPE_WLAN};
 #endif
-  float frequency_;
+  float frequency_{0};
 };
 
 }  // namespace waybar::modules

--- a/include/util/rfkill.hpp
+++ b/include/util/rfkill.hpp
@@ -5,6 +5,8 @@
 #include <sigc++/signal.h>
 #include <sigc++/trackable.h>
 
+#include <atomic>
+
 namespace waybar::util {
 
 class Rfkill : public sigc::trackable {
@@ -17,7 +19,7 @@ class Rfkill : public sigc::trackable {
 
  private:
   enum rfkill_type rfkill_type_;
-  bool state_ = false;
+  std::atomic_bool state_ = false;
   int fd_ = -1;
 
   bool on_event(Glib::IOCondition cond);

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -16,6 +16,11 @@ Addressed by *network*
 	typeof: string ++
 	Use the defined interface instead of auto-detection. Accepts wildcard.
 
+*rfkill*: ++
+	typeof: bool ++
+	default: true ++
+	If enabled, the *disabled* format will be used when rfkill is blocking wlan interfaces.
+
 *interval*: ++
 	typeof: integer ++
 	default: 60 ++
@@ -49,7 +54,7 @@ Addressed by *network*
 
 *format-disabled*: ++
 	typeof: string ++
-	This format is used when the displayed interface is disabled.
+	This format is used when rfkill is blocking wlan interfaces.
 
 *format-icons*: ++
 	typeof: array/object ++
@@ -127,7 +132,7 @@ Addressed by *network*
 
 *tooltip-format-disabled*: ++
 	typeof: string ++
-	This format is used when the displayed interface is disabled.
+	This format is used when rfkill is blocking wlan interfaces.
 
 *menu*: ++
 	typeof: string ++

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -162,7 +162,7 @@ Addressed by *network*
 
 *{netmask}*: The subnetmask corresponding to the IP(V4).
 
-*{netmask6}*: The subnetmask corresponding to the IP(V6). 
+*{netmask6}*: The subnetmask corresponding to the IP(V6).
 
 *{cidr}*: The subnetmask corresponding to the IP(V4) in CIDR notation.
 

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -405,6 +405,7 @@ void waybar::modules::Network::clearIface() {
   netmask_.clear();
   netmask6_.clear();
   carrier_ = false;
+  is_p2p_ = false;
   cidr_ = 0;
   cidr6_ = 0;
   signal_strength_dbm_ = 0;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -78,25 +78,7 @@ waybar::modules::Network::readBandwidthUsage() {
 }
 
 waybar::modules::Network::Network(const std::string &id, const Json::Value &config)
-    : ALabel(config, "network", id, DEFAULT_FORMAT, 60),
-      ifid_(-1),
-      addr_pref_(IPV4),
-      efd_(-1),
-      ev_fd_(-1),
-      want_route_dump_(false),
-      want_link_dump_(false),
-      want_addr_dump_(false),
-      dump_in_progress_(false),
-      is_p2p_(false),
-      cidr_(0),
-      cidr6_(0),
-      signal_strength_dbm_(0),
-      signal_strength_(0),
-#ifdef WANT_RFKILL
-      rfkill_{RFKILL_TYPE_WLAN},
-#endif
-      frequency_(0.0) {
-
+    : ALabel(config, "network", id, DEFAULT_FORMAT, 60) {
   // Start with some "text" in the module's label_. update() will then
   // update it. Since the text should be different, update() will be able
   // to show or hide the event_box_. This is to work around the case where

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -271,11 +271,12 @@ void waybar::modules::Network::worker() {
 }
 
 const std::string waybar::modules::Network::getNetworkState() const {
+  if (ifid_ == -1 || !carrier_) {
 #ifdef WANT_RFKILL
-  if (rfkill_.getState() && ifid_ == -1) return "disabled";
+    if (rfkill_.getState()) return "disabled";
 #endif
-  if (ifid_ == -1) return "disconnected";
-  if (!carrier_) return "disconnected";
+    return "disconnected";
+  }
   if (ipaddr_.empty() && ipaddr6_.empty()) return "linked";
   if (essid_.empty()) return "ethernet";
   return "wifi";

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -273,7 +273,11 @@ void waybar::modules::Network::worker() {
 const std::string waybar::modules::Network::getNetworkState() const {
   if (ifid_ == -1 || !carrier_) {
 #ifdef WANT_RFKILL
-    if (rfkill_.getState()) return "disabled";
+    bool display_rfkill = true;
+    if (config_["rfkill"].isBool()) {
+      display_rfkill = config_["rfkill"].asBool();
+    }
+    if (rfkill_.getState() && display_rfkill) return "disabled";
 #endif
     return "disconnected";
   }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -494,6 +494,11 @@ int waybar::modules::Network::handleEvents(struct nl_msg *msg, void *data) {
           net->ifname_ = new_ifname;
           net->ifid_ = ifi->ifi_index;
           if (ifi->ifi_flags & IFF_POINTOPOINT) net->is_p2p_ = true;
+          if ((ifi->ifi_flags & IFF_UP) == 0) {
+            // With some network drivers (e.g. mt7921e), the interface may
+            // report having a carrier even though interface is down.
+            carrier = false;
+          }
           if (carrier.has_value()) {
             net->carrier_ = carrier.value();
           }


### PR DESCRIPTION
This setting makes it possible to have a configuration with two network modules where one of them displays the ethernet state (disconnected, linked, ethernet), and the other, the wifi state (disabled, disconnected, linked, wifi).
Otherwise the ethernet state would show up as "disabled" (instead of "disconnected") when rfkill is active.