### PR TITLE
fix: owerwrite handleScroll to remove any scrolling handling from group

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -30,6 +30,7 @@ class Group : public AModule {
   bool handleMouseEnter(GdkEventCrossing* const& ev) override;
   bool handleMouseLeave(GdkEventCrossing* const& ev) override;
   bool handleToggle(GdkEventButton* const& ev) override;
+  bool handleScroll(GdkEventScroll* e) override;
   void show_group();
   void hide_group();
 };

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -124,6 +124,11 @@ auto Group::update() -> void {
   // noop
 }
 
+bool Group::handleScroll(GdkEventScroll* e) {
+  // no scroll.
+  return true;
+}
+
 Gtk::Box& Group::getBox() { return is_drawer ? (is_first_widget ? box : revealer_box) : box; }
 
 void Group::addWidget(Gtk::Widget& widget) {


### PR DESCRIPTION
Hi!

This PR completely removes execution of any command on scroll (even set specifically with "on-scroll-up" or "on-scroll-down") by overwriting handleScroll method for group module. 