### PR TITLE
fix(pulseaudio-slider): Use `background` in CSS example

### DIFF
--- a/man/waybar-pulseaudio-slider.5.scd
+++ b/man/waybar-pulseaudio-slider.5.scd
@@ -77,12 +77,12 @@ The slider is a component with multiple CSS Nodes, of which the following are ex
     min-height: 80px;
     min-width: 10px;
     border-radius: 5px;
-    background-color: black;
+    background: black;
 }
 
 #pulseaudio-slider highlight {
     min-width: 10px;
     border-radius: 5px;
-    background-color: green;
+    background: green;
 }
 ```


### PR DESCRIPTION
The `background-color` property does not work as expected for the slider. Using the `background` shorthand property correctly applies the color.