### PR TITLE
add openbsd support 

### DIFF
--- a/include/util/SafeSignal.hpp
+++ b/include/util/SafeSignal.hpp
@@ -11,6 +11,11 @@
 #include <type_traits>
 #include <utility>
 
+#ifdef __OpenBSD__
+#define SIGRTMIN SIGUSR1-1
+#define SIGRTMAX SIGUSR1+1
+#endif
+
 namespace waybar {
 
 /**

--- a/src/modules/cpu_frequency/bsd.cpp
+++ b/src/modules/cpu_frequency/bsd.cpp
@@ -5,12 +5,12 @@
 
 std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
   std::vector<float> frequencies;
-  char buffer[256];
   size_t len;
   int32_t freq;
-  uint32_t i = 0;
 
 #ifndef __OpenBSD__
+  char buffer[256];
+  uint32_t i = 0;
   while (true) {
     len = 4;
     snprintf(buffer, 256, "dev.cpu.%u.freq", i);
@@ -19,11 +19,10 @@ std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
     ++i;
   }
 #else
-  size_t sz;
-  int psize, cpuspeed, getMhz[] = {CTL_HW, HW_CPUSPEED};
-  sz = sizeof(cpuspeed);
-  sysctl(getMhz, 2, &cpuspeed, &sz, NULL, 0);
-  frequencies.push_back((float)cpuspeed);
+  int getMhz[] = {CTL_HW, HW_CPUSPEED};
+  len = sizeof(freq);
+  sysctl(getMhz, 2, &freq, &len, NULL, 0);
+  frequencies.push_back((float)freq);
 #endif
 
   if (frequencies.empty()) {

--- a/src/modules/cpu_frequency/bsd.cpp
+++ b/src/modules/cpu_frequency/bsd.cpp
@@ -10,6 +10,7 @@ std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
   int32_t freq;
   uint32_t i = 0;
 
+#ifndef __OpenBSD__
   while (true) {
     len = 4;
     snprintf(buffer, 256, "dev.cpu.%u.freq", i);
@@ -17,6 +18,13 @@ std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
     frequencies.push_back(freq);
     ++i;
   }
+#else
+  size_t sz;
+  int psize, cpuspeed, getMhz[] = {CTL_HW, HW_CPUSPEED};
+  sz = sizeof(cpuspeed);
+  sysctl(getMhz, 2, &cpuspeed, &sz, NULL, 0);
+  frequencies.push_back((float)cpuspeed);
+#endif
 
   if (frequencies.empty()) {
     spdlog::warn("cpu/bsd: parseCpuFrequencies failed, not found in sysctl");

--- a/src/modules/user.cpp
+++ b/src/modules/user.cpp
@@ -62,7 +62,13 @@ long User::uptime_as_seconds() {
 
 #if HAVE_CPU_BSD
   struct timespec s_info;
-  if (0 == clock_gettime(CLOCK_UPTIME_PRECISE, &s_info)) {
+  int flags = 0;
+#ifndef __OpenBSD__
+  flags = CLOCK_UPTIME_PRECISE;
+#else
+  flags = CLOCK_UPTIME;
+#endif
+  if (0 == clock_gettime(flags, &s_info)) {
     uptime = s_info.tv_sec;
   }
 #endif

--- a/src/modules/wayfire/workspaces.cpp
+++ b/src/modules/wayfire/workspaces.cpp
@@ -74,9 +74,9 @@ auto Workspaces::handleScroll(GdkEventScroll* e) -> bool {
     const auto& wset = ipc->get_wsets().at(output.wset_idx);
     auto n = wset.ws_w * wset.ws_h;
     auto i = (wset.ws_idx() + delta + n) % n;
-    data["x"] = i % wset.ws_w;
-    data["y"] = i / wset.ws_h;
-    data["output-id"] = output.id;
+    data["x"] = Json::Value((uint64_t)i % wset.ws_w);
+    data["y"] = Json::Value((uint64_t)i / wset.ws_h);
+    data["output-id"] = Json::Value((uint64_t)output.id);
   }
   ipc->send("vswitch/set-workspace", std::move(data));
 
@@ -108,9 +108,9 @@ auto Workspaces::update_box() -> void {
     if (!config_["disable-click"].asBool()) {
       btn.signal_pressed().connect([=, this] {
         Json::Value data;
-        data["x"] = i % ws_w;
-        data["y"] = i / ws_h;
-        data["output-id"] = output.id;
+        data["x"] = Json::Value((uint64_t)i % ws_w);
+        data["y"] = Json::Value((uint64_t)i / ws_h);
+        data["output-id"] = Json::Value((uint64_t)output.id);
         ipc->send("vswitch/set-workspace", std::move(data));
       });
     }

--- a/src/util/css_reload_helper.cpp
+++ b/src/util/css_reload_helper.cpp
@@ -2,7 +2,13 @@
 
 #include <poll.h>
 #include <spdlog/spdlog.h>
+#ifndef __OpenBSD__
 #include <sys/inotify.h>
+#else
+#include <sys/types.h>
+#include <sys/event.h>
+#include <sys/time.h>
+#endif
 
 #include <filesystem>
 #include <fstream>


### PR DESCRIPTION
Hi Alexays !

As an openbsd user who love wayland and waybar,  I did a fast-fix for Waybar.

There some points:
src/main.cpp, src/modules/image.cpp and src/modules/custom.cpp: uses SIGRTMIN and SIGRTMAX neither available or used by OpenBSD.

src/modules/config.cpp: OpenBSD prefer glob than wordexp ( I made a pre-prog condition.)

src/modules/cpu_frequency: OpenBSD don't use sysctlbyname,  instead they kept sysctl(2). FreeBSD/NetBSD probably does, iirc.

Some issues on Json::Value constructor where i'd to cast size_t into uint64_t.