### PR TITLE
fix(bar): ensure exception safety for group module allocation

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -545,9 +545,11 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
           if (group_config["modules"].isNull()) {
             spdlog::warn("Group definition '{}' has not been found, group will be hidden", ref);
           }
-          auto* group_module = new waybar::Group(id_name, class_name, group_config, vertical);
-          getModules(factory, ref, group_module);
-          module = group_module;
+          auto group_module = std::make_unique<waybar::Group>(
+          id_name, class_name, group_config, vertical);
+
+          getModules(factory, ref, group_module.get());
+          module = group_module.release();
         } else {
           module = factory.makeModule(ref, pos);
         }


### PR DESCRIPTION
Replace raw allocation of group modules with std::unique_ptr
to ensure exception safety during initialization.

If getModules throws or a module fails to initialize, the allocated
object is properly cleaned up before ownership transfer.

Tested with:
- simple group modules
- nested groups
- invalid module configurations

Verified no crashes and correct behavior.
Valgrind shows no leaks in this code path.