### PR TITLE
Network: fix: delete correct address type

### DIFF
--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -677,12 +677,15 @@ int waybar::modules::Network::handleEvents(struct nl_msg* msg, void* data) {
                               changed_cidr);
               }
             } else {
-              net->ipaddr_.clear();
-              net->ipaddr6_.clear();
-              net->cidr_ = 0;
-              net->cidr6_ = 0;
-              net->netmask_.clear();
-              net->netmask6_.clear();
+              if (ifa->ifa_family == AF_INET) {
+                net->ipaddr_.clear();
+                net->cidr_ = 0;
+                net->netmask_.clear();
+              } else if (ifa->ifa_family == AF_INET6) {
+                net->ipaddr6_.clear();
+                net->cidr6_ = 0;
+                net->netmask6_.clear();
+              }
               spdlog::debug("network: {} addr deleted {}/{}", net->ifname_,
                             inet_ntop(ifa->ifa_family, RTA_DATA(ifa_rta), ipaddr, sizeof(ipaddr)),
                             ifa->ifa_prefixlen);


### PR DESCRIPTION
This fixes at least two situations where Waybar thinks the interface is in "linked" (no IP) state even though there is an IP address assigned:

1. When only one of the address type is deleted (For example IPv6 with `ip addr del dev wlan0 <IPv6 here>`), even though the other type (IPv4) is still available.
2. In my setup when resuming from suspend state, my interface somehow retains the IPv4 address but the IPv6 address is deleted and added again. Under default settings of `"family": "ipv4"`, the deletion event causes both addresses to be deleted but the addition event of IPv6 is ignored due to the `net->addr_pref_ == ip_addr_pref::IPV6` check being false. So the interface ends up in "linked" state even though a valid IPv4 is assigned.