### PR TITLE
feat: support Pango markup in remaining tooltips

### DIFF
--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -292,7 +292,7 @@ auto SystemdFailedUnits::update() -> void {
           fmt::arg("user_state", user_state_), fmt::arg("overall_state", overall_state_),
           fmt::arg("failed_units_list", failed_list)));
     } else {
-      label_.set_tooltip_text("");
+      label_.set_tooltip_markup("");
     }
   }
   ALabel::update();


### PR DESCRIPTION
This PR replaces remaining set_tooltip_text usages with set_tooltip_markup for more consistent Pango markup support across modules.