### PR TITLE
hyprland/workspaces: don't show persistent special workspaces if show-special is disabled

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -296,6 +296,11 @@ void Workspaces::loadPersistentWorkspacesFromWorkspaceRules(const Json::Value &c
     auto workspace = rule.isMember("defaultName") ? rule["defaultName"].asString()
                                                   : rule["workspaceString"].asString();
 
+    // There could be persistent special workspaces, only show those when show-special is enabled.
+    if (workspace.starts_with("special:") && !showSpecial()) {
+      continue;
+    }
+
     // The prefix "name:" cause mismatches with workspace names taken anywhere else.
     if (workspace.starts_with("name:")) {
       workspace = workspace.substr(5);


### PR DESCRIPTION
Fixes #4756

(Solution by @vp1981)

