### PR TITLE
feat(language): add tooltip support with configurable tooltip-format

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -58,6 +58,25 @@ auto Language::update() -> void {
     label_.hide();
   }
 
+  // Tooltip support
+  if (tooltipEnabled()) {
+    std::string tooltipFormat;
+    if (config_["tooltip-format"].isString()) {
+      tooltipFormat = config_["tooltip-format"].asString();
+    } else {
+      tooltipFormat = "{long}";
+    }
+    auto tooltipText = trim(fmt::format(
+        fmt::runtime(tooltipFormat),
+        fmt::arg("long", layout_.full_name),
+        fmt::arg("short", layout_.short_name),
+        fmt::arg("shortDescription", layout_.short_description),
+        fmt::arg("variant", layout_.variant)));
+    label_.set_tooltip_text(tooltipText);
+  } else {
+    label_.set_tooltip_text("");
+  }
+
   ALabel::update();
 }
 


### PR DESCRIPTION
## Description

Adds tooltip support to the hyprland/language module. When `tooltip` is enabled (default), the tooltip displays the keyboard layout information using `tooltip-format` config option, with the same format replacements as the `format` option.

## Config Example

```jsonc
"hyprland/language": {
    "format": "{short}",
    "tooltip": true,
    "tooltip-format": "Layout: {long}"
}
```

When `tooltip-format` is not specified, it defaults to `{long}` (the full layout name).

Available format replacements:
- `{long}` — Full layout description (e.g., "English (US, intl., with dead keys)")
- `{short}` — Short layout name (e.g., "us")
- `{shortDescription}` — Brief layout description (e.g., "en")
- `{variant}` — Layout variant (e.g., "intl")

## Changes

- `src/modules/hyprland/language.cpp` — Added tooltip text setting using `label_.set_tooltip_text()` with configurable `tooltip-format`
- `include/modules/hyprland/language.hpp` — No changes needed (Layout struct already has all fields)

Closes #3693