### PR TITLE
Add "ignore-workspaces" option to sway/workspaces module

### DIFF
--- a/include/modules/sway/workspaces.hpp
+++ b/include/modules/sway/workspaces.hpp
@@ -30,6 +30,8 @@ class Workspaces : public AModule, public sigc::trackable {
   static int convertWorkspaceNameToNum(const std::string& name);
   static int windowRewritePriorityFunction(std::string const& window_rule);
 
+  auto populateIgnoreWorkspacesConfig(const Json::Value& config) -> void;
+  bool isWorkspaceIgnored(std::string const& name);
   void onCmd(const struct Ipc::ipc_response&);
   void onEvent(const struct Ipc::ipc_response&);
   bool filterButtons();
@@ -49,6 +51,7 @@ class Workspaces : public AModule, public sigc::trackable {
   std::vector<std::string> workspaces_order_;
   Gtk::Box box_;
   std::string m_formatWindowSeparator;
+  std::vector<std::regex> m_ignoreWorkspaces;
   util::RegexCollection m_windowRewriteRules;
   util::JsonParser parser_;
   std::unordered_map<std::string, Gtk::Button> buttons_;

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -69,6 +69,7 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
     m_windowRewriteRules = waybar::util::RegexCollection(
         windowRewrite, std::move(windowRewriteDefault), windowRewritePriorityFunction);
   }
+  populateIgnoreWorkspacesConfig(config);
   ipc_.subscribe(R"(["workspace"])");
   ipc_.subscribe(R"(["window"])");
   ipc_.signal_event.connect(sigc::mem_fun(*this, &Workspaces::onEvent));
@@ -97,6 +98,36 @@ void Workspaces::onEvent(const struct Ipc::ipc_response& res) {
   }
 }
 
+auto Workspaces::populateIgnoreWorkspacesConfig(const Json::Value& config) -> void {
+  auto ignoreWorkspaces = config["ignore-workspaces"];
+  if (ignoreWorkspaces.isArray()) {
+    for (const auto& workspaceRegex : ignoreWorkspaces) {
+      if (workspaceRegex.isString()) {
+        std::string ruleString = workspaceRegex.asString();
+        try {
+          const std::regex rule{ruleString, std::regex_constants::icase};
+          m_ignoreWorkspaces.emplace_back(rule);
+        } catch (const std::regex_error& e) {
+          spdlog::error("Invalid rule {}: {}", ruleString, e.what());
+        }
+      } else {
+        spdlog::error("Not a string: '{}'", workspaceRegex);
+      }
+    }
+  }
+}
+
+bool Workspaces::isWorkspaceIgnored(std::string const& name) {
+  for (auto& rule : m_ignoreWorkspaces) {
+    if (std::regex_match(name, rule)) {
+      return true;
+      break;
+    }
+  }
+
+  return false;
+}
+
 void Workspaces::onCmd(const struct Ipc::ipc_response& res) {
   if (res.type == IPC_GET_TREE) {
     try {
@@ -118,8 +149,9 @@ void Workspaces::onCmd(const struct Ipc::ipc_response& res) {
                      });
 
         for (auto& output : outputs) {
-          std::copy(output["nodes"].begin(), output["nodes"].end(),
-                    std::back_inserter(workspaces_));
+          std::copy_if(
+              output["nodes"].begin(), output["nodes"].end(), std::back_inserter(workspaces_),
+              [&](const auto& node) { return !(isWorkspaceIgnored(node["name"].asString())); });
           std::copy(output["floating_nodes"].begin(), output["floating_nodes"].end(),
                     std::back_inserter(workspaces_));
         }


### PR DESCRIPTION
This is a very small change I needed personally. 

My use case is that I want to keep a bunch of workspaces open for my work time, and others for my free time. When working, I don't want to see (and cycle through) the free-time ones, and vice versa.

I wrote a little script to rename workspaces 1 → _1 and vice-versa. I just needed a way to hide the underscore-prefixed workspaces.

This is not great code, as the workspace stays hidden even when focused, but perhaps it will help searchers.

Have a nice day