### PR TITLE
fix: add const qualifier to Glib::ustring formatter to fix compile error

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -92,7 +92,7 @@ struct formatter<pow_format> {
 template <>
 struct formatter<Glib::ustring> : formatter<std::string> {
   template <typename FormatContext>
-  auto format(const Glib::ustring& value, FormatContext& ctx) {
+  auto format(const Glib::ustring& value, FormatContext& ctx) const {
     return formatter<std::string>::format(static_cast<std::string>(value), ctx);
   }
 };


### PR DESCRIPTION
### Problem
Compiling Waybar gtk4 branch on Arch Linux fails with the following error:

The root cause is that the `format` method of `fmt::formatter<Glib::ustring>` is not declared as `const`, while fmt library calls it on a const object.

### Solution
Add `const` qualifier to the `format` method in `include/util/format.hpp`.

### Test
- Tested on Arch Linux (GCC 13.2.1, fmt 12.1.1, gtk4 4.12.5)
- Compiles successfully after the fix
- Waybar runs normally with gtk4 features (e.g., color-mix)
