### PR TITLE
Prevent child zombie process from tearing down Hyprland IPC

### DIFF
--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -42,6 +42,7 @@ class IPC {
   util::JsonParser parser_;
   std::list<std::pair<std::string, EventHandler*>> callbacks_;
   int socketfd_;  // the hyprland socket file descriptor
+  pid_t socketOwnerPid_;
   bool running_ = true;
 };
 

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -46,9 +46,14 @@ std::filesystem::path IPC::getSocketFolder(const char* instanceSig) {
 IPC::IPC() {
   // will start IPC and relay events to parseIPC
   ipcThread_ = std::thread([this]() { socketListener(); });
+  socketOwnerPid_ = getpid();
 }
 
 IPC::~IPC() {
+  // Do no stop Hyprland IPC if a child process (with successful fork() but
+  // failed exec()) exits.
+  if (getpid() != socketOwnerPid_) return;
+
   running_ = false;
   spdlog::info("Hyprland IPC stopping...");
   if (socketfd_ != -1) {


### PR DESCRIPTION
In rare circumstances, we may fork(), e.g., as part of a custom module, and the child process may fail to exec() and exit. In those cases, the IPC destructor will be called in the child process.

Prior to this commit, this call would then result in the shared socket being closed. Prevent this by only closing the socket from the original process.