### PR TITLE
fix(niri): Increase named workspace icon priority

### DIFF
--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -174,16 +174,16 @@ std::string Workspaces::getIcon(const std::string& value, const Json::Value& ws)
 
   if (ws["is_urgent"].asBool() && icons["urgent"]) return icons["urgent"].asString();
 
+  if (ws["name"]) {
+    const auto &name = ws["name"].asString();
+    if (icons[name]) return icons[name].asString();
+  }
+
   if (ws["is_active"].asBool() && icons["active"]) return icons["active"].asString();
 
   if (ws["is_focused"].asBool() && icons["focused"]) return icons["focused"].asString();
 
   if (ws["active_window_id"].isNull() && icons["empty"]) return icons["empty"].asString();
-
-  if (ws["name"]) {
-    const auto& name = ws["name"].asString();
-    if (icons[name]) return icons[name].asString();
-  }
 
   const auto idx = ws["idx"].asString();
   if (icons[idx]) return icons[idx].asString();


### PR DESCRIPTION
This PR aims to change the priority of workspace icons for the Niri `workspaces` module, where a **named** workspace's icon will take priority over all other types **except** the urgent one.

According to the [Niri documentation itself](https://yalter.github.io/niri/Configuration%3A-Named-Workspaces.html):
> Contrary to normal dynamic workspaces, named workspaces always exist, even when they have no windows.

Named workspaces behave like "pinned" workspaces, which are always present: I think this change reflects this behavior better than the current one, since their own icon will now always be shown (if defined).

Of course, I'd like to hear what other Niri users think of this and I'm open to make changes if necessary. Cheers!