### PR TITLE
fix(cava): remove silent CSS class on reactivation

### DIFF
--- a/src/modules/cava/cavaRaw.cpp
+++ b/src/modules/cava/cavaRaw.cpp
@@ -26,6 +26,7 @@ void waybar::modules::cava::Cava::pause_resume() { backend_->doPauseResume(); }
 auto waybar::modules::cava::Cava::onUpdate(const std::string& input) -> void {
   Glib::signal_idle().connect_once([this, input]() {
     if (silence_) {
+      silence_ = false;
       label_.get_style_context()->remove_class("silent");
       if (!label_.get_style_context()->has_class("updated"))
         label_.get_style_context()->add_class("updated");
@@ -38,7 +39,6 @@ auto waybar::modules::cava::Cava::onUpdate(const std::string& input) -> void {
     label_.show();
     ALabel::update();
   });
-  silence_ = false;
 }
 
 auto waybar::modules::cava::Cava::onSilence() -> void {


### PR DESCRIPTION
Fixes #4873

## Problem

When the cava module reactivates after silence, the `silent` CSS class 
was never being removed from the label, causing any styles applied to 
it to persist permanently.

## Root cause

In `onUpdate`, `silence_` was being set to `false` **outside** and 
**before** the GTK idle lambda executes:
```cpp
Glib::signal_idle().connect_once([this, input]() {
    if (silence_) {  // always false by the time this runs
        label_.get_style_context()->remove_class("silent");
        ...
    }
});
silence_ = false;  // this runs first, before the lambda
```

Because `Glib::signal_idle()` defers execution to the GTK main loop, 
by the time the lambda checks `silence_`, it has already been set to 
`false`, so the block that removes the `silent` class never executes.

Note that `onSilence` correctly sets `silence_ = true` inside the 
lambda — this fix brings `onUpdate` in line with that same pattern.

## Fix

Move `silence_ = false` inside the idle lambda, consistent with how 
`onSilence` handles `silence_ = true`:
```cpp
Glib::signal_idle().connect_once([this, input]() {
    if (silence_) {
        silence_ = false;  // moved here
        label_.get_style_context()->remove_class("silent");
        ...
    }
});
```