### PR TITLE
fix(hyprland/workspaces): fix IPC call when using move-to-monitor

### DIFF
--- a/src/modules/hyprland/backend.cpp
+++ b/src/modules/hyprland/backend.cpp
@@ -320,7 +320,7 @@ std::string IPC::buildLuaDispatch(const std::string& dispatcher, const std::stri
   // New format:  /dispatch hl.dsp.focus({ workspace = "1" })
   //
   // Old format:  dispatch focusworkspaceoncurrentmonitor 2
-  // New format:  /dispatch hl.dsp.focus({ workspace = "2", monitor = "current" })
+  // New format:  /dispatch hl.dsp.focus({ workspace = "2", on_current_monitor = true })
   //
   // Old format:  dispatch togglespecialworkspace name
   // New format:  /dispatch hl.dsp.workspace.toggle_special("name")
@@ -329,7 +329,7 @@ std::string IPC::buildLuaDispatch(const std::string& dispatcher, const std::stri
     return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\" })";
   }
   if (dispatcher == "focusworkspaceoncurrentmonitor") {
-    return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\", monitor = \"current\" })";
+    return "/dispatch hl.dsp.focus({ workspace = \"" + arg + "\", on_current_monitor = true })";
   }
   if (dispatcher == "togglespecialworkspace") {
     if (arg.empty()) {

--- a/test/hyprland/backend.cpp
+++ b/test/hyprland/backend.cpp
@@ -160,7 +160,7 @@ TEST_CASE("buildLuaDispatch focusworkspaceoncurrentmonitor", "[buildLuaDispatch]
       IPCTestHelper::buildLuaDispatch("focusworkspaceoncurrentmonitor", "3");
   REQUIRE(
       result ==
-      "/dispatch hl.dsp.focus({ workspace = \"3\", monitor = \"current\" })");
+      "/dispatch hl.dsp.focus({ workspace = \"3\", on_current_monitor = true })");
 }
 
 TEST_CASE("buildLuaDispatch togglespecialworkspace", "[buildLuaDispatch]") {


### PR DESCRIPTION
#5013 failed to fix the issue when `move-to-monitor` is set to true.
This PR fixes this case.