### PR TITLE
respect gtk color scheme variant for gtk css variable

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -151,15 +151,19 @@ void waybar::Client::handleDeferredMonitorRemoval(Glib::RefPtr<Gdk::Monitor> mon
 
 const std::string waybar::Client::getStyle(const std::string &style,
                                            std::optional<Appearance> appearance = std::nullopt) {
+  auto gtk_settings = Gtk::Settings::get_default();
   std::optional<std::string> css_file;
+
   if (style.empty()) {
     std::vector<std::string> search_files;
     switch (appearance.value_or(portal->getAppearance())) {
       case waybar::Appearance::LIGHT:
         search_files.emplace_back("style-light.css");
+        gtk_settings->property_gtk_application_prefer_dark_theme() = false;
         break;
       case waybar::Appearance::DARK:
         search_files.emplace_back("style-dark.css");
+        gtk_settings->property_gtk_application_prefer_dark_theme() = true;
         break;
       case waybar::Appearance::UNKNOWN:
         break;
@@ -169,9 +173,11 @@ const std::string waybar::Client::getStyle(const std::string &style,
   } else {
     css_file = style;
   }
+
   if (!css_file) {
     throw std::runtime_error("Missing required resource files");
   }
+
   spdlog::info("Using CSS file {}", css_file.value());
   return css_file.value();
 };


### PR DESCRIPTION
Addresses #4291

This might a breaking change for people who's setup expect the value of the GTK CSS variables to just always be the default variant. However I feel like this is more inline with expectations (at least mine) and better for the future.

Also I am not very familiar with the GTK C++ APIs and if this is the best way to accomplish this. But this works for me on my local build.