### PR TITLE
fix(hyprland): keep workspace hover over taskbar icons

### DIFF
--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -30,6 +30,7 @@ class Workspace {
  public:
   explicit Workspace(const Json::Value& workspace_data, Workspaces& workspace_manager,
                      const Json::Value& clients_data = Json::Value::nullRef);
+  ~Workspace();
   std::string& selectIcon(std::map<std::string, std::string>& icons_map);
   Gtk::Button& button() { return m_button; };
 

--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -45,6 +45,15 @@ class Workspace {
   bool isUrgent() const { return m_isUrgent; };
 
   bool handleClicked(GdkEventButton* bt) const;
+
+  bool handleEnter(GdkEventCrossing* event);
+  bool handleLeave(GdkEventCrossing* event);
+
+  void startHoverCheck();
+  void stopHoverCheck();
+  bool syncHoverClass();
+  bool pointerInsideButton();
+
   void setActive(bool value = true) { m_isActive = value; };
   void setPersistentRule(bool value = true) { m_isPersistentRule = value; };
   void setPersistentConfig(bool value = true) { m_isPersistentConfig = value; };
@@ -79,6 +88,8 @@ class Workspace {
   bool m_isPersistentConfig = false;  // represents the persistent state in the Waybar config
   bool m_isUrgent = false;
   bool m_isVisible = false;
+
+  sigc::connection m_hoverCheckConnection;
 
   std::vector<WindowRepr> m_windowMap;
 

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -1,5 +1,6 @@
 #include <json/value.h>
 #include <spdlog/spdlog.h>
+#include <glibmm/main.h>
 
 #include <memory>
 #include <string>
@@ -30,6 +31,11 @@ Workspace::Workspace(const Json::Value& workspace_data, Workspaces& workspace_ma
   }
 
   m_button.add_events(Gdk::BUTTON_PRESS_MASK);
+  m_button.add_events(Gdk::ENTER_NOTIFY_MASK | Gdk::LEAVE_NOTIFY_MASK);
+
+  m_button.signal_enter_notify_event().connect(sigc::mem_fun(*this, &Workspace::handleEnter));
+  m_button.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Workspace::handleLeave));
+
   m_button.signal_button_press_event().connect(sigc::mem_fun(*this, &Workspace::handleClicked),
                                                false);
 
@@ -66,6 +72,102 @@ std::optional<WindowRepr> Workspace::closeWindow(WindowAddress const& addr) {
   return std::nullopt;
 }
 
+bool Workspace::pointerInsideButton() {
+  auto display = Gdk::Display::get_default();
+  if (!display) {
+    return false;
+  }
+
+  auto seat = display->get_default_seat();
+  if (!seat) {
+    return false;
+  }
+
+  auto pointer = seat->get_pointer();
+  if (!pointer) {
+    return false;
+  }
+
+  Glib::RefPtr<Gdk::Screen> screen;
+  int pointerRootX = 0;
+  int pointerRootY = 0;
+
+  pointer->get_position(screen, pointerRootX, pointerRootY);
+
+  Gtk::Widget* toplevel = m_button.get_toplevel();
+  if (toplevel == nullptr || !toplevel->get_window()) {
+    return false;
+  }
+
+  int buttonX = 0;
+  int buttonY = 0;
+
+  if (!m_button.translate_coordinates(*toplevel, 0, 0, buttonX, buttonY)) {
+    return false;
+  }
+
+  int windowRootX = 0;
+  int windowRootY = 0;
+  toplevel->get_window()->get_root_origin(windowRootX, windowRootY);
+
+  const auto allocation = m_button.get_allocation();
+
+  const int buttonRootX = windowRootX + buttonX;
+  const int buttonRootY = windowRootY + buttonY;
+  const int buttonWidth = allocation.get_width();
+  const int buttonHeight = allocation.get_height();
+
+  return pointerRootX >= buttonRootX && pointerRootY >= buttonRootY &&
+         pointerRootX < buttonRootX + buttonWidth &&
+         pointerRootY < buttonRootY + buttonHeight;
+}
+
+bool Workspace::syncHoverClass() {
+  auto styleContext = m_button.get_style_context();
+
+  if (pointerInsideButton()) {
+    styleContext->add_class("workspace-hover");
+    return true;
+  }
+
+  styleContext->remove_class("workspace-hover");
+  stopHoverCheck();
+  return false;
+}
+
+void Workspace::startHoverCheck() {
+  if (m_hoverCheckConnection.connected()) {
+    return;
+  }
+
+  m_hoverCheckConnection = Glib::signal_timeout().connect(
+      sigc::mem_fun(*this, &Workspace::syncHoverClass),
+      50);
+}
+
+void Workspace::stopHoverCheck() {
+  if (m_hoverCheckConnection.connected()) {
+    m_hoverCheckConnection.disconnect();
+  }
+}
+
+bool Workspace::handleEnter(GdkEventCrossing* /*event*/) {
+  m_button.get_style_context()->add_class("workspace-hover");
+  startHoverCheck();
+  return false;
+}
+
+bool Workspace::handleLeave(GdkEventCrossing* /*event*/) {
+  /*
+   * Do not remove immediately.
+   * Workspace taskbar children can fire misleading leave events while the
+   * pointer is still visually inside the workspace button.
+   *
+   * The polling check will remove the class once the pointer really leaves.
+   */
+  startHoverCheck();
+  return false;
+}
 bool Workspace::handleClicked(GdkEventButton* bt) const {
   if (bt->type == GDK_BUTTON_PRESS) {
     try {

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -51,6 +51,12 @@ Workspace::Workspace(const Json::Value& workspace_data, Workspaces& workspace_ma
   initializeWindowMap(clients_data);
 }
 
+Workspace::~Workspace() {
+  // Disconnect the hover-check timeout so it can't fire on this destroyed
+  // instance (Workspaces are removed at runtime while a check may be armed).
+  stopHoverCheck();
+}
+
 void addOrRemoveClass(const Glib::RefPtr<Gtk::StyleContext>& context, bool condition,
                       const std::string& class_name) {
   if (condition) {


### PR DESCRIPTION
## Summary

Fixes hover styling for `hyprland/workspaces` when `workspace-taskbar.enable = true`.

When the pointer moves from the workspace label/button area onto a taskbar window icon, GTK can stop matching `#workspaces button:hover` for the parent workspace button. Visually, the pointer is still inside the workspace button, but CSS rules targeting the parent hover state are no longer applied.

This patch adds a dedicated `workspace-hover` style class while the pointer is inside the workspace button area. This gives users a stable selector for styling the parent workspace button while hovering taskbar child widgets.

Example CSS:

```css
#workspaces button:hover,
#workspaces button.workspace-hover {
  /* hover styling */
}
```

## Why

`workspace-taskbar` adds child widgets for window icons inside the workspace button. GTK crossing events can make the parent button lose its normal `:hover` state when the pointer enters one of those child widgets.

This is especially visible when users dim inactive workspace buttons or icons with opacity: the workspace appears to lose hover styling when moving from the workspace label to a window icon.

The added `workspace-hover` class keeps the parent workspace styling available while the pointer remains inside the workspace button area.

## Implementation notes

The class is added on enter events.

On leave, the patch does not immediately remove the class, because leave events can also be emitted when moving into child taskbar widgets. Instead, it uses a small timeout-based check to verify whether the pointer has actually left the workspace button area before removing `workspace-hover`.

## Tested

Tested locally with:

- Waybar built from this branch
- Hyprland
- `hyprland/workspaces`
- `workspace-taskbar.enable = true`
- CSS using both `#workspaces button:hover` and `#workspaces button.workspace-hover`

Checked behavior:

- Hovering the workspace label applies hover styling
- Moving from the workspace label to a taskbar window icon keeps hover styling
- Moving between taskbar window icons keeps hover styling
- Moving outside the workspace button removes hover styling

## Related

Related / similar discussion:

- https://github.com/Alexays/Waybar/discussions/4419
