### PR TITLE
feat(niri/language): add CSS classes

### DIFF
--- a/include/modules/niri/language.hpp
+++ b/include/modules/niri/language.hpp
@@ -33,6 +33,7 @@ class Language : public ALabel, public EventHandler {
 
   std::vector<Layout> layouts_;
   unsigned current_idx_;
+  std::string last_short_name_;
 };
 
 }  // namespace waybar::modules::niri

--- a/man/waybar-niri-language.5.scd
+++ b/man/waybar-niri-language.5.scd
@@ -61,3 +61,12 @@ Addressed by *niri/language*
 # STYLE
 
 - *#language*
+
+Additionally, a CSS class matching the current layout's short name is added to the widget. This
+allows per-language styling, for example:
+
+```
+#language.us { color: #00ff00; }
+#language.de { color: #ff0000; }
+#language.fr { color: #0000ff; }
+```

--- a/src/modules/niri/language.cpp
+++ b/src/modules/niri/language.cpp
@@ -58,6 +58,16 @@ void Language::doUpdate() {
   spdlog::debug("niri language update with short description {}", layout.short_description);
   spdlog::debug("niri language update with variant {}", layout.variant);
 
+  if (!last_short_name_.empty()) {
+    label_.get_style_context()->remove_class(last_short_name_);
+  }
+  if (!layout.short_name.empty()) {
+    label_.get_style_context()->add_class(layout.short_name);
+    last_short_name_ = layout.short_name;
+  } else {
+    last_short_name_.clear();
+  }
+
   std::string layoutName = std::string{};
   if (config_.isMember("format-" + layout.short_description + "-" + layout.variant)) {
     const auto propName = "format-" + layout.short_description + "-" + layout.variant;


### PR DESCRIPTION
Add CSS classes to the `niri/language` to allow targeting of individual languages, similar to how `sway/language` already supports.

Closes https://github.com/Alexays/Waybar/issues/3657