### PR TITLE
clarify logical condition in wlr taskbar module

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -198,7 +198,7 @@ void Task::handle_title(const char* title) {
   title_ = title;
   hide_if_ignored();
 
-  if (!with_icon_ && !with_name_ || app_info_) {
+  if ((!with_icon_ && !with_name_) || app_info_) {
     return;
   }
 


### PR DESCRIPTION
Clarify logical condition in wlr taskbar module

The original condition relies on operator precedence between && and ||,
which can be harder to read and may lead to misinterpretation.

This change adds explicit parentheses to make the intended logic clear
without altering behavior.

No functional change.