### PR TITLE
Feature/tray order

### DIFF
--- a/include/modules/sni/host.hpp
+++ b/include/modules/sni/host.hpp
@@ -6,6 +6,7 @@
 #include <json/json.h>
 
 #include <tuple>
+#include <vector>
 
 #include <unordered_map>
 
@@ -54,6 +55,9 @@ class Host {
   bool reorder_pending_{false};
   std::size_t next_seq_{0};
   std::unordered_map<Item*, std::size_t> seq_;
+  std::unordered_map<std::string, std::size_t> order_index_;
+  std::vector<std::string> order_list_;  // normalized keys in configured order
+  bool unknown_after_{true};  // configured icons first, unknown icons after (default)
 };
 
 }  // namespace waybar::modules::SNI

--- a/include/modules/sni/host.hpp
+++ b/include/modules/sni/host.hpp
@@ -7,6 +7,8 @@
 
 #include <tuple>
 
+#include <unordered_map>
+
 #include "bar.hpp"
 #include "modules/sni/item.hpp"
 
@@ -18,6 +20,8 @@ class Host {
        const std::function<void(std::unique_ptr<Item>&)>&,
        const std::function<void(std::unique_ptr<Item>&)>&);
   ~Host();
+
+  void requestReorder();
 
  private:
   void busAcquired(const Glib::RefPtr<Gio::DBus::Connection>&, Glib::ustring);
