### PR TITLE
feature: group - add reveal-delay config option for drawer

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -10,6 +10,8 @@
 namespace waybar {
 
 class Group : public AModule {
+ sigc::connection reveal_timeout_;
+
  public:
   Group(const std::string&, const std::string&, const Json::Value&, bool);
   ~Group() override = default;
@@ -26,6 +28,7 @@ class Group : public AModule {
   bool is_first_widget = true;
   bool is_drawer = false;
   bool click_to_reveal = false;
+  int reveal_delay = 0;
   std::string add_class_to_drawer_children;
   bool handleMouseEnter(GdkEventCrossing* const& ev) override;
   bool handleMouseLeave(GdkEventCrossing* const& ev) override;

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -63,6 +63,7 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
                                     ? drawer_config["transition-left-to-right"].asBool()
                                     : true);
     click_to_reveal = drawer_config["click-to-reveal"].asBool();
+    reveal_delay = drawer_config["reveal-delay"].asInt();
 
     const bool start_expanded =
         (drawer_config["start-expanded"].isBool() ? drawer_config["start-expanded"].asBool()
@@ -104,13 +105,27 @@ void Group::hide_group() {
 
 bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
   if (!click_to_reveal) {
-    show_group();
+    if (reveal_delay > 0) {
+      if (reveal_timeout_.connected()) {
+        reveal_timeout_.disconnect();
+      }    
+
+      reveal_timeout_ = Glib::signal_timeout().connect(
+                          [this]() { show_group(); return false; }, 
+                        reveal_delay);
+    } else {
+      show_group();
+    }
   }
   return false;
 }
 
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
   if (!click_to_reveal && e->detail != GDK_NOTIFY_INFERIOR) {
+    if (reveal_delay > 0 && reveal_timeout_.connected()) {
+      reveal_timeout_.disconnect();
+    }
+
     hide_group();
   }
   return false;


### PR DESCRIPTION
Adds "reveal-delay" option for drawer. 

## Use case  

I have a group module that combines pulseaudio and pulseaudio/slider modules:
```json
    "group/group-volume": {
        "orientation": "horizontal",
        "drawer": {
            "transition-duration": 600,
            "transition-left-to-right": true
        },
        "modules" : [
            "pulseaudio", "pulseaudio/slider"
        ]
    },
```

The slider will be revealed immediately on hover, but for example, user might have some actions bound to right/left clicking the top module (pulseaudio in this example). There is simply no time to click it. `"reveal-delay"` adds optional delay in milliseconds before revealing the back module.