### PR TITLE
fix(amodule): prevent crash when cursor timeout fires after destruction

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -57,6 +57,7 @@ class AModule : public IModule {
   bool hasUserEvents_;
   gdouble distance_scrolled_y_;
   gdouble distance_scrolled_x_;
+  sigc::connection cursor_timeout_conn_;
   std::map<std::string, std::string> eventActionMap_;
   static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{
       {std::make_pair(1, GdkEventType::GDK_BUTTON_PRESS), "on-click"},

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -17,7 +17,8 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
       isTooltip{config_["tooltip"].isBool() ? config_["tooltip"].asBool() : true},
       isExpand{config_["expand"].isBool() ? config_["expand"].asBool() : false},
       distance_scrolled_y_(0.0),
-      distance_scrolled_x_(0.0) {
+      distance_scrolled_x_(0.0),
+      cursor_timeout_conn_() {
   // Configure module action Map
   const Json::Value actions{config_["actions"]};
 
@@ -83,6 +84,9 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
 }
 
 AModule::~AModule() {
+  if (cursor_timeout_conn_.connected()) {
+    cursor_timeout_conn_.disconnect();
+  }
   for (const auto& pid : pid_children_) {
     if (pid != -1) {
       killpg(pid, SIGTERM);
@@ -118,7 +122,7 @@ void AModule::setCursor(Gdk::CursorType const& c) {
   } else {
     // window may not be accessible yet, in this case,
     // schedule another call for setting the cursor in 1 sec
-    Glib::signal_timeout().connect_seconds(
+    cursor_timeout_conn_ = Glib::signal_timeout().connect_seconds(
         [this, c]() {
           setCursor(c);
           return false;


### PR DESCRIPTION
Hey,
Waybar segfaults when my monitor turns off as stated in #5055

I narrowed it down to AModule::setCursor():
When the window isn't ready, setCursor() schedules a 1-second retry. If the output gets removed and the module is destroyed before that timeout fires it crashes.

The fix stores the timeout connection and disconnects it in the destructor, kinda same as what privacy and idle_inhibitor modules already do.

Tested with my config that was crashing 100% after the monitor was shutdown and turned back on, and the crashes have stopped.

Fixes #5055