### PR TITLE
fix(cava): don't update immediately after silence

### DIFF
--- a/src/modules/cava.cpp
+++ b/src/modules/cava.cpp
@@ -159,7 +159,7 @@ auto waybar::modules::Cava::update() -> void {
     // Do transformation under raw data
     audio_raw_fetch(&audio_raw_, &prm_, &rePaint_, plan_);
 
-    if (rePaint_ == 1) {
+    if (rePaint_ == 1 && !label_.get_style_context()->has_class("silent")) {
       text_.clear();
 
       for (int i{0}; i < audio_raw_.number_of_bars; ++i) {


### PR DESCRIPTION
Sometimes cava updates fft view and then gets stuck for 1 second. This prevents the initial view update

### Video of this issue:

https://github.com/user-attachments/assets/02584eed-f965-40b6-a477-7fe177bb7558

The cava should close and open with an animation, but the animation doesn't play when the fft gets updated too quickly or there is a race condition (audio started playing while the animation was closing)

### Cava config

```jsonc
    "cava": {
        "framerate": 60,
        "autosens": 1,
        "bars": 10,
        "lower_cutoff_freq": 50,
        "higher_cutoff_freq": 10000,
        "stereo": true,
        "reverse": false,
        "bar_delimiter": 0,
        "monstercat": false,
        "waves": true,
        "sleep_timer": 1,
        "format_silent": "quiet",
        "hide_on_silence": false,
        "noise_reduction": 0.77,
        "input_delay": 1,
        "format-icons" : [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"],
        "on-scroll-up": "wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%+",
        "on-scroll-down": "wpctl set-volume @DEFAULT_AUDIO_SINK@ 2%-",
    },
```

### Cava style

```css
.module {
    /* ... */
    transition: min-width 1s ease-in-out,
	        width 1s ease-in-out,
	        color .4s,
	        background-color .4s;
}


#cava {
	font-family: 'Hack Nerd Font Propo';
	font-size: 25px;
	transition: min-width 1s ease-in-out,
		    color .4s,
		    background-color .4s;
}

#cava:not(.silent) {
	min-width: 150px;
	color: transparent;
}

#cava.silent {
	color: @accent;
	animation-name: show;
	animation-duration: 1s;
	animation-timing-function: steps(12);
	animation-iteration-count: 1;
	animation-direction: normal;
}

#cava.updated {
	min-width: 150px;
	color: @accent;
}

@keyframes show {
	from {
		color: transparent;
	}
}
```