### PR TITLE
bugfix: expanding wildcards in config includes (#4354)

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -35,7 +35,8 @@ class Config {
   void setupConfig(Json::Value &dst, const std::string &config_file, int depth);
   void resolveConfigIncludes(Json::Value &config, int depth);
   void mergeConfig(Json::Value &a_config_, Json::Value &b_config_);
-  static std::optional<std::string> findIncludePath(const std::string &name);
+  static std::vector<std::string> findIncludePath(
+      const std::string &name, const std::vector<std::string> &dirs = CONFIG_DIRS);
 
   std::string config_file_;
 

--- a/test/config.cpp
+++ b/test/config.cpp
@@ -84,6 +84,33 @@ TEST_CASE("Load simple config with include", "[config]") {
   }
 }
 
+TEST_CASE("Load simple config with wildcard include", "[config]") {
+  waybar::Config conf;
+  conf.load("test/config/include-wildcard.json");
+
+  auto& data = conf.getConfig();
+  SECTION("validate cpu include file") { REQUIRE(data["cpu"]["format"].asString() == "goo"); }
+  SECTION("validate memory include file") { REQUIRE(data["memory"]["format"].asString() == "foo"); }
+}
+
+TEST_CASE("Load config using relative paths and wildcards", "[config]") {
+  waybar::Config conf;
+
+  const char* old_config_path = std::getenv(waybar::Config::CONFIG_PATH_ENV);
+  setenv(waybar::Config::CONFIG_PATH_ENV, "test/config", 1);
+
+  conf.load("test/config/include-relative-path.json");
+
+  auto& data = conf.getConfig();
+  SECTION("validate cpu include file") { REQUIRE(data["cpu"]["format"].asString() == "goo"); }
+  SECTION("validate memory include file") { REQUIRE(data["memory"]["format"].asString() == "foo"); }
+
+  if (old_config_path)
+    setenv(waybar::Config::CONFIG_PATH_ENV, old_config_path, 1);
+  else
+    unsetenv(waybar::Config::CONFIG_PATH_ENV);
+}
+
 TEST_CASE("Load multiple bar config with include", "[config]") {
   waybar::Config conf;
   conf.load("test/config/include-multi.json");

--- a/test/config/include-relative-path.json
+++ b/test/config/include-relative-path.json
@@ -1,0 +1,5 @@
+{
+  "include": ["modules/*.jsonc"],
+  "position": "top",
+  "nullOption": null
+}

--- a/test/config/include-wildcard.json
+++ b/test/config/include-wildcard.json
@@ -1,0 +1,5 @@
+{
+  "include": ["test/config/modules/*.jsonc"],
+  "position": "top",
+  "nullOption": null
+}

--- a/test/config/modules/cpu.jsonc
+++ b/test/config/modules/cpu.jsonc
@@ -1,0 +1,6 @@
+{
+    "cpu": {
+        "interval": 2,
+        "format": "goo"
+    }
+}

--- a/test/config/modules/memory.jsonc
+++ b/test/config/modules/memory.jsonc
@@ -1,0 +1,6 @@
+{
+    "memory": {
+        "interval": 2,
+        "format": "foo",
+    }
+}


### PR DESCRIPTION
This bugfix tries to solve regression #4354

As it turns out, initial implementation used `findConfigPath` which was made with a different purpose. So, I had to update `findIncludePath` to use original `tryExpandPath` which provides full set of results instead of only one as `findConfigPath` does. This implementation produces expected result.

During manual test, one should use this file for `memory.jsonc` (there is a typo in original issue)
```
// modules/memory.jsonc
{
  "memory": {
    "interval": 2,
    "format": "foo: {used:0.1f}G",
  }
}
```