### PR TITLE
Fix example error about update moudle by signal in man page

### DIFF
--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -234,7 +234,6 @@ $text\\n$tooltip\\n$class*
 ```
 "custom/pacman": {
 	"format": "{text}  ",
-	"interval": 3600,                     // every hour
 	"exec": "checkupdates | wc -l",       // # of updates
 	"exec-if": "exit 0",                  // always run; consider advanced run conditions
 	"on-click": "termite -e 'sudo pacman -Syu'; pkill -SIGRTMIN+8 waybar", // update system
@@ -242,7 +241,7 @@ $text\\n$tooltip\\n$class*
 }
 ```
 
-You can use the signal and update the number of available packages with *pkill -RTMIN+8 waybar*.
+Under the premise that interval is not defined, you can use the signal and update the number of available packages with *pkill -RTMIN+8 waybar*.
 
 # STYLE
 


### PR DESCRIPTION
If define the `interval`, Unable to update via signal.

Fixing example error in man page.