### PR TITLE
Add simple calendar tooltip example for clock module

### DIFF
--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -259,7 +259,19 @@ View all valid format options in *strftime(3)* or have a look https://en.cpprefe
 	"tooltip-format": "{tz_list}"
 }
 ```
+5. Simple calendar tooltip
 
+```
+"clock": {
+"format": "{:%H:%M}",
+"tooltip-format": "<tt>{calendar}</tt>",
+"calendar": {
+"format": {
+"today": "<span color='#ffcc66'><b>{}</b></span>"
+}
+}
+}
+```
 # STYLE
 
 - *#clock*


### PR DESCRIPTION
Adds a simple example showing how to display the calendar in the clock tooltip using `{calendar}`.

This helps users understand how to configure a calendar tooltip in Waybar.