### PR TITLE
fix(sway/workspaces): window-rewrite: do not check for window-format

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -179,7 +179,6 @@ n.b.: the list of outputs can be obtained from command line using *swaymsg -t ge
   "format": "<span size='larger'>{name}</span> {windows}",
   "format-window-separator": " | ",
   "window-rewrite-default": "{name}",
-  "window-format": "<span color='#e0e0e0'>{name}</span>",
   "window-rewrite": {
     "class<firefox>": "",
     "class<kitty>": "k",

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -331,7 +331,7 @@ auto Workspaces::update() -> void {
     }
     std::string output = (*it)["name"].asString();
     std::string windows = "";
-    if (config_["window-format"].isString()) {
+    if (config_["window-rewrite"].isObject()) {
       updateWindows((*it), windows);
     }
     if (config_["format"].isString()) {


### PR DESCRIPTION
Remove check for unused window-format option.

Fixes #3797.