### PR TITLE
Relative paths in included configs

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -35,6 +35,7 @@ class Config {
   void setupConfig(Json::Value &dst, const std::string &config_file, int depth);
   void resolveConfigIncludes(Json::Value &config, int depth);
   void mergeConfig(Json::Value &a_config_, Json::Value &b_config_);
+  std::optional<std::string> findIncludePath(const std::string name);
 
   std::string config_file_;
 

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -35,7 +35,7 @@ class Config {
   void setupConfig(Json::Value &dst, const std::string &config_file, int depth);
   void resolveConfigIncludes(Json::Value &config, int depth);
   void mergeConfig(Json::Value &a_config_, Json::Value &b_config_);
-  std::optional<std::string> findIncludePath(const std::string name);
+  static std::optional<std::string> findIncludePath(const std::string &name);
 
   std::string config_file_;
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -496,7 +496,11 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
           auto vertical = (group != nullptr ? group->getBox().get_orientation()
                                             : box_.get_orientation()) == Gtk::ORIENTATION_VERTICAL;
 
-          auto* group_module = new waybar::Group(id_name, class_name, config[ref], vertical);
+          auto group_config = config[ref];
+          if (group_config["modules"].isNull()) {
+            spdlog::warn("Group definition '{}' has not been found, group will be hidden", ref);
+          }
+          auto* group_module = new waybar::Group(id_name, class_name, group_config, vertical);
           getModules(factory, ref, group_module);
           module = group_module;
         } else {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -89,19 +89,33 @@ void Config::setupConfig(Json::Value &dst, const std::string &config_file, int d
   mergeConfig(dst, tmp_config);
 }
 
+std::optional<std::string> Config::findIncludePath(const std::string name) {
+  auto match1 = tryExpandPath(name, "");
+  if (!match1.empty()) {
+    return match1.front();
+  }
+  return findConfigPath({name});
+}
+
 void Config::resolveConfigIncludes(Json::Value &config, int depth) {
   Json::Value includes = config["include"];
   if (includes.isArray()) {
     for (const auto &include : includes) {
       spdlog::info("Including resource file: {}", include.asString());
-      for (const auto &match : tryExpandPath(include.asString(), "")) {
-        setupConfig(config, match, depth + 1);
+      auto match = findIncludePath(include.asString());
+      if (match.has_value()) {
+        setupConfig(config, match.value(), depth + 1);
+      } else {
+        spdlog::warn("Unable to find resource file: {}", include.asString());
       }
     }
   } else if (includes.isString()) {
     spdlog::info("Including resource file: {}", includes.asString());
-    for (const auto &match : tryExpandPath(includes.asString(), "")) {
-      setupConfig(config, match, depth + 1);
+    auto match = findIncludePath(includes.asString());
+    if (match.has_value()) {
+      setupConfig(config, match.value(), depth + 1);
+    } else {
+      spdlog::warn("Unable to find resource file: {}", includes.asString());
     }
   }
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -89,7 +89,7 @@ void Config::setupConfig(Json::Value &dst, const std::string &config_file, int d
   mergeConfig(dst, tmp_config);
 }
 
-std::optional<std::string> Config::findIncludePath(const std::string name) {
+std::optional<std::string> Config::findIncludePath(const std::string &name) {
   auto match1 = tryExpandPath(name, "");
   if (!match1.empty()) {
     return match1.front();

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -14,6 +14,9 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
       percentage_(0),
       fp_(nullptr),
       pid_(-1) {
+  if (config.isNull()) {
+    spdlog::warn("There is no configuration for 'custom/{}', element will be hidden", name);
+  }
   dp.emit();
   if (!config_["signal"].empty() && config_["interval"].empty() &&
       config_["restart-interval"].empty()) {


### PR DESCRIPTION
This is a two part PR, it appears when I was tinkering with my `waybar` config in my ``~/.config/waybar/` directory and occasionally did 
```
includes: [
  "modules/custom.jsonc",
  "modules/groups.jsonc"
]
```
and suddenly half of my waybar just disappeared. It took me a long time to trace the issue, since there was zero messages in logs, even with `-l debug` key.

So, as a result here is the PR:

1. I've added couple of warning statements that elements description is missing. My assumption is that unlike any other elements (e.g. "cpu"), "custom" and "group" elements has no defaults to fall into, so if there is no configuration found (it can be wrong include as in my case, or just a typo) then this element will always be hidden. And so it is legit to warn user that this may happen.

2. I've added config search for include files in the same manner as regular `config` search. The only difference, I do not want for existing configs to be broken, so it is slightly more complex than just call `findConfigPath`. In this implementation if user uses absolute paths they work as usual, and this change only kicks in if user uses relative paths (which I presume mostly case of newcomers).

I've tried it in my environment and it is working as expected.

Also, I am flexible, can split this PR in two if needed or do modifications if some parts of this set up are unacceptable.