### PR TITLE
cava bump & fixing memory leaks

### DIFF
--- a/include/modules/cava/cava_backend.hpp
+++ b/include/modules/cava/cava_backend.hpp
@@ -43,13 +43,13 @@ class CavaBackend final {
   util::SleeperThread thread_;
   util::SleeperThread read_thread_;
   // Cava API to read audio source
-  ::cava::ptr input_source_;
+  ::cava::ptr input_source_{NULL};
 
   struct ::cava::error_s error_{};          // cava errors
   struct ::cava::config_params prm_{};      // cava parameters
   struct ::cava::audio_raw audio_raw_{};    // cava handled raw audio data(is based on audio_data)
   struct ::cava::audio_data audio_data_{};  // cava audio data
-  struct ::cava::cava_plan* plan_;          //{new cava_plan{}};
+  struct ::cava::cava_plan* plan_{NULL};    //{new cava_plan{}};
 
   std::chrono::seconds fetch_input_delay_{4};
   // Delay to handle audio source

--- a/meson.build
+++ b/meson.build
@@ -498,7 +498,7 @@ else
 endif
 
 cava = dependency('cava',
-                  version : '>=0.10.4',
+                  version : '>=0.10.6',
                   required: get_option('cava'),
                   fallback : ['cava', 'cava_dep'],
                   not_found_message: 'cava is not found. Building waybar without cava')

--- a/subprojects/cava.wrap
+++ b/subprojects/cava.wrap
@@ -1,7 +1,11 @@
-[wrap-file]
-directory = cava-0.10.4
-source_url = https://github.com/LukashonakV/cava/archive/0.10.4.tar.gz
-source_filename = cava-0.10.4.tar.gz
-source_hash =7bc1c1f9535f2bcc5cd2ae8a2434a2e3a05f5670b1c96316df304137ffc65756
+[wrap-git]
+url = https://github.com/LukashonakV/cava.git
+revision = 23efcced43b5a395747b18a2e5f2171fc0925d18
+depth = 1
+
+#directory = cava-0.10.6
+#source_url = https://github.com/LukashonakV/cava/archive/0.10.6.tar.gz
+#source_filename = cava-0.10.6.tar.gz
+#source_hash = e715c4c6a625b8dc063e57e8e81c80e4d1015ec1b98db69a283b2c6770f839f4
 [provide]
 cava = cava_dep


### PR DESCRIPTION
Hi @Alexays ,

1. libcava bump to 0.10.6
2. Some memory leaks fixing
3. module adaptation  (LukashonakV/cava#32)
4. Meson wrap file temporary transformed to the wrap git(because of dependency on LukashonakV/cava@23efcced43b5a395747b18a2e5f2171fc0925d18)