### PR TITLE
feat: add `{tooltip}` in format replacements in custom module

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -182,9 +182,10 @@ auto waybar::modules::Custom::update() -> void {
         if (tooltipEnabled()) {
           if (tooltip_format_enabled_) {
             auto tooltip = config_["tooltip-format"].asString();
-            tooltip = fmt::format(
-                fmt::runtime(tooltip), fmt::arg("text", text_), fmt::arg("alt", alt_),
-                fmt::arg("icon", getIcon(percentage_, alt_)), fmt::arg("percentage", percentage_));
+            tooltip = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
+                                  fmt::arg("tooltip", tooltip_), fmt::arg("alt", alt_),
+                                  fmt::arg("icon", getIcon(percentage_, alt_)),
+                                  fmt::arg("percentage", percentage_));
             label_.set_tooltip_markup(tooltip);
           } else if (text_ == tooltip_) {
             label_.set_tooltip_markup(str);


### PR DESCRIPTION
### Description
This PR fixes a key issue in custom module. `tooltip` cannot be passed in `"tooltip": "{tooltip} some random text"` when return-type is `json`, as `{tooltip}` is not added in format replacements.

**Before**:
`~/.config/waybar/scripts/pacman-updates.py`
```py
#!/usr/bin/env python3

import subprocess
import json
import logging
import sys

logger = logging.getLogger(__name__)

class PacmanUpdates:
    def __init__(self):
        self.updates = 0

    def get_updates(self):
        logger.debug("Checking for updates...")
        try:
            result = subprocess.run(
                ["checkupdates"],
                stdout=subprocess.PIPE,
                stderr=subprocess.DEVNULL,
                text=True,
                check=False,
            )
            lines = result.stdout.strip().splitlines()
            self.updates = len(lines) if lines else 0

        except Exception as e:
            logger.error(f"Error checking for updates: {e}")
            self.updates = 0

    def to_waybar_json(self):
        if self.updates > 0:
            logger.debug(f"{self.updates} updates available.")
            return {
                "text": f" {self.updates}",
                "tooltip": f"{self.updates} updates available",
            }
        else:
            logger.debug("No updates available.")
            return {
                "text": "",
                "tooltip": "System is up to date",
            }


def main():
    logging.basicConfig(level=logging.DEBUG, format="[%(asctime)s] [%(levelname)s] custom-pacman: %(message)s", stream=sys.stderr)

    pacman = PacmanUpdates()
    pacman.get_updates()
    sys.stdout.write(json.dumps(pacman.to_waybar_json()) + "\n")
    sys.stdout.flush()


if __name__ == "__main__":
    main()
```
`custom-pacman.jsonc`
```jsonc
    "custom/pacman": {
        "format": "󰏔 {text}",
        "exec": "~/.config/waybar/scripts/pacman-updates.py",
        "on-click": "kitty --hold yay -Syu && pkill -SIGRTMIN+8 waybar",
        "on-click-right": "~/.config/waybar/scripts/pacman-updates.py",
        "signal": 8,
        "return-type": "json",
        "tooltip": true,
        "tooltip-format": "󰏔 {tooltip}", // this way not working
        "escape": true
    }
```
```log
[2026-02-10 00:03:19.806] [error] custom/pacman: argument not found
```

### Verification 
Tested locally, working fine.

Closes #4786 