### PR TITLE
fix(hyprland): support custom scroll commands

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -135,6 +135,14 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	default: false ++
 	If set to false, you can't scroll to cycle throughout workspaces from the entire bar. If set to true this behaviour is enabled.
 
+*on-scroll-up*: ++
+	typeof: string ++
+	Command to execute when scrolling up on the module. This replaces the default behaviour of workspace cycling.
+
+*on-scroll-down*: ++
+	typeof: string ++
+	Command to execute when scrolling down on the module. This replaces the default behaviour of workspace cycling.
+
 *ignore-workspaces*: ++
 	typeof: array ++
 	default: [] ++

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -50,7 +50,8 @@ void Workspaces::init() {
   if (m_scrollEventConnection_.connected()) {
     m_scrollEventConnection_.disconnect();
   }
-  if (barScroll()) {
+  bool hasScrollConfig = config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString();
+  if (barScroll() || hasScrollConfig) {
     auto& window = const_cast<Bar&>(m_bar).window;
     window.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     m_scrollEventConnection_ =
@@ -1188,6 +1189,12 @@ bool Workspaces::handleScroll(GdkEventScroll* e) {
   if (gdk_event_get_pointer_emulated((GdkEvent*)e)) {
     return false;
   }
+
+  // Check for custom scroll commands first; delegate to base class
+  if (config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString()) {
+    return AModule::handleScroll(e);
+  }
+
   auto dir = AModule::getScrollDir(e);
   if (dir == SCROLL_DIR::NONE) {
     return true;


### PR DESCRIPTION
The [Hyprland wiki page](https://github.com/Alexays/Waybar/wiki/Module:-Hyprland) references `on-scroll-up` and `on-scroll-down` configuration options that actually **do not work**.

This fixes the behavior: If `on-scroll-up` or `on-scroll-down` is set, the module delegates to `AModule::handleScroll(e)` as in other modules (allows for custom commands). Otherwise the previous behavior is kept (cycle workspaces if `enable-bar-scroll` is set).