### PR TITLE
bar: warn on invalid height type in configuration

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -172,6 +172,10 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     right_.set_spacing(spacing);
   }
 
+  if (config.isMember("height") && !config["height"].isUInt()) {
+  spdlog::warn("Invalid type for 'height', expected unsigned integer");
+  }
+
   height_ = config["height"].isUInt() ? config["height"].asUInt() : 0;
   width_ = config["width"].isUInt() ? config["width"].asUInt() : 0;
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -173,7 +173,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   }
 
   if (config.isMember("height") && !config["height"].isUInt()) {
-  spdlog::warn("Invalid type for 'height', expected unsigned integer");
+    spdlog::warn("Invalid type for 'height', expected unsigned integer");
   }
 
   height_ = config["height"].isUInt() ? config["height"].asUInt() : 0;


### PR DESCRIPTION
Waybar currently accepts invalid values such as `"height": null`
without emitting any warning, silently falling back to 0.

However, Waybar already emits warnings for other invalid values
(e.g. when height is below the minimum allowed). This creates
inconsistent behavior where some invalid inputs are reported,
while others are silently ignored.

This change ensures that invalid types for `height` are also
reported with a warning, improving consistency and helping users
identify configuration issues.

### Testing

- Set `"height": null` in config → warning is shown
- Removed `height` key → no warning
- Set valid value (`"height": 22` or higher) → no warning
- Set small value (`"height": 20`) → existing warning still works