### PR TITLE
fix: use pango markup for consistent formatting in format and tooltip-format

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -58,11 +58,11 @@ auto waybar::modules::Backlight::update() -> void {
           tooltip_format = config_["tooltip-format"].asString();
         }
         if (!tooltip_format.empty()) {
-          label_.set_tooltip_text(fmt::format(fmt::runtime(tooltip_format),
-                                              fmt::arg("percent", percent),
-                                              fmt::arg("icon", getIcon(percent))));
+          label_.set_tooltip_markup(fmt::format(fmt::runtime(tooltip_format),
+                                                fmt::arg("percent", percent),
+                                                fmt::arg("icon", getIcon(percent))));
         } else {
-          label_.set_tooltip_text(desc);
+          label_.set_tooltip_markup(desc);
         }
       }
     } else {

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -27,7 +27,7 @@ auto waybar::modules::Cpu::update() -> void {
   auto [cpu_usage, tooltip] = CpuUsage::getCpuUsage(prev_times_);
   auto [max_frequency, min_frequency, avg_frequency] = CpuFrequency::getCpuFrequency();
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(tooltip);
+    label_.set_tooltip_markup(tooltip);
   }
   auto format = format_;
   auto total_usage = cpu_usage.empty() ? 0 : cpu_usage[0];

--- a/src/modules/cpu_frequency/common.cpp
+++ b/src/modules/cpu_frequency/common.cpp
@@ -24,7 +24,7 @@ auto waybar::modules::CpuFrequency::update() -> void {
     auto tooltip =
         fmt::format("Minimum frequency: {}\nAverage frequency: {}\nMaximum frequency: {}\n",
                     min_frequency, avg_frequency, max_frequency);
-    label_.set_tooltip_text(tooltip);
+    label_.set_tooltip_markup(tooltip);
   }
   auto format = format_;
   auto state = getState(avg_frequency);

--- a/src/modules/cpu_usage/common.cpp
+++ b/src/modules/cpu_usage/common.cpp
@@ -21,7 +21,7 @@ auto waybar::modules::CpuUsage::update() -> void {
   // TODO: as creating dynamic fmt::arg arrays is buggy we have to calc both
   auto [cpu_usage, tooltip] = CpuUsage::getCpuUsage(prev_times_);
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(tooltip);
+    label_.set_tooltip_markup(tooltip);
   }
   auto format = format_;
   auto total_usage = cpu_usage.empty() ? 0 : cpu_usage[0];

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -81,7 +81,7 @@ auto waybar::modules::Disk::update() -> void {
     if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_.set_tooltip_text(fmt::format(
+    label_.set_tooltip_markup(fmt::format(
         fmt::runtime(tooltip_format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
         fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
         fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),

--- a/src/modules/dwl/window.cpp
+++ b/src/modules/dwl/window.cpp
@@ -116,7 +116,7 @@ void Window::handle_frame() {
   updateAppIconName(appid_, "");
   updateAppIcon();
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(title_);
+    label_.set_tooltip_markup(title_);
   }
 }
 

--- a/src/modules/gamemode.cpp
+++ b/src/modules/gamemode.cpp
@@ -212,7 +212,7 @@ auto Gamemode::update() -> void {
   // Tooltip
   if (tooltip) {
     std::string text = fmt::format(fmt::runtime(tooltip_format), fmt::arg("count", gameCount));
-    box_.set_tooltip_text(text);
+    box_.set_tooltip_markup(text);
   }
 
   // Label format

--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -60,7 +60,7 @@ auto Submap::update() -> void {
   } else {
     label_.set_markup(fmt::format(fmt::runtime(format_), submap_));
     if (tooltipEnabled()) {
-      label_.set_tooltip_text(submap_);
+      label_.set_tooltip_markup(submap_);
     }
     event_box_.show();
   }

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -72,13 +72,13 @@ auto Window::update() -> void {
       tooltip_format = config_["tooltip-format"].asString();
     }
     if (!tooltip_format.empty()) {
-      label_.set_tooltip_text(
+      label_.set_tooltip_markup(
           fmt::format(fmt::runtime(tooltip_format), fmt::arg("title", windowName),
                       fmt::arg("initialTitle", windowData_.initial_title),
                       fmt::arg("class", windowData_.class_name),
                       fmt::arg("initialClass", windowData_.initial_class_name)));
     } else if (!label_text.empty()) {
-      label_.set_tooltip_text(label_text);
+      label_.set_tooltip_markup(label_text);
     }
   }
 

--- a/src/modules/hyprland/windowcount.cpp
+++ b/src/modules/hyprland/windowcount.cpp
@@ -58,7 +58,7 @@ auto WindowCount::update() -> void {
   } else if (!format.empty()) {
     label_.set_markup(fmt::format(fmt::runtime(format), workspace_.windows));
   } else {
-    label_.set_text(fmt::format("{}", workspace_.windows));
+    label_.set_markup(fmt::format("{}", workspace_.windows));
   }
 
   label_.show();

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -300,7 +300,7 @@ void Workspace::updateTaskbar(const std::string& workspace_icon) {
     }
 
     auto window_box = Gtk::make_managed<Gtk::Box>(Gtk::ORIENTATION_HORIZONTAL);
-    window_box->set_tooltip_text(window_repr.window_title);
+    window_box->set_tooltip_markup(window_repr.window_title);
     window_box->get_style_context()->add_class("taskbar-window");
     if (window_repr.isActive) {
       window_box->get_style_context()->add_class("active");

--- a/src/modules/inhibitor.cpp
+++ b/src/modules/inhibitor.cpp
@@ -123,7 +123,7 @@ auto Inhibitor::update() -> void {
   label_.get_style_context()->add_class(status_text);
 
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(status_text);
+    label_.set_tooltip_markup(status_text);
   }
 
   return ALabel::update();

--- a/src/modules/jack.cpp
+++ b/src/modules/jack.cpp
@@ -80,7 +80,7 @@ auto JACK::update() -> void {
   if (tooltipEnabled()) {
     std::string tooltip_format = "{bufsize}/{samplerate} {latency}ms";
     if (config_["tooltip-format"].isString()) tooltip_format = config_["tooltip-format"].asString();
-    label_.set_tooltip_text(fmt::format(
+    label_.set_tooltip_markup(fmt::format(
         fmt::runtime(tooltip_format), fmt::arg("load", std::round(load_)),
         fmt::arg("bufsize", bufsize_), fmt::arg("samplerate", samplerate_),
         fmt::arg("latency", fmt::format("{:.2f}", latency)), fmt::arg("xruns", xruns_)));

--- a/src/modules/load.cpp
+++ b/src/modules/load.cpp
@@ -22,7 +22,7 @@ auto waybar::modules::Load::update() -> void {
   auto [load1, load5, load15] = Load::getLoad();
   if (tooltipEnabled()) {
     auto tooltip = fmt::format("Load 1: {}\nLoad 5: {}\nLoad 15: {}", load1, load5, load15);
-    label_.set_tooltip_text(tooltip);
+    label_.set_tooltip_markup(tooltip);
   }
   auto format = format_;
   auto state = getState(load1);

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -69,7 +69,7 @@ auto waybar::modules::Memory::update() -> void {
     if (tooltipEnabled()) {
       if (config_["tooltip-format"].isString()) {
         auto tooltip_format = config_["tooltip-format"].asString();
-        label_.set_tooltip_text(fmt::format(
+        label_.set_tooltip_markup(fmt::format(
             fmt::runtime(tooltip_format), used_ram_percentage,
             fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
             fmt::arg("percentage", used_ram_percentage),
@@ -78,7 +78,7 @@ auto waybar::modules::Memory::update() -> void {
             fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
             fmt::arg("swapAvail", available_swap_gigabytes)));
       } else {
-        label_.set_tooltip_text(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
+        label_.set_tooltip_markup(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
       }
     }
   } else {

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -110,7 +110,7 @@ void waybar::modules::MPD::setLabel() {
                            ? config_["tooltip-format-disconnected"].asString()
                            : "MPD (disconnected)";
       // Nothing to format
-      label_.set_tooltip_text(tooltip_format);
+      label_.set_tooltip_markup(tooltip_format);
     }
     return;
   }
@@ -210,7 +210,7 @@ void waybar::modules::MPD::setLabel() {
           fmt::arg("stateIcon", stateIcon), fmt::arg("consumeIcon", consumeIcon),
           fmt::arg("randomIcon", randomIcon), fmt::arg("repeatIcon", repeatIcon),
           fmt::arg("singleIcon", singleIcon), fmt::arg("filename", filename), fmt::arg("uri", uri));
-      label_.set_tooltip_text(tooltip_text);
+      label_.set_tooltip_markup(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpd: format error (tooltip): {}", e.what());
     }

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -734,7 +734,7 @@ auto Mpris::update() -> void {
           fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
           fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
 
-      label_.set_tooltip_text(tooltip_text);
+      label_.set_tooltip_markup(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpris: format error (tooltip): {}", e.what());
     }

--- a/src/modules/niri/window.cpp
+++ b/src/modules/niri/window.cpp
@@ -67,7 +67,7 @@ void Window::doUpdate() {
 
     updateAppIconName(appId, "");
 
-    if (tooltipEnabled()) label_.set_tooltip_text(title);
+    if (tooltipEnabled()) label_.set_tooltip_markup(title);
 
     const auto id = window["id"].asUInt64();
     const auto workspaceId = window["workspace_id"].asUInt64();

--- a/src/modules/power_profiles_daemon.cpp
+++ b/src/modules/power_profiles_daemon.cpp
@@ -157,7 +157,7 @@ auto PowerProfilesDaemon::update() -> void {
     store.push_back(fmt::arg("icon", getIcon(0, profile.name)));
     label_.set_markup(fmt::vformat(format_, store));
     if (tooltipEnabled()) {
-      label_.set_tooltip_text(fmt::vformat(tooltipFormat_, store));
+      label_.set_tooltip_markup(fmt::vformat(tooltipFormat_, store));
     }
 
     // Set CSS class

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -138,7 +138,7 @@ auto waybar::modules::Pulseaudio::update() -> void {
           fmt::arg("source_volume", source_volume), fmt::arg("source_desc", source_desc),
           fmt::arg("icon", getIcon(sink_volume, getPulseIcon()))));
     } else {
-      label_.set_tooltip_text(sink_desc);
+      label_.set_tooltip_markup(sink_desc);
     }
   }
 

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -25,9 +25,9 @@ auto waybar::modules::Clock::update() -> void {
     if (config_["tooltip-format"].isString()) {
       auto tooltip_format = config_["tooltip-format"].asString();
       auto tooltip_text = fmt::format(fmt::runtime(tooltip_format), localtime);
-      label_.set_tooltip_text(tooltip_text);
+      label_.set_tooltip_markup(tooltip_text);
     } else {
-      label_.set_tooltip_text(text);
+      label_.set_tooltip_markup(text);
     }
   }
   // Call parent update

--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -44,7 +44,7 @@ auto Mode::update() -> void {
   } else {
     label_.set_markup(fmt::format(fmt::runtime(format_), mode_));
     if (tooltipEnabled()) {
-      label_.set_tooltip_text(mode_);
+      label_.set_tooltip_markup(mode_);
     }
     event_box_.show();
   }

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -99,7 +99,7 @@ auto Window::update() -> void {
                   fmt::arg("shell", shell_), fmt::arg("marks", marks_)),
       config_["rewrite"]));
   if (tooltipEnabled()) {
-    label_.set_tooltip_text(window_);
+    label_.set_tooltip_markup(window_);
   }
 
   updateAppIcon();

--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -479,12 +479,12 @@ auto waybar::modules::Wireplumber::update() -> void {
     }
 
     if (!tooltipFormat.empty()) {
-      label_.set_tooltip_text(fmt::format(
+      label_.set_tooltip_markup(fmt::format(
           fmt::runtime(tooltipFormat), fmt::arg("node_name", node_name_), fmt::arg("volume", vol),
           fmt::arg("icon", getIcon(vol)), fmt::arg("format_source", formatted_source),
           fmt::arg("source_volume", source_vol), fmt::arg("source_desc", source_name_)));
     } else {
-      label_.set_tooltip_text(node_name_);
+      label_.set_tooltip_markup(node_name_);
     }
   }
 

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -509,7 +509,7 @@ void Task::update() {
     if (markup)
       button.set_tooltip_markup(txt);
     else
-      button.set_tooltip_text(txt);
+      button.set_tooltip_markup(txt);
   }
 }
 


### PR DESCRIPTION
### Description
This PR replaces all `format` and `tooltip-format` to use pango markup for consistent formatting across modules.