### PR TITLE
memory: feature - add "unit" config option

### DIFF
--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -19,9 +19,13 @@ class Memory : public ALabel {
  private:
   void parseMeminfo();
 
+  static float calc_divisor(const std::string& divisor);
+
   std::unordered_map<std::string, unsigned long> meminfo_;
 
   util::SleeperThread thread_;
+
+  std::string unit_;
 };
 
 }  // namespace waybar::modules

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -102,23 +102,29 @@ Addressed by *memory*
 	default: false ++
 	Enables this module to consume all left over space dynamically.
 
+*unit*: ++
+	typeof: string ++
+	default: GiB ++
+	Used to specify unit for total, swapTotal, used, swapUsed, avail, swapAvail,
+	and swapState. Accepts B, kB, kiB, MB, MiB, GB, GiB, TB, and TiB.
+
 # FORMAT REPLACEMENTS
 
 *{percentage}*: Percentage of memory in use.
 
 *{swapPercentage}*: Percentage of swap in use.
 
-*{total}*: Amount of total memory available in GiB.
+*{total}*: Amount of total memory available. Defaults to GiB.
 
-*{swapTotal}*: Amount of total swap available in GiB.
+*{swapTotal}*: Amount of total swap available. Defaults to GiB.
 
-*{used}*: Amount of used memory in GiB.
+*{used}*: Amount of used memory. Defaults to GiB.
 
-*{swapUsed}*: Amount of used swap in GiB.
+*{swapUsed}*: Amount of used swap. Defaults to GiB.
 
-*{avail}*: Amount of available memory in GiB.
+*{avail}*: Amount of available memory. Defaults to GiB.
 
-*{swapAvail}*: Amount of available swap in GiB.
+*{swapAvail}*: Amount of available swap. Defaults to GiB.
 
 *{swapState}*: Signals if swap is activated or not
 

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -6,6 +6,9 @@ waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config
     dp.emit();
     thread_.sleep_for(interval_);
   };
