### PR TITLE
DOCS: Add missing config options of 'workspace-taskbar' to the man page

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -50,6 +50,11 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	default: false ++
 	Enables the workspace taskbar mode.
 
+		*update-active-window*: ++
+	typeof: bool ++
+	default: false ++
+	If true, the active/focused window will have an 'active' class. Could cause higher CPU usage due to more frequent redraws.
+
 		*format*: ++
 	typeof: string ++
 	default: {icon} ++
@@ -69,6 +74,19 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	typeof: "horizontal" | "vertical" ++
 	default: horizontal ++
 	Direction in which the workspace taskbar is displayed.
+
+		*ignore-list*: ++
+	typeof: array ++
+	default: [] ++
+	Regex patterns to match against window class or window title. If a window's class OR title matches any of the patterns, it will not be shown.
+
+		*on-click-window*: ++
+	typeof: string ++
+	default: "" ++
+	Command to run when a window is clicked. Available placeholders are: ++
+	  - {address} Hyprland address of the clicked window. ++
+	  - {button} Pressed button number, see https://api.gtkd.org/gdk.c.types.GdkEventButton.button.html. ++
+	See https://github.com/Alexays/Waybar/wiki/Module:-Hyprland#workspace-taskbars-example for a full example.
 
 *show-special*: ++
 	typeof: bool ++
@@ -216,4 +234,6 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces button.special*
 - *#workspaces button.urgent*
 - *#workspaces button.hosting-monitor* (gets applied if workspace-monitor == waybar-monitor)
-- *#workspaces .taskbar-window* (each window in the taskbar)
+- *#workspaces .workspace-label*
+- *#workspaces .taskbar-window* (each window in the taskbar, only if 'workspace-taskbar.enable' is true)
+- *#workspaces .taskbar-window.active* (applied to the focused window, only if 'workspace-taskbar.update-active-window' is true)


### PR DESCRIPTION
This is a follow-up to #3868. Some config options were documented in the wiki (and the PR description), but they were missing from the man page. Detected in #4367.

This PR brings the man up to date with the wiki.