### PR TITLE
fix(keyboard-state): fix segfault on device hotplug removal

### DIFF
--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -3,6 +3,7 @@
 #include <fmt/chrono.h>
 #include <gtkmm/label.h>
 
+#include <mutex>
 #include <set>
 #include <unordered_map>
 
@@ -41,6 +42,7 @@ class KeyboardState : public AModule {
 
   struct libinput* libinput_;
   std::unordered_map<std::string, struct libinput_device*> libinput_devices_;
+  std::mutex devices_mutex_;  // protects libinput_devices_
   std::set<int> binding_keys;
 
   util::SleeperThread libinput_thread_, hotplug_thread_;

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -232,9 +232,12 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
           }
           tryAddDevice(dev_path);
         } else if (event->mask & IN_DELETE) {
+          std::lock_guard<std::mutex> lock(devices_mutex_);
           auto it = libinput_devices_.find(dev_path);
           if (it != libinput_devices_.end()) {
             spdlog::info("Keyboard {} has been removed.", dev_path);
+            libinput_path_remove_device(it->second);
+            libinput_device_unref(it->second);
             libinput_devices_.erase(it);
           }
         }
@@ -245,6 +248,7 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
 }
 
 waybar::modules::KeyboardState::~KeyboardState() {
+  std::lock_guard<std::mutex> lock(devices_mutex_);
   for (const auto& [_, dev_ptr] : libinput_devices_) {
     libinput_path_remove_device(dev_ptr);
   }
@@ -256,11 +260,17 @@ auto waybar::modules::KeyboardState::update() -> void {
 
   try {
     std::string dev_path;
-    if (config_["device-path"].isString() &&
-        libinput_devices_.find(config_["device-path"].asString()) != libinput_devices_.end()) {
-      dev_path = config_["device-path"].asString();
-    } else {
-      dev_path = libinput_devices_.begin()->first;
+    {
+      std::lock_guard<std::mutex> lock(devices_mutex_);
+      if (libinput_devices_.empty()) {
+        return;
+      }
+      if (config_["device-path"].isString() &&
+          libinput_devices_.find(config_["device-path"].asString()) != libinput_devices_.end()) {
+        dev_path = config_["device-path"].asString();
+      } else {
+        dev_path = libinput_devices_.begin()->first;
+      }
     }
     int fd = openFile(dev_path, O_NONBLOCK | O_CLOEXEC | O_RDONLY);
     auto dev = openDevice(fd);
@@ -308,10 +318,15 @@ auto waybar::modules ::KeyboardState::tryAddDevice(const std::string& dev_path) 
     auto dev = openDevice(fd);
     if (supportsLockStates(dev)) {
       spdlog::info("Found device {} at '{}'", libevdev_get_name(dev), dev_path);
+      std::lock_guard<std::mutex> lock(devices_mutex_);
       if (libinput_devices_.find(dev_path) == libinput_devices_.end()) {
         auto device = libinput_path_add_device(libinput_, dev_path.c_str());
-        libinput_device_ref(device);
-        libinput_devices_[dev_path] = device;
+        if (device) {
+          libinput_device_ref(device);
+          libinput_devices_[dev_path] = device;
+        } else {
+          spdlog::warn("keyboard-state: Failed to add device to libinput: {}", dev_path);
+        }
       }
     }
     libevdev_free(dev);


### PR DESCRIPTION
## Summary

Fixes a segfault (SIGSEGV in `libinput_device_ref`) in the keyboard-state module when input devices appear or disappear in `/dev/input/`.

Three bugs fixed:

- **Missing NULL check (crash cause)**: `tryAddDevice()` passes the return value of `libinput_path_add_device()` directly to `libinput_device_ref()` without checking for NULL. On laptops, virtual input devices (power buttons, lid switch, etc.) appear and disappear; if libinput can't open one, the NULL return causes the segfault.
- **Missing cleanup on device removal**: The `IN_DELETE` handler erased devices from the map without calling `libinput_path_remove_device()`, leaving dangling pointers in the libinput context.
- **Thread safety**: Added `std::mutex` to protect `libinput_devices_` which was accessed from 3 threads without synchronization.

Fixes #4851

## Test plan

- [ ] Build waybar with this patch
- [ ] Verify keyboard-state module works normally
- [ ] Unplug/replug a USB keyboard while waybar is running — should not crash
- [ ] On a laptop: trigger device enumeration (e.g., suspend/resume) — should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)