### PR TITLE
fix(hyprland/workspaces): move-to-monitor option breaking workspace buttons

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -128,7 +128,6 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	default: false ++
 	If set to true, open the workspace on the current monitor when clicking on a workspace button.
 	Otherwise, the workspace will open on the monitor where it was previously assigned.
-	Analog to using `focusworkspaceoncurrentmonitor` dispatcher instead of `workspace` in Hyprland.
 
 *enable-bar-scroll*: ++
 	typeof: bool ++

--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -320,7 +320,7 @@ std::string IPC::buildLuaDispatch(const std::string& dispatcher, const std::stri
   // New format:  /dispatch hl.dsp.focus({ workspace = "1" })
   //
   // Old format:  dispatch focusworkspaceoncurrentmonitor 2
-  // New format:  /dispatch hl.dsp.focus({ workspace = "2", monitor = "current" })
+  // New format:  /dispatch hl.dsp.focus({ workspace = "2", on_current_monitor = true })
   //
   // Old format:  dispatch togglespecialworkspace name
   // New format:  /dispatch hl.dsp.workspace.toggle_special("name")
@@ -329,7 +329,7 @@ std::string IPC::buildLuaDispatch(const std::string& dispatcher, const std::stri
     return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\" })";
   }
   if (dispatcher == "focusworkspaceoncurrentmonitor") {
-    return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\", monitor = \"current\" })";
+    return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\", on_current_monitor = true })";
   }
   if (dispatcher == "togglespecialworkspace") {
     if (arg.empty()) {

--- a/test/hyprland/backend.cpp
+++ b/test/hyprland/backend.cpp
@@ -160,7 +160,7 @@ TEST_CASE("buildLuaDispatch focusworkspaceoncurrentmonitor", "[buildLuaDispatch]
       IPCTestHelper::buildLuaDispatch("focusworkspaceoncurrentmonitor", "3");
   REQUIRE(
       result ==
-      "/dispatch hl.dsp.focus({ workspace = \"3\", monitor = \"current\" })");
+      "/dispatch hl.dsp.focus({ workspace = \"3\", on_current_monitor = true })");
 }
 
 TEST_CASE("buildLuaDispatch togglespecialworkspace", "[buildLuaDispatch]") {


### PR DESCRIPTION
the dispatcher called when move-to-monitor is true was failing because of the `monitor = "current"` parameter