### PR TITLE
Support millisecond precision for script intervals

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -21,7 +21,7 @@ class ALabel : public AModule {
  protected:
   Gtk::Label label_;
   std::string format_;
-  const std::chrono::seconds interval_;
+  const std::chrono::milliseconds interval_;
   bool alt_ = false;
   std::string default_format_;
 

--- a/include/modules/image.hpp
+++ b/include/modules/image.hpp
@@ -31,7 +31,7 @@ class Image : public AModule {
   std::string path_;
   std::string tooltip_;
   int size_;
-  int interval_;
+  std::chrono::milliseconds interval_;
   util::command::res output_;
 
   util::SleeperThread thread_;

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -11,9 +11,10 @@ The *cpu* module displays the current CPU utilization.
 # CONFIGURATION
 
 *interval*: ++
-	typeof: integer ++
+	typeof: integer or float ++
 	default: 10 ++
-	The interval in which the information gets polled.
+	The interval in which the information gets polled. ++
+	Minimum value is 0.001 (1ms). Values smaller than 1ms will be set to 1ms.
 
 *format*: ++
 	typeof: string  ++

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -35,15 +35,17 @@ Addressed by *custom/<name>*
 	See *return-type*
 
 *interval*: ++
-	typeof: integer ++
+	typeof: integer or float ++
 	The interval (in seconds) in which the information gets polled. ++
+	Minimum value is 0.001 (1ms). Values smaller than 1ms will be set to 1ms. ++
 	Use *once* if you want to execute the module only on startup. ++
 	You can update it manually with a signal. If no *interval* or *signal* is defined, it is assumed that the out script loops itself. ++
 	If a *signal* is defined then the script will run once on startup and will only update with a signal.
 
 *restart-interval*: ++
-	typeof: integer ++
+	typeof: integer or float ++
 	The restart interval (in seconds). ++
+	Minimum value is 0.001 (1ms). Values smaller than 1ms will be set to 1ms. ++
 	Can't be used with the *interval* option, so only with continuous scripts. ++
 	Once the script exits, it'll be re-executed after the *restart-interval*.
 

--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -24,8 +24,9 @@ The *image* module displays an image from a path.
 	The width/height to render the image.
 
 *interval*: ++
-	typeof: integer ++
+	typeof: integer or float ++
 	The interval (in seconds) to re-render the image. ++
+	Minimum value is 0.001 (1ms). Values smaller than 1ms will be set to 1ms. ++
 	This is useful if the contents of *path* changes. ++
 	If no *interval* is defined, the image will only be rendered once.
 

--- a/man/waybar-jack.5.scd
+++ b/man/waybar-jack.5.scd
@@ -45,7 +45,7 @@ Addressed by *jack*
 	The format of information displayed in the tooltip.
 
 *interval*: ++
-	typeof: integer ++
+	typeof: integer or float ++
 	default: 1 ++
 	The interval in which the information gets polled.
 

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -40,7 +40,7 @@ Addressed by *temperature*
 	The threshold before it is considered critical (Celsius).
 
 *interval*: ++
-	typeof: integer ++
+	typeof: integer or float ++
 	default: 10 ++
 	The interval in which the information gets polled.
 

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -18,9 +18,11 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
               enable_scroll),
       format_(config_["format"].isString() ? config_["format"].asString() : format),
       interval_(config_["interval"] == "once"
-                    ? std::chrono::seconds::max()
-                    : std::chrono::seconds(
-                          config_["interval"].isUInt() ? config_["interval"].asUInt() : interval)),
+                    ? std::chrono::milliseconds::max()
+                    : std::chrono::milliseconds(
+                          std::max(1L, // Minimum 1ms due to millisecond precision
+                                   static_cast<long>(
+                                       (config_["interval"].isNumeric() ? config_["interval"].asDouble() : interval) * 1000)))),
       default_format_(format_) {
   label_.set_name(name);
   if (!id.empty()) {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -89,9 +89,11 @@ void waybar::modules::Custom::continuousWorker() {
         dp.emit();
         spdlog::error("{} stopped unexpectedly, is it endless?", name_);
       }
-      if (config_["restart-interval"].isUInt()) {
+      if (config_["restart-interval"].isNumeric()) {
         pid_ = -1;
-        thread_.sleep_for(std::chrono::seconds(config_["restart-interval"].asUInt()));
+        thread_.sleep_for(std::chrono::milliseconds(
+            std::max(1L, // Minimum 1ms due to millisecond precision
+                     static_cast<long>(config_["restart-interval"].asDouble() * 1000))));
         fp_ = util::command::open(cmd, pid_, output_name_);
         if (!fp_) {
           throw std::runtime_error("Unable to open " + cmd);

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -14,14 +14,19 @@ waybar::modules::Image::Image(const std::string& id, const Json::Value& config)
 
   size_ = config["size"].asInt();
 
-  interval_ = config_["interval"].asInt();
+  interval_ = config_["interval"] == "once"
+                   ? std::chrono::milliseconds::max()
+                   : std::chrono::milliseconds(
+                         std::max(1L, // Minimum 1ms due to millisecond precision
+                                  static_cast<long>(
+                                      (config_["interval"].isNumeric() ? config_["interval"].asDouble() : 0) * 1000)));
 
   if (size_ == 0) {
     size_ = 16;
   }
 
-  if (interval_ == 0) {
-    interval_ = INT_MAX;
+  if (interval_.count() == 0) {
+    interval_ = std::chrono::milliseconds::max();
   }
 
   delayWorker();
@@ -30,8 +35,7 @@ waybar::modules::Image::Image(const std::string& id, const Json::Value& config)
 void waybar::modules::Image::delayWorker() {
   thread_ = [this] {
     dp.emit();
-    auto interval = std::chrono::seconds(interval_);
-    thread_.sleep_for(interval);
+    thread_.sleep_for(interval_);
   };
 }
 


### PR DESCRIPTION
Closes #537 and #3261 

Allows for "interval" and "restart-interval" to be doubles, allowing for scripts to be run a maximum frequency of every 1 ms instead of every 1 second.

Also, I don't know any C++ and mostly relied on Claude to get this PR done so apologizes in advance if I did anything stupid.