### PR TITLE
feat(niri/workspaces): Niri per-workspace taskbar feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ vgcore.*
 *.swp
 packagecache
 /subprojects/**/
+/subprojects/.wraplock
 /build*
 /dist
 /meson.egg-info

--- a/include/modules/niri/workspaces.hpp
+++ b/include/modules/niri/workspaces.hpp
@@ -6,25 +6,50 @@
 #include "AModule.hpp"
 #include "bar.hpp"
 #include "modules/niri/backend.hpp"
+#include "util/icon_loader.hpp"
 
 namespace waybar::modules::niri {
 
+class Workspace {
+ public:
+  Workspace(const Json::Value& config, const uint64_t id, const std::string& name);
+  void update(const Json::Value& workspace_data, const std::vector<Json::Value>& windows_data,
+              const std::string& display);
+
+  Gtk::Button& button() { return button_; }
+  // Gtk::Box& content() { return content_; }
+  // Gtk::Label& labelBefore() { return labelBefore_; }
+  // Gtk::Label& labelAfter() { return labelAfter_; }
+
+ private:
+  std::string getIcon(const std::string& value, const Json::Value& ws);
+  void updateTaskbar(const std::vector<Json::Value>& windows_data);
+
+  IconLoader iconLoader_;
+  uint64_t id_;
+  std::string name_;
+  Gtk::Button button_;
+  Gtk::Box content_;
+  Gtk::Label label_;
+  Json::Value config_;
+  Json::Value taskBarConfig_;
+};
+
 class Workspaces : public AModule, public EventHandler {
  public:
-  Workspaces(const std::string &, const Bar &, const Json::Value &);
+  Workspaces(const std::string&, const Bar&, const Json::Value&);
   ~Workspaces() override;
   void update() override;
 
  private:
-  void onEvent(const Json::Value &ev) override;
+  void onEvent(const Json::Value& ev) override;
   void doUpdate();
-  Gtk::Button &addButton(const Json::Value &ws);
-  std::string getIcon(const std::string &value, const Json::Value &ws);
+  void addWorkspace(const Json::Value& workspace_data,
+                    const std::vector<Json::Value>& windows_data);
 
-  const Bar &bar_;
+  const Bar& bar_;
   Gtk::Box box_;
-  // Map from niri workspace id to button.
-  std::unordered_map<uint64_t, Gtk::Button> buttons_;
+  std::unordered_map<uint64_t, std::unique_ptr<Workspace>> workspaces_;
 };
 
 }  // namespace waybar::modules::niri

--- a/include/modules/niri/workspaces.hpp
+++ b/include/modules/niri/workspaces.hpp
@@ -23,7 +23,7 @@ class Workspace {
 
  private:
   std::string getIcon(const std::string& value, const Json::Value& ws);
-  void updateTaskbar(const std::vector<Json::Value>& windows_data);
+  void updateTaskbar(const std::vector<Json::Value>& windows_data, const uint64_t active_window_id);
 
   IconLoader iconLoader_;
   uint64_t id_;

--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -67,7 +67,17 @@ Addressed by *niri/workspaces*
 		*separator*: ++
 	typeof: string ++
 	default: " " ++
-	The separator to be used between windows in a workspace. ++
+	The separator to be used between windows in a workspace.
+
+		*format*: ++
+	typeof: string ++
+	default: "{icon}" ++
+	Format to use for each window in the workspace taskbar. Available placeholders are {icon}, {title} and {app_id}.
+
+		*tooltip-format*: ++
+	typeof: string ++
+	default: "{title}" ++
+	The format, how information in the tooltip should be displayed. Available placeholders are {title} and {app_id}. ++
 	This setting is ignored if *workspace-taskbar.enable* is set to true.
 
 # FORMAT REPLACEMENTS
@@ -127,3 +137,5 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces .taskbar-window* (each window in the taskbar, only if 'workspace-taskbar.enable' is true)
 - *#workspaces .taskbar-window.focused* (applied to the focused window)
 - *#workspaces .taskbar-window.urgent* (applied to urgent windows)
+- *#workspaces .taskbar-window.floating* (applied to floating windows)
+- *#workspaces .taskbar-window.active* (applied to the active window within every workspace)

--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -50,6 +50,26 @@ Addressed by *niri/workspaces*
 	default: false ++
 	Enables this module to consume all left over space dynamically.
 
+*workspace-taskbar*: ++
+	typeof: object ++
+	Contains settings for the workspace taskbar, an alternative mode for the workspaces module which displays the window icons as images instead of text.
+	
+		*enable*: ++
+	typeof: bool ++
+	default: false ++
+	Enables the workspace taskbar mode.
+
+		*icon-size*: ++
+	typeof: int ++
+	default: 16 ++
+	Size of the icons in the workspace taskbar.
+
+		*separator*: ++
+	typeof: string ++
+	default: " " ++
+	The separator to be used between windows in a workspace. ++
+	This setting is ignored if *workspace-taskbar.enable* is set to true.
+
 # FORMAT REPLACEMENTS
 
 *{value}*: Name of the workspace, or index for unnamed workspaces,
@@ -103,3 +123,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
   the bar that it is displayed on.
 - *#workspaces button#niri-workspace-<name>*: Workspaces named this, or index
   for unnamed workspaces.
+- *#workspaces .workspace-label*
+- *#workspaces .taskbar-window* (each window in the taskbar, only if 'workspace-taskbar.enable' is true)
+- *#workspaces .taskbar-window.focused* (applied to the focused window)
+- *#workspaces .taskbar-window.urgent* (applied to urgent windows)

--- a/src/modules/niri/backend.cpp
+++ b/src/modules/niri/backend.cpp
@@ -202,6 +202,18 @@ void IPC::parseIPC(const std::string &line) {
       for (auto &win : windows_) {
         win["is_focused"] = focused && win["id"].asUInt64() == id;
       }
+    } else if (const auto &payload = ev["WindowLayoutsChanged"]) {
+      const auto &values = payload["changes"];
+      for (const auto &changed : values) {
+        const auto id = changed[0].asUInt64();
+        const auto &change = changed[1];
+        for (auto &win : windows_) {
+          if (win["id"].asUInt64() == id) {
+            win["layout"] = change;
+            break;
+          }
+        }
+      }
     }
   }
 

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -77,6 +77,7 @@ void Workspace::updateTaskbar(const std::vector<Json::Value>& windows_data) {
   for (auto child : content_.get_children()) {
     if (child != &label_) {
       content_.remove(*child);
+      delete child;
     }
   }
 
@@ -92,11 +93,11 @@ void Workspace::updateTaskbar(const std::vector<Json::Value>& windows_data) {
             });
   int window_count = 0;
   for (const auto& window : sorted_windows_data) {
+    if (window["workspace_id"].asUInt64() != id_) continue;
     if (window_count++ != 0 && !separator.empty()) {
       auto windowSeparator = Gtk::make_managed<Gtk::Label>(separator);
       content_.pack_start(*windowSeparator, false, false);
     }
-    if (window["workspace_id"].asUInt64() != id_) continue;
 
     auto window_box = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL);
     window_box->set_tooltip_text(window["title"].asString());


### PR DESCRIPTION
Per #3745

- Add a **Workspace** class.
- Keep previous functionalities.
- Add basic functionality of [Workspace taskbars from Hyprland module](https://github.com/Alexays/Waybar/wiki/Module:-Hyprland#workspace-taskbars). 
- Windows are sorted as scrolling layout.
- Click on icon to focus.

<img width="354" height="106" alt="Screenshot from 2025-10-22 16-03-59" src="https://github.com/user-attachments/assets/38d5cd12-c961-47a5-adfe-debaa38ce556" />

