### PR TITLE
Moved workspace id failing to parse from an error to part of the trace

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1129,7 +1129,7 @@ std::optional<int> Workspaces::parseWorkspaceId(std::string const &workspaceIdSt
   try {
     return workspaceIdStr == "special" ? -99 : std::stoi(workspaceIdStr);
   } catch (std::exception const &e) {
-    spdlog::error("Failed to parse workspace ID: {}", e.what());
+    spdlog::debug("Workspace \"{}\" is not bound to an id: {}", workspaceIdStr, e.what());
     return std::nullopt;
   }
 }


### PR DESCRIPTION
With named persistent workspaces it is expected behavior that they have no id since their workspace may not have been created by hyprland yet.