+  if (config["unit"].isString()) {
+    unit_ = config["unit"].asString();
+  }
 }
 
 auto waybar::modules::Memory::update() -> void {
@@ -13,15 +16,15 @@ auto waybar::modules::Memory::update() -> void {
 
   unsigned long memtotal = meminfo_["MemTotal"];
   unsigned long swaptotal = 0;
-  if (meminfo_.count("SwapTotal")) {
+  if (meminfo_.contains("SwapTotal")) {
     swaptotal = meminfo_["SwapTotal"];
   }
   unsigned long memfree;
   unsigned long swapfree = 0;
-  if (meminfo_.count("SwapFree")) {
+  if (meminfo_.contains("SwapFree")) {
     swapfree = meminfo_["SwapFree"];
   }
-  if (meminfo_.count("MemAvailable")) {
+  if (meminfo_.contains("MemAvailable")) {
     // New kernels (3.4+) have an accurate available memory field.
     memfree = meminfo_["MemAvailable"] + meminfo_["zfs_size"];
   } else {
@@ -31,18 +34,19 @@ auto waybar::modules::Memory::update() -> void {
   }
 
   if (memtotal > 0 && memfree >= 0) {
-    float total_ram_gigabytes =
-        0.01 * round(memtotal / 10485.76);  // 100*10485.76 = 2^20 = 1024^2 = GiB/KiB
-    float total_swap_gigabytes = 0.01 * round(swaptotal / 10485.76);
     int used_ram_percentage = 100 * (memtotal - memfree) / memtotal;
     int used_swap_percentage = 0;
-    if (swaptotal) {
+    if ((bool) swaptotal) {
       used_swap_percentage = 100 * (swaptotal - swapfree) / swaptotal;
     }
-    float used_ram_gigabytes = 0.01 * round((memtotal - memfree) / 10485.76);
-    float used_swap_gigabytes = 0.01 * round((swaptotal - swapfree) / 10485.76);
-    float available_ram_gigabytes = 0.01 * round(memfree / 10485.76);
-    float available_swap_gigabytes = 0.01 * round(swapfree / 10485.76);
+
+    float divisor = calc_divisor(unit_);
+    float total_ram = memtotal / divisor;
+    float total_swap = swaptotal / divisor;
+    float used_ram = (memtotal - memfree) / divisor;
+    float used_swap = (swaptotal - swapfree) / divisor;
+    float available_ram = memfree / divisor;
+    float available_swap = swapfree / divisor;
 
     auto format = format_;
     auto state = getState(used_ram_percentage);
@@ -58,12 +62,12 @@ auto waybar::modules::Memory::update() -> void {
       label_.set_markup(fmt::format(
           fmt::runtime(format), used_ram_percentage,
           fmt::arg("icon", getIcon(used_ram_percentage, icons)),
-          fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
+          fmt::arg("total", total_ram), fmt::arg("swapTotal", total_swap),
           fmt::arg("percentage", used_ram_percentage),
           fmt::arg("swapState", swaptotal == 0 ? "Off" : "On"),
-          fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram_gigabytes),
-          fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
-          fmt::arg("swapAvail", available_swap_gigabytes)));
+          fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram),
+          fmt::arg("swapUsed", used_swap), fmt::arg("avail", available_ram),
+          fmt::arg("swapAvail", available_swap)));
     }
 
     if (tooltipEnabled()) {
@@ -71,14 +75,14 @@ auto waybar::modules::Memory::update() -> void {
         auto tooltip_format = config_["tooltip-format"].asString();
         label_.set_tooltip_markup(fmt::format(
             fmt::runtime(tooltip_format), used_ram_percentage,
-            fmt::arg("total", total_ram_gigabytes), fmt::arg("swapTotal", total_swap_gigabytes),
+            fmt::arg("total", total_ram), fmt::arg("swapTotal", total_swap),
             fmt::arg("percentage", used_ram_percentage),
             fmt::arg("swapState", swaptotal == 0 ? "Off" : "On"),
-            fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram_gigabytes),
-            fmt::arg("swapUsed", used_swap_gigabytes), fmt::arg("avail", available_ram_gigabytes),
-            fmt::arg("swapAvail", available_swap_gigabytes)));
+            fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram),
+            fmt::arg("swapUsed", used_swap), fmt::arg("avail", available_ram),
+            fmt::arg("swapAvail", available_swap)));
       } else {
-        label_.set_tooltip_markup(fmt::format("{:.{}f}GiB used", used_ram_gigabytes, 1));
+        label_.set_tooltip_markup(fmt::format("{:.{}f}GiB used", used_ram, 1));
       }
     }
   } else {
@@ -86,4 +90,26 @@ auto waybar::modules::Memory::update() -> void {
   }
   // Call parent update
   ALabel::update();
+}
+
+float waybar::modules::Memory::calc_divisor(const std::string& divisor) {
+  if (divisor == "kB") {
+    return 1.0;
+  } else if (divisor == "kiB") {
+    return 1.024;
+  } else if (divisor == "MB") {
+    return 1.000 * 1000.0;
+  } else if (divisor == "MiB") {
+    return 1.024 * 1024.0;
+  } else if (divisor == "GB") {
+    return 1.000 * 1000.0 * 1000.0;
+  } else if (divisor == "GiB") {
+    return 1.024 * 1024.0 * 1024.0;
+  } else if (divisor == "TB") {
+    return 1.000 * 1000.0 * 1000.0 * 1000.0;
+  } else if (divisor == "TiB") {
+    return 1.024 * 1024.0 * 1024.0 * 1024.0;
+  } else {  // default to GiB if it is anything that we don't recongnise
+    return 1.024 * 1024.0 * 1024.0;
+  }
 }


### PR DESCRIPTION
This PR adds a "unit" config option to the memory module to fix issue #2572.

I also manually updated the documentation in /man.