### PR TITLE
fix(river): hide vacant tags on initial startup

### DIFF
--- a/include/modules/river/tags.hpp
+++ b/include/modules/river/tags.hpp
@@ -21,6 +21,7 @@ class Tags : public waybar::AModule {
   void handle_view_tags(struct wl_array *tags);
   void handle_urgent_tags(uint32_t tags);
 
+  void handle_show();
   void handle_primary_clicked(uint32_t tag);
   bool handle_button_press(GdkEventButton *event_button, uint32_t tag);
 

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -150,11 +150,7 @@ Tags::Tags(const std::string &id, const waybar::Bar &bar, const Json::Value &con
     button.show();
   }
 
-  struct wl_output *output = gdk_wayland_monitor_get_wl_output(bar_.output->monitor->gobj());
-  output_status_ = zriver_status_manager_v1_get_river_output_status(status_manager_, output);
-  zriver_output_status_v1_add_listener(output_status_, &output_status_listener_impl, this);
-
-  zriver_status_manager_v1_destroy(status_manager_);
+  box_.signal_show().connect(sigc::mem_fun(*this, &Tags::handle_show));
 }
 
 Tags::~Tags() {
@@ -165,6 +161,19 @@ Tags::~Tags() {
   if (control_) {
     zriver_control_v1_destroy(control_);
   }
+
+  if (status_manager_) {
+    zriver_status_manager_v1_destroy(status_manager_);
+  }
+}
+
+void Tags::handle_show() {
+  struct wl_output *output = gdk_wayland_monitor_get_wl_output(bar_.output->monitor->gobj());
+  output_status_ = zriver_status_manager_v1_get_river_output_status(status_manager_, output);
+  zriver_output_status_v1_add_listener(output_status_, &output_status_listener_impl, this);
+
+  zriver_status_manager_v1_destroy(status_manager_);
+  status_manager_ = nullptr;
 }
 
 void Tags::handle_primary_clicked(uint32_t tag) {


### PR DESCRIPTION
Before this, vacant tags would show with `hide-vacant` set on initial startup, because we receive initial tag events from River before we show the bar. In that case, we won't call `set_visible(false)` on the respective buttons because they're not shown yet. This registers the output status listener after we show the bar so we won't miss any events.