### PR TITLE
fix(hyprland/window): Fix segfault caused by use-after-free

### DIFF
--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -19,20 +19,19 @@ std::shared_mutex windowIpcSmtx;
 
 Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
     : AAppIconLabel(config, "window", id, "{title}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
-  std::unique_lock<std::shared_mutex> windowIpcUniqueLock(windowIpcSmtx);
-
   separateOutputs_ = config["separate-outputs"].asBool();
 
+  update();
+
   // register for hyprland ipc
+  std::unique_lock<std::shared_mutex> windowIpcUniqueLock(windowIpcSmtx);
   m_ipc.registerForIPC("activewindow", this);
   m_ipc.registerForIPC("closewindow", this);
   m_ipc.registerForIPC("movewindow", this);
   m_ipc.registerForIPC("changefloatingmode", this);
   m_ipc.registerForIPC("fullscreen", this);
-
   windowIpcUniqueLock.unlock();
 
-  update();
   dp.emit();
 }
 


### PR DESCRIPTION
The window module registers itself with the Hyprland IPC singleton at
the start of its constructor, before calling update(). If update()
throws an exception (e.g. from an invalid format string), the object is
destroyed without the destructor running, leaving a dangling pointer in
the IPC callback list. When the IPC thread receives an event, it
attempts to call onEvent() on this invalid memory, causing a crash.

Moving the update() call before IPC registration ensures that any
initialization errors occur before the pointer is shared. If the
configuration is invalid, the module fails to construct and is
gracefully disabled by the factory without leaving a "landmine" in the
background IPC thread.

Fixes: #4923

Signed-off-by: Emir Baha Yıldırım <jayshozie@gmail.com>
