### PR TITLE
fix: sync tooltip updates without resetting hover state

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -35,6 +35,7 @@ class Custom : public ALabel {
   std::string id_;
   std::string alt_;
   std::string tooltip_;
+  std::string last_tooltip_markup_;
   const bool tooltip_format_enabled_;
   std::vector<std::string> class_;
   int percentage_;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -1,6 +1,7 @@
 #include "modules/custom.hpp"
 
 #include <spdlog/spdlog.h>
+#include <utility>
 
 #include "util/scope_guard.hpp"
 
@@ -180,21 +181,22 @@ auto waybar::modules::Custom::update() -> void {
       } else {
         label_.set_markup(str);
         if (tooltipEnabled()) {
+          std::string tooltip_markup;
           if (tooltip_format_enabled_) {
             auto tooltip = config_["tooltip-format"].asString();
-            tooltip = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
-                                  fmt::arg("tooltip", tooltip_), fmt::arg("alt", alt_),
-                                  fmt::arg("icon", getIcon(percentage_, alt_)),
-                                  fmt::arg("percentage", percentage_));
-            label_.set_tooltip_markup(tooltip);
+            tooltip_markup = fmt::format(fmt::runtime(tooltip), fmt::arg("text", text_),
+                                         fmt::arg("tooltip", tooltip_), fmt::arg("alt", alt_),
+                                         fmt::arg("icon", getIcon(percentage_, alt_)),
+                                         fmt::arg("percentage", percentage_));
           } else if (text_ == tooltip_) {
-            if (label_.get_tooltip_markup() != str) {
-              label_.set_tooltip_markup(str);
-            }
+            tooltip_markup = str;
           } else {
-            if (label_.get_tooltip_markup() != tooltip_) {
-              label_.set_tooltip_markup(tooltip_);
-            }
+            tooltip_markup = tooltip_;
+          }
+
+          if (last_tooltip_markup_ != tooltip_markup) {
+            label_.set_tooltip_markup(tooltip_markup);
+            last_tooltip_markup_ = std::move(tooltip_markup);
           }
         }
         auto style = label_.get_style_context();


### PR DESCRIPTION
Keep custom module tooltip content in sync while avoiding hover regressions.

Instead of calling set_tooltip_markup() on every refresh, compute the desired
tooltip string and only update the GTK tooltip when the value changes using a
local cache (last_tooltip_markup_).

This preserves tooltip-format/{tooltip} behavior from the earlier tooltip sync
change while preventing frequent tooltip resets from disrupting hover/prelight.

Should fix #4519