### PR TITLE
feat: support arbitrary command for clicking on sway workspace button

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -78,6 +78,11 @@ Addressed by *sway/workspaces*
 	typeof: bool ++
 	Whether to disable *workspace_auto_back_and_forth* when clicking on workspaces. If this is set to *true*, clicking on a workspace you are already on won't do anything, even if *workspace_auto_back_and_forth* is enabled in the Sway configuration.
 
+*on-click*: ++
+	typeof: string ++
+	default: swaymsg workspace {} ++
+	What command to run when clicking a workspace button, should have one placeholder for the workspace name.
+
 *alphabetical_sort*: ++
 	typeof: bool ++
 	Whether to sort workspaces alphabetically. Please note this can make "swaymsg workspace prev/next" move to workspaces inconsistent with the ordering shown in Waybar.

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -1,10 +1,13 @@
 #include "modules/sway/workspaces.hpp"
+#include <util/command.hpp>
 
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
 #include <cctype>
 #include <string>
+#include <format>
+#include <iostream>
 
 namespace waybar::modules::sway {
 
@@ -363,18 +366,8 @@ Gtk::Button &Workspaces::addButton(const Json::Value &node) {
   if (!config_["disable-click"].asBool()) {
     button.signal_pressed().connect([this, node] {
       try {
-        if (node["target_output"].isString()) {
-          ipc_.sendCmd(IPC_COMMAND,
-                       fmt::format(persistent_workspace_switch_cmd_, "--no-auto-back-and-forth",
-                                   node["name"].asString(), node["target_output"].asString(),
-                                   "--no-auto-back-and-forth", node["name"].asString()));
-        } else {
-          ipc_.sendCmd(IPC_COMMAND, fmt::format("workspace {} \"{}\"",
-                                                config_["disable-auto-back-and-forth"].asBool()
-                                                    ? "--no-auto-back-and-forth"
-                                                    : "",
-                                                node["name"].asString()));
-        }
+        // TODO default value seem to not be working
+        util::command::forkExec(fmt::format(fmt::runtime(config_["on-click"].asString()), node["name"].asString()));
       } catch (const std::exception &e) {
         spdlog::error("Workspaces: {}", e.what());
       }


### PR DESCRIPTION
Instead of #4685 this allows executing an arbitrary command when clicking a workspace button. It seem the default value in the `.scd` is not working for some reason, any idea why?