### PR TITLE
fix: right and middle button not work in ext/workspace module

### DIFF
--- a/src/modules/ext/workspace_manager.cpp
+++ b/src/modules/ext/workspace_manager.cpp
@@ -349,11 +349,11 @@ Workspace::Workspace(const Json::Value &config, WorkspaceManager &manager,
   }
   const bool config_on_click_middle = config["on-click-middle"].isString();
   if (config_on_click_middle) {
-    on_click_middle_action_ = config["on-click"].asString();
+    on_click_middle_action_ = config["on-click-middle"].asString();
   }
   const bool config_on_click_right = config["on-click-right"].isString();
   if (config_on_click_right) {
-    on_click_right_action_ = config["on-click"].asString();
+    on_click_right_action_ = config["on-click-right"].asString();
   }
 
   // setup UI


### PR DESCRIPTION
When parsing the configuration, the configuration of the left button was mistakenly parsed as that of the middle button and the right button, resulting in both the middle button and the right button being able to only trigger the action of the left button