### PR TITLE
fix: resolve memory leak by removing old CSS provider before reloading CSS styles

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -183,16 +183,24 @@ const std::string waybar::Client::getStyle(const std::string &style,
 };
 
 auto waybar::Client::setupCss(const std::string &css_file) -> void {
-  css_provider_ = Gtk::CssProvider::create();
-  style_context_ = Gtk::StyleContext::create();
+  auto screen = Gdk::Screen::get_default();
+  if (!screen) {
+    throw std::runtime_error("No default screen");
+  }
 
-  // Load our css file, wherever that may be hiding
+  if (css_provider_) {
+    Gtk::StyleContext::remove_provider_for_screen(screen, css_provider_);
+    css_provider_.reset();
+  }
+
+  css_provider_ = Gtk::CssProvider::create();
   if (!css_provider_->load_from_path(css_file)) {
+    css_provider_.reset();
     throw std::runtime_error("Can't open style file");
   }
-  // there's always only one screen
-  style_context_->add_provider_for_screen(Gdk::Screen::get_default(), css_provider_,
-                                          GTK_STYLE_PROVIDER_PRIORITY_USER);
+
+  Gtk::StyleContext::add_provider_for_screen(screen, css_provider_,
+                                             GTK_STYLE_PROVIDER_PRIORITY_USER);
 }
 
 void waybar::Client::bindInterfaces() {


### PR DESCRIPTION
This PR fixes a CPU usage issue caused by the CSS reloading logic.

Each time the CSS file was reloaded, a new Gtk::CssProvider was added to the screen without removing the previous one. Over time, this led to multiple active providers and steadily increasing CPU usage.

Although #846 was closed, this fixes another cause of the high CPU usage.