### PR TITLE
Fix unnecessary allocation in GTK callback

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -116,9 +116,8 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
         }
         submenus_[key] = GTK_MENU_ITEM(item);
         menuActionsMap_[key] = it->asString();
-        g_signal_connect(submenus_[key], "activate",
-                 G_CALLBACK(handleGtkMenuEvent),
-                 (gpointer)g_strdup(menuActionsMap_[key].c_str()));          
+        g_signal_connect(submenus_[key], "activate", G_CALLBACK(handleGtkMenuEvent),
+                         (gpointer)menuActionsMap_[key].c_str());
       }
       g_object_unref(builder);
     } catch (std::runtime_error& e) {


### PR DESCRIPTION
This reverts #4925.

After reviewing the lifetime guarantees of menuActionsMap_,
the original c_str() usage is already safe in this context.

The use of g_strdup is unnecessary here.

Restoring the original implementation.