### PR TITLE
Add max-windows option to hyprland/workspaces

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -56,6 +56,7 @@ class Workspaces : public AModule, public EventHandler {
   auto taskbarReverseDirection() const -> bool { return m_taskbarReverseDirection; }
   auto onClickWindow() const -> std::string { return m_onClickWindow; }
   auto getIgnoredWindows() const -> std::vector<std::regex> { return m_ignoreWindows; }
+  auto maxWindows() const -> int { return m_maxWindows; }
 
   enum class ActiveWindowPosition { NONE, FIRST, LAST };
   auto activeWindowPosition() const -> ActiveWindowPosition { return m_activeWindowPosition; }
@@ -89,6 +90,7 @@ class Workspaces : public AModule, public EventHandler {
   auto populateIgnoreWorkspacesConfig(const Json::Value& config) -> void;
   auto populateFormatWindowSeparatorConfig(const Json::Value& config) -> void;
   auto populateWindowRewriteConfig(const Json::Value& config) -> void;
+  auto populateMaxWindowsConfig(const Json::Value& config) -> void;
   auto populateWorkspaceTaskbarConfig(const Json::Value& config) -> void;
 
   void registerIpc();
@@ -202,6 +204,7 @@ class Workspaces : public AModule, public EventHandler {
   };
   std::string m_onClickWindow;
   std::string m_currentActiveWindowAddress;
+  int m_maxWindows = 0;
 
   std::vector<std::regex> m_ignoreWorkspaces;
   std::vector<std::regex> m_ignoreWindows;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -98,6 +98,11 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	  - {button} Pressed button number, see https://api.gtkd.org/gdk.c.types.GdkEventButton.button.html. ++
 	See https://github.com/Alexays/Waybar/wiki/Module:-Hyprland#workspace-taskbars-example for a full example.
 
+*max-windows*: ++
+	typeof: int ++
+	default: 0 (unlimited) ++
+	Maximum number of windows to show per workspace. When set, newest windows beyond the limit are not shown. Set to 0 for unlimited windows.
+
 *show-special*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -247,13 +247,14 @@ void Workspace::update(const std::string& workspace_icon) {
     auto windowSeparator = m_workspaceManager.getWindowSeparator();
 
     bool isNotFirst = false;
+    auto end_it = m_workspaceManager.maxWindows() == 0 ? m_windowMap.end() : m_windowMap.begin() + m_workspaceManager.maxWindows();
 
-    for (const auto& window_repr : m_windowMap) {
+    for (auto it = m_windowMap.begin(); it != end_it; ++it) {
       if (isNotFirst) {
         windows.append(windowSeparator);
       }
       isNotFirst = true;
-      windows.append(window_repr.repr_rewrite);
+      windows.append(it->repr_rewrite);
     }
   }
 
@@ -339,12 +340,16 @@ void Workspace::updateTaskbar(const std::string& workspace_icon) {
   };
 
   if (m_workspaceManager.taskbarReverseDirection()) {
-    for (auto it = m_windowMap.rbegin(); it != m_windowMap.rend(); ++it) {
+    auto rend_it = m_workspaceManager.maxWindows() == 0 ? m_windowMap.rend() : m_windowMap.rbegin() + m_workspaceManager.maxWindows();
+
+    for (auto it = m_windowMap.rbegin(); it != rend_it; ++it) {
       processWindow(*it);
     }
   } else {
-    for (const auto& window_repr : m_windowMap) {
-      processWindow(window_repr);
+    auto end_it = m_workspaceManager.maxWindows() == 0 ? m_windowMap.end() : m_windowMap.begin() + m_workspaceManager.maxWindows();
+
+    for (auto it = m_windowMap.begin(); it != end_it; ++it) {
+      processWindow(*it);
     }
   }
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -665,6 +665,7 @@ auto Workspaces::parseConfig(const Json::Value& config) -> void {
   populateIgnoreWorkspacesConfig(config);
   populateFormatWindowSeparatorConfig(config);
   populateWindowRewriteConfig(config);
+  populateMaxWindowsConfig(config);
 
   if (withWindows) {
     populateWorkspaceTaskbarConfig(config);
@@ -744,6 +745,15 @@ auto Workspaces::populateWindowRewriteConfig(const Json::Value& config) -> void 
   m_windowRewriteRules = util::RegexCollection(
       windowRewrite, windowRewriteDefault,
       [this](std::string& window_rule) { return windowRewritePriorityFunction(window_rule); });
+}
+
+auto Workspaces::populateMaxWindowsConfig(const Json::Value& config) -> void {
+  if (config["max-windows"].isInt()) {
+    m_maxWindows = config["max-windows"].asInt();
+    if (m_maxWindows < 0) {
+      m_maxWindows = 0;
+    }
+  }
 }
 
 auto Workspaces::populateWorkspaceTaskbarConfig(const Json::Value& config) -> void {


### PR DESCRIPTION
Implements https://github.com/Alexays/Waybar/issues/4980

## Summary
   - add `max-windows` option
   - limit the number of windows by this option in both taskbar and window-rewrite mode
   - `max-windows` oldest created windows are shown

## Configuration Examples
```jsonc
"hyprland/workspaces": {
    "format": "{windows}",
    "max-windows": 1,
    "workspace-taskbar": {
        "enable": true
    }
}
```
```jsonc
"hyprland/workspaces": {
    "format": "{windows}",
    "max-windows": 1,
    "window-rewrite": {
        "class<kitty> title<rmpc>": "󰎇"
    }
}
```