### PR TITLE
Fix include of poll.h

### DIFF
--- a/include/modules/battery.hpp
+++ b/include/modules/battery.hpp
@@ -6,7 +6,7 @@
 #if defined(__linux__)
 #include <sys/inotify.h>
 #endif
-#include <sys/poll.h>
+#include <poll.h>
 
 #include <algorithm>
 #include <fstream>


### PR DESCRIPTION
This resolves the warning produced when building on Alpine Linux (or more specifically systems with musl libc).