### PR TITLE
memory: use markup rather than text for memory tooltip

### DIFF
--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -69,7 +69,7 @@ auto waybar::modules::Memory::update() -> void {
     if (tooltipEnabled()) {
       if (config_["tooltip-format"].isString()) {
         auto tooltip_format = config_["tooltip-format"].asString();
-        label_.set_tooltip_text(fmt::format(
+        label_.set_tooltip_markup(fmt::format(
             fmt::runtime(tooltip_format), used_ram_percentage,
             fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
             fmt::arg("percentage", used_ram_percentage),


### PR DESCRIPTION
Seems a little strange to me that we can format the tooltip text, but can't use markup like we can elsewhere.