### PR TITLE
Fix timeout created by most recent gtk-layer-shell release when creating bars for multiple monitors.

### DIFF
--- a/include/client.hpp
+++ b/include/client.hpp
@@ -44,6 +44,7 @@ class Client {
                            const char* interface, uint32_t version);
   static void handleGlobalRemove(void* data, struct wl_registry* registry, uint32_t name);
   static void handleOutputDone(void*, struct zxdg_output_v1*);
+  void createBarsBatch();
   static void handleOutputName(void*, struct zxdg_output_v1*, const char*);
   static void handleOutputDescription(void*, struct zxdg_output_v1*, const char*);
   void handleMonitorAdded(Glib::RefPtr<Gdk::Monitor> monitor);
@@ -58,6 +59,8 @@ class Client {
   std::string m_cssFile;
   sigc::connection monitor_added_connection_;
   sigc::connection monitor_removed_connection_;
+  std::vector<waybar_output*> pending_outputs_;
+  bool bars_scheduled_ = false;
 };
 
 }  // namespace waybar

--- a/include/client.hpp
+++ b/include/client.hpp
@@ -59,7 +59,7 @@ class Client {
   std::string m_cssFile;
   sigc::connection monitor_added_connection_;
   sigc::connection monitor_removed_connection_;
-  std::vector<waybar_output*> pending_outputs_;
+  std::list<waybar_output*> pending_outputs_;
   bool bars_scheduled_ = false;
 };
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -107,8 +107,7 @@ void waybar::Client::handleOutputDone(void* data, struct zxdg_output_v1* /*xdg_o
 }
 
 void waybar::Client::createBarsBatch() {
-  pending_outputs_.remove_if([this](auto* output) { return std::none_of(outputs_.begin(), outputs_.end(),
-    [output](const auto& o) { return &o == output; }); });
+  pending_outputs_.remove_if([this](auto* output) { return std::none_of(outputs_.begin(), outputs_.end(), [output](const auto& o) { return &o == output; }); });
   for (auto* output : pending_outputs_) {
     try {
       auto configs = getOutputConfigs(*output);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -91,16 +91,37 @@ void waybar::Client::handleOutputDone(void* data, struct zxdg_output_v1* /*xdg_o
       output.xdg_output.reset();
       spdlog::debug("Output detection done: {} ({})", output.name, output.identifier);
 
-      auto configs = client->getOutputConfigs(output);
-      if (!configs.empty()) {
-        for (const auto& config : configs) {
-          client->bars.emplace_back(std::make_unique<Bar>(&output, config));
-        }
+      client->pending_outputs_.push_back(&output);
+
+      if (!client->bars_scheduled_) {
+        client->bars_scheduled_ = true;
+      
+        Glib::signal_idle().connect_once([client]() {
+          client->createBarsBatch();
+        }, Glib::PRIORITY_HIGH_IDLE);
       }
     }
   } catch (const std::exception& e) {
     spdlog::warn("caught exception in zxdg_output_v1_listener::done: {}", e.what());
   }
+}
+
+void waybar::Client::createBarsBatch() {
+  for (auto* output : pending_outputs_) {
+    try {
+      auto configs = getOutputConfigs(*output);
+      if (!configs.empty()) {
+        for (const auto& config : configs) {
+          bars.emplace_back(std::make_unique<Bar>(output, config));
+        }
+      }
+    } catch (const std::exception& e) {
+      spdlog::warn("Error creating bar: {}", e.what());
+    }
+  }
+
+  pending_outputs_.clear();
+  bars_scheduled_ = false;
 }
 
 void waybar::Client::handleOutputName(void* data, struct zxdg_output_v1* /*xdg_output*/,

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -95,7 +95,7 @@ void waybar::Client::handleOutputDone(void* data, struct zxdg_output_v1* /*xdg_o
 
       if (!client->bars_scheduled_) {
         client->bars_scheduled_ = true;
-      
+
         Glib::signal_idle().connect_once([client]() {
           client->createBarsBatch();
         }, Glib::PRIORITY_HIGH_IDLE);
@@ -107,6 +107,8 @@ void waybar::Client::handleOutputDone(void* data, struct zxdg_output_v1* /*xdg_o
 }
 
 void waybar::Client::createBarsBatch() {
+  pending_outputs_.remove_if([this](auto* output) { return std::none_of(outputs_.begin(), outputs_.end(),
+    [output](const auto& o) { return &o == output; }); });
   for (auto* output : pending_outputs_) {
     try {
       auto configs = getOutputConfigs(*output);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -107,7 +107,7 @@ void waybar::Client::handleOutputDone(void* data, struct zxdg_output_v1* /*xdg_o
 }
 
 void waybar::Client::createBarsBatch() {
-  pending_outputs_.remove_if([this](auto* output) { return std::none_of(outputs_.begin(), outputs_.end(), [output](const auto& o) { return &o == output; }); });
+  pending_outputs_.remove_if([this](auto* output) { return std::none_of(outputs_.begin(), outputs_.end(), [&output](const auto& o) { return &o == output; }); });
   for (auto* output : pending_outputs_) {
     try {
       auto configs = getOutputConfigs(*output);


### PR DESCRIPTION
Attempts to fix https://github.com/Alexays/Waybar/issues/4978

I do not think I am great at C++, so this might be terrible, but this appears to work fine. At the very least, if this is bad, it is an example of the base steps needed to fix the problem.

This first gathers all the monitor information before creating any bars rather than creating them each individually per each .done