### PR TITLE
fix: issue #4955 wrong behaviour of regex for sway/window 'rewrite'

### DIFF
--- a/src/util/rewrite_string.cpp
+++ b/src/util/rewrite_string.cpp
@@ -18,7 +18,7 @@ std::string rewriteString(const std::string& value, const Json::Value& rules) {
         // malformated regexes will cause an exception.
         // in this case, log error and try the next rule.
         const std::regex rule{it.key().asString(), std::regex_constants::icase};
-        if (std::regex_match(value, rule)) {
+        if (std::regex_match(res, rule)) {
           res = std::regex_replace(res, rule, it->asString());
         }
       } catch (const std::regex_error& e) {


### PR DESCRIPTION
Fixed issue #4955 where the compared regex value wasn't consistent