### PR TITLE
fix : dwl/window no waybar empty class and added current app id class

### DIFF
--- a/include/modules/dwl/window.hpp
+++ b/include/modules/dwl/window.hpp
@@ -30,7 +30,11 @@ class Window : public AAppIconLabel, public sigc::trackable {
   std::string title_;
   std::string appid_;
   std::string layout_symbol_;
+  std::string oldAppid_;
+
   uint32_t layout_;
+
+  void setClass(const std::string&, bool enable);
 
   struct zdwl_ipc_output_v2* output_status_;
 };

--- a/src/modules/dwl/window.cpp
+++ b/src/modules/dwl/window.cpp
@@ -98,6 +98,17 @@ Window::~Window() {
   }
 }
 
+void Window::setClass(const std::string& classname, bool enable) {
+  if (enable) {
+    if (!bar_.window.get_style_context()->has_class(classname)) {
+      bar_.window.get_style_context()->add_class(classname);
+    }
+  } else {
+    bar_.window.get_style_context()->remove_class(classname);
+  }
+}
+
+
 void Window::handle_title(const char* title) { title_ = Glib::Markup::escape_text(title); }
 
 void Window::handle_appid(const char* appid) { appid_ = Glib::Markup::escape_text(appid); }
@@ -109,12 +120,19 @@ void Window::handle_layout_symbol(const char* layout_symbol) {
 void Window::handle_layout(const uint32_t layout) { layout_ = layout; }
 
 void Window::handle_frame() {
+
   label_.set_markup(waybar::util::rewriteString(
       fmt::format(fmt::runtime(format_), fmt::arg("title", title_),
                   fmt::arg("layout", layout_symbol_), fmt::arg("app_id", appid_)),
       config_["rewrite"]));
   updateAppIconName(appid_, "");
   updateAppIcon();
+  setClass("empty",title_.empty());
+  if (oldAppid_ != appid_) {
+    if (!oldAppid_.empty()) setClass(oldAppid_, false);
+    setClass(appid_, true);
+    oldAppid_ = appid_;
+  }
   if (tooltipEnabled()) {
     label_.set_tooltip_markup(title_);
   }


### PR DESCRIPTION
In  `dwl/window`
Fixes : 
<img width="2160" height="49" alt="image" src="https://github.com/user-attachments/assets/fba7b483-5852-465e-bebc-6198deaed203" />

* this red thing in middle is background of #window module but there is no way to make it transparent when in workspace with no window , this pull request addresses this issue. so this `window#waybar.empty #window` selector can be used to hide it .


Adds : 
* like [this](https://github.com/Alexays/Waybar/wiki/Module:-Hyprland#style-1:~:text=This%20will%20change%20the%20color%20of%20the%20entire%20bar%20when%20either%20Chromium%20or%20kitty%20occupy%20the%20screen) , added support for window#waybar.<app_id> . 

These styles can be useful for a person using dwl & mangowc.