### PR TITLE
feat(cpu): add {icons} format replacement for all per-core icons

### DIFF
--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -106,6 +106,8 @@ The *cpu* module displays the current CPU utilization.
 
 *{icon*{n}*}*: Icon for CPU core n usage. Use like {icon0}.
 
+*{icon0}{icon1}{icon2}{icon3}*: All per-core icons concatenated. Equivalent to {icon0}{icon1}...{icon*N*} but adapts to the number of cores automatically.
+
 # EXAMPLES
 
 Basic configuration:
@@ -124,6 +126,16 @@ CPU usage per core rendered as icons:
 "cpu": {
 	"interval": 1,
 	"format": "{icon0}{icon1}{icon2}{icon3} {usage:>2}% ",
+	"format-icons": ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"],
+},
+```
+
+Automatically determine number of icons according to number of logical cores:
+
+```
+"cpu": {
+	"interval": 1,
+	"format": "{icons} {usage:>2}% ",
 	"format-icons": ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"],
 },
 ```

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -48,13 +48,17 @@ auto waybar::modules::Cpu::update() -> void {
     store.push_back(fmt::arg("avg_frequency", avg_frequency));
     std::vector<std::string> arg_names;
     arg_names.reserve(cpu_usage.size() * 2);
+    std::string all_icons;
     for (size_t i = 1; i < cpu_usage.size(); ++i) {
       auto core_i = i - 1;
       arg_names.push_back(fmt::format("usage{}", core_i));
       store.push_back(fmt::arg(arg_names.back().c_str(), cpu_usage[i]));
+      auto core_icon = getIcon(cpu_usage[i], icons);
+      all_icons += core_icon;
       arg_names.push_back(fmt::format("icon{}", core_i));
-      store.push_back(fmt::arg(arg_names.back().c_str(), getIcon(cpu_usage[i], icons)));
+      store.push_back(fmt::arg(arg_names.back().c_str(), core_icon));
     }
+    store.push_back(fmt::arg("icons", all_icons));
     label_.set_markup(fmt::vformat(format, store));
 
     if (tooltipEnabled()) {

--- a/src/modules/cpu_usage/common.cpp
+++ b/src/modules/cpu_usage/common.cpp
@@ -38,13 +38,17 @@ auto waybar::modules::CpuUsage::update() -> void {
     store.push_back(fmt::arg("icon", getIcon(total_usage, icons)));
     std::vector<std::string> arg_names;
     arg_names.reserve(cpu_usage.size() * 2);
+    std::string all_icons;
     for (size_t i = 1; i < cpu_usage.size(); ++i) {
       auto core_i = i - 1;
       arg_names.push_back(fmt::format("usage{}", core_i));
       store.push_back(fmt::arg(arg_names.back().c_str(), cpu_usage[i]));
+      auto core_icon = getIcon(cpu_usage[i], icons);
+      all_icons += core_icon;
       arg_names.push_back(fmt::format("icon{}", core_i));
-      store.push_back(fmt::arg(arg_names.back().c_str(), getIcon(cpu_usage[i], icons)));
+      store.push_back(fmt::arg(arg_names.back().c_str(), core_icon));
     }
+    store.push_back(fmt::arg("icons", all_icons));
     label_.set_markup(fmt::vformat(format, store));
 
     if (tooltipEnabled()) {


### PR DESCRIPTION
Adds a new `{icons}` format to the `cpu` and `cpu_usage` modules.

Specifying `{icon0}{icon1}...{iconN}` manually depending on the number of cores bloats the config file, and makes it harder to share configs between different machines.

With this change, by using `{icons}`, the icons get populated automatically.

Example before this change:
```json
"format": "<span rise='1000'></span> {usage:>2}% {icon0}{icon1}{icon2}{icon3}{icon4}{icon5}{icon6}{icon7}{icon8}{icon9}{icon10}{icon11}"
```

And after:
```json
"format": "<span rise='1000'></span> {usage:>2}% {icons}"
```

- Old `{iconN}` syntax still works
- Tests passing

Closes #4240