### PR TITLE
feat(wlr/taskbar): add `truncate` option to ellipsize long button text

### DIFF
--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -84,6 +84,11 @@ Addressed by *wlr/taskbar*
 	default: false ++
 	If set to true, task buttons stretch to fill the available space in the taskbar and long titles are ellipsized to fit. Only takes effect on a horizontal bar; on a vertical bar the buttons keep their content-based size. If set to false, buttons are sized to their content.
 
+*truncate*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, the task button text will be ellipsized (truncated with …) when the available button width is smaller than the label text.
+
 *on-click*: ++
 	typeof: string ++
 	The action which should be triggered when clicking on the application button with the left mouse button.

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -138,6 +138,17 @@ Task::Task(const waybar::Bar& bar, const Json::Value& config, Taskbar* tbar,
   content_.show();
   button.add(content_);
 
+  // Apply optional label truncation (ellipsize).
+  if (config_["truncate"].isBool() && config_["truncate"].asBool()) {
+    text_before_.set_single_line_mode(true);
+    text_before_.set_ellipsize(Pango::ELLIPSIZE_END);
+    text_before_.set_line_wrap(false);
+
+    text_after_.set_single_line_mode(true);
+    text_after_.set_ellipsize(Pango::ELLIPSIZE_END);
+    text_after_.set_line_wrap(false);
+  }
+
   format_before_.clear();
   format_after_.clear();
 


### PR DESCRIPTION
## Summary
This PR adds an optional boolean `truncate` to the `wlr/taskbar` module. When enabled, task button text is ellipsized (… at the end) whenever the label would exceed the button's available width. This keeps the taskbar tidy when window titles are long or when space is tight. It will fix issue #3770 for `wlr/taskbar`.

## Configuration
It is off by default and enabling requires:

```jsonc
"wlr/taskbar": {
  "truncate": true
}
```

* No breaking changes. The new behavior is opt-in.
* Existing configs continue to behave the same.

## Screenshots
*Before:* different length of taskbar button label.
<img width="1669" height="28" alt="image" src="https://github.com/user-attachments/assets/0439f30e-f940-449b-97ef-ad641df8bcc8" />

*After:* with `"truncate": true` (visuals depend on theme and spacing).
<img width="1280" height="28" alt="image" src="https://github.com/user-attachments/assets/44e7e0fd-db3b-488f-a18e-67e5d0a566c8" />

*Before:* huge amount of taskbar buttons.
<img width="1875" height="28" alt="image" src="https://github.com/user-attachments/assets/0e1ccdd2-6e15-48e9-b85d-d010ca455d9e" />

*After:* with `"truncate": "true"`
<img width="1280" height="28" alt="image" src="https://github.com/user-attachments/assets/1e41abb9-bdf8-4033-8ccc-49600fda8df9" />

## Docs
* Add the new `truncate` key to the `wlr/taskbar` module documentation with accepted values and defaults.

## Testing
1. Enable the option:
```jsonc
"wlr/taskbar": { "truncate": true }
```
2. Enforce a static width with:
```jsonc
"width": 1280
```
3. Open an app with a very long title (e.g., a browser tab with a long page title).
4. Reduce available taskbar width (resize bar/monitor or open more tasks).
5. Verify the label is a single line and ends with an ellipsis rather than wrapping or pushing layout.

## Motivation
Long window titles can cause layout jitter or overflow in the taskbar. Providing a first-class switch to ellipsize labels gives users a simple, predictable way to keep the module compact, regardless of how many tasks are present or how verbose their titles are.