### PR TITLE
feat(hyprland/workspaces): add deduplicate-windows option

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -41,6 +41,7 @@ class Workspaces : public AModule, public EventHandler {
   auto specialVisibleOnly() const -> bool { return m_specialVisibleOnly; }
   auto persistentOnly() const -> bool { return m_persistentOnly; }
   auto moveToMonitor() const -> bool { return m_moveToMonitor; }
+  auto deduplicateWindows() const -> bool { return m_deduplicateWindows; }
   auto enableTaskbar() const -> bool { return m_enableTaskbar; }
   auto taskbarWithIcon() const -> bool { return m_taskbarWithIcon; }
 
@@ -145,6 +146,7 @@ class Workspaces : public AModule, public EventHandler {
   bool m_specialVisibleOnly = false;
   bool m_persistentOnly = false;
   bool m_moveToMonitor = false;
+  bool m_deduplicateWindows = false;
   Json::Value m_persistentWorkspaceConfig;
 
   // Map for windows stored in workspaces not present in the current bar.

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -631,6 +631,7 @@ auto Workspaces::parseConfig(const Json::Value &config) -> void {
   populateBoolConfig(config, "persistent-only", m_persistentOnly);
   populateBoolConfig(config, "active-only", m_activeOnly);
   populateBoolConfig(config, "move-to-monitor", m_moveToMonitor);
+  populateBoolConfig(config, "deduplicate-windows", m_deduplicateWindows);
 
   m_persistentWorkspaceConfig = config.get("persistent-workspaces", Json::Value());
   populateSortByConfig(config);


### PR DESCRIPTION
Add a new configuration option 'deduplicate-windows' that filters duplicate application entries from workspace window lists.

When enabled, this feature tracks seen window representations and skips duplicates based on their rewritten representation (after window-rewrite rules are applied).

The deduplication works for both display modes:
  - Regular {windows} format string substitution
  - Workspace taskbar feature

This is useful when multiple windows of the same application appear in a workspace and users prefer to see only unique entries.

Usage:
```
    "hyprland/workspaces": {
      "deduplicate-windows": true
    ]
```