### PR TITLE
fix(wireplumber): reorder initializer list to match header and fix -Wreorder

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -14,16 +14,18 @@ waybar::modules::Wireplumber::Wireplumber(const std::string& id, const Json::Val
       mixer_api_(nullptr),
       def_nodes_api_(nullptr),
       default_node_name_(nullptr),
-      default_source_name_(nullptr),
       pending_plugins_(0),
       muted_(false),
-      source_muted_(false),
       volume_(0.0),
-      source_volume_(0.0),
       min_step_(0.0),
       node_id_(0),
+      node_name_(""),
+      source_name_(""),
+      type_(nullptr),
       source_node_id_(0),
-      type_(nullptr) {
+      source_muted_(false),
+      source_volume_(0.0),
+      default_source_name_(nullptr) {
   waybar::modules::Wireplumber::modules.push_back(this);
 
   wp_init(WP_INIT_PIPEWIRE);


### PR DESCRIPTION
This fixes several `-Wreorder` warnings in the Wireplumber module.

The constructor's initializer list did not follow the field declaration
order defined in `wireplumber.hpp`. GCC warns when initializer order
differs from the header order, because the actual initialization always
follows the header declaration order.

This patch reorders the initializer list to match the header, removing
all `-Wreorder` warnings during build. No functional behavior changes.
