### PR TITLE
fix(docs): pulseaudio man page example

### DIFF
--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -173,8 +173,8 @@ to be selected when the corresponding audio device is muted. This applies to *de
 	"format-icons": {
 		"alsa_output.pci-0000_00_1f.3.analog-stereo": "",
 		"alsa_output.pci-0000_00_1f.3.analog-stereo-muted": "",
-		"headphones": "",
-		"handsfree": "",
+		"headphone": "",
+		"hands-free": "",
 		"headset": "",
 		"phone": "",
 		"phone-muted": "",


### PR DESCRIPTION
The example configuration in the man page used 'headphones' and 'handsfree' as keys for format-icons. The correct keys are 'headphone' and 'hands-free'.

I followed the examples in the man page and was a bit confused that my icons weren't quite working. I dug into the source code and realized the example keys don't match the hardcoded values.

This PR fixes the examples so other users don't run into the same issue.