### PR TITLE
feat(wlr/taskbar): add active-last option

### DIFF
--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -52,10 +52,15 @@ Addressed by *wlr/taskbar*
 	default: false ++
 	If set to true, always reorder the tasks in the taskbar so that the currently active one is first. Otherwise don't reorder.
 
+*active-last*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, always reorder the tasks in the taskbar so that the currently active one is last. Otherwise don't reorder.
+
 *sort-by-app-id*: ++
 	typeof: bool ++
 	default: false ++
-	If set to true, group tasks by their app_id. Cannot be used with 'active-first'.
+	If set to true, group tasks by their app_id. Cannot be used with 'active-first' or 'active-last'.
 
 *on-click*: ++
 	typeof: string ++

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -350,8 +350,11 @@ void Task::handle_done() {
     button.get_style_context()->remove_class("fullscreen");
   }
 
-  if (config_["active-first"].isBool() && config_["active-first"].asBool() && active())
+  if (config_["active-first"].isBool() && config_["active-first"].asBool() && active()) {
     tbar_->move_button(button, 0);
+  } else if (config_["active-last"].isBool() && config_["active-last"].asBool() && active()) {
+    tbar_->move_button(button, -1);
+  }
 
   tbar_->dp.emit();
 }


### PR DESCRIPTION
This PR adds a new configuration option `active-last` to the `wlr/taskbar` module, which moves the currently active window to the last (rightmost) position in the taskbar.

## Motivation
The existing `active-first` option moves the active window to the first position, but there was no equivalent option to move it to the last position. This feature provides symmetry and gives users more flexibility in organizing their taskbar layout.

## Changes
- Added `active-last` boolean option to `wlr/taskbar` module
- Updated man page documentation for `waybar-wlr-taskbar.5.scd`
- Implementation mirrors the existing `active-first` logic

## Usage
json
"wlr/taskbar": {
   "active-last": true
}

## Notes
- `active-first` and `active-last` are mutually exclusive (only one should be used at a time)
- Uses GTK's `move_button(button, -1)` to move to the last position
- Minimal code change (3 lines in taskbar.cpp)

## Testing
Tested on Arch Linux with Hyprland. The active window icon correctly moves to the rightmost position when switching between applications.