### PR TITLE
waybar: expose accessible buttons for interactive modules

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <gtkmm/button.h>
 #include <glibmm/markup.h>
 #include <gtkmm/label.h>
 #include <json/json.h>
@@ -20,6 +21,7 @@ class ALabel : public AModule {
 
  protected:
   Gtk::Label label_;
+  Gtk::Button accessible_button_;
   std::string format_;
   const std::chrono::milliseconds interval_;
   bool alt_ = false;

--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -42,6 +42,8 @@ class AModule : public IModule {
   Gtk::EventBox event_box_;
 
   virtual void setCursor(Gdk::CursorType const& c);
+  void setupAccessibleButton(Gtk::Button& button);
+  bool usesAccessibleButton() const;
 
   virtual bool handleToggle(GdkEventButton* const& ev);
   virtual bool handleMouseEnter(GdkEventCrossing* const& ev);

--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -3,6 +3,7 @@
 #include <dbus-status-notifier-item.h>
 #include <giomm/dbusproxy.h>
 #include <glibmm/refptr.h>
+#include <gtkmm/button.h>
 #include <gtkmm/eventbox.h>
 #include <gtkmm/icontheme.h>
 #include <gtkmm/image.h>
@@ -39,6 +40,7 @@ class Item : public sigc::trackable {
   int icon_size;
   int effective_icon_size;
   Gtk::Image image;
+  Gtk::Button button;
   Gtk::EventBox event_box;
   std::string category;
   std::string id;
@@ -89,6 +91,7 @@ class Item : public sigc::trackable {
   double getScaledIconSize();
   static void onMenuDestroyed(Item* self, GObject* old_menu_pointer);
   void makeMenu();
+  void updateAccessibleName();
   bool handleClick(GdkEventButton* const& /*ev*/);
   bool handleScroll(GdkEventScroll* const&);
   bool handleMouseEnter(GdkEventCrossing* const&);

--- a/src/AIconLabel.cpp
+++ b/src/AIconLabel.cpp
@@ -52,7 +52,10 @@ AIconLabel::AIconLabel(const Json::Value& config, const std::string& name, const
     box_.add(image_);
   }
 
-  event_box_.add(box_);
+  auto& container =
+      usesAccessibleButton() ? static_cast<Gtk::Bin&>(accessible_button_) : static_cast<Gtk::Bin&>(event_box_);
+  container.remove();
+  container.add(box_);
 }
 
 auto AIconLabel::update() -> void {

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -34,7 +34,6 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
     label_.get_style_context()->add_class(id);
   }
   label_.get_style_context()->add_class(MODULE_CLASS);
-  event_box_.add(label_);
   if (config_["max-length"].isUInt()) {
     label_.set_max_width_chars(config_["max-length"].asInt());
     label_.set_ellipsize(Pango::EllipsizeMode::ELLIPSIZE_END);
@@ -134,6 +133,14 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
     } else if (justify_str == "center") {
       label_.set_justify(Gtk::Justification::JUSTIFY_CENTER);
     }
+  }
+
+  if (usesAccessibleButton()) {
+    setupAccessibleButton(accessible_button_);
+    accessible_button_.add(label_);
+    event_box_.add(accessible_button_);
+  } else {
+    event_box_.add(label_);
   }
 }
 

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -45,12 +45,10 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
                config[eventEntry.second].isString();
       }) != eventMap_.cend();
 
-  if (enable_click || hasUserEvents) {
-    hasUserEvents_ = true;
+  hasUserEvents_ = enable_click || hasUserEvents;
+  if (hasUserEvents_) {
     event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
     event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &AModule::handleToggle));
-  } else {
-    hasUserEvents_ = false;
   }
 
   bool hasReleaseEvent =
@@ -59,13 +57,14 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
         return eventEntry.first.second == GdkEventType::GDK_BUTTON_RELEASE &&
                config[eventEntry.second].isString();
       }) != eventMap_.cend();
+  bool hasScrollEvents = config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString() ||
+                         config_["on-scroll-left"].isString() ||
+                         config_["on-scroll-right"].isString() || enable_scroll;
   if (hasReleaseEvent) {
     event_box_.add_events(Gdk::BUTTON_RELEASE_MASK);
     event_box_.signal_button_release_event().connect(sigc::mem_fun(*this, &AModule::handleRelease));
   }
-  if (config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString() ||
-      config_["on-scroll-left"].isString() || config_["on-scroll-right"].isString() ||
-      enable_scroll) {
+  if (hasScrollEvents) {
     event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     event_box_.signal_scroll_event().connect(sigc::mem_fun(*this, &AModule::handleScroll));
   }
@@ -125,6 +124,40 @@ void AModule::setCursor(Gdk::CursorType const& c) {
         },
         1);
   }
+}
+
+void AModule::setupAccessibleButton(Gtk::Button& button) {
+  if (!usesAccessibleButton()) {
+    return;
+  }
+
+  auto eventMask = event_box_.get_events();
+  button.set_relief(Gtk::RELIEF_NONE);
+  button.set_focus_on_click(false);
+  button.get_style_context()->add_class("flat");
+
+  if (hasUserEvents_) {
+    button.add_events(Gdk::BUTTON_PRESS_MASK);
+    button.signal_button_press_event().connect(sigc::mem_fun(*this, &AModule::handleToggle), false);
+  }
+
+  if (eventMask & Gdk::BUTTON_RELEASE_MASK) {
+    button.add_events(Gdk::BUTTON_RELEASE_MASK);
+    button.signal_button_release_event().connect(sigc::mem_fun(*this, &AModule::handleRelease), false);
+  }
+
+  if (eventMask & (Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK)) {
+    button.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
+    button.signal_scroll_event().connect(sigc::mem_fun(*this, &AModule::handleScroll), false);
+  }
+}
+
+bool AModule::usesAccessibleButton() const {
+  if (hasUserEvents_) {
+    return true;
+  }
+
+  return (event_box_.get_events() & Gdk::BUTTON_RELEASE_MASK) != 0;
 }
 
 bool AModule::handleMouseEnter(GdkEventCrossing* const& e) {

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -1,7 +1,9 @@
 #include "modules/sni/item.hpp"
 
+#include <atk/atk.h>
 #include <gdkmm/general.h>
 #include <glibmm/main.h>
+#include <gtkmm/cssprovider.h>
 #include <gtkmm/tooltip.h>
 #include <spdlog/spdlog.h>
 
@@ -38,6 +40,33 @@ namespace waybar::modules::SNI {
 static const Glib::ustring SNI_INTERFACE_NAME = sn_item_interface_info()->name;
 static const unsigned UPDATE_DEBOUNCE_TIME = 10;
 
+namespace {
+Glib::RefPtr<Gtk::CssProvider> trayButtonCssProvider() {
+  static auto provider = [] {
+    auto css = Gtk::CssProvider::create();
+    css->load_from_data(R"CSS(
+.waybar-accessible-tray-button {
+  padding: 0;
+  margin: 0;
+  min-width: 0;
+  min-height: 0;
+  border-width: 0;
+  border-style: none;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.waybar-accessible-tray-button > image {
+  padding: 0;
+  margin: 0;
+}
+)CSS");
+    return css;
+  }();
+  return provider;
+}
+}  // namespace
+
 Item::Item(const std::string& bn, const std::string& op, const Json::Value& config, const Bar& bar,
            const std::function<void(Item&)>& on_ready,
            const std::function<void(Item&)>& on_invalidate, const std::function<void()>& on_updated)
@@ -62,12 +91,22 @@ Item::Item(const std::string& bn, const std::string& op, const Json::Value& conf
 
   auto& window = const_cast<Bar&>(bar).window;
   window.signal_configure_event().connect_notify(sigc::mem_fun(*this, &Item::onConfigure));
-  event_box.add(image);
-  event_box.add_events(Gdk::BUTTON_PRESS_MASK | Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
-  event_box.signal_button_press_event().connect(sigc::mem_fun(*this, &Item::handleClick));
-  event_box.signal_scroll_event().connect(sigc::mem_fun(*this, &Item::handleScroll));
-  event_box.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Item::handleMouseEnter));
-  event_box.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Item::handleMouseLeave));
+  button.set_relief(Gtk::RELIEF_NONE);
+  button.set_border_width(0);
+  button.set_focus_on_click(false);
+  button.set_can_focus(false);
+  button.get_style_context()->add_class("flat");
+  button.get_style_context()->add_class("waybar-accessible-tray-button");
+  button.get_style_context()->add_provider(trayButtonCssProvider(),
+                                           GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  button.add(image);
+  event_box.add(button);
+  button.add_events(Gdk::BUTTON_PRESS_MASK | Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK |
+                    Gdk::ENTER_NOTIFY_MASK | Gdk::LEAVE_NOTIFY_MASK);
+  button.signal_button_press_event().connect(sigc::mem_fun(*this, &Item::handleClick));
+  button.signal_scroll_event().connect(sigc::mem_fun(*this, &Item::handleScroll));
+  button.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Item::handleMouseEnter));
+  button.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Item::handleMouseLeave));
   // initial visibility
   event_box.show_all();
   event_box.set_visible(show_passive_);
@@ -182,11 +221,10 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       } else {
         setCustomIcon(id);
       }
+      updateAccessibleName();
     } else if (name == "Title") {
       title = get_variant<std::string>(value);
-      if (tooltip.text.empty()) {
-        event_box.set_tooltip_markup(title);
-      }
+      updateAccessibleName();
     } else if (name == "Status") {
       setStatus(get_variant<Glib::ustring>(value));
     } else if (name == "IconName") {
@@ -205,9 +243,7 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       attention_movie_name = get_variant<std::string>(value);
     } else if (name == "ToolTip") {
       tooltip = get_variant<ToolTip>(value);
-      if (!tooltip.text.empty()) {
-        event_box.set_tooltip_markup(tooltip.text);
-      }
+      updateAccessibleName();
     } else if (name == "IconThemePath") {
       icon_theme_path = get_variant<std::string>(value);
       if (!icon_theme_path.empty()) {
@@ -258,6 +294,29 @@ void Item::invalidate() {
     ready_ = false;
   }
   on_invalidate_(*this);
+}
+
+void Item::updateAccessibleName() {
+  if (!tooltip.text.empty()) {
+    button.set_tooltip_markup(tooltip.text);
+  } else if (!title.empty()) {
+    button.set_tooltip_markup(title);
+  }
+
+  std::string accessible_name;
+  if (!title.empty()) {
+    accessible_name = title;
+  } else if (!id.empty()) {
+    accessible_name = id;
+  } else if (!tooltip.text.empty()) {
+    accessible_name = tooltip.text.raw();
+  } else {
+    accessible_name = bus_name;
+  }
+
+  if (auto* accessible = gtk_widget_get_accessible(GTK_WIDGET(button.gobj())); accessible != nullptr) {
+    atk_object_set_name(accessible, accessible_name.c_str());
+  }
 }
 
 void Item::setCustomIcon(const std::string& id) {


### PR DESCRIPTION
Expose clickable label modules and tray items as accessible buttons instead of generic containers.

This adds the accessibility metadata and action wiring needed for a11y AT-SPI to recognize interactive Waybar elements consistently.