### PR TITLE
docs: add missing reverse-mouse-scrolling to pulseaudio module man page

### DIFF
--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -97,7 +97,11 @@ Additionally, you can control the volume by scrolling *up* or *down* while the c
 
 *reverse-scrolling*: ++
 	typeof: bool ++
-	Option to reverse the scroll direction.
+	Option to reverse the scroll direction for touchpads.
+
+*reverse-mouse-scrolling*: ++
+	typeof: bool ++
+	Option to reverse the scroll direction for mice.
 
 *tooltip*: ++
 	typeof: bool ++


### PR DESCRIPTION
Updated the documentation for `reverse-mouse-scrolling`. Change from https://github.com/Alexays/Waybar/pull/2267