### PR TITLE
fix-cava-audio-height-init

### DIFF
--- a/src/modules/cava/cava_backend.cpp
+++ b/src/modules/cava/cava_backend.cpp
@@ -183,10 +183,10 @@ void waybar::modules::cava::CavaBackend::loadConfig() {
   prm_.inAtty = 0;
   auto const output{prm_.output};
   // prm_.output = ::cava::output_method::OUTPUT_RAW;
-  if (config_["data_format"].isString()) {
-    if (prm_.data_format) free(prm_.data_format);
-    prm_.data_format = strdup(config_["data_format"].asString().c_str());
-  }
+  if (prm_.data_format) free(prm_.data_format);
+  // Default to ascii for format-icons output; allow user override
+  prm_.data_format = strdup(
+      config_["data_format"].isString() ? config_["data_format"].asString().c_str() : "ascii");
   if (config_["raw_target"].isString()) {
     if (prm_.raw_target) free(prm_.raw_target);
     prm_.raw_target = strdup(config_["raw_target"].asString().c_str());


### PR DESCRIPTION
This might fix #4244

The cava module bars always peak at maximum regardless of sensitivity settings.

`data_format` was changed from always being `"ascii"` to only being set when user-provided. Without an explicit value, cava defaults to `"binary"`, which calculates `height = pow(2, 16) - 1 = 65535` instead of `ascii_range`. This causes `audio_raw_fetch()` to scale bars incorrectly.

Default `data_format` to `"ascii"` while preserving user override capability. This mantains the previous default.

---

<!-- PR_SUMMARY_START -->
- fix(cava): default data_format to ascii for correct bar scaling

  data_format was changed from always "ascii" to user-configurable,
  but without a default. This caused cava to use "binary", calculating
  height as 65535 instead of ascii_range, making bars always peak.
<!-- PR_SUMMARY_END -->