### PR TITLE
River/tags: Add static CSS classes for all available tags.

### DIFF
--- a/man/waybar-river-tags.5.scd
+++ b/man/waybar-river-tags.5.scd
@@ -50,6 +50,7 @@ Addressed by *river/tags*
 - *#tags button.occupied*
 - *#tags button.focused*
 - *#tags button.urgent*
+- *#tags button.tag-N*
 
 Note that occupied/focused/urgent status may overlap. That is, a tag may be
 both occupied and focused at the same time.

--- a/src/modules/river/tags.cpp
+++ b/src/modules/river/tags.cpp
@@ -149,6 +149,7 @@ Tags::Tags(const std::string& id, const waybar::Bar& bar, const Json::Value& con
         button.signal_button_press_event().connect(
             sigc::bind(sigc::mem_fun(*this, &Tags::handle_button_press), (1 << tag)));
     }
+    button.get_style_context()->add_class("tag-" + std::to_string(tag + 1));
     button.show();
   }
 


### PR DESCRIPTION
The current implementation of river/tags does not make it possible to set all tags to static colors based on their absolute index if hide-vacant is set to true, as the only way to do that is through :nth-child selectors, which don't take into consideration the hidden vacant tags.

This PR adds static CSS classes `.tag-N`, N ranging from `1` to `num-tags`, to the river/tags module that allow all tags to be referred to by their absolute river index.