### PR TITLE
fix: use SafeSignal in ipc in order to not call GTK funcs from a thread

### DIFF
--- a/include/modules/sway/ipc/client.hpp
+++ b/include/modules/sway/ipc/client.hpp
@@ -13,6 +13,7 @@
 
 #include "ipc.hpp"
 #include "util/sleeper_thread.hpp"
+#include "util/SafeSignal.hpp"
 
 namespace waybar::modules::sway {
 
@@ -27,8 +28,8 @@ class Ipc {
     std::string payload;
   };
 
-  sigc::signal<void, const struct ipc_response&> signal_event;
-  sigc::signal<void, const struct ipc_response&> signal_cmd;
+  ::waybar::SafeSignal<const struct ipc_response&> signal_event;
+  ::waybar::SafeSignal<const struct ipc_response&> signal_cmd;
 
   void sendCmd(uint32_t type, const std::string& payload = "");
   void subscribe(const std::string& payload);


### PR DESCRIPTION
As analyzed in https://github.com/Alexays/Waybar/issues/4777#issuecomment-3892022955, the current logic calls GTK functions in a thread-unsafe way. I think the fix probably is just to switch the client IPC to use `SafeSignal` instead of `sigc::signal`.

I have tested that this code builds and that swaybar at least starts seemingly correctly on my machine. I have not yet observed it long enough to tell if it really fixes the crashes.

Fixes #4751
Fixes #4777