### PR TITLE
feat: sway/workspaces: add custom workspace sorting functionality

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -4,6 +4,7 @@
 #include <gtkmm/button.h>
 #include <gtkmm/label.h>
 
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 
@@ -44,6 +45,7 @@ class Workspaces : public AModule, public sigc::trackable {
   std::string getCycleWorkspace(std::vector<Json::Value>::iterator, bool prev) const;
   uint16_t getWorkspaceIndex(const std::string& name) const;
   static std::string trimWorkspaceName(const std::string&);
+  std::optional<uint16_t> getCustomSortIndex(const std::string& name) const;
   bool handleScroll(GdkEventScroll* /*unused*/) override;
 
   const Bar& bar_;
@@ -56,6 +58,7 @@ class Workspaces : public AModule, public sigc::trackable {
   util::RegexCollection m_windowRewriteRules;
   util::JsonParser parser_;
   std::unordered_map<std::string, Gtk::Button> buttons_;
+  std::unordered_map<std::string, uint16_t> custom_sort_priorities_;
   std::mutex mutex_;
   Ipc ipc_;
 };

--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -96,6 +96,11 @@ Addressed by *sway/workspaces*
 	typeof: bool ++
 	Whether to sort workspaces alphabetically. Please note this can make "swaymsg workspace prev/next" move to workspaces inconsistent with the ordering shown in Waybar.
 
+*custom-sort*: ++
+	typeof: array ++
+	default: [] ++
+	Defines an explicit ordering for workspace names. Entries earlier in the array appear first. Both full names and the trimmed portion after ":" are matched. Any workspace not listed here falls back to the default ordering (or alphabetical ordering when *alphabetical_sort* is true).
+
 warp-on-scroll: ++
 	typeof: bool ++
 	default: true ++

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -50,6 +50,21 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
       high_priority_named_.push_back(it.asString());
     }
   }
+  if (config_["custom-sort"].isArray()) {
+    uint16_t priority = 0;
+    for (const auto& entry : config_["custom-sort"]) {
+      if (!entry.isString()) {
+        continue;
+      }
+      auto const name = entry.asString();
+      custom_sort_priorities_.insert_or_assign(name, priority);
+      auto const trimmed = trimWorkspaceName(name);
+      if (trimmed != name) {
+        custom_sort_priorities_.insert_or_assign(trimmed, priority);
+      }
+      ++priority;
+    }
+  }
   box_.set_name("workspaces");
   if (!id.empty()) {
     box_.get_style_context()->add_class(id);
@@ -235,6 +250,20 @@ void Workspaces::onCmd(const struct Ipc::ipc_response& res) {
                     auto rname = rhs["name"].asString();
                     int l = lhs["sort"].asInt();
                     int r = rhs["sort"].asInt();
+
+                    if (!custom_sort_priorities_.empty()) {
+                      auto const lcustom = getCustomSortIndex(lname);
+                      auto const rcustom = getCustomSortIndex(rname);
+                      if (lcustom && rcustom) {
+                        if (*lcustom != *rcustom) {
+                          return *lcustom < *rcustom;
+                        }
+                      } else if (lcustom) {
+                        return true;
+                      } else if (rcustom) {
+                        return false;
+                      }
+                    }
 
                     if (l == r || config_["alphabetical_sort"].asBool()) {
                       // In case both integers are the same, lexicographical
@@ -570,6 +599,24 @@ std::string Workspaces::trimWorkspaceName(const std::string& name) {
     return name.substr(found + 1);
   }
   return name;
+}
+
+std::optional<uint16_t> Workspaces::getCustomSortIndex(const std::string& name) const {
+  if (custom_sort_priorities_.empty()) {
+    return std::nullopt;
+  }
+  auto it = custom_sort_priorities_.find(name);
+  if (it != custom_sort_priorities_.end()) {
+    return it->second;
+  }
+  auto trimmed = trimWorkspaceName(name);
+  if (trimmed != name) {
+    auto trimmed_it = custom_sort_priorities_.find(trimmed);
+    if (trimmed_it != custom_sort_priorities_.end()) {
+      return trimmed_it->second;
+    }
+  }
+  return std::nullopt;
 }
 
 bool is_focused_recursive(const Json::Value& node) {


### PR DESCRIPTION
Added `custom-sort` property to `sway/workspaces` that allows the user to specify their own order for each of the workspaces.

### BEFORE:
<img width="924" height="266" alt="2025-10-09_06-50_BEFORE" src="https://github.com/user-attachments/assets/1a6cc59f-2601-4be5-9a34-da1e0a594f05" />

### AFTER:
<img width="949" height="263" alt="2025-10-09_06-48" src="https://github.com/user-attachments/assets/0c1d47d6-014d-44ad-98fa-e3523562d60d" />

---

Helps when alphabetical sort is not ordering how you want it to.