### PR TITLE
Additional options when muted for the PulseAudio-Slider module

### DIFF
--- a/include/modules/pulseaudio_slider.hpp
+++ b/include/modules/pulseaudio_slider.hpp
@@ -6,7 +6,6 @@
 #include "util/audio_backend.hpp"
 namespace waybar::modules {
 
-
 class PulseaudioSlider : public ASlider {
  public:
   PulseaudioSlider(const std::string&, const Json::Value&);

--- a/include/modules/pulseaudio_slider.hpp
+++ b/include/modules/pulseaudio_slider.hpp
@@ -6,10 +6,6 @@
 #include "util/audio_backend.hpp"
 namespace waybar::modules {
 
-enum class PulseaudioSliderTarget {
-  Sink,
-  Source,
-};
 
 class PulseaudioSlider : public ASlider {
  public:
@@ -21,7 +17,15 @@ class PulseaudioSlider : public ASlider {
 
  private:
   std::shared_ptr<util::AudioBackend> backend = nullptr;
-  PulseaudioSliderTarget target = PulseaudioSliderTarget::Sink;
+  util::PulseaudioTarget target = util::PulseaudioTarget::Sink;
+
+  bool zero_on_mute = true;
+  bool unmute_on_volume_change = true;
+  // zero_on_mute and unmute_on_volume_change default to true
+  // in order to maintain previous behaviour when using a
+  // config in which these values are undefined
+
+  bool previously_muted = false;
 };
 
 }  // namespace waybar::modules

--- a/include/util/audio_backend.hpp
+++ b/include/util/audio_backend.hpp
@@ -14,6 +14,11 @@
 
 namespace waybar::util {
 
+enum class PulseaudioTarget {
+  Sink,
+  Source,
+};
+
 class AudioBackend {
  private:
   static void subscribeCb(pa_context*, pa_subscription_event_type_t, uint32_t, void*);
@@ -91,6 +96,10 @@ class AudioBackend {
 
   void toggleSourceMute();
   void toggleSourceMute(bool);
+
+  uint16_t getVolume(PulseaudioTarget) const;
+  bool getMuted(PulseaudioTarget) const;
+  void unmute(PulseaudioTarget);
 
   bool isBluetooth();
 };

--- a/man/waybar-pulseaudio-slider.5.scd
+++ b/man/waybar-pulseaudio-slider.5.scd
@@ -28,9 +28,20 @@ The volume can be controlled by dragging the slider across the bar or clicking o
     The orientation of the slider. Can be either `horizontal` or `vertical`.
 
 *expand*: ++
-	typeof: bool ++
-	default: false ++
-	Enables this module to consume all left over space dynamically.
+    typeof: bool ++
+    default: false ++
+    Enables this module to consume all left over space dynamically.
+
+*zero-on-mute*: ++
+    typeof: bool ++
+    default: true ++
+    `true` = The slider will be set to `min` when the source/sink is muted. ++
+    `false` = The slider will continue to show the unmuted volume level when the source/sink is muted.
+
+*unmute-on-volume-change*: ++
+    typeof: bool ++
+    default: true ++
+    Specifies whether to unmute a muted souce/sink when its volume is changed by the user moving the slider.
 
 # EXAMPLES
 
@@ -41,7 +52,9 @@ The volume can be controlled by dragging the slider across the bar or clicking o
 "pulseaudio/slider": {
     "min": 0,
     "max": 100,
-    "orientation": "horizontal"
+    "orientation": "horizontal",
+    "zero-on-mute": false,
+    "unmute-on-volume-change": false
 }
 ```
 
@@ -51,6 +64,9 @@ The slider is a component with multiple CSS Nodes, of which the following are ex
 
 *#pulseaudio-slider*: ++
     Controls the style of the box *around* the slider and bar.
+
+*#pulseaudio-slider.muted*: ++
+    Controls the style when the audio source/sink is muted.
 
 *#pulseaudio-slider slider*: ++
     Controls the style of the slider handle.
@@ -84,5 +100,9 @@ The slider is a component with multiple CSS Nodes, of which the following are ex
     min-width: 10px;
     border-radius: 5px;
     background: green;
+}
+
+#pulseaudio-slider.muted highlight {
+    background-color: orange;
 }
 ```

--- a/src/modules/pulseaudio_slider.cpp
+++ b/src/modules/pulseaudio_slider.cpp
@@ -10,73 +10,49 @@ PulseaudioSlider::PulseaudioSlider(const std::string& id, const Json::Value& con
   if (config_["target"].isString()) {
     std::string target = config_["target"].asString();
     if (target == "sink") {
-      this->target = PulseaudioSliderTarget::Sink;
+      this->target = util::PulseaudioTarget::Sink;
     } else if (target == "source") {
-      this->target = PulseaudioSliderTarget::Source;
+      this->target = util::PulseaudioTarget::Source;
     }
+  }
+
+  if (config_["zero-on-mute"].isBool()) {
+    zero_on_mute = config_["zero-on-mute"].asBool();
+  }
+
+  if (config_["unmute-on-volume-change"].isBool()) {
+    unmute_on_volume_change = config_["unmute-on-volume-change"].asBool();
   }
 }
 
 void PulseaudioSlider::update() {
-  switch (target) {
-    case PulseaudioSliderTarget::Sink:
-      if (backend->getSinkMuted()) {
-        scale_.set_value(min_);
-      } else {
-        scale_.set_value(backend->getSinkVolume());
-      }
-      break;
+  uint16_t display_value = backend->getVolume(target);
+  bool is_muted = backend->getMuted(target);
 
-    case PulseaudioSliderTarget::Source:
-      if (backend->getSourceMuted()) {
-        scale_.set_value(min_);
-      } else {
-        scale_.set_value(backend->getSourceVolume());
-      }
-      break;
+  if (is_muted && !previously_muted) {
+    if (zero_on_mute) {
+      display_value = min_;
+    }
+    scale_.get_style_context()->add_class("muted");
+  } else if (previously_muted && !is_muted) {
+    scale_.get_style_context()->remove_class("muted");
   }
+
+  scale_.set_value(display_value);
+
+  previously_muted = is_muted;
 }
 
 void PulseaudioSlider::onValueChanged() {
-  bool is_mute = false;
+  uint16_t slider_value = scale_.get_value();
 
-  switch (target) {
-    case PulseaudioSliderTarget::Sink:
-      if (backend->getSinkMuted()) {
-        is_mute = true;
-      }
-      break;
-
-    case PulseaudioSliderTarget::Source:
-      if (backend->getSourceMuted()) {
-        is_mute = true;
-      }
-      break;
-  }
-
-  uint16_t volume = scale_.get_value();
-
-  if (is_mute) {
-    // Avoid setting sink/source to volume 0 if the user muted if via another mean.
-    if (volume == 0) {
-      return;
+  // Avoid setting sink/source to volume 0 if the user muted it via other means.
+  if (!backend->getMuted(target) || slider_value != 0) {
+    if (unmute_on_volume_change) {
+      backend->unmute(target);
     }
-
-    // If the sink/source is mute, but the user clicked the slider, unmute it!
-    else {
-      switch (target) {
-        case PulseaudioSliderTarget::Sink:
-          backend->toggleSinkMute(false);
-          break;
-
-        case PulseaudioSliderTarget::Source:
-          backend->toggleSourceMute(false);
-          break;
-      }
-    }
+    backend->changeVolume(slider_value, min_, max_);
   }
-
-  backend->changeVolume(volume, min_, max_);
 }
 
 }  // namespace waybar::modules

--- a/src/modules/pulseaudio_slider.cpp
+++ b/src/modules/pulseaudio_slider.cpp
@@ -29,12 +29,14 @@ void PulseaudioSlider::update() {
   uint16_t display_value = backend->getVolume(target);
   bool is_muted = backend->getMuted(target);
 
-  if (is_muted && !previously_muted) {
+  if (is_muted) {
     if (zero_on_mute) {
       display_value = min_;
     }
-    scale_.get_style_context()->add_class("muted");
-  } else if (previously_muted && !is_muted) {
+    if (!previously_muted) {
+      scale_.get_style_context()->add_class("muted");
+    }
+  } else if (previously_muted) {
     scale_.get_style_context()->remove_class("muted");
   }
 

--- a/src/util/audio_backend.cpp
+++ b/src/util/audio_backend.cpp
@@ -263,9 +263,9 @@ void AudioBackend::serverInfoCb(pa_context* context, const pa_server_info* i, vo
 
 uint16_t AudioBackend::getVolume(PulseaudioTarget target) const {
   if (target == PulseaudioTarget::Source) {
-      return source_volume_;
+    return source_volume_;
   } else {
-      return volume_;
+    return volume_;
   }
 }
 
@@ -380,9 +380,9 @@ void AudioBackend::changeVolume(ChangeType change_type, double step, uint16_t ma
 
 bool AudioBackend::getMuted(PulseaudioTarget target) const {
   if (target == PulseaudioTarget::Source) {
-      return source_muted_;
+    return source_muted_;
   } else {
-      return muted_;
+    return muted_;
   }
 }
 
@@ -424,9 +424,9 @@ void AudioBackend::toggleSourceMute(bool mute) {
 
 void AudioBackend::unmute(PulseaudioTarget target) {
   if (target == PulseaudioTarget::Source) {
-      toggleSourceMute(false);
+    toggleSourceMute(false);
   } else {
-      toggleSinkMute(false);
+    toggleSinkMute(false);
   }
 }
 

--- a/src/util/audio_backend.cpp
+++ b/src/util/audio_backend.cpp
@@ -259,6 +259,14 @@ void AudioBackend::serverInfoCb(pa_context* context, const pa_server_info* i, vo
   pa_context_get_source_info_list(context, sourceInfoCb, data);
 }
 
+uint16_t AudioBackend::getVolume(PulseaudioTarget target) const {
+  if (target == PulseaudioTarget::Source) {
+      return source_volume_;
+  } else {
+      return volume_;
+  }
+}
+
 void AudioBackend::changeVolume(uint16_t volume, uint16_t min_volume, uint16_t max_volume) {
   // Early return if context is not ready
   if ((context_ == nullptr) || pa_context_get_state(context_) != PA_CONTEXT_READY) {
@@ -368,6 +376,14 @@ void AudioBackend::changeVolume(ChangeType change_type, double step, uint16_t ma
   pa_threaded_mainloop_unlock(mainloop_);
 }
 
+bool AudioBackend::getMuted(PulseaudioTarget target) const {
+  if (target == PulseaudioTarget::Source) {
+      return source_muted_;
+  } else {
+      return muted_;
+  }
+}
+
 void AudioBackend::toggleSinkMute() {
   if (context_ == nullptr || pa_context_get_state(context_) != PA_CONTEXT_READY) return;
   muted_ = !muted_;
@@ -402,6 +418,14 @@ void AudioBackend::toggleSourceMute(bool mute) {
   pa_context_set_source_mute_by_index(context_, source_idx_, static_cast<int>(source_muted_),
                                       nullptr, nullptr);
   pa_threaded_mainloop_unlock(mainloop_);
+}
+
+void AudioBackend::unmute(PulseaudioTarget target) {
+  if (target == PulseaudioTarget::Source) {
+      toggleSourceMute(false);
+  } else {
+      toggleSinkMute(false);
+  }
 }
 
 bool AudioBackend::isBluetooth() {


### PR DESCRIPTION
Hi, this change would add the following:

- A "muted" class for styling the muted state of the PulseAudio-Slider module.
- A "zero-on-mute" boolean option to control slider position when muted.
- A "unmute-on-volume-change" boolean option to control whether to automatically unmute when the slider is changed.

The reason for wanting it is that I am using the PulseAudio module next to the PulseAudio-Slider module, in order to have both a numerical display with clickable area and also a slider.  These changes enable that combination to be styled appropriately in the muted state.

Example:
<img width="289" height="173" alt="waybar-pa-slider-example" src="https://github.com/user-attachments/assets/d4a7f674-cf70-4609-9f7f-e8e89b417504" />

