### PR TITLE
fix(sni): use std::make_unique for Item allocation

### DIFF
--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -178,9 +178,11 @@ void Host::addRegisteredItem(const std::string& service) {
     return bus_name == item->bus_name && object_path == item->object_path;
   });
   if (it == items_.end()) {
-    items_.emplace_back(new Item(
-        bus_name, object_path, config_, bar_, [this](Item& item) { itemReady(item); },
-        [this](Item& item) { itemInvalidated(item); }, on_update_));
+    items_.emplace_back(std::make_unique<Item>(
+      bus_name, object_path, config_, bar_,
+      [this](Item& item) { itemReady(item); },
+      [this](Item& item) { itemInvalidated(item); },
+      on_update_));
   }
 }
 


### PR DESCRIPTION
Replace raw allocation of Item with std::make_unique to improve memory safety
and align with modern C++ practices.

Using std::make_unique avoids manual ownership handling and ensures exception
safety during object construction, while preserving existing behavior.
Tested:
-Built successfully with Meson/Ninja
-Ran Waybar without crashes
-Verified SNI tray items appear correctly
-Confirmed tray interaction (e.g., Bluetooth icon opens application)
-Checked with Valgrind (no leaks related to this change)
No behavior changes are expected.