### PR TITLE
hyprland/workspaces: allow sorting by 'output'

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -148,13 +148,14 @@ class Workspaces : public AModule, public EventHandler {
   // and doesn't share windows across bars (a.k.a `all-outputs` = false)
   std::map<WindowAddress, WindowRepr, std::less<>> m_orphanWindowMap;
 
-  enum class SortMethod { ID, NAME, NUMBER, SPECIAL_CENTERED, DEFAULT };
+  enum class SortMethod { ID, NAME, NUMBER, SPECIAL_CENTERED, OUTPUT, DEFAULT };
   util::EnumParser<SortMethod> m_enumParser;
   SortMethod m_sortBy = SortMethod::DEFAULT;
   std::map<std::string, SortMethod> m_sortMap = {{"ID", SortMethod::ID},
                                                  {"NAME", SortMethod::NAME},
                                                  {"NUMBER", SortMethod::NUMBER},
                                                  {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
+                                                 {"OUTPUT", SortMethod::OUTPUT},
                                                  {"DEFAULT", SortMethod::DEFAULT}};
 
   std::string m_formatBefore;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -114,6 +114,7 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	If set to name, workspaces will sort by name.
 	If set to id, workspaces will sort by id.
 	If set to special-centered, workspaces will sort by default with special workspaces in the center.
+	If set to output, workspaces will sort by the output (monitor) name.
 	If none of those, workspaces will sort with default behavior.
 
 *expand*: ++

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -913,12 +913,15 @@ void Workspaces::sortWorkspaces() {
         // Helper comparisons
         auto isIdLess = a->id() < b->id();
         auto isNameLess = a->name() < b->name();
+        auto isOutputLess = a->output() < b->output();
 
         switch (m_sortBy) {
           case SortMethod::ID:
             return isIdLess;
           case SortMethod::NAME:
             return isNameLess;
+          case SortMethod::OUTPUT:
+            return isOutputLess;
           case SortMethod::NUMBER:
             try {
               return std::stoi(a->name()) < std::stoi(b->name());


### PR DESCRIPTION
Sorting workspaces by output works really well with 'active-only' and 'all-outputs' with multi-monitor setups, allowing to keep the order of the buttons while swapping workspaces.