### PR TITLE
[RFC]Refactor: remove some action that passing `this` ptr as callback param in constructor

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -19,7 +19,7 @@ class AModule : public IModule {
   virtual auto refresh(int shouldRefresh) -> void {};
   operator Gtk::Widget&() override;
   auto doAction(const std::string& name) -> void override;
-
+  void init();
   /// Emitting on this dispatcher triggers a update() call
   Glib::Dispatcher dp;
 
@@ -37,12 +37,14 @@ class AModule : public IModule {
   bool tooltipEnabled() const;
 
   std::vector<int> pid_children_;
+  bool enable_scroll_;
+  bool enable_click_;
   const std::string name_;
   const Json::Value& config_;
   Gtk::EventBox event_box_;
 
   virtual void setCursor(Gdk::CursorType const& c);
-
+  virtual void do_init() {};  // implemented by derived class if needed
   virtual bool handleToggle(GdkEventButton* const& ev);
   virtual bool handleMouseEnter(GdkEventCrossing* const& ev);
   virtual bool handleMouseLeave(GdkEventCrossing* const& ev);

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -67,6 +67,9 @@ class Workspaces : public AModule, public EventHandler {
   bool windowRewriteConfigUsesTitle() const { return m_anyWindowRewriteRuleUsesTitle; }
   const IconLoader& iconLoader() const { return m_iconLoader; }
 
+ protected:
+  void do_init() override;
+
  private:
   void onEvent(const std::string& e) override;
   void updateWindowCount();

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -12,21 +12,40 @@ namespace waybar {
 
 AModule::AModule(const Json::Value& config, const std::string& name, const std::string& id,
                  bool enable_click, bool enable_scroll)
-    : name_(name),
+    : enable_scroll_(enable_scroll),
+      enable_click_(enable_click),
+      name_(name),
       config_(config),
       isTooltip{config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true},
       isExpand{config_["expand"].isBool() ? config_["expand"].asBool() : false},
       distance_scrolled_y_(0.0),
-      distance_scrolled_x_(0.0) {
+      distance_scrolled_x_(0.0) {}
+
+AModule::~AModule() {
+  for (const auto& pid : pid_children_) {
+    if (pid != -1) {
+      killpg(pid, SIGTERM);
+    }
+  }
+  if (menu_ != nullptr) {
+    g_object_unref(menu_);
+    menu_ = nullptr;
+  }
+}
+
+void AModule::init() {
+  // here are the point where obj is fully constructed
+  // we can do sth like connect signal that requires well constructed object
+  do_init();
   // Configure module action Map
   const Json::Value actions{config_["actions"]};
-
+  const auto& config = config_;
   for (Json::Value::const_iterator it = actions.begin(); it != actions.end(); ++it) {
     if (it.key().isString() && it->isString())
       if (!eventActionMap_.contains(it.key().asString())) {
         eventActionMap_.insert({it.key().asString(), it->asString()});
-        enable_click = true;
-        enable_scroll = true;
+        enable_click_ = true;
+        enable_scroll_ = true;
       } else
         spdlog::warn("Duplicate action is ignored: {0}", it.key().asString());
     else
@@ -45,7 +64,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
                config[eventEntry.second].isString();
       }) != eventMap_.cend();
 
-  if (enable_click || hasUserEvents) {
+  if (enable_click_ || hasUserEvents) {
     hasUserEvents_ = true;
     event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
     event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &AModule::handleToggle));
@@ -65,7 +84,7 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
   }
   if (config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString() ||
       config_["on-scroll-left"].isString() || config_["on-scroll-right"].isString() ||
-      enable_scroll) {
+      enable_scroll_) {
     event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     event_box_.signal_scroll_event().connect(sigc::mem_fun(*this, &AModule::handleScroll));
   }
@@ -79,18 +98,6 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
     } else {
       spdlog::warn("unknown cursor option configured on module {}", name_);
     }
-  }
-}
-
-AModule::~AModule() {
-  for (const auto& pid : pid_children_) {
-    if (pid != -1) {
-      killpg(pid, SIGTERM);
-    }
-  }
-  if (menu_ != nullptr) {
-    g_object_unref(menu_);
-    menu_ = nullptr;
   }
 }
 

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -552,6 +552,7 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
           module = group_module.release();
         } else {
           module = factory.makeModule(ref, pos);
+          module->init();
         }
 
         std::shared_ptr<AModule> module_sp(module);

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -27,10 +27,6 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
   }
   m_box.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(m_box);
-
-  setCurrentMonitorId();
-  init();
-  registerIpc();
 }
 
 Workspaces::~Workspaces() {
@@ -40,6 +36,12 @@ Workspaces::~Workspaces() {
   m_ipc.unregisterForIPC(this);
   // wait for possible event handler to finish
   std::lock_guard<std::mutex> lg(m_mutex);
+}
+
+void Workspaces::do_init() {
+  setCurrentMonitorId();
+  init();
+  registerIpc();
 }
 
 void Workspaces::init() {


### PR DESCRIPTION
Related issue #4995 , It's been danger to pass `this` as a callback ptr or do something that may throw error in constructor. its recommend to call `init()` after construct. so i declare two func in `Class AModule` `void init()` to register callback pass `this` to framework,  `virtual void do_init()` derived class can implement it and put error-throw action here rather than in constructor.And `init()` would be call after `factory.MakeModule()`, inside `init()` then it call `do_init()`
```
    module = factory.makeModule(ref, pos);
    module->init();
```
```
void AModule::init() {
  // here are the point where obj is fully constructed
  // we can do sth like connect signal that requires well constructed object
  do_init();
  .....
```
It is noticed that i only modify the `hyprland/workspaces` and `AModule` consider that overhaul every module is danger and i wasnt pretty sure if the community appreciate this refactor. So i need some advice about it. If it work, i can refactor the rest of them

And i have no idea if it need some test code, and idk how to test the situation like this, so yes, please let me know if u have better idea!