### PR TITLE
mpd: Implement idle events for Playing state

### DIFF
--- a/include/modules/mpd/state.hpp
+++ b/include/modules/mpd/state.hpp
@@ -82,6 +82,7 @@ class Idle : public State {
 class Playing : public State {
   Context* const ctx_;
   sigc::connection timer_connection_;
+  sigc::connection idle_connection_;
 
  public:
   Playing(Context* const ctx) : ctx_{ctx} {}
@@ -98,7 +99,10 @@ class Playing : public State {
   Playing(Playing const&) = delete;
   Playing& operator=(Playing const&) = delete;
 
+  void timer() noexcept;
+  void idle() noexcept;
   bool on_timer();
+  bool on_io(Glib::IOCondition const&);
 };
 
 class Paused : public State {

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -96,19 +96,16 @@ bool Idle::on_io(Glib::IOCondition const&) {
   }
 
   ctx_->fetchState();
+  ctx_->emit();
   mpd_state state = ctx_->state();
 
   if (state == MPD_STATE_STOP) {
-    ctx_->emit();
     ctx_->setState(std::make_unique<Stopped>(ctx_));
   } else if (state == MPD_STATE_PLAY) {
-    ctx_->emit();
     ctx_->setState(std::make_unique<Playing>(ctx_));
   } else if (state == MPD_STATE_PAUSE) {
-    ctx_->emit();
     ctx_->setState(std::make_unique<Paused>(ctx_));
   } else {
-    ctx_->emit();
     // self transition
     ctx_->setState(std::make_unique<Idle>(ctx_));
   }
@@ -177,6 +174,7 @@ bool Playing::on_timer() {
     ctx_->fetchState();
 
     if (!ctx_->is_playing()) {
+      ctx_->emit();
       if (ctx_->is_paused()) {
         ctx_->setState(std::make_unique<Paused>(ctx_));
       } else {
@@ -212,6 +210,7 @@ bool Playing::on_io(Glib::IOCondition const&) {
     ctx_->fetchState();
 
     if (!ctx_->is_playing()) {
+      ctx_->emit();
       if (ctx_->is_paused()) {
         ctx_->setState(std::make_unique<Paused>(ctx_));
       } else {
@@ -293,7 +292,6 @@ bool Paused::on_timer() {
     }
 
     ctx_->fetchState();
-
     ctx_->emit();
 
     if (ctx_->is_paused()) {
@@ -364,7 +362,6 @@ bool Stopped::on_timer() {
     }
 
     ctx_->fetchState();
-
     ctx_->emit();
 
     if (ctx_->is_stopped()) {

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -19,17 +19,17 @@ auto format_as(enum mpd_idle val) {
 
 namespace waybar::modules::detail {
 
-#define RUN_NOIDLE_AND_CMD(STATE, ...)                                      \
-  if (idle_connection_.connected()) {                                     \
-    idle_connection_.disconnect();                                        \
-    auto conn = ctx_->connection().get();                                 \
-    if (!mpd_run_noidle(conn)) {                                          \
-      if (mpd_connection_get_error(conn) != MPD_ERROR_SUCCESS) {          \
+#define RUN_NOIDLE_AND_CMD(STATE, ...)                                     \
+  if (idle_connection_.connected()) {                                      \
+    idle_connection_.disconnect();                                         \
+    auto conn = ctx_->connection().get();                                  \
+    if (!mpd_run_noidle(conn)) {                                           \
+      if (mpd_connection_get_error(conn) != MPD_ERROR_SUCCESS) {           \
         spdlog::error("mpd: STATE: failed to unregister for IDLE events"); \
-        ctx_->checkErrors(conn);                                          \
-      }                                                                   \
-    }                                                                     \
-    __VA_ARGS__;                                                          \
+        ctx_->checkErrors(conn);                                           \
+      }                                                                    \
+    }                                                                      \
+    __VA_ARGS__;                                                           \
   }
 
 void Idle::play() {
@@ -49,7 +49,6 @@ void Idle::stop() {
 
   ctx_->setState(std::make_unique<Stopped>(ctx_));
 }
-
 
 void Idle::update() noexcept {
   // This is intentionally blank.
@@ -140,7 +139,6 @@ void Playing::timer() noexcept {
   timer_connection_ = Glib::signal_timeout().connect_seconds(timer_slot, 1);
 }
 
-
 void Playing::idle() noexcept {
   auto conn = ctx_->connection().get();
   assert(conn != nullptr);
@@ -218,7 +216,6 @@ bool Playing::on_io(Glib::IOCondition const&) {
       return false;
     }
 
-    ctx_->queryMPD();
     ctx_->emit();
 
     if (!mpd_send_idle_mask(
@@ -239,25 +236,23 @@ bool Playing::on_io(Glib::IOCondition const&) {
 }
 
 void Playing::stop() {
-  RUN_NOIDLE_AND_CMD(Playing,
-    if (timer_connection_.connected()) {
-      timer_connection_.disconnect();
+  RUN_NOIDLE_AND_CMD(
+      Playing, if (timer_connection_.connected()) {
+        timer_connection_.disconnect();
 
-      mpd_run_stop(ctx_->connection().get());
-    }
-  );
+        mpd_run_stop(ctx_->connection().get());
+      });
 
   ctx_->setState(std::make_unique<Stopped>(ctx_));
 }
 
 void Playing::pause() {
-  RUN_NOIDLE_AND_CMD(Playing,
-    if (timer_connection_.connected()) {
-      timer_connection_.disconnect();
+  RUN_NOIDLE_AND_CMD(
+      Playing, if (timer_connection_.connected()) {
+        timer_connection_.disconnect();
 
-      mpd_run_pause(ctx_->connection().get(), true);
-    }
-  );
+        mpd_run_pause(ctx_->connection().get(), true);
+      });
 
   ctx_->setState(std::make_unique<Paused>(ctx_));
 }

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -19,13 +19,13 @@ auto format_as(enum mpd_idle val) {
 
 namespace waybar::modules::detail {
 
-#define IDLE_RUN_NOIDLE_AND_CMD(...)                                      \
+#define RUN_NOIDLE_AND_CMD(STATE, ...)                                      \
   if (idle_connection_.connected()) {                                     \
     idle_connection_.disconnect();                                        \
     auto conn = ctx_->connection().get();                                 \
     if (!mpd_run_noidle(conn)) {                                          \
       if (mpd_connection_get_error(conn) != MPD_ERROR_SUCCESS) {          \
-        spdlog::error("mpd: Idle: failed to unregister for IDLE events"); \
+        spdlog::error("mpd: STATE: failed to unregister for IDLE events"); \
         ctx_->checkErrors(conn);                                          \
       }                                                                   \
     }                                                                     \
@@ -33,24 +33,23 @@ namespace waybar::modules::detail {
   }
 
 void Idle::play() {
-  IDLE_RUN_NOIDLE_AND_CMD(mpd_run_play(conn));
+  RUN_NOIDLE_AND_CMD(Idle, mpd_run_play(conn));
 
   ctx_->setState(std::make_unique<Playing>(ctx_));
 }
 
 void Idle::pause() {
-  IDLE_RUN_NOIDLE_AND_CMD(mpd_run_pause(conn, true));
+  RUN_NOIDLE_AND_CMD(Idle, mpd_run_pause(conn, true));
 
   ctx_->setState(std::make_unique<Paused>(ctx_));
 }
 
 void Idle::stop() {
-  IDLE_RUN_NOIDLE_AND_CMD(mpd_run_stop(conn));
+  RUN_NOIDLE_AND_CMD(Idle, mpd_run_stop(conn));
 
   ctx_->setState(std::make_unique<Stopped>(ctx_));
 }
 
-#undef IDLE_RUN_NOIDLE_AND_CMD
 
 void Idle::update() noexcept {
   // This is intentionally blank.
@@ -118,15 +117,47 @@ bool Idle::on_io(Glib::IOCondition const&) {
 }
 
 void Playing::entry() noexcept {
-  sigc::slot<bool> timer_slot = sigc::mem_fun(*this, &Playing::on_timer);
-  timer_connection_ = Glib::signal_timeout().connect_seconds(timer_slot, 1);
+  timer();
+  idle();
   spdlog::debug("mpd: Playing: enabled 1 second periodic timer.");
 }
 
 void Playing::exit() noexcept {
+  if (idle_connection_.connected()) {
+    idle_connection_.disconnect();
+    spdlog::debug("mpd: Playing: unwatching FD");
+  }
+
   if (timer_connection_.connected()) {
     timer_connection_.disconnect();
     spdlog::debug("mpd: Playing: disabled 1 second periodic timer.");
+  }
+}
+
+void Playing::timer() noexcept {
+  if (timer_connection_.connected()) {
+    timer_connection_.disconnect();
+  }
+
+  sigc::slot<bool> timer_slot = sigc::mem_fun(*this, &Playing::on_timer);
+  timer_connection_ = Glib::signal_timeout().connect_seconds(timer_slot, 1);
+}
+
+
+void Playing::idle() noexcept {
+  auto conn = ctx_->connection().get();
+  assert(conn != nullptr);
+
+  if (!mpd_send_idle_mask(
+          conn, static_cast<mpd_idle>(MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_QUEUE))) {
+    ctx_->checkErrors(conn);
+    spdlog::error("mpd: Playing: failed to register for IDLE events");
+  } else if (!idle_connection_.connected()) {
+    spdlog::trace("mpd: Playing: watching FD");
+    sigc::slot<bool, Glib::IOCondition const&> idle_slot = sigc::mem_fun(*this, &Playing::on_io);
+    idle_connection_ =
+        Glib::signal_io().connect(idle_slot, mpd_connection_get_fd(conn),
+                                  Glib::IO_IN | Glib::IO_PRI | Glib::IO_ERR | Glib::IO_HUP);
   }
 }
 
@@ -141,6 +172,8 @@ bool Playing::on_timer() {
       return false;
     }
 
+    RUN_NOIDLE_AND_CMD(Playing);
+
     ctx_->fetchState();
 
     if (!ctx_->is_playing()) {
@@ -154,6 +187,50 @@ bool Playing::on_timer() {
 
     ctx_->queryMPD();
     ctx_->emit();
+
+    idle();
+  } catch (std::exception const& e) {
+    spdlog::warn("mpd: Playing: error: {}", e.what());
+    ctx_->setState(std::make_unique<Disconnected>(ctx_));
+    return false;
+  }
+
+  return true;
+}
+
+bool Playing::on_io(Glib::IOCondition const&) {
+  auto conn = ctx_->connection().get();
+
+  // callback should do this:
+  enum mpd_idle events = mpd_recv_idle(conn, /* ignore_timeout?= */ false);
+  spdlog::debug("mpd: Playing: recv_idle events -> {}", events);
+
+  mpd_response_finish(conn);
+  try {
+    ctx_->checkErrors(conn);
+
+    ctx_->fetchState();
+
+    if (!ctx_->is_playing()) {
+      if (ctx_->is_paused()) {
+        ctx_->setState(std::make_unique<Paused>(ctx_));
+      } else {
+        ctx_->setState(std::make_unique<Stopped>(ctx_));
+      }
+      return false;
+    }
+
+    ctx_->queryMPD();
+    ctx_->emit();
+
+    if (!mpd_send_idle_mask(
+            conn, static_cast<mpd_idle>(MPD_IDLE_PLAYER | MPD_IDLE_OPTIONS | MPD_IDLE_QUEUE))) {
+      ctx_->checkErrors(conn);
+      spdlog::error("mpd: Playing: failed to register for IDLE events");
+    }
+
+    // Defer the next timer
+    timer();
   } catch (std::exception const& e) {
     spdlog::warn("mpd: Playing: error: {}", e.what());
     ctx_->setState(std::make_unique<Disconnected>(ctx_));
@@ -164,21 +241,25 @@ bool Playing::on_timer() {
 }
 
 void Playing::stop() {
-  if (timer_connection_.connected()) {
-    timer_connection_.disconnect();
+  RUN_NOIDLE_AND_CMD(Playing,
+    if (timer_connection_.connected()) {
+      timer_connection_.disconnect();
 
-    mpd_run_stop(ctx_->connection().get());
-  }
+      mpd_run_stop(ctx_->connection().get());
+    }
+  );
 
   ctx_->setState(std::make_unique<Stopped>(ctx_));
 }
 
 void Playing::pause() {
-  if (timer_connection_.connected()) {
-    timer_connection_.disconnect();
+  RUN_NOIDLE_AND_CMD(Playing,
+    if (timer_connection_.connected()) {
+      timer_connection_.disconnect();
 
-    mpd_run_pause(ctx_->connection().get(), true);
-  }
+      mpd_run_pause(ctx_->connection().get(), true);
+    }
+  );
 
   ctx_->setState(std::make_unique<Paused>(ctx_));
 }
@@ -387,4 +468,5 @@ bool Disconnected::on_timer() {
 
 void Disconnected::update() noexcept { ctx_->do_update(); }
 
+#undef RUN_NOIDLE_AND_CMD
 }  // namespace waybar::modules::detail


### PR DESCRIPTION
I've reused the macro from the Idle state where possible. It should be possible to drop querying MPD from on_timer entirely and just estimate the elapsed time, but that's a bigger change.

I've tested this locally including killing MPD at strange times or trying to otherwise get it into a strange state. The module updates instantly while playing instead of being delayed for up to a second.

Closes #2513

Fixes state not being updated when playing finishes: https://github.com/Alexays/Waybar/issues/782#issuecomment-4468523336