### PR TITLE
fix(hyprland/workspaces): adapt dispatch commands for Lua IPC protocol

### DIFF
--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <list>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <thread>
 #include <utility>
@@ -35,12 +36,25 @@ class IPC {
   Json::Value getSocket1JsonReply(const std::string& rq);
   static std::filesystem::path getSocketFolder(const char* instanceSig);
 
+  /// Dispatch a Hyprland command. Automatically uses the correct protocol
+  /// (legacy text or Lua-based) depending on the running Hyprland version.
+  static std::string dispatch(const std::string& dispatcher, const std::string& arg);
+
  protected:
   static std::filesystem::path socketFolder_;
 
  private:
   void socketListener();
   void parseIPC(const std::string&);
+
+  /// Detect whether the running Hyprland uses the Lua-based IPC protocol.
+  /// Returns true for Hyprland >= 0.54 (Lua config), false for older versions.
+  static bool isLuaProtocol();
+
+  /// Build a Lua-format dispatch command string.
+  static std::string buildLuaDispatch(const std::string& dispatcher, const std::string& arg);
+
+  static std::optional<bool> s_luaProtocolDetected_;  // cached detection result
 
   std::thread ipcThread_;
   std::mutex callbackMutex_;

--- a/include/modules/hyprland/backend.hpp
+++ b/include/modules/hyprland/backend.hpp
@@ -40,21 +40,21 @@ class IPC {
   /// (legacy text or Lua-based) depending on the running Hyprland version.
   static std::string dispatch(const std::string& dispatcher, const std::string& arg);
 
+  /// Build a Lua-format dispatch command string.
+  static std::string buildLuaDispatch(const std::string& dispatcher, const std::string& arg);
+
  protected:
   static std::filesystem::path socketFolder_;
-
- private:
-  void socketListener();
-  void parseIPC(const std::string&);
 
   /// Detect whether the running Hyprland uses the Lua-based IPC protocol.
   /// Returns true for Hyprland >= 0.54 (Lua config), false for older versions.
   static bool isLuaProtocol();
 
-  /// Build a Lua-format dispatch command string.
-  static std::string buildLuaDispatch(const std::string& dispatcher, const std::string& arg);
-
   static std::optional<bool> s_luaProtocolDetected_;  // cached detection result
+
+ private:
+  void socketListener();
+  void parseIPC(const std::string&);
 
   std::thread ipcThread_;
   std::mutex callbackMutex_;

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -13,6 +13,7 @@
 #include <cerrno>
 #include <cstring>
 #include <filesystem>
+#include <optional>
 #include <string>
 
 #include "util/scoped_fd.hpp"
@@ -20,6 +21,7 @@
 namespace waybar::modules::hyprland {
 
 std::filesystem::path IPC::socketFolder_;
+std::optional<bool> IPC::s_luaProtocolDetected_;
 
 std::filesystem::path IPC::getSocketFolder(const char* instanceSig) {
   static std::mutex folderMutex;
@@ -288,6 +290,71 @@ Json::Value IPC::getSocket1JsonReply(const std::string& rq) {
   }
 
   return parser_.parse(reply);
+}
+
+bool IPC::isLuaProtocol() {
+  if (s_luaProtocolDetected_.has_value()) {
+    return *s_luaProtocolDetected_;
+  }
+
+  // Probe: send a harmless old-style dispatch and check the error.
+  // In Lua-based Hyprland (>= 0.54) the error contains "hl.dispatch".
+  // In older versions it returns "ok" or a different error.
+  auto reply = getSocket1Reply("dispatch workspace __waybar_probe__");
+  bool luaProto = reply.find("hl.dispatch") != std::string::npos;
+
+  if (luaProto) {
+    spdlog::info("Hyprland IPC: detected Lua-based dispatch protocol (Hyprland >= 0.54)");
+  } else {
+    spdlog::info("Hyprland IPC: detected legacy dispatch protocol");
+  }
+
+  s_luaProtocolDetected_ = luaProto;
+  return luaProto;
+}
+
+std::string IPC::buildLuaDispatch(const std::string& dispatcher, const std::string& arg) {
+  // Map old-style dispatchers to the new Lua hl.dsp API.
+  //
+  // Old format:  dispatch workspace 1
+  // New format:  /dispatch hl.dsp.focus({ workspace = "1" })
+  //
+  // Old format:  dispatch focusworkspaceoncurrentmonitor 2
+  // New format:  /dispatch hl.dsp.focus({ workspace = "2", monitor = "current" })
+  //
+  // Old format:  dispatch togglespecialworkspace name
+  // New format:  /dispatch hl.dsp.workspace.toggle_special("name")
+
+  if (dispatcher == "workspace") {
+    return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\" })";
+  }
+  if (dispatcher == "focusworkspaceoncurrentmonitor") {
+    return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\", monitor = \"current\" })";
+  }
+  if (dispatcher == "togglespecialworkspace") {
+    if (arg.empty()) {
+      return "/dispatch hl.dsp.workspace.toggle_special()";
+    }
+    return "/dispatch hl.dsp.workspace.toggle_special(\"" + arg + "\")";
+  }
+
+  // Fallback for any other dispatcher: try the old format wrapped in dispatch().
+  // This may not work for all dispatchers, but it's a reasonable default.
+  spdlog::warn("Hyprland IPC: unknown dispatcher '{}' in Lua mode, attempting generic format",
+               dispatcher);
+  return "/dispatch hl.dsp." + dispatcher + "(\"" + arg + "\")";
+}
+
+std::string IPC::dispatch(const std::string& dispatcher, const std::string& arg) {
+  if (isLuaProtocol()) {
+    return getSocket1Reply(buildLuaDispatch(dispatcher, arg));
+  }
+  // Legacy format: "dispatch <dispatcher> <arg>"
+  std::string cmd = "dispatch " + dispatcher;
+  if (!arg.empty()) {
+    cmd += " " + arg;
+  }
+  return getSocket1Reply(cmd);
 }
 
 }  // namespace waybar::modules::hyprland

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -71,20 +71,20 @@ bool Workspace::handleClicked(GdkEventButton* bt) const {
     try {
       if (id() > 0) {  // normal
         if (m_workspaceManager.moveToMonitor()) {
-          m_ipc.getSocket1Reply("dispatch focusworkspaceoncurrentmonitor " + std::to_string(id()));
+          IPC::dispatch("focusworkspaceoncurrentmonitor", std::to_string(id()));
         } else {
-          m_ipc.getSocket1Reply("dispatch workspace " + std::to_string(id()));
+          IPC::dispatch("workspace", std::to_string(id()));
         }
       } else if (!isSpecial()) {  // named (this includes persistent)
         if (m_workspaceManager.moveToMonitor()) {
-          m_ipc.getSocket1Reply("dispatch focusworkspaceoncurrentmonitor name:" + name());
+          IPC::dispatch("focusworkspaceoncurrentmonitor", "name:" + name());
         } else {
-          m_ipc.getSocket1Reply("dispatch workspace name:" + name());
+          IPC::dispatch("workspace", "name:" + name());
         }
       } else if (id() != -99) {  // named special
-        m_ipc.getSocket1Reply("dispatch togglespecialworkspace " + name());
+        IPC::dispatch("togglespecialworkspace", name());
       } else {  // special
-        m_ipc.getSocket1Reply("dispatch togglespecialworkspace");
+        IPC::dispatch("togglespecialworkspace", "");
       }
       return true;
     } catch (const std::exception& e) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1195,15 +1195,15 @@ bool Workspaces::handleScroll(GdkEventScroll* e) {
 
   if (dir == SCROLL_DIR::DOWN || dir == SCROLL_DIR::RIGHT) {
     if (allOutputs()) {
-      m_ipc.getSocket1Reply("dispatch workspace e+1");
+      IPC::dispatch("workspace", "e+1");
     } else {
-      m_ipc.getSocket1Reply("dispatch workspace m+1");
+      IPC::dispatch("workspace", "m+1");
     }
   } else if (dir == SCROLL_DIR::UP || dir == SCROLL_DIR::LEFT) {
     if (allOutputs()) {
-      m_ipc.getSocket1Reply("dispatch workspace e-1");
+      IPC::dispatch("workspace", "e-1");
     } else {
-      m_ipc.getSocket1Reply("dispatch workspace m-1");
+      IPC::dispatch("workspace", "m-1");
     }
   }
 

--- a/test/hyprland/backend.cpp
+++ b/test/hyprland/backend.cpp
@@ -15,6 +15,10 @@ namespace {
 class IPCTestHelper : public hyprland::IPC {
  public:
   static void resetSocketFolder() { socketFolder_.clear(); }
+  static void resetLuaProtocolDetection() { s_luaProtocolDetected_.reset(); }
+  static void setLuaProtocolDetected(bool value) { s_luaProtocolDetected_ = value; }
+  using hyprland::IPC::buildLuaDispatch;
+  using hyprland::IPC::isLuaProtocol;
 };
 
 std::size_t countOpenFds() {
@@ -133,3 +137,78 @@ TEST_CASE("getSocket1Reply failure paths do not leak fds", "[getSocket1Reply][fd
   REQUIRE(after_connect_failures == baseline);
 }
 #endif
+
+// --- Tests for new Lua IPC dispatch functions ---
+
+TEST_CASE("buildLuaDispatch workspace", "[buildLuaDispatch]") {
+  SECTION("numeric workspace") {
+    auto result = IPCTestHelper::buildLuaDispatch("workspace", "1");
+    REQUIRE(result == "/dispatch hl.dsp.focus({ workspace = \"1\" })");
+  }
+  SECTION("named workspace") {
+    auto result = IPCTestHelper::buildLuaDispatch("workspace", "name:term");
+    REQUIRE(result == "/dispatch hl.dsp.focus({ workspace = \"name:term\" })");
+  }
+  SECTION("relative workspace") {
+    auto result = IPCTestHelper::buildLuaDispatch("workspace", "e+1");
+    REQUIRE(result == "/dispatch hl.dsp.focus({ workspace = \"e+1\" })");
+  }
+}
+
+TEST_CASE("buildLuaDispatch focusworkspaceoncurrentmonitor", "[buildLuaDispatch]") {
+  auto result =
+      IPCTestHelper::buildLuaDispatch("focusworkspaceoncurrentmonitor", "3");
+  REQUIRE(
+      result ==
+      "/dispatch hl.dsp.focus({ workspace = \"3\", monitor = \"current\" })");
+}
+
+TEST_CASE("buildLuaDispatch togglespecialworkspace", "[buildLuaDispatch]") {
+  SECTION("with name") {
+    auto result =
+        IPCTestHelper::buildLuaDispatch("togglespecialworkspace", "scratchpad");
+    REQUIRE(result ==
+            "/dispatch hl.dsp.workspace.toggle_special(\"scratchpad\")");
+  }
+  SECTION("empty arg") {
+    auto result =
+        IPCTestHelper::buildLuaDispatch("togglespecialworkspace", "");
+    REQUIRE(result == "/dispatch hl.dsp.workspace.toggle_special()");
+  }
+}
+
+TEST_CASE("buildLuaDispatch unknown dispatcher fallback", "[buildLuaDispatch]") {
+  auto result =
+      IPCTestHelper::buildLuaDispatch("unknown_dispatcher", "some_arg");
+  REQUIRE(result ==
+          "/dispatch hl.dsp.unknown_dispatcher(\"some_arg\")");
+}
+
+TEST_CASE("dispatch throws when Hyprland is not running", "[dispatch]") {
+  unsetenv("HYPRLAND_INSTANCE_SIGNATURE");
+  IPCTestHelper::resetSocketFolder();
+  IPCTestHelper::resetLuaProtocolDetection();
+
+  CHECK_THROWS(hyprland::IPC::dispatch("workspace", "1"));
+}
+
+TEST_CASE("isLuaProtocol uses cached value and avoids socket call",
+          "[isLuaProtocol]") {
+  unsetenv("HYPRLAND_INSTANCE_SIGNATURE");
+  IPCTestHelper::resetSocketFolder();
+
+  SECTION("cached false") {
+    IPCTestHelper::setLuaProtocolDetected(false);
+    // Should return false without throwing (no socket call needed)
+    REQUIRE(IPCTestHelper::isLuaProtocol() == false);
+  }
+
+  SECTION("cached true") {
+    IPCTestHelper::setLuaProtocolDetected(true);
+    // Should return true without throwing (no socket call needed)
+    REQUIRE(IPCTestHelper::isLuaProtocol() == true);
+  }
+
+  // Cleanup: reset detection so other tests aren't affected
+  IPCTestHelper::resetLuaProtocolDetection();
+}


### PR DESCRIPTION
Hyprland 0.54 replaced the text-based dispatch socket protocol with a Lua-based one. Commands like "dispatch workspace 1" are now interpreted as invalid Lua (return hl.dispatch(workspace 1)), breaking workspace clicks and scroll navigation.

Add IPC::dispatch() that probes the running Hyprland on first call and routes commands through the new hl.dsp Lua API when the Lua protocol is detected, falling back to the old text format otherwise.

**Affected dispatchers:** `workspace`, `focusworkspaceoncurrentmonitor`, `togglespecialworkspace`  