### PR TITLE
wireplumber: fix states & support for microphone

### DIFF
--- a/include/modules/wireplumber.hpp
+++ b/include/modules/wireplumber.hpp
@@ -23,6 +23,7 @@ class Wireplumber : public ALabel {
   static void updateVolume(waybar::modules::Wireplumber* self, uint32_t id);
   static void updateNodeName(waybar::modules::Wireplumber* self, uint32_t id);
   static void updateSourceVolume(waybar::modules::Wireplumber* self, uint32_t id);
+  static void updateSourceName(waybar::modules::Wireplumber* self, uint32_t id);  // NEW
   static void onPluginActivated(WpObject* p, GAsyncResult* res, waybar::modules::Wireplumber* self);
   static void onDefaultNodesApiLoaded(WpObject* p, GAsyncResult* res,
                                       waybar::modules::Wireplumber* self);
@@ -47,6 +48,7 @@ class Wireplumber : public ALabel {
   double min_step_;
   uint32_t node_id_{0};
   std::string node_name_;
+  std::string source_name_;
   gchar* type_;
   uint32_t source_node_id_;
   bool source_muted_;

--- a/include/modules/wireplumber.hpp
+++ b/include/modules/wireplumber.hpp
@@ -22,6 +22,7 @@ class Wireplumber : public ALabel {
   void activatePlugins();
   static void updateVolume(waybar::modules::Wireplumber* self, uint32_t id);
   static void updateNodeName(waybar::modules::Wireplumber* self, uint32_t id);
+  static void updateSourceVolume(waybar::modules::Wireplumber* self, uint32_t id);
   static void onPluginActivated(WpObject* p, GAsyncResult* res, waybar::modules::Wireplumber* self);
   static void onDefaultNodesApiLoaded(WpObject* p, GAsyncResult* res,
                                       waybar::modules::Wireplumber* self);
@@ -47,6 +48,10 @@ class Wireplumber : public ALabel {
   uint32_t node_id_{0};
   std::string node_name_;
   gchar* type_;
+  uint32_t source_node_id_;
+  bool source_muted_;
+  double source_volume_;
+  gchar* default_source_name_;
 };
 
 }  // namespace waybar::modules

--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -340,11 +340,20 @@ auto waybar::modules::Wireplumber::update() -> void {
   }
 
   int vol = round(volume_ * 100.0);
+
+  // Get the state and apply state-specific format if available
+  auto state = getState(vol);
+  if (!state.empty()) {
+    std::string format_name = muted_ ? "format-muted" : "format";
+    std::string state_format_name = format_name + "-" + state;
+    if (config_[state_format_name].isString()) {
+      format = config_[state_format_name].asString();
+    }
+  }
+
   std::string markup = fmt::format(fmt::runtime(format), fmt::arg("node_name", node_name_),
                                    fmt::arg("volume", vol), fmt::arg("icon", getIcon(vol)));
   label_.set_markup(markup);
-
-  getState(vol);
 
   if (tooltipEnabled()) {
     if (tooltipFormat.empty() && config_["tooltip-format"].isString()) {


### PR DESCRIPTION
**In these two commits I’ve:**
- Fixed the issue where the `states` were not updating (see issue #3672).
- Added a microphone source, allowing us to define `format-source` and `format-source-muted` just like with the PulseAudio module. (issue #3983).

This feature has been on my wishlist for a long time, and since there hadn’t been any movement on it, I took some free time to dive into the code and implement it. I hope it aligns with Alexis’s coding style!

For PipeWire users, it’s much better to use the WirePlumber protocol directly rather than routing through PulseAudio (which was my previous approach).

*Later on I might tackle the `format-bluetooth` support and open a follow‑up PR…*
