### PR TITLE
draft: add generic layout detection to keyboard-state

### DIFF
--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -5,6 +5,7 @@
 #include <gtkmm/box.h>
 #include <wayland-client.h>
 #include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbregistry.h>
 
 #include <memory>
 #include <string>
@@ -24,22 +25,28 @@ class KeyboardState : public AModule {
 
  private:
   Gtk::Box box_;
+  Gtk::Label layout_label_;
   Gtk::Label numlock_label_;
   Gtk::Label capslock_label_;
   Gtk::Label scrolllock_label_;
 
+  std::string layout_format_;
   std::string numlock_format_;
   std::string capslock_format_;
   std::string scrolllock_format_;
+  std::string tooltip_format_ = "";
   std::string icon_locked_;
   std::string icon_unlocked_;
+  bool hide_single_;
 
   struct wl_seat *seat_;
   struct wl_keyboard *keyboard_;
   struct xkb_context *xkb_context_;
   struct xkb_state *xkb_state_;
   struct xkb_keymap *xkb_keymap_;
+  struct rxkb_context *rxkb_context_;
 
+  void update_layout(std::string full_name);
   void update_led(Gtk::Label *, std::string format, std::string name, bool locked);
 
  public:

--- a/meson.build
+++ b/meson.build
@@ -88,8 +88,8 @@ pipewire = dependency('libpipewire-0.3', required: get_option('pipewire'))
 playerctl = dependency('playerctl', version : ['>=2.0.0'], required: get_option('mpris'))
 libpulse = dependency('libpulse', required: get_option('pulseaudio'))
 libudev = dependency('libudev', required: get_option('libudev'))
-libevdev = dependency('libevdev', required: get_option('libevdev'))
 libmpdclient = dependency('libmpdclient', required: get_option('mpd'))
+xkbcommon = dependency('xkbcommon')
 xkbregistry = dependency('xkbregistry')
 libjack = dependency('jack', required: get_option('jack'))
 libwireplumber = dependency('wireplumber-0.5', required: get_option('wireplumber'))
@@ -167,6 +167,7 @@ src_files = files(
     'src/modules/disk.cpp',
     'src/modules/idle_inhibitor.cpp',
     'src/modules/image.cpp',
+    'src/modules/keyboard_state.cpp',
     'src/modules/load.cpp',
     'src/modules/temperature.cpp',
     'src/modules/user.cpp',
@@ -193,6 +194,7 @@ man_files = files(
     'man/waybar-disk.5.scd',
     'man/waybar-idle-inhibitor.5.scd',
     'man/waybar-image.5.scd',
+    'man/waybar-keyboard-state.5.scd',
     'man/waybar-states.5.scd',
     'man/waybar-menu.5.scd',
     'man/waybar-temperature.5.scd',
@@ -453,13 +455,6 @@ if libudev.found() and (is_linux or libepoll.found())
     )
 endif
 
-if libevdev.found() and (is_linux or libepoll.found()) and libinput.found() and (is_linux or libinotify.found())
-    add_project_arguments('-DHAVE_LIBEVDEV', language: 'cpp')
-    add_project_arguments('-DHAVE_LIBINPUT', language: 'cpp')
-    src_files += files('src/modules/keyboard_state.cpp')
-    man_files += files('man/waybar-keyboard-state.5.scd')
-endif
-
 if libmpdclient.found()
     add_project_arguments('-DHAVE_LIBMPDCLIENT', language: 'cpp')
     src_files += files(
@@ -548,11 +543,11 @@ executable(
         libinotify,
         libepoll,
         libmpdclient,
-        libevdev,
         gtk_layer_shell,
         libsndio,
         tz_dep,
-		xkbregistry,
+        xkbcommon,
+        xkbregistry,
         cava,
         libgps
     ],

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -73,9 +73,6 @@
 #include "modules/backlight.hpp"
 #include "modules/backlight_slider.hpp"
 #endif
-#ifdef HAVE_LIBEVDEV
-#include "modules/keyboard_state.hpp"
-#endif
 #ifdef HAVE_GAMEMODE
 #include "modules/gamemode.hpp"
 #endif
@@ -120,6 +117,7 @@
 #include "modules/cffi.hpp"
 #include "modules/custom.hpp"
 #include "modules/image.hpp"
+#include "modules/keyboard_state.hpp"
 #include "modules/temperature.hpp"
 #include "modules/user.hpp"
 
@@ -277,6 +275,9 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
     if (ref == "image") {
       return new waybar::modules::Image(id, config_[name]);
     }
+    if (ref == "keyboard-state") {
+      return new waybar::modules::KeyboardState(id, bar_, config_[name]);
+    }
 #ifdef HAVE_DBUSMENU
     if (ref == "tray") {
       return new waybar::modules::SNI::Tray(id, bar_, config_[name]);
@@ -293,11 +294,6 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
     }
     if (ref == "backlight/slider") {
       return new waybar::modules::BacklightSlider(id, config_[name]);
-    }
-#endif
-#ifdef HAVE_LIBEVDEV
-    if (ref == "keyboard-state") {
-      return new waybar::modules::KeyboardState(id, bar_, config_[name]);
     }
 #endif
 #ifdef HAVE_LIBPULSE


### PR DESCRIPTION
Fixes #4101, #4184, and potentially some others. This also has the potential to replace the language modules for sway, hyprland, and niri.

As a first step, I re-implemented the keyboard-state module to use the keyboard information provided by wayland rather than libinput. In a second step, I added layout detection based on that same information.

This works for me (on labwc), but at the same time it sounds too good to be true. So there might well be a huge downside to this approach that I am not aware of.

Currently this is a rough draft and could use some cleanup. But I wanted to get feedback on the general approach before spending too much time.