### PR TITLE
Improve multiple battery support

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -46,6 +46,7 @@ class Battery : public ALabel {
   std::string old_status_;
   std::string last_event_;
   bool warnFirstTime_{true};
+  bool weightedAverage_{true};
   const Bar& bar_;
 
   util::SleeperThread thread_;

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -93,7 +93,7 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 
 *weighted-average*: ++
     typeof: bool ++
-    default: false ++
+    default: true ++
     Option to combine multiple batteries with different capacities.
 
 *on-scroll-down*: ++
@@ -180,7 +180,7 @@ The *battery* module allows one to define custom formats based on up to two fact
 Every entry in the *events* object consists of a *<event-name>* (typeof: *string*) and a *<command>* (typeof: *string*). ++
 *<event-name>* can be in one of the following formats:
 
-- *on-<status>-<state>* 
+- *on-<status>-<state>*
 - *on-<status>-<capacity>*
 
 Where:

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -27,6 +27,8 @@ waybar::modules::Battery::Battery(const std::string& id, const Bar& bar, const J
   if (global_watch < 0) {
     throw std::runtime_error("Could not watch for battery plug/unplug");
   }
+
+  if (config_["weighted-average"].isBool()) weightedAverage_ = config_["weighted-average"].asBool();
 #endif
   spdlog::debug("battery: worker interval is {}", interval_.count());
   worker();
@@ -585,8 +587,7 @@ waybar::modules::Battery::getInfos() {
     }
 
     // Handle weighted-average
-    if ((config_["weighted-average"].isBool() ? config_["weighted-average"].asBool() : false) &&
-        total_energy_exists && total_energy_full_exists) {
+    if (weightedAverage_ && total_energy_exists && total_energy_full_exists) {
       if (total_energy_full > 0.0f)
         calculated_capacity = ((float)total_energy * 100.0f / (float)total_energy_full);
     }


### PR DESCRIPTION
- Adds information about `weighted-average` to the manpage
- Defaults `weighted-average` to true, following the principle of least astonishment

I'm not sure why the configuration option was added in the first place, because a non-weighted average would sometimes just give wrong numbers, or am I missing something? When would a non-weighted average be desirable?

See also https://github.com/Alexays/Waybar/issues/3682