### PR TITLE
Clock Module: Independent clock tooltip formatting and fix for blank line at the end of the timezone list

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -62,6 +62,7 @@ class Clock final : public ALabel {
   std::vector<const date::time_zone*> tzList_;  // time zones list
   int tzCurrIdx_;                               // current time zone index for tzList_
   std::string tzText_{""};                      // time zones text to print
+  std::string tzTooltipFormat_{""};             // optional timezone tooltip format
   util::SleeperThread thread_;
 
   // ordinal date in tooltip

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -39,6 +39,12 @@ $XDG_CONFIG_HOME/waybar/config ++
 :[ A list of timezones (as in *timezone*) to use for time display, changed using
    the scroll wheel. Do not specify *timezone* option when *timezones* is specified.
    "" represents the system's local timezone
+|[ *timezone-tooltip-format*
+:[ string
+:[
+:[ Format to use for displaying timezones in the tooltip. When set, this allows showing
+   timezone information (like timezone abbreviations) in the tooltip while keeping the
+   main display clean. Uses the same format options as *format*
 |[ *locale*
 :[ string
 :[
@@ -226,6 +232,25 @@ View all valid format options in *strftime(3)* or have a look https://en.cpprefe
 	"tooltip": true,
 	"format": "{:%H.%M}",
 	"tooltip-format": "{:%Y-%m-%d}",
+}
+```
+
+4. Show timezone in tooltip only
+
+```
+"clock": {
+	"interval": 60,
+	"format": "{:%H:%M}",
+	"timezone-tooltip-format": "{:%H:%M %Z}",
+	"timezones": [
+		"",
+		"America/Chicago",
+		"America/Los_Angeles",
+		"Europe/Paris",
+		"UTC"
+	],
+	"tooltip": true,
+	"tooltip-format": "{tz_list}"
 }
 ```
 

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -191,10 +191,13 @@ auto waybar::modules::Clock::getTZtext(sys_seconds now) -> std::string {
   std::stringstream os;
   bool first = true;
   for (size_t tz_idx{0}; tz_idx < tzList_.size(); ++tz_idx) {
+    // Skip local timezone (nullptr) - never show it in tooltip
+    if (tzList_[tz_idx] == nullptr) continue;
+    
     // Skip current timezone unless timezone-tooltip-format is specified
     if (static_cast<int>(tz_idx) == tzCurrIdx_ && tzTooltipFormat_.empty()) continue;
     
-    const auto* tz = tzList_[tz_idx] != nullptr ? tzList_[tz_idx] : local_zone();
+    const auto* tz = tzList_[tz_idx];
     auto zt{zoned_time{tz, now}};
     
     // Add newline before each entry except the first


### PR DESCRIPTION
The changes implement:

1. **`timezone-tooltip-format` option**: You can now show timezone acronyms in the tooltip without being forced to show the timezone acronym in waybar. This helps keep the main display clean and gives the user more choice. 

2. **Trailing newline fix**: The extra blank line at the bottom of the timezone list has been removed.

Fixes: [https://github.com/Alexays/Waybar/issues/4329](https://github.com/Alexays/Waybar/issues/4329)

<img width="433" height="125" alt="image" src="https://github.com/user-attachments/assets/bb1d407f-a797-4dc3-a6ec-e9c960ad6cf9" />