@@ -32,6 +36,9 @@ class Host {
   std::tuple<std::string, std::string> getBusNameAndObjectPath(const std::string);
   void addRegisteredItem(std::string service);
 
+  void reorderItems();  // remove/sort/add
+  static std::string toLowerAscii(std::string s);
+
   std::vector<std::unique_ptr<Item>> items_;
   const std::string bus_name_;
   const std::string object_path_;
@@ -43,6 +50,10 @@ class Host {
   const Bar& bar_;
   const std::function<void(std::unique_ptr<Item>&)> on_add_;
   const std::function<void(std::unique_ptr<Item>&)> on_remove_;
+
+  bool reorder_pending_{false};
+  std::size_t next_seq_{0};
+  std::unordered_map<Item*, std::size_t> seq_;
 };
 
 }  // namespace waybar::modules::SNI

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -18,6 +18,8 @@
 
 namespace waybar::modules::SNI {
 
+class Host;
+
 struct ToolTip {
   Glib::ustring icon_name;
   Glib::ustring text;
@@ -25,7 +27,7 @@ struct ToolTip {
 
 class Item : public sigc::trackable {
  public:
-  Item(const std::string&, const std::string&, const Json::Value&, const Bar&);
+  Item(Host& host, const std::string&, const std::string&, const Json::Value&, const Bar&);
   ~Item();
 
   std::string bus_name;
@@ -38,6 +40,7 @@ class Item : public sigc::trackable {
   std::string category;
   std::string id;
 
+  std::string sort_key;
   std::string title;
   std::string icon_name;
   Glib::RefPtr<Gdk::Pixbuf> icon_pixmap;
@@ -58,6 +61,7 @@ class Item : public sigc::trackable {
   bool item_is_menu = true;
 
  private:
+  Host& host_;
   void onConfigure(GdkEventConfigure* ev);
   void proxyReady(Glib::RefPtr<Gio::AsyncResult>& result);
   void setProperty(const Glib::ustring& name, Glib::VariantBase& value);

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -42,6 +42,24 @@ Addressed by *tray*
 	default: false ++
 	Enables this module to consume all left over space dynamically.
 
+*order*: ++
+	typeof: array ++
+	A list of tray item keys in the desired order. ++
+	Items listed here are ordered according to this list. ++
+	Items not present in the list are ordered alphabetically by their key. ++
+	Matching is performed case-insensitively. ++
+	The values must match the key printed in the log line:
+
+	tray: item key='<KEY>' ...
+
+*order-unknown*: ++
+	typeof: string ++
+	default: after ++
+	Controls where items not present in *order* are placed.
+
+	*after*  – configured items come first, unconfigured items follow. ++
+	*before* – unconfigured items come first, configured items follow.
+
 # EXAMPLES
 
 ```
@@ -51,7 +69,12 @@ Addressed by *tray*
   "icons": {
     "blueman": "bluetooth",
     "TelegramDesktop": "$HOME/.local/share/icons/hicolor/16x16/apps/telegram.png"
-  }
+  },
+	"order": [
+		"TelegramDesktop",
+		"signal desktop",
+	],
+	"order-unknown": "after",
 }
 
 ```

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -178,6 +178,7 @@ void Host::addRegisteredItem(std::string service) {
     items_.emplace_back(new Item(*this, bus_name, object_path, config_, bar_));
     seq_[items_.back().get()] = next_seq_++;
     on_add_(items_.back());
+    requestReorder();
   }
 }
 

--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cctype>
 #include <glibmm/main.h>
+#include <unordered_set>
 
 namespace waybar::modules::SNI {
 
@@ -21,7 +22,38 @@ Host::Host(const std::size_t id, const Json::Value& config, const Bar& bar,
       config_(config),
       bar_(bar),
       on_add_(on_add),
-      on_remove_(on_remove) {}
+      on_remove_(on_remove) {
+  // Parse "order" list: map key -> index (0..n-1)
+  order_list_.clear();
+  if (config_["order"].isArray()) {
+    order_list_.reserve(config_["order"].size());
+    for (Json::ArrayIndex i = 0; i < config_["order"].size(); ++i) {
+      const auto& v = config_["order"][i];
+      if (!v.isString()) continue;
+      auto key = toLowerAscii(v.asString());
+      order_list_.push_back(key);
+      order_index_[key] = static_cast<std::size_t>(order_list_.size() - 1);
+    }
+  }
+
+  // Unknown placement: "after" (default) or "before"
+  if (config_["order-unknown"].isString()) {
+    const auto s = toLowerAscii(config_["order-unknown"].asString());
+    if (s == "before") unknown_after_ = false;
+    else if (s == "after") unknown_after_ = true;
+  }
+
+  if (!order_list_.empty()) {
+    std::string line = "tray: configured order:";
+    for (const auto& k : order_list_) {
+      line += " [";
+      line += k;
+      line += "]";
+    }
+    line += unknown_after_ ? " unknown=after" : " unknown=before";
+    spdlog::info("{}", line);
+  }
+}
 
 Host::~Host() {
   if (bus_name_id_ > 0) {
@@ -176,28 +208,40 @@ void Host::reorderItems() {
 
   // 2) Sort canonical item storage by sort_key (stable)
   std::stable_sort(items_.begin(), items_.end(),
-                   [this](const std::unique_ptr<Item>& a, const std::unique_ptr<Item>& b) {
-                     const auto& ka = a->sort_key;
-                     const auto& kb = b->sort_key;
+    [this](const std::unique_ptr<Item>& a, const std::unique_ptr<Item>& b) {
 
-                     const bool a_known = !ka.empty();
-                     const bool b_known = !kb.empty();
+      const auto& ka_raw = a->sort_key;
+      const auto& kb_raw = b->sort_key;
+      const bool a_has = !ka_raw.empty();
+      const bool b_has = !kb_raw.empty();
 
-                     if (a_known != b_known) {
-                       return a_known;  // known keys first
-                     }
+      // keep empty keys deterministic
+      if (a_has != b_has) return a_has;
 
-                     if (a_known && b_known) {
-                       const auto la = toLowerAscii(ka);
-                       const auto lb = toLowerAscii(kb);
-                       if (la != lb) {
-                         return la < lb;
-                       }
-                     }
+      const auto ka = a_has ? toLowerAscii(ka_raw) : std::string{};
+      const auto kb = b_has ? toLowerAscii(kb_raw) : std::string{};
 
-                     // tie-break: insertion order, deterministic
-                     return seq_[a.get()] < seq_[b.get()];
-                   });
+      const auto ia = a_has ? order_index_.find(ka) : order_index_.end();
+      const auto ib = b_has ? order_index_.find(kb) : order_index_.end();
+
+      const bool a_cfg = (ia != order_index_.end());
+      const bool b_cfg = (ib != order_index_.end());
+
+      if (a_cfg != b_cfg) {
+        // unknown_after_==true  -> configured first
+        // unknown_after_==false -> unknown first
+        return unknown_after_ ? a_cfg : !a_cfg;
+      }
+
+      if (a_cfg && b_cfg) {
+        if (ia->second != ib->second) return ia->second < ib->second;
+        // fall through to alpha/seq
+      }
+
+      if (a_has && b_has && ka != kb) return ka < kb;
+
+      return seq_[a.get()] < seq_[b.get()];
+    });
 
   // 3) Add all items back to UI in a way that matches Tray's packing direction.
   const bool reverse =
@@ -232,6 +276,40 @@ void Host::reorderItems() {
       line += "]";
     }
     spdlog::info("{}", line);
+  }
+
+  if (!order_list_.empty()) {
+    std::unordered_set<std::string> seen;
+    seen.reserve(items_.size());
+
+    for (const auto& it : items_) {
+      if (!it->sort_key.empty()) {
+        seen.insert(toLowerAscii(it->sort_key));
+      }
+    }
+
+    std::string found = "tray: order found:";
+    std::string missing = "tray: order missing:";
+
+    bool any_found = false;
+    bool any_missing = false;
+
+    for (const auto& k : order_list_) {
+      if (seen.find(k) != seen.end()) {
+        found += " [";
+        found += k;
+        found += "]";
+        any_found = true;
+      } else {
+        missing += " [";
+        missing += k;
+        missing += "]";
+        any_missing = true;
+      }
+    }
+
+    if (any_found) spdlog::info("{}", found);
+    if (any_missing) spdlog::info("{}", missing);
   }
 }
 

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -14,6 +14,8 @@
 #include "util/format.hpp"
 #include "util/gtk_icon.hpp"
 
+#include "modules/sni/host.hpp"
+
 template <>
 struct fmt::formatter<Glib::VariantBase> : formatter<std::string> {
   bool is_printable(const Glib::VariantBase& value) const {
@@ -37,8 +39,9 @@ namespace waybar::modules::SNI {
 static const Glib::ustring SNI_INTERFACE_NAME = sn_item_interface_info()->name;
 static const unsigned UPDATE_DEBOUNCE_TIME = 10;
 
-Item::Item(const std::string& bn, const std::string& op, const Json::Value& config, const Bar& bar)
-    : bus_name(bn),
+Item::Item(Host& host, const std::string& bn, const std::string& op, const Json::Value& config, const Bar& bar)
+    : host_(host),
+      bus_name(bn),
       object_path(op),
       icon_size(16),
       effective_icon_size(0),
@@ -151,6 +154,8 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       category = get_variant<std::string>(value);
     } else if (name == "Id") {
       id = get_variant<std::string>(value);
+      sort_key = id;  // default
+      const auto old_key = sort_key;
 
       /*
        * HACK: Electron apps seem to have the same ID, but tooltip seems correct, so use that as ID
@@ -165,10 +170,18 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
         this->proxy_->get_cached_property(value, "ToolTip");
         tooltip = get_variant<ToolTip>(value);
         if (!tooltip.text.empty()) {
-          setCustomIcon(tooltip.text.lowercase());
+          sort_key = tooltip.text.lowercase();
+          setCustomIcon(sort_key);
         }
       } else {
         setCustomIcon(id);
+      }
+      // Single log line that users can copy into later ordering config:
+      spdlog::info("tray: item key='{}' (id='{}') title='{}' icon='{}' bus='{}' path='{}'",
+                   sort_key, id, title, icon_name, bus_name, object_path);
+      if (!sort_key.empty() && sort_key != old_key) {
+        spdlog::info("tray: sort_key has changed to '{}', requesting reordering", sort_key);
+        host_.requestReorder();
       }
     } else if (name == "Title") {
       title = get_variant<std::string>(value);

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -155,7 +155,6 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
     } else if (name == "Id") {
       id = get_variant<std::string>(value);
       sort_key = id;  // default
-      const auto old_key = sort_key;
 
       /*
        * HACK: Electron apps seem to have the same ID, but tooltip seems correct, so use that as ID
@@ -179,8 +178,7 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       // Single log line that users can copy into later ordering config:
       spdlog::info("tray: item key='{}' (id='{}') title='{}' icon='{}' bus='{}' path='{}'",
                    sort_key, id, title, icon_name, bus_name, object_path);
-      if (!sort_key.empty() && sort_key != old_key) {
-        spdlog::info("tray: sort_key has changed to '{}', requesting reordering", sort_key);
+      if (!sort_key.empty()) {
         host_.requestReorder();
       }
     } else if (name == "Title") {


### PR DESCRIPTION
## Deterministic and Configurable Tray Icon Ordering

This PR adds a new feature to the Waybar tray module: **stable and user-configurable ordering of tray icons.**

### Problem

Before this change, tray icons were shown in the order in which applications registered themselves via D-Bus. This caused several issues:

* The order depended on application start timing
* Icons could appear in a different order after each login
* Multiple monitors could show different tray orders
* Restarting Waybar often shuffled the tray randomly

There was no reliable way to control or stabilize this behavior.

---

### What this PR adds

#### 1. Stable default behavior

Even without any configuration, tray icons are now sorted deterministically in **alphabetical order** based on an internal key (`sort_key`).

This ensures that:

* Tray order is consistent across all monitors
* Order does not depend on application start timing
* Restarting Waybar keeps the same layout

#### 2. New user configuration options

Users can now explicitly define their preferred tray order using a simple list:

```json
"tray": {
  "order": [
    "vesktop",
    "signal desktop"
  ],
  "order-unknown": "after"
}
```

* `order` allows specifying tray icons in the exact desired order
* Items not listed are sorted alphabetically
* `order-unknown` controls whether unconfigured items appear before or after configured ones

Available keys can be easily discovered via log messages like:

```
tray: item key='<KEY>' ...
```

#### 3. Improved handling of Electron apps

Many Electron-based applications register generic tray IDs such as `chrome_status_icon_1`.
This PR improves that by:

* Deriving a meaningful key from the tooltip text
* Using that key consistently for sorting

This makes it possible to reliably sort apps like Signal, Vesktop, etc.

---

### How it works internally

* Each tray item now provides a stable `sort_key`
* The SNI Host component performs centralized reordering
* Reordering is triggered automatically when an item identity becomes available
* Sorting priority is:

  1. Items listed in the user-defined `order`
  2. All other items alphabetically
  3. Stable tie-break using insertion sequence

This guarantees deterministic results across all Waybar instances.

---

### Differences to PR #4643

This implementation differs significantly from PR #4643:

* Configuration uses a **simple ordered list** instead of numeric priorities
* Provides deterministic alphabetical ordering by default
* Sorting is triggered directly when item identity becomes known
* Includes explicit support for Electron app quirks
* Adds user-friendly logging to discover available keys

Overall, this approach focuses on simplicity and predictable behavior.

---

### Personal note

I want to mention explicitly that I have **very limited experience with C++**.
This feature was created almost entirely with the help of ChatGPT, which guided me through the design, refactoring, and implementation process step by step.

Feedback and suggestions are very welcome!