### PR TITLE
fix: hyprland named persistent workspaces

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -253,10 +253,8 @@ void Workspaces::loadPersistentWorkspacesFromConfig(Json::Value const &clientsJs
       // value is an array => create defined workspaces for this monitor
       if (canCreate) {
         for (const Json::Value &workspace : value) {
-          if (workspace.isInt()) {
-            spdlog::debug("Creating workspace {} on monitor {}", workspace, currentMonitor);
-            persistentWorkspacesToCreate.emplace_back(std::to_string(workspace.asInt()));
-          }
+          spdlog::debug("Creating workspace {} on monitor {}", workspace, currentMonitor);
+          persistentWorkspacesToCreate.emplace_back(workspace.asString());
         }
       } else {
         // key is the workspace and value is array of monitors to create on


### PR DESCRIPTION
allowed persistent workspaces to be defined with names instead of just id's. 

Example:
```json
"persistent-workspaces": {
    "DP-3": [
        "home",
        "firefox",
        "dev",
        "game",
        "scratchpad"
    ],
    "DP-2": [
        "music",
        "firefox-ref",
        "scratchpad2"
    ]
}
```