### PR TITLE
feat(niri): niri depends on socket

### DIFF
--- a/include/modules/niri/backend.hpp
+++ b/include/modules/niri/backend.hpp
@@ -17,7 +17,7 @@ class EventHandler {
 
 class IPC {
  public:
-  IPC() { startIPC(); }
+  IPC();
 
   void registerForIPC(const std::string& ev, EventHandler* ev_handler);
   void unregisterForIPC(EventHandler* handler);

--- a/src/modules/niri/backend.cpp
+++ b/src/modules/niri/backend.cpp
@@ -20,6 +20,8 @@
 
 namespace waybar::modules::niri {
 
+IPC::IPC() { startIPC(); }
+
 int IPC::connectToSocket() {
   const char* socket_path = getenv("NIRI_SOCKET");
 


### PR DESCRIPTION
Don't attempt to use niri modules when socket connection fails. Prevents rendering modules when running another compositor. In same concept as previous Hyprland change https://github.com/Alexays/Waybar/commit/4295faa7c4b23b7f6e86669d1fe8c93562e10241

Trying niri out and noticed this issue we previously had with Hyprland workspaces. When enabling multiple compositors in a same config, we should only render what's relevant / usable. 
<img width="728" height="92" alt="image" src="https://github.com/user-attachments/assets/a7a8ad17-5bcb-45c2-a5b6-9a9719b2b1fb" />

AFTER: 
```bash
[2026-02-09 08:58:34.824] [warning] module niri/workspaces: Disabling module "niri/workspaces", Niri IPC: NIRI_SOCKET was not set! (Is Niri running?)
[2026-02-09 08:58:34.841] [warning] module sway/workspaces: Disabling module "sway/workspaces", Socket path is empty
[2026-02-09 08:58:34.843] [warning] module niri/window: Disabling module "niri/window", Niri IPC: NIRI_SOCKET was not set! (Is Niri running?)
[2026-02-09 08:58:34.858] [warning] module sway/window: Disabling module "sway/window", Socket path is empty
```
Properly disable the modules to not render blank spaces. 
