### PR TITLE
fix(network): prevent near-zero bandwidth on rapid event-driven updates

### DIFF
--- a/include/modules/network.hpp
+++ b/include/modules/network.hpp
@@ -70,6 +70,8 @@ class Network : public ALabel {
 
   unsigned long long bandwidth_down_total_{0};
   unsigned long long bandwidth_up_total_{0};
+  unsigned long long bandwidth_down_prev_{0};
+  unsigned long long bandwidth_up_prev_{0};
   std::chrono::steady_clock::time_point bandwidth_last_sample_time_;
 
   std::string state_;

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -280,23 +280,39 @@ auto waybar::modules::Network::update() -> void {
   std::string tooltip_format;
   auto now = std::chrono::steady_clock::now();
   auto elapsed_seconds = std::chrono::duration<double>(now - bandwidth_last_sample_time_).count();
-  if (elapsed_seconds <= 0.0) {
-    elapsed_seconds = std::chrono::duration<double>(interval_).count();
-  }
-  bandwidth_last_sample_time_ = now;
 
-  auto bandwidth = readBandwidthUsage();
   auto bandwidth_down = 0ull;
   auto bandwidth_up = 0ull;
-  if (bandwidth.has_value()) {
-    auto down_octets = (*bandwidth).first;
-    auto up_octets = (*bandwidth).second;
 
-    bandwidth_down = down_octets - bandwidth_down_total_;
-    bandwidth_down_total_ = down_octets;
+  // Only recalculate bandwidth when enough time has elapsed since the last
+  // sample.  Event-driven dp.emit() calls (link/addr/route changes) can
+  // trigger update() between timer intervals, which would consume the byte
+  // delta prematurely and show near-zero bandwidth.
+  auto min_elapsed = std::chrono::duration<double>(interval_).count() * 0.5;
+  if (elapsed_seconds >= min_elapsed) {
+    if (elapsed_seconds <= 0.0) {
+      elapsed_seconds = std::chrono::duration<double>(interval_).count();
+    }
+    bandwidth_last_sample_time_ = now;
 
-    bandwidth_up = up_octets - bandwidth_up_total_;
-    bandwidth_up_total_ = up_octets;
+    auto bandwidth = readBandwidthUsage();
+    if (bandwidth.has_value()) {
+      auto down_octets = (*bandwidth).first;
+      auto up_octets = (*bandwidth).second;
+
+      bandwidth_down = down_octets - bandwidth_down_total_;
+      bandwidth_down_total_ = down_octets;
+
+      bandwidth_up = up_octets - bandwidth_up_total_;
+      bandwidth_up_total_ = up_octets;
+
+      bandwidth_down_prev_ = bandwidth_down;
+      bandwidth_up_prev_ = bandwidth_up;
+    }
+  } else {
+    bandwidth_down = bandwidth_down_prev_;
+    bandwidth_up = bandwidth_up_prev_;
+    elapsed_seconds = std::chrono::duration<double>(interval_).count();
   }
 
   if (!alt_) {


### PR DESCRIPTION
## Summary
- Network bandwidth shows near-zero values during downloads when netlink events fire between timer intervals
- `update()` is called from both the timer thread and event handlers (link/addr/route changes), each call consuming the byte delta and resetting `bandwidth_down_total_`
- Cache the last computed bandwidth values and skip recalculation when `update()` is called within half the configured interval, reusing cached values instead

## Test Plan
- Verified with standalone C++ bandwidth tester ([ `bandwidth_test.cpp`](https://gist.github.com/adrianlzt/13ea4052551870da96ecc99d8d697916)) replicating exact measurement logic
- Also verified downloading a big file