### PR TITLE
fix: USR1/USR2 handling on OpenBSD

### DIFF
--- a/include/util/SafeSignal.hpp
+++ b/include/util/SafeSignal.hpp
@@ -12,11 +12,6 @@
 #include <type_traits>
 #include <utility>
 
-#ifdef __OpenBSD__
-#define SIGRTMIN SIGUSR1 - 1
-#define SIGRTMAX SIGUSR1 + 1
-#endif
-
 namespace waybar {
 
 /**

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -55,9 +55,11 @@ static void catchSignals(waybar::SafeSignal<int>& signal_handler) {
   std::signal(SIGINT, writeSignalToPipe);
   std::signal(SIGCHLD, writeSignalToPipe);
 
+#ifdef SIGRTMIN
   for (int sig = SIGRTMIN + 1; sig <= SIGRTMAX; ++sig) {
     std::signal(sig, writeSignalToPipe);
   }
+#endif
 
   while (true) {
     int signum;
@@ -119,13 +121,15 @@ void handleUserSignal(int signal, bool& reload) {
 // If this signal should restart or close the bar, this function will write
 // `true` or `false`, respectively, into `reload`.
 static void handleSignalMainThread(int signum, bool& reload) {
+#ifdef SIGRTMIN
   if (signum >= SIGRTMIN + 1 && signum <= SIGRTMAX) {
     for (auto& bar : waybar::Client::inst()->bars) {
       bar->handleSignal(signum);
     }
     return;
   }
-
+#endif
+  
   switch (signum) {
     case SIGUSR1:
       handleUserSignal(SIGUSR1, reload);

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -138,9 +138,11 @@ void waybar::modules::Custom::waitingWorker() {
 }
 
 void waybar::modules::Custom::refresh(int sig) {
+#ifdef SIGRTMIN
   if (config_["signal"].isInt() && sig == SIGRTMIN + config_["signal"].asInt()) {
     thread_.wake_up();
   }
+#endif
 }
 
 void waybar::modules::Custom::handleEvent() {

--- a/src/modules/image.cpp
+++ b/src/modules/image.cpp
@@ -46,9 +46,11 @@ void waybar::modules::Image::delayWorker() {
 }
 
 void waybar::modules::Image::refresh(int sig) {
+#ifdef SIGRTMIN
   if (config_["signal"].isInt() && sig == SIGRTMIN + config_["signal"].asInt()) {
     thread_.wake_up();
   }
+#endif
 }
 
 auto waybar::modules::Image::update() -> void {


### PR DESCRIPTION
Unfortunately one part of https://github.com/Alexays/Waybar/pull/4278 introduced a bug that breaks USR1/USR2 handling for OpenBSD by treating them the same as SIGRT*

Instead of redefining SIGRTMIN and SIGRTMAX (which do not exist on OpenBSD), I would like to propose to only include the code sections that make use of those signals when SIGRTMIN is defined.

This will also make it explicit for those maintaining the OpenBSD port, when a feature is added or modified that makes use of those signals and that accordingly may need to be disabled or worked around on OpenBSD.

Thank you in advance for considering.

Cc: @rwsalie 