### PR TITLE
Hyprland/language: fix to get tooltip to work

### DIFF
--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -43,6 +43,20 @@ Addressed by *hyprland/language*
 	default: false ++
 	Enables this module to consume all left over space dynamically.
 
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to enable/disable tooltip on hover.
+
+*tooltip-format*: ++
+	typeof: string ++
+	default: {long} ++
+	The format of the tooltip. Uses the same format replacements as the main format.
+
+*tooltip-format-<lang>*: ++
+	typeof: string ++
+	Provide an alternative tooltip format per language where <lang> is the short description of your language (e.g. "en", "es"). Can be passed multiple times with multiple languages.
+
 
 # FORMAT REPLACEMENTS
 
@@ -63,6 +77,27 @@ Addressed by *hyprland/language*
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"
+}
+```
+
+```
+"hyprland/language": {
+	"format": "  {}",
+	"format-en": "US",
+	"format-es": "ES",
+	"tooltip": true,
+	"tooltip-format": "{long}"
+}
+```
+
+```
+"hyprland/language": {
+	"format": "  {}",
+	"format-en": "US",
+	"format-es": "ES",
+	"tooltip": true,
+	"tooltip-format-en": "English (United States)",
+	"tooltip-format-es": "Español (España)"
 }
 ```
 

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -56,6 +56,34 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    
+    // Handle tooltip
+    if (tooltipEnabled()) {
+      std::string tooltip_format;
+      std::string tooltipText;
+      
+      // Check for tooltip-format configuration
+      if (config_.isMember("tooltip-format-" + layout_.short_description + "-" + layout_.variant)) {
+        tooltip_format = config_["tooltip-format-" + layout_.short_description + "-" + layout_.variant].asString();
+      } else if (config_.isMember("tooltip-format-" + layout_.short_description)) {
+        tooltip_format = config_["tooltip-format-" + layout_.short_description].asString();
+      } else if (config_.isMember("tooltip-format")) {
+        tooltip_format = config_["tooltip-format"].asString();
+      } else {
+        // Default to showing the full name if no tooltip format is specified
+        tooltip_format = "{long}";
+      }
+      
+      // Format the tooltip text
+      tooltipText = trim(fmt::format(fmt::runtime(tooltip_format), 
+                                     fmt::arg("long", layout_.full_name),
+                                     fmt::arg("short", layout_.short_name),
+                                     fmt::arg("shortDescription", layout_.short_description),
+                                     fmt::arg("variant", layout_.variant)));
+      
+      label_.set_tooltip_markup(tooltipText);
+      spdlog::debug("hyprland language tooltip text: {}", tooltipText);
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Using member method to call tooltipEnabled.

Supersedes: [https://github.com/Alexays/Waybar/pull/3698](https://github.com/Alexays/Waybar/pull/3698)
Closes: [https://github.com/Alexays/Waybar/issues/3693](https://github.com/Alexays/Waybar/issues/3693)