### PR TITLE
feat: Add a 'background' configuration layer

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -30,6 +30,7 @@ struct waybar_output {
 };
 
 enum class bar_layer : uint8_t {
+  BACKGROUND,
   BOTTOM,
   TOP,
   OVERLAY,

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -66,6 +66,8 @@ void from_json(const Json::Value& j, bar_layer& l) {
     l = bar_layer::BOTTOM;
   } else if (j == "top") {
     l = bar_layer::TOP;
+  } else if (j == "background") {
+    l = bar_layer::BACKGROUND;
   } else if (j == "overlay") {
     l = bar_layer::OVERLAY;
   }
@@ -350,13 +352,15 @@ void waybar::Bar::setMode(const struct bar_mode& mode) {
     layer = GTK_LAYER_SHELL_LAYER_TOP;
   } else if (mode.layer == bar_layer::OVERLAY) {
     layer = GTK_LAYER_SHELL_LAYER_OVERLAY;
+  } else if (mode.layer == bar_layer::BACKGROUND) {
+    layer = GTK_LAYER_SHELL_LAYER_BACKGROUND;
   }
   gtk_layer_set_layer(gtk_window, layer);
 
   if (mode.exclusive) {
     gtk_layer_auto_exclusive_zone_enable(gtk_window);
   } else {
-    gtk_layer_set_exclusive_zone(gtk_window, 0);
+    gtk_layer_set_exclusive_zone(gtk_window, -1);
   }
 
   setPassThrough(passthrough_ = mode.passthrough);


### PR DESCRIPTION
First of all I love Waybar thanks for maintaining it !

Currently Niri is unable to see waybar in a backround layer. In order to do that I added a way to put Waybar in the background layer with a simple new option the layer key.
But to be detected as a 'wallpaper' type of app, I needed to set the exclusive zone to -1 with `gtk_layer_set_exclusive_zone(gtk_window, -1);`
> I used the same behavior as the swaybg, following the instruction of the niri wiki 
   https://github.com/YaLTeR/niri/blob/e837e39623457dc5ad29c34a5ce4d4616e5fbf1e/docs/wiki/Overview.md?plain=1#L89C1-L90C1
   https://github.com/swaywm/swaybg/blob/1bf721fcb61a7c78cc618868640a3ab24c5a3077/main.c#L319 

I dont know what is the impact of that modification, and If I should add news settings to opt in this behavior.
Also should I add some docs about it, or tests ?
