### PR TITLE
niri/workspaces: feature - add "hide-empty" config option 

### DIFF
--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -114,6 +114,11 @@ void Workspaces::doUpdate() {
         button.show();
       else
         button.hide();
+    } else if (config_["hide-empty"].asBool()) {
+      if (ws["active_window_id"].isNull() && !ws["is_focused"].asBool())
+          button.hide();
+      else
+          button.show();
     } else {
       button.show();
     }


### PR DESCRIPTION
This PR adds "hide-empty" option for niri/workspace module. #4965 