### PR TITLE
feat: add compact versions of bandwidthBytes to network module

### DIFF
--- a/include/util/format.hpp
+++ b/include/util/format.hpp
@@ -5,12 +5,13 @@
 
 class pow_format {
  public:
-  pow_format(long long val, std::string&& unit, bool binary = false)
-      : val_(val), unit_(unit), binary_(binary) {};
+  pow_format(long long val, std::string&& unit, bool binary = false, int min_pow_for_decimal = 0)
+      : val_(val), unit_(unit), binary_(binary), min_pow_for_decimal_(min_pow_for_decimal) {};
 
   long long val_;
   std::string unit_;
   bool binary_;
+  int min_pow_for_decimal_;
 };
 
 namespace fmt {
@@ -74,7 +75,8 @@ struct formatter<pow_format> {
         break;
       case 0:
       default:
-        format = "{coefficient:.1f}{prefix}{unit}";
+        format = pow < s.min_pow_for_decimal_ ? "{coefficient:.0f}{prefix}{unit}"
+                                              : "{coefficient:.1f}{prefix}{unit}";
         break;
     }
     return fmt::format_to(

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -368,6 +368,10 @@ auto waybar::modules::Network::update() -> void {
                pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "o/s")),
       fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / elapsed_seconds, "B/s")),
       fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / elapsed_seconds, "B/s")),
+      fmt::arg("bandwidthDownBytesCompact",
+               pow_format(bandwidth_down / elapsed_seconds, "B", false, 2)),
+      fmt::arg("bandwidthUpBytesCompact",
+               pow_format(bandwidth_up / elapsed_seconds, "B", false, 2)),
       fmt::arg("bandwidthTotalBytes",
                pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "B/s")));
   if (text.compare(label_.get_label()) != 0) {
@@ -401,6 +405,10 @@ auto waybar::modules::Network::update() -> void {
                    pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "o/s")),
           fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / elapsed_seconds, "B/s")),
           fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / elapsed_seconds, "B/s")),
+          fmt::arg("bandwidthDownBytesCompact",
+                   pow_format(bandwidth_down / elapsed_seconds, "B", false, 2)),
+          fmt::arg("bandwidthUpBytesCompact",
+                   pow_format(bandwidth_up / elapsed_seconds, "B", false, 2)),
           fmt::arg("bandwidthTotalBytes",
                    pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "B/s")));
       if (label_.get_tooltip_text() != tooltip_text) {


### PR DESCRIPTION
Adds the following:
- bandwidthDownBytesCompact
- bandwidthUpBytesCompact

Differences from normal version:
- drop the "/s" suffix
- drop the decimal part if less than 1MB/s

is there a better to add this change other than introducing a new format argument ? 
should this be added for other bandwidth-related format arguments ? 