### PR TITLE
fix the io failure for hotplug-in device

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -126,11 +126,11 @@ void waybar::modules::Battery::refreshBatteries() {
           // Ignore non-system power supplies unless explicitly requested
           if (!bat_defined && fs::exists(node.path() / "scope")) {
             std::string scope;
-            try{
-              //for hotplug-in device, access it is always unstable because you may remove the device anytime
-              //so just allow failure happen and do nothing
-              std::ifstream(node.path()/"scope")>>scope;
-            }catch(const std::ifstream::failure& e){
+            try {
+              // for hotplug-in device, access it is always unstable because you may remove the
+              // device anytime so just allow failure happen and do nothing
+              std::ifstream(node.path() / "scope") >> scope;
+            } catch (const std::ifstream::failure& e) {
               scope.clear();
               continue;
             }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -126,7 +126,14 @@ void waybar::modules::Battery::refreshBatteries() {
           // Ignore non-system power supplies unless explicitly requested
           if (!bat_defined && fs::exists(node.path() / "scope")) {
             std::string scope;
-            std::ifstream(node.path() / "scope") >> scope;
+            try{
+              //for hotplug-in device, access it is always unstable because you may remove the device anytime
+              //so just allow failure happen and do nothing
+              std::ifstream(node.path()/"scope")>>scope;
+            }catch(const std::ifstream::failure& e){
+              scope.clear();
+              continue;
+            }
             if (g_ascii_strcasecmp(scope.data(), "device") == 0) {
               continue;
             }


### PR DESCRIPTION
related issue #4901. When remove the device that need power-management, Waybar would crash due to uncatch exception