### PR TITLE
feat(dwl/tags): add empty tag option

### DIFF
--- a/man/waybar-dwl-tags.5.scd
+++ b/man/waybar-dwl-tags.5.scd
@@ -43,6 +43,7 @@ Addressed by *dwl/tags*
 
 - *#tags button*
 - *#tags button.occupied*
+- *#tags button.empty*
 - *#tags button.focused*
 - *#tags button.urgent*
 

--- a/src/modules/dwl/tags.cpp
+++ b/src/modules/dwl/tags.cpp
@@ -187,6 +187,12 @@ void Tags::handle_view_tags(uint32_t tag, uint32_t state, uint32_t clients, uint
     button.get_style_context()->remove_class("occupied");
   }
 
+  if (clients & TAG_INACTIVE) {
+    button.get_style_context()->remove_class("empty");
+  } else {
+    button.get_style_context()->add_class("empty");
+  }
+
   if (state & TAG_ACTIVE) {
     button.get_style_context()->add_class("focused");
   } else {


### PR DESCRIPTION
Added option in the `dwl/tags` to theme empty tags (i.e. tags without any clients) in `style.css` using `#tags button.empty`.

### Example
Before:
<img width="377" height="47" alt="20251209_07h32m58s_grim" src="https://github.com/user-attachments/assets/55711618-d37d-49a9-976f-4db7d210392e" />

After:
<img width="369" height="45" alt="20251209_07h33m22s_grim" src="https://github.com/user-attachments/assets/b9f4d5b1-fb03-4836-a78c-bfe35dc8c0af" />
