### PR TITLE
backlight: gracefully handle a null epoll device

### DIFF
--- a/src/util/backlight_backend.cpp
+++ b/src/util/backlight_backend.cpp
@@ -201,7 +201,9 @@ BacklightBackend::BacklightBackend(std::chrono::milliseconds interval,
         const auto &event = events[i];
         check_eq(event.data.fd, udev_fd, "unexpected udev fd");
         std::unique_ptr<udev_device, UdevDeviceDeleter> dev{udev_monitor_receive_device(mon.get())};
-        check_nn(dev.get(), "epoll dev was null");
+        if (!dev) {
+          continue;
+        }
         upsert_device(devices, dev.get());
       }
 


### PR DESCRIPTION
recently i switched my laptop from using `eudev` to `mdevd` with [libudev-zero](https://github.com/illiliti/libudev-zero), a daemonless replacement for `libudev`, and `waybar` started crashing on me

i tracked it down to [this](https://github.com/Alexays/Waybar/blob/559079e9a6afda77754afaf7c8d3f588c1d6206d/src/util/backlight_backend.cpp#L204) line

apparently a [similar issue](https://codeberg.org/dnkl/yambar/issues/109)  existed in `yambar` and was fixed as well

---

i hope you will consider accepting this patch so i may continue to enjoy `waybar` without maintaining my own patch set...

i appreciate your time and consideration in reviewing this PR :bowing_man: