### PR TITLE
fix(json): use local CharReaderBuilder for thread safety

### DIFF
--- a/include/util/json.hpp
+++ b/include/util/json.hpp
@@ -30,15 +30,16 @@ class JsonParser {
 
     std::istringstream jsonStream(modifiedJsonStr);
     std::string errs;
-    if (!Json::parseFromStream(m_readerBuilder, jsonStream, &root, &errs)) {
+    // Use local CharReaderBuilder for thread safety - the IPC singleton's
+    // parser can be called concurrently from multiple module threads
+    Json::CharReaderBuilder readerBuilder;
+    if (!Json::parseFromStream(readerBuilder, jsonStream, &root, &errs)) {
       throw std::runtime_error("Error parsing JSON: " + errs);
     }
     return root;
   }
 
  private:
-  Json::CharReaderBuilder m_readerBuilder;
-
   static std::string replaceHexadecimalEscape(const std::string& str) {
     static std::regex re("\\\\x");
     return std::regex_replace(str, re, "\\u00");


### PR DESCRIPTION
## Problem

Crash with:
```
unhandled exception (type std::exception) in signal handler:
what: in Json::Value::find(begin, end): requires objectValue or nullValue
```

## Root Cause

The `JsonParser` class uses a shared `CharReaderBuilder` member that gets accessed concurrently from multiple threads:

- **IPC thread**: Event handlers call `getSocket1JsonReply()` → `parser_.parse()`
- **GTK thread**: Update functions call `getSocket1JsonReply()` → `parser_.parse()`

Each module has its own mutex, but they all share the same `IPC::inst()` singleton. The module mutexes don't protect the shared parser.

`Json::CharReaderBuilder` is not thread-safe for concurrent use without synchronization.

## Fix

Use a local `CharReaderBuilder` in `parse()` instead of a member variable. This makes each parse call independent and thread-safe.