### PR TITLE
docs: add fraudulent site notice on proj README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ Contributions welcome!<br>
 Have fun :)<br>
 The style guidelines are [Google's](https://google.github.io/styleguide/cppguide.html)
 
+> [!CAUTION]
+> Distributions of Waybar are only released on the [official GitHub page](https://github.com/Alexays/Waybar).<br/>
+> Waybar does **not** have an official website. Do not trust any sites that claim to be official.
+
 ## License
 
 Waybar is licensed under the MIT license. [See LICENSE for more information](https://github.com/Alexays/Waybar/blob/master/LICENSE).


### PR DESCRIPTION
Resolves #4752.

This can be merged without attribution since it is admittedly a very minor contribution, if even one at all. Mirrors similar notices given for [czkawa](https://github.com/qarmin/czkawka?tab=readme-ov-file#officially-supported-projects) and [minimap2](https://github.com/lh3/minimap2?tab=readme-ov-file#getting-started) until the site's(') removal.
