### PR TITLE
Handle menu creation error by nullifying menu_

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -121,6 +121,7 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
       }
       g_object_unref(builder);
     } catch (std::runtime_error& e) {
+      menu_ = nullptr;
       spdlog::warn("Error while creating the menu : {}. Menu popup not activated.", e.what());
     }
   }


### PR DESCRIPTION
Set menu_ to nullptr on error during menu creation.

`menu_` is a member of `AModule` that is not defined in the `AModule` ctor. The ctor of `ALabel` is the only place where this variable is set. If the definition of the menu crash (for example I have no file for the menu), this variable will be unset and used as is in `AModule`. It leads to a segfault crash for me.

I set the variable to `nullptr` if the function failed.


```
Thread 1 "waybar" received signal SIGSEGV, Segmentation fault.
0x00007ffff735b34e in gtk_widget_show_all (widget=0xb) at ../gtk/gtk/gtkwidget.c:5022
5022	  g_return_if_fail (GTK_IS_WIDGET (widget));
(gdb) bt
#0  0x00007ffff735b34e in gtk_widget_show_all (widget=0xb) at ../gtk/gtk/gtkwidget.c:5022
#1  0x00005555555c9411 in waybar::AModule::handleUserEvent (this=0x555555852060, 
    e=@0x7fffffffcb18: 0x555555de9570) at ../src/AModule.cpp:173
#2  0x00005555555d14c5 in waybar::modules::Custom::handleToggle (this=0x555555852060, 
    e=<optimized out>) at ../src/modules/custom.cpp:157
```