### PR TITLE
fix: close sni menu on item destruction

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -26,7 +26,7 @@ struct ToolTip {
 class Item : public sigc::trackable {
  public:
   Item(const std::string&, const std::string&, const Json::Value&, const Bar&);
-  ~Item() = default;
+  ~Item();
 
   std::string bus_name;
   std::string object_path;

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -74,6 +74,13 @@ Item::Item(const std::string& bn, const std::string& op, const Json::Value& conf
                                    cancellable_, interface);
 }
 
+Item::~Item() {
+  if (this->gtk_menu != nullptr) {
+    this->gtk_menu->popdown();
+    this->gtk_menu->detach();
+  }
+}
+
 bool Item::handleMouseEnter(GdkEventCrossing* const& e) {
   event_box.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   return false;


### PR DESCRIPTION
If a tray menu is open and hovered as the item disappears from the tray, its GTK menu is left in an invalid state and locks up waybar.

This gets spammed in the logs:
```
(waybar:54340): Gtk-CRITICAL **: 13:56:28.088: _gtk_widget_captured_event: assertion 'WIDGET_REALIZED_FOR_EVENT (widget, event)' failed
```