### PR TITLE
fix: update tooltip method to use pango markup formatting

### DIFF
--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -101,7 +101,7 @@ auto waybar::modules::Temperature::update() -> void {
     if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_.set_tooltip_text(fmt::format(
+    label_.set_tooltip_markup(fmt::format(
         fmt::runtime(tooltip_format), fmt::arg("temperatureC", temperature_c),
         fmt::arg("temperatureF", temperature_f), fmt::arg("temperatureK", temperature_k)));
   }


### PR DESCRIPTION
### Description
This PR updates the tooltip format to use pango markup

Closes #4830