### PR TITLE
feature: add on-click-copy clipboard functionality

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -26,6 +26,7 @@ class ALabel : public AModule {
   std::string default_format_;
 
   bool handleToggle(GdkEventButton* const& e) override;
+  void copyToClipboard(const std::string&);
   virtual std::string getState(uint8_t value, bool lesser = false);
 
   std::map<std::string, GtkMenuItem*> submenus_;

--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -78,7 +78,8 @@ class AModule : public IModule {
       {std::make_pair(9, GdkEventType::GDK_BUTTON_PRESS), "on-click-forward"},
       {std::make_pair(9, GdkEventType::GDK_BUTTON_RELEASE), "on-click-forward-release"},
       {std::make_pair(9, GdkEventType::GDK_2BUTTON_PRESS), "on-double-click-forward"},
-      {std::make_pair(9, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-forward"}};
+      {std::make_pair(9, GdkEventType::GDK_3BUTTON_PRESS), "on-triple-click-forward"},
+      {std::make_pair(10, GdkEventType::GDK_BUTTON_PRESS), "on-click-copy"}};
 };
 
 }  // namespace waybar

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -116,9 +116,8 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
         }
         submenus_[key] = GTK_MENU_ITEM(item);
         menuActionsMap_[key] = it->asString();
-        g_signal_connect(submenus_[key], "activate",
-                 G_CALLBACK(handleGtkMenuEvent),
-                 (gpointer)g_strdup(menuActionsMap_[key].c_str()));          
+        g_signal_connect(submenus_[key], "activate", G_CALLBACK(handleGtkMenuEvent),
+                         (gpointer)g_strdup(menuActionsMap_[key].c_str()));
       }
       g_object_unref(builder);
     } catch (std::runtime_error& e) {
@@ -190,6 +189,10 @@ std::string ALabel::getIcon(uint16_t percentage, const std::vector<std::string>&
   return "";
 }
 
+void ALabel::copyToClipboard(const std::string& literal) {
+  Gtk::Clipboard::get()->set_text(literal);
+}
+
 bool waybar::ALabel::handleToggle(GdkEventButton* const& e) {
   if (config_["format-alt-click"].isUInt() && e->button == config_["format-alt-click"].asUInt()) {
     alt_ = !alt_;
@@ -198,6 +201,10 @@ bool waybar::ALabel::handleToggle(GdkEventButton* const& e) {
     } else {
       format_ = default_format_;
     }
+  }
+
+  if (config_["on-click-copy"].isBool() && config_["on-click-copy"].asBool()) {
+    copyToClipboard(label_.get_text());
   }
   return AModule::handleToggle(e);
 }

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -42,7 +42,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
       std::find_if(eventMap_.cbegin(), eventMap_.cend(), [&config](const auto& eventEntry) {
         // True if there is any non-release type event
         return eventEntry.first.second != GdkEventType::GDK_BUTTON_RELEASE &&
-               config[eventEntry.second].isString();
+               (config[eventEntry.second].isString() || config[eventEntry.second].isBool());
       }) != eventMap_.cend();
 
   if (enable_click || hasUserEvents) {


### PR DESCRIPTION
Adding a new config key word "on-click-copy" that takes a boolean and if the boolean is true then whenever the label is clicked it copies the values of the label to the clipboard.


Addressing: #4655