### PR TITLE
Fix: style: show active workspace on hyprland

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -63,7 +63,7 @@ button:hover {
     background: rgba(0, 0, 0, 0.2);
 }
 
-#workspaces button.focused {
+#workspaces button.focused, #workspaces button.active {
     background-color: #64727D;
     box-shadow: inset 0 -3px #ffffff;
 }


### PR DESCRIPTION
The `hyprland/workspaces` module has the CSS class `active` rather than `focused` for the current workspace.

Update the default CSS selector for the current workspace to match both `button.focused` and `button.active`.

It is a sensible default, isn't it?