### PR TITLE
fix: prevent duplicate layer surfaces on monitor hotplug

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -56,6 +56,8 @@ class Client {
   std::list<struct waybar_output> outputs_;
   std::unique_ptr<CssReloadHelper> m_cssReloadHelper;
   std::string m_cssFile;
+  sigc::connection monitor_added_connection_;
+  sigc::connection monitor_removed_connection_;
 };
 
 }  // namespace waybar

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -219,13 +219,22 @@ void waybar::Client::bindInterfaces() {
   if (xdg_output_manager == nullptr) {
     throw std::runtime_error("Failed to acquire required resources.");
   }
+
+  // Disconnect previous signal handlers to prevent duplicate handlers on reload
+  monitor_added_connection_.disconnect();
+  monitor_removed_connection_.disconnect();
+
+  // Clear stale outputs from previous run
+  outputs_.clear();
+
   // add existing outputs and subscribe to updates
   for (auto i = 0; i < gdk_display->get_n_monitors(); ++i) {
     auto monitor = gdk_display->get_monitor(i);
     handleMonitorAdded(monitor);
   }
-  gdk_display->signal_monitor_added().connect(sigc::mem_fun(*this, &Client::handleMonitorAdded));
-  gdk_display->signal_monitor_removed().connect(
+  monitor_added_connection_ = gdk_display->signal_monitor_added().connect(
+      sigc::mem_fun(*this, &Client::handleMonitorAdded));
+  monitor_removed_connection_ = gdk_display->signal_monitor_removed().connect(
       sigc::mem_fun(*this, &Client::handleMonitorRemoved));
 }
 


### PR DESCRIPTION
This PR fixes duplicate waybar layer surfaces appearing after monitor hotplug events.

The `signal_monitor_added` and `signal_monitor_removed` handlers were never disconnected during SIGUSR2 reload. Each reload accumulated additional handlers, so when monitors were hotplugged, all accumulated handlers fired and created duplicate layer surfaces.

Changes:
- Store signal connections as class members
- Disconnect them before reconnecting in `bindInterfaces()`
- Clear stale `outputs_` on reload