### PR TITLE
fix: ensure AAppIconLabel image remains not visibile if icons are disabled

### DIFF
--- a/src/AAppIconLabel.cpp
+++ b/src/AAppIconLabel.cpp
@@ -151,7 +151,7 @@ void AAppIconLabel::updateAppIconName(const std::string& app_identifier,
 }
 
 void AAppIconLabel::updateAppIcon() {
-  if (update_app_icon_) {
+  if (update_app_icon_ || (!iconEnabled() && image_.get_visible())) {
     update_app_icon_ = false;
     if (app_icon_name_.empty()) {
       image_.set_visible(false);


### PR DESCRIPTION
When using dwl/window (and possibly other modules) with icons disabled, on startup `AAppIconLabel` can end up in a state where `image_` is set to visible but `update_app_icon_` is set to false, meaning `updateAppIcon` always returns early and the `image_` is never set back to not visible. This means an empty gap is left for the non-existent icon (see #4641 for an example).

This PR changes `updateAppIcon'`s guard from `if (update_app_icon_)` to `if (update_app_icon_ || (!iconEnabled() && image_.get_visible()))` so that `updateAppIcon` will correctly set `image_`'s visibility back to false in this case.