### PR TITLE
fix: remove unnecessary console log for battery status

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -686,7 +686,7 @@ auto waybar::modules::Battery::update() -> void {
     status = getAdapterStatus(capacity);
   }
   auto status_pretty = status;
-  puts(status.c_str());
+
   // Transform to lowercase  and replace space with dash
   std::ranges::transform(status.begin(), status.end(), status.begin(),
                          [](char ch) { return ch == ' ' ? '-' : std::tolower(ch); });


### PR DESCRIPTION
### Description
This PR removes the battery status log printed on every module update.

Closes #4840
Closes #4887

<img width="936" height="506" alt="image" src="https://github.com/user-attachments/assets/40bf6b87-1d43-4d34-9a80-2c318850c8f9" />
