### PR TITLE
fix(clock): fix freebsd compatibility

### DIFF
--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -230,7 +230,7 @@ const unsigned cldRowsInMonth(const year_month& ym, const weekday& firstdow) {
 auto cldGetWeekForLine(const year_month& ym, const weekday& firstdow, const unsigned line)
     -> const year_month_weekday {
   const unsigned idx = line - 2;
-  const std::chrono::weekday_indexed indexed_first_day_of_week =
+  const auto indexed_first_day_of_week =
       weekday{ym / 1} == firstdow ? firstdow[idx + 1] : firstdow[idx];
 
   return ym / indexed_first_day_of_week;


### PR DESCRIPTION
Recently introduced for ISO 8601 calendar compatibility. But, lib differences causing the explicit type to break freebsd.


```bash
FAILED: [code=1] waybar.p/src_modules_clock.cpp.o 
c++ -Iwaybar.p -I. -I.. -I../include -I../subprojects/date-3.0.1/include -Iresources/icons -Iprotocol -I/usr/local/include -I/usr/local/include/libepoll-shim -I/usr/local/include/sigc++-2.0 -I/usr/local/lib/sigc++-2.0/include -I/usr/local/include/gtkmm-3.0 -I/usr/local/lib/gtkmm-3.0/include -I/usr/local/include/atkmm-1.6 -I/usr/local/lib/atkmm-1.6/include -I/usr/local/include/gtk-3.0/unix-print -I/usr/local/include/gdkmm-3.0 -I/usr/local/lib/gdkmm-3.0/include -I/usr/local/include/giomm-2.4 -I/usr/local/lib/giomm-2.4/include -I/usr/local/include/gtk-3.0 -I/usr/local/include/cairo -I/usr/local/include/at-spi2-atk/2.0 -I/usr/local/include/at-spi-2.0 -I/usr/local/include/atk-1.0 -I/usr/local/libdata/pkgconfig/../../include/dbus-1.0 -I/usr/local/libdata/pkgconfig/../../lib/dbus-1.0/include -I/usr/local/include/gio-unix-2.0 -I/usr/local/include/pangomm-1.4 -I/usr/local/lib/pangomm-1.4/include -I/usr/local/include/glibmm-2.4 -I/usr/local/lib/glibmm-2.4/include -I/usr/local/include/cairomm-1.0 -I/usr/local/lib/cairomm-1.0/include -I/usr/local/include/pango-1.0 -I/usr/local/include/pixman-1 -I/usr/local/include/fribidi -I/usr/local/include/harfbuzz -I/usr/local/include/freetype2 -I/usr/local/include/libpng16 -I/usr/local/include/gdk-pixbuf-2.0 -I/usr/local/include/glib-2.0 -I/usr/local/lib/glib-2.0/include -I/usr/local/include/libdbusmenu-gtk3-0.4 -I/usr/local/include/libdbusmenu-glib-0.4 -I/usr/local/include/libupower-glib -I/usr/local/include/polkit-1 -I/usr/local/include/pipewire-0.3 -I/usr/local/include/spa-0.2 -I/usr/local/include/libevdev-1.0 -I/usr/local/include/gtk-layer-shell -I/usr/local/include/libxml2 -fdiagnostics-color=always -D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_FAST -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c++20 -O3 '-DVERSION="08e0f29 (branch '"'"'HEAD'"'"')"' '-DSYSCONFDIR="/usr/local/etc"' -DHAVE_CPU_BSD -DHAVE_MEMORY_BSD -DHAVE_SWAY -DHAVE_WLR_TASKBAR -DHAVE_EXT_WORKSPACES -DHAVE_RIVER -DHAVE_DWL -DHAVE_HYPRLAND -DHAVE_NIRI -DHAVE_WAYFIRE -DHAVE_LOGIN_PROXY -DHAVE_GAMEMODE -DHAVE_LOGIND_INHIBITOR -DHAVE_UPOWER -DHAVE_PIPEWIRE -DHAVE_LIBPULSE -DHAVE_LIBJACK -DHAVE_DBUSMENU -DHAVE_LIBUDEV -DHAVE_LIBMPDCLIENT -DHAVE_LIBSNDIO -DHAVE_LIBDATE -isystem/usr/local/include -DUSE_OS_TZDB=1 -pthread -D_REENTRANT -D_THREAD_SAFE -DSPDLOG_SHARED_LIB -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -MD -MQ waybar.p/src_modules_clock.cpp.o -MF waybar.p/src_modules_clock.cpp.o.d -o waybar.p/src_modules_clock.cpp.o -c ../src/modules/clock.cpp
../src/modules/clock.cpp:233:38: error: no viable conversion from 'weekday_indexed' to 'const std::chrono::weekday_indexed'
  233 |   const std::chrono::weekday_indexed indexed_first_day_of_week =
      |                                      ^
  234 |       weekday{ym / 1} == firstdow ? firstdow[idx + 1] : firstdow[idx];
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/__chrono/weekday.h:128:7: note: candidate constructor (the implicit copy constructor) not viable: no known conversion from 'weekday_indexed' to 'const weekday_indexed &' for 1st argument
  128 | class weekday_indexed {
      |       ^~~~~~~~~~~~~~~
/usr/include/c++/v1/__chrono/weekday.h:128:7: note: candidate constructor (the implicit move constructor) not viable: no known conversion from 'weekday_indexed' to 'weekday_indexed &&' for 1st argument
  128 | class weekday_indexed {
      |       ^~~~~~~~~~~~~~~
../src/modules/clock.cpp:236:13: error: invalid operands to binary expression ('const year_month' and 'const std::chrono::weekday_indexed')
  236 |   return ym / indexed_first_day_of_week;
```

Linux failures addressed in https://github.com/Alexays/Waybar/pull/4578
Nix failure addressed in https://github.com/Alexays/Waybar/pull/4577