### PR TITLE
feat(hyprland/workspace): improved styling for named special workspaces

### DIFF
--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -241,6 +241,7 @@ void Workspace::update(const std::string &workspace_icon) {
   auto styleContext = m_button.get_style_context();
   addOrRemoveClass(styleContext, isActive(), "active");
   addOrRemoveClass(styleContext, isSpecial(), "special");
+  addOrRemoveClass(styleContext, isSpecial(), name());
   addOrRemoveClass(styleContext, isEmpty(), "empty");
   addOrRemoveClass(styleContext, isPersistent(), "persistent");
   addOrRemoveClass(styleContext, isUrgent(), "urgent");

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -161,6 +161,13 @@ std::string &Workspace::selectIcon(std::map<std::string, std::string> &icons_map
     }
   }
 
+  if (isActive() && isSpecial()) {
+    auto activeIconIt = icons_map.find("active:" + name());
+    if (activeIconIt != icons_map.end()) {
+      return activeIconIt->second;
+    }
+  }
+
   if (isActive()) {
     auto activeIconIt = icons_map.find("active");
     if (activeIconIt != icons_map.end()) {


### PR DESCRIPTION
Allows you to set icon specifically for active named special workspace.
```jsonc
"hyperland/workspaces": {
  "format-icons": {
    "active:<workspace name>" : " ",
  }
}
```

As well as targeting those workspaces in styling.
```css
#workspaces button.special.workspace_name {}
#workspaces button.special.workspace_name.active {}
```