### PR TITLE
Fix module and tray item staying in hover state after opening menu

### DIFF
--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -172,6 +172,10 @@ bool AModule::handleUserEvent(GdkEventButton* const& e) {
       // Popup the menu
       gtk_widget_show_all(GTK_WIDGET(menu_));
       gtk_menu_popup_at_pointer(GTK_MENU(menu_), reinterpret_cast<GdkEvent*>(e));
+      // Manually reset prelight to make sure the module doesn't stay in a hover state
+      if (auto* module = event_box_.get_child(); module != nullptr) {
+        module->unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
+      }
     }
   }
   // Second call user scripts

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -443,6 +443,9 @@ void Item::makeMenu() {
       gtk_menu->attach_to_widget(event_box);
     }
   }
+  // Manually reset prelight to make sure the tray item doesn't stay in a hover state even though
+  // the menu is focused
+  event_box.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
 }
 
 bool Item::handleClick(GdkEventButton* const& ev) {


### PR DESCRIPTION
This PR fixes #3980 where widgets stay in a hover state after using them to open a menu on click, even after closing the menu, making :hover in CSS very annoying to use with menus.

I couldn't find the reason why this happens. I assume the methods that handle the mouse leaving the widget don't get called because the menu gets focused before the pointer actually leaves the widget, but I couldn't find a way to fix this elegantly. The current fix simply unsets the prelight flag of the widget when the menu is opened, achieving the desired effect.

Also, I've had this happen to me for modules and tray icons, but it may happen in other places as well. I've tried searching the code for other classes working with menus but I couldn't find any so I left it there.