### PR TITLE
fix: display icons for userwide installed applications

### DIFF
--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -63,7 +63,8 @@ std::optional<std::string> getDesktopFilePath(const std::string& app_identifier,
     return {};
   }
 
-  const auto data_dirs = Glib::get_system_data_dirs();
+  auto data_dirs = Glib::get_system_data_dirs();
+  data_dirs.insert(data_dirs.begin(), Glib::get_user_data_dir());
   for (const auto& data_dir : data_dirs) {
     const auto data_app_dir = data_dir + "/applications/";
     auto desktop_file_suffix = app_identifier + ".desktop";


### PR DESCRIPTION
Previously Waybar only displayed icons for applications which were installed systemwide.  Icons were resolved via `.desktop` files in directories specified by the environment variable `XDG_DATA_DIRS`. However the [XDG specification](https://specifications.freedesktop.org/basedir-spec/0.8/#variables) notes that this variable should only consulted **in addition** to `XDG_DATA_HOME`:

> `$XDG_DATA_DIRS` defines the preference-ordered set of base
> directories to search for data files in addition to the
> `$XDG_DATA_HOME` base directory.

This because `XDG_DATA_DIRS` contains only systemwide directories, whereas `XDG_DATA_HOME` contains the userwide directory.  Also including the latter when looking up `.desktop` files allows Waybar to display icons for applications which where installed userwide.