### PR TITLE
Add native Triad IPC modules

### DIFF
--- a/include/modules/triad/backend.hpp
+++ b/include/modules/triad/backend.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "util/json.hpp"
+
+namespace waybar::modules::triad {
+
+class EventHandler {
+ public:
+  virtual void onEvent(const Json::Value& ev) = 0;
+  virtual ~EventHandler() = default;
+};
+
+class IPC {
+ public:
+  IPC();
+
+  void registerForIPC(const std::string& ev, EventHandler* ev_handler);
+  void unregisterForIPC(EventHandler* handler);
+
+  static Json::Value send(const Json::Value& request);
+  static Json::Value action(const std::string& action_name);
+  static Json::Value action(const std::string& action_name, const std::string& key,
+                            const Json::Value& value);
+
+  std::lock_guard<std::mutex> lockData() { return std::lock_guard(dataMutex_); }
+  const std::vector<Json::Value>& workspaces() const { return workspaces_; }
+  const std::vector<Json::Value>& windows() const { return windows_; }
+  const std::vector<Json::Value>& outputs() const { return outputs_; }
+  const std::vector<std::string>& keyboardLayoutNames() const { return keyboardLayoutNames_; }
+  unsigned keyboardLayoutCurrent() const { return keyboardLayoutCurrent_; }
+
+ private:
+  void startIPC();
+  static int connectToSocket();
+  static Json::Value request(const std::string& name);
+  void loadState();
+  void parseIPC(const std::string&);
+  void parseState(const Json::Value& state);
+  void parseLayoutState(const Json::Value& state);
+  void parseWindowChanged(const Json::Value& window);
+
+  std::mutex dataMutex_;
+  std::vector<Json::Value> workspaces_;
+  std::vector<Json::Value> windows_;
+  std::vector<Json::Value> outputs_;
+  std::vector<std::string> keyboardLayoutNames_;
+  unsigned keyboardLayoutCurrent_ = 0;
+
+  util::JsonParser parser_;
+  std::mutex callbackMutex_;
+  std::list<std::pair<std::string, EventHandler*>> callbacks_;
+};
+
+inline std::unique_ptr<IPC> gIPC;
+
+}  // namespace waybar::modules::triad

--- a/include/modules/triad/language.hpp
+++ b/include/modules/triad/language.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "ALabel.hpp"
+#include "bar.hpp"
+#include "modules/triad/backend.hpp"
+
+namespace waybar::modules::triad {
+
+class Language : public ALabel, public EventHandler {
+ public:
+  Language(const std::string&, const Bar&, const Json::Value&);
+  ~Language() override;
+  void update() override;
+
+ private:
+  void updateFromIPC();
+  void onEvent(const Json::Value& ev) override;
+  void doUpdate();
+
+  struct Layout {
+    std::string full_name;
+    std::string short_name;
+    std::string variant;
+    std::string short_description;
+  };
+
+  static Layout getLayout(const std::string& fullName);
+
+  std::mutex mutex_;
+  const Bar& bar_;
+
+  std::vector<Layout> layouts_;
+  unsigned current_idx_ = 0;
+  std::string last_short_name_;
+};
+
+}  // namespace waybar::modules::triad

--- a/include/modules/triad/window.hpp
+++ b/include/modules/triad/window.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <gtkmm/button.h>
+#include <json/value.h>
+
+#include "AAppIconLabel.hpp"
+#include "bar.hpp"
+#include "modules/triad/backend.hpp"
+
+namespace waybar::modules::triad {
+
+class Window : public AAppIconLabel, public EventHandler {
+ public:
+  Window(const std::string&, const Bar&, const Json::Value&);
+  ~Window() override;
+  void update() override;
+
+ private:
+  void onEvent(const Json::Value& ev) override;
+  void doUpdate();
+  void setClass(const std::string& className, bool enable);
+
+  const Bar& bar_;
+  std::string oldAppId_;
+};
+
+}  // namespace waybar::modules::triad

--- a/include/modules/triad/workspaces.hpp
+++ b/include/modules/triad/workspaces.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <gtkmm/button.h>
+#include <json/value.h>
+
+#include <unordered_map>
+
+#include "AModule.hpp"
+#include "bar.hpp"
+#include "modules/triad/backend.hpp"
+
+namespace waybar::modules::triad {
+
+class Workspaces : public AModule, public EventHandler {
+ public:
+  Workspaces(const std::string&, const Bar&, const Json::Value&);
+  ~Workspaces() override;
+  void update() override;
+
+ private:
+  void onEvent(const Json::Value& ev) override;
+  void doUpdate();
+  Gtk::Button& addButton(const Json::Value& ws);
+  std::string getIcon(const std::string& value, const Json::Value& ws);
+  static bool isEmpty(const Json::Value& ws);
+
+  const Bar& bar_;
+  Gtk::Box box_;
+  std::unordered_map<uint64_t, Gtk::Button> buttons_;
+};
+
+}  // namespace waybar::modules::triad

--- a/man/waybar-triad-language.5.scd
+++ b/man/waybar-triad-language.5.scd
@@ -1,0 +1,73 @@
+waybar-triad-language(5)
+
+# NAME
+
+waybar - Triad language module
+
+# DESCRIPTION
+
+The *language* module shows Triad's current keyboard layout. It reads the layout
+list and selected index from Triad's native IPC state.
+
+# CONFIGURATION
+
+Addressed by *triad/language*
+
+*format*: ++
+	typeof: string ++
+	default: {} ++
+	The text to display.
+
+*format-<lang>* ++
+	typeof: string++
+	An alternate label for a layout. The suffix is the short language
+	description, such as *en* or *de*.
+
+*menu*: ++
+	typeof: string ++
+	Action that opens the menu.
+
+*menu-file*: ++
+	typeof: string ++
+	Path to the menu descriptor. It must contain a GtkMenu element with the ID
+	*menu*.
+
+*menu-actions*: ++
+	typeof: array ++
+	Actions for the menu buttons.
+
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Allows this module to take remaining bar space.
+
+# FORMAT REPLACEMENTS
+
+*{short}*: Short layout name, such as "us". This is also used for {}.
+
+*{shortDescription}*: Short layout description, such as "en".
+
+*{long}*: Long layout name, such as "English (Dvorak)".
+
+*{variant}*: Layout variant, such as "dvorak".
+
+# EXAMPLES
+
+```
+"triad/language": {
+	"format": "{short}",
+	"format-en": "EN",
+	"format-de": "DE"
+}
+```
+
+# STYLE
+
+- *#language*
+
+The widget also gets a CSS class matching the current layout's short name:
+
+```
+#language.us { color: #00ff00; }
+#language.de { color: #ff0000; }
+```

--- a/man/waybar-triad-window.5.scd
+++ b/man/waybar-triad-window.5.scd
@@ -1,0 +1,84 @@
+waybar-triad-window(5)
+
+# NAME
+
+waybar - Triad window module
+
+# DESCRIPTION
+
+The *window* module shows the title of the focused Triad window. By default it
+follows the globally focused workspace. With *separate-outputs*, it follows the
+workspace visible on the bar's output.
+
+# CONFIGURATION
+
+Addressed by *triad/window*
+
+*format*: ++
+	typeof: string ++
+	default: {title} ++
+	The text to display. A bare {} displays the current title.
+
+*rewrite*: ++
+	typeof: object ++
+	Rules for rewriting window titles. See *rewrite rules*.
+
+*separate-outputs*: ++
+	typeof: bool ++
+	Show the focused window for the output the bar belongs to, instead of the
+	global focused window.
+
+*icon*: ++
+	typeof: bool ++
+	default: false ++
+	Shows or hides the application icon.
+
+*icon-size*: ++
+	typeof: integer ++
+	default: 24 ++
+	Sets the application icon size.
+
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Allows this module to take remaining bar space.
+
+# FORMAT REPLACEMENTS
+
+Use `triad msg windows` to inspect the fields Triad reports.
+
+*{title}*: The title of the focused window.
+
+*{app_id}*: The app ID of the focused window.
+
+# REWRITE RULES
+
+*rewrite* is an object. Keys are regular expressions. Values are replacements
+used when a key matches the title, and may refer to capture groups.
+
+Regular expressions and replacements follow ECMAScript rules. If no expression
+matches, the title is shown as Triad reported it. Invalid expressions are
+skipped.
+
+# EXAMPLES
+
+```
+"triad/window": {
+	"format": "{title}",
+	"rewrite": {
+		"(.*) - Mozilla Firefox": "$1",
+		"(.*) - zsh": "> [$1]"
+	}
+}
+```
+
+# STYLE
+
+- *#window*
+- *window#waybar.empty #window*: No window is focused for the selected workspace.
+
+The classes below are applied to the Waybar window:
+
+- *window#waybar.empty*: No window is focused for the selected workspace.
+- *window#waybar.solo*: Only one window is on the selected workspace.
+- *window#waybar.<app-id>*: The app ID of that single window.

--- a/man/waybar-triad-workspaces.5.scd
+++ b/man/waybar-triad-workspaces.5.scd
@@ -1,0 +1,113 @@
+waybar-triad-workspaces(5)
+
+# NAME
+
+waybar - Triad workspaces module
+
+# DESCRIPTION
+
+The *workspaces* module shows Triad workspaces. It talks to Triad through the
+native IPC socket, so it uses Triad's stable tag IDs while displaying the
+workspace index and name you see in the session.
+
+# CONFIGURATION
+
+Addressed by *triad/workspaces*
+
+*all-outputs*: ++
+	typeof: bool ++
+	default: false ++
+	If false, the bar shows only the workspaces on its own output. If true, each
+	bar shows every workspace.
+
+*format*: ++
+	typeof: string ++
+	default: {value} ++
+	The text shown for each workspace.
+
+*format-icons*: ++
+	typeof: array ++
+	Chooses an icon by workspace name, index, or state. See *icons*.
+
+*disable-click*: ++
+	typeof: bool ++
+	default: false ++
+	If false, clicking a workspace focuses it in Triad.
+
+*disable-markup*: ++
+	typeof: bool ++
+	default: false ++
+	If true, labels are shown as plain text instead of Pango markup.
+
+*current-only*: ++
+	typeof: bool ++
+	default: false ++
+	If true, show only the focused workspace, or only the visible workspace on
+	this output when *all-outputs* is false.
+
+*hide-empty*: ++
+	typeof: bool ++
+	default: false ++
+	If true, hide empty workspaces unless they are focused.
+
+*on-update*: ++
+	typeof: string ++
+	Command to run when the module updates.
+
+*expand*: ++
+	typeof: bool ++
+	default: false ++
+	Allows this module to take remaining bar space.
+
+# FORMAT REPLACEMENTS
+
+*{value}*: The workspace name, or its index when it has no name.
+
+*{name}*: The workspace name.
+
+*{icon}*: The selected icon.
+
+*{index}*: The workspace index.
+
+*{id}*: The stable Triad tag ID.
+
+*{output}*: The output where the workspace is visible.
+
+*{layout}*: The current layout ID for the workspace.
+
+# ICONS
+
+The module first checks the state icons below, then the workspace name, then the
+workspace index.
+
+- *default*: Used when nothing else matches.
+- *focused*: The globally focused workspace.
+- *active*: A workspace visible on an output.
+- *urgent*: A workspace with urgent windows.
+- *empty*: A workspace with no windows.
+
+# EXAMPLES
+
+```
+"triad/workspaces": {
+	"format": "{icon}",
+	"format-icons": {
+		"term": "",
+		"web": "",
+		"focused": "",
+		"active": "",
+		"default": ""
+	}
+}
+```
+
+# STYLE
+
+- *#workspaces button*
+- *#workspaces button.focused*: The globally focused workspace.
+- *#workspaces button.active*: A workspace visible on an output.
+- *#workspaces button.urgent*: A workspace with urgent windows.
+- *#workspaces button.empty*: A workspace with no windows.
+- *#workspaces button.current_output*: A workspace on the same output as the bar.
+- *#workspaces button#triad-workspace-<name>*: A workspace with this name, or
+  this index when unnamed.

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -411,6 +411,9 @@ A group may hide all but one element, showing them only on mouse hover. In order
 - *waybar-niri-language(5)*
 - *waybar-niri-window(5)*
 - *waybar-niri-workspaces(5)*
+- *waybar-triad-language(5)*
+- *waybar-triad-window(5)*
+- *waybar-triad-workspaces(5)*
 - *waybar-idle-inhibitor(5)*
 - *waybar-image(5)*
 - *waybar-inhibitor(5)*

--- a/meson.build
+++ b/meson.build
@@ -348,6 +348,21 @@ if get_option('niri')
     )
 endif
 
+if get_option('triad')
+    add_project_arguments('-DHAVE_TRIAD', language: 'cpp')
+    src_files += files(
+        'src/modules/triad/backend.cpp',
+        'src/modules/triad/language.cpp',
+        'src/modules/triad/window.cpp',
+        'src/modules/triad/workspaces.cpp',
+    )
+    man_files += files(
+        'man/waybar-triad-language.5.scd',
+        'man/waybar-triad-window.5.scd',
+        'man/waybar-triad-workspaces.5.scd',
+    )
+endif
+
 if true
     add_project_arguments('-DHAVE_WAYFIRE', language: 'cpp')
     src_files += files(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -20,5 +20,6 @@ option('jack', type: 'feature', value: 'auto', description: 'Enable support for 
 option('wireplumber', type: 'feature', value: 'auto', description: 'Enable support for WirePlumber')
 option('cava', type: 'feature', value: 'auto', description: 'Enable support for Cava')
 option('niri', type: 'boolean', description: 'Enable support for niri')
+option('triad', type: 'boolean', value: false, description: 'Enable support for Triad')
 option('login-proxy', type: 'boolean', description: 'Enable interfacing with dbus login interface')
 option('gps', type: 'feature', value: 'auto', description: 'Enable support for gps')

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -42,6 +42,11 @@
 #include "modules/niri/window.hpp"
 #include "modules/niri/workspaces.hpp"
 #endif
+#ifdef HAVE_TRIAD
+#include "modules/triad/language.hpp"
+#include "modules/triad/window.hpp"
+#include "modules/triad/workspaces.hpp"
+#endif
 #ifdef HAVE_WAYFIRE
 #include "modules/wayfire/window.hpp"
 #include "modules/wayfire/workspaces.hpp"
@@ -229,6 +234,17 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
     }
     if (ref == "niri/workspaces") {
       return new waybar::modules::niri::Workspaces(id, bar_, config_[name]);
+    }
+#endif
+#ifdef HAVE_TRIAD
+    if (ref == "triad/language") {
+      return new waybar::modules::triad::Language(id, bar_, config_[name]);
+    }
+    if (ref == "triad/window") {
+      return new waybar::modules::triad::Window(id, bar_, config_[name]);
+    }
+    if (ref == "triad/workspaces") {
+      return new waybar::modules::triad::Workspaces(id, bar_, config_[name]);
     }
 #endif
 #ifdef HAVE_WAYFIRE

--- a/src/modules/triad/backend.cpp
+++ b/src/modules/triad/backend.cpp
@@ -1,0 +1,289 @@
+#include "modules/triad/backend.hpp"
+
+#include <netdb.h>
+#include <netinet/in.h>
+#include <spdlog/spdlog.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cstdlib>
+#include <sstream>
+#include <string>
+#include <thread>
+
+#include "giomm/datainputstream.h"
+#include "giomm/dataoutputstream.h"
+#include "giomm/unixinputstream.h"
+#include "giomm/unixoutputstream.h"
+#include "util/scoped_fd.hpp"
+
+namespace waybar::modules::triad {
+namespace {
+
+constexpr int kTriadIpcVersion = 1;
+
+Json::Value triadRequest(const std::string& request) {
+  Json::Value root(Json::objectValue);
+  auto& triad = (root["triad"] = Json::Value(Json::objectValue));
+  triad["version"] = kTriadIpcVersion;
+  triad["request"] = request;
+  return root;
+}
+
+Json::Value triadPayload(const Json::Value& response) {
+  if (!response["ok"].asBool()) {
+    throw std::runtime_error(response["error"].asString());
+  }
+
+  const auto& payload = response["triad"];
+  if (!payload || payload["version"].asInt() != kTriadIpcVersion) {
+    throw std::runtime_error("invalid Triad IPC response");
+  }
+
+  return payload;
+}
+
+bool sortByOutputAndIndex(const Json::Value& a, const Json::Value& b) {
+  const auto& aOutput = a["output"].asString();
+  const auto& bOutput = b["output"].asString();
+  const auto aIdx = a["workspace_idx"].asUInt();
+  const auto bIdx = b["workspace_idx"].asUInt();
+  if (aOutput == bOutput) return aIdx < bIdx;
+  return aOutput < bOutput;
+}
+
+std::string serializeRequest(const Json::Value& request) {
+  Json::StreamWriterBuilder builder;
+  builder["indentation"] = "";
+  std::unique_ptr<Json::StreamWriter> writer(builder.newStreamWriter());
+  std::ostringstream oss;
+  writer->write(request, &oss);
+  oss << '\n';
+  return oss.str();
+}
+
+}  // namespace
+
+IPC::IPC() {
+  loadState();
+  startIPC();
+}
+
+int IPC::connectToSocket() {
+  const char* socket_path = getenv("TRIAD_SOCKET");
+  std::string fallback_path;
+
+  if (socket_path == nullptr || socket_path[0] == '\0') {
+    const char* runtime_dir = getenv("XDG_RUNTIME_DIR");
+    fallback_path =
+        std::string(runtime_dir != nullptr && runtime_dir[0] != '\0' ? runtime_dir : "/tmp") +
+        "/triad.sock";
+    socket_path = fallback_path.c_str();
+  }
+
+  struct sockaddr_un addr;
+  util::ScopedFd socketfd(socket(AF_UNIX, SOCK_STREAM, 0));
+
+  if (socketfd == -1) {
+    throw std::runtime_error("socketfd failed");
+  }
+
+  addr.sun_family = AF_UNIX;
+  strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
+  addr.sun_path[sizeof(addr.sun_path) - 1] = 0;
+
+  int l = sizeof(struct sockaddr_un);
+
+  if (connect(socketfd, (struct sockaddr*)&addr, l) == -1) {
+    throw std::runtime_error("unable to connect to Triad IPC socket");
+  }
+
+  return socketfd.release();
+}
+
+Json::Value IPC::request(const std::string& name) { return send(triadRequest(name)); }
+
+void IPC::loadState() {
+  const auto payload = triadPayload(request("state"));
+  parseState(payload["state"]);
+}
+
+void IPC::startIPC() {
+  int socketfd = connectToSocket();
+
+  std::thread([this, socketfd]() {
+    spdlog::info("Triad IPC starting");
+
+    auto unix_istream = Gio::UnixInputStream::create(socketfd, true);
+    auto unix_ostream = Gio::UnixOutputStream::create(socketfd, false);
+    auto istream = Gio::DataInputStream::create(unix_istream);
+    auto ostream = Gio::DataOutputStream::create(unix_ostream);
+
+    Json::Value request(Json::objectValue);
+    auto& triad = (request["triad"] = Json::Value(Json::objectValue));
+    triad["version"] = kTriadIpcVersion;
+    triad["request"] = "event-stream";
+    auto& events = (triad["events"] = Json::Value(Json::arrayValue));
+    events.append("state");
+    events.append("layout");
+    events.append("window");
+
+    if (!ostream->put_string(serializeRequest(request)) || !ostream->flush()) {
+      spdlog::error("Triad IPC: failed to start event stream");
+      return;
+    }
+
+    std::string line;
+    while (istream->read_line(line)) {
+      spdlog::debug("Triad IPC: received {}", line);
+
+      try {
+        parseIPC(line);
+      } catch (std::exception& e) {
+        spdlog::warn("Failed to parse Triad IPC message: {}, reason: {}", line, e.what());
+      } catch (...) {
+        throw;
+      }
+
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+  }).detach();
+}
+
+void IPC::parseIPC(const std::string& line) {
+  const auto root = parser_.parse(line);
+  if (root["ok"].isBool()) {
+    if (!root["ok"].asBool()) {
+      spdlog::error("Triad IPC error: {}", root["error"].asString());
+    }
+    return;
+  }
+
+  const auto& payload = root["triad"];
+  if (!payload || payload["version"].asInt() != kTriadIpcVersion) {
+    throw std::runtime_error("invalid Triad IPC event");
+  }
+
+  const auto event = payload["event"].asString();
+  if (event == "state-changed") {
+    parseState(payload["state"]);
+  } else if (event == "layout-state-changed") {
+    auto lock = lockData();
+    parseLayoutState(payload["state"]);
+  } else if (event == "window-changed") {
+    auto lock = lockData();
+    parseWindowChanged(payload["window"]);
+  } else {
+    return;
+  }
+
+  std::unique_lock lock(callbackMutex_);
+  for (auto& [eventname, handler] : callbacks_) {
+    if (eventname == event) {
+      handler->onEvent(payload);
+    }
+  }
+}
+
+void IPC::parseState(const Json::Value& state) {
+  auto lock = lockData();
+
+  parseLayoutState(state["layout"]);
+
+  outputs_.clear();
+  const auto& outputs = state["outputs"];
+  std::copy(outputs.begin(), outputs.end(), std::back_inserter(outputs_));
+
+  windows_.clear();
+  const auto& windows = state["windows"];
+  std::copy(windows.begin(), windows.end(), std::back_inserter(windows_));
+
+  keyboardLayoutNames_.clear();
+  const auto& names = state["keyboard_layouts"];
+  for (const auto& name : names) keyboardLayoutNames_.push_back(name.asString());
+  keyboardLayoutCurrent_ = state["current_keyboard_layout_idx"].asUInt();
+}
+
+void IPC::parseLayoutState(const Json::Value& state) {
+  workspaces_.clear();
+  const auto& workspaces = state["workspaces"];
+  std::copy(workspaces.begin(), workspaces.end(), std::back_inserter(workspaces_));
+  std::sort(workspaces_.begin(), workspaces_.end(), sortByOutputAndIndex);
+}
+
+void IPC::parseWindowChanged(const Json::Value& window) {
+  const auto id = window["id"].asUInt64();
+  auto it = std::find_if(windows_.begin(), windows_.end(),
+                         [id](const auto& win) { return win["id"].asUInt64() == id; });
+  if (it == windows_.end()) {
+    windows_.push_back(window);
+  } else {
+    *it = window;
+  }
+}
+
+void IPC::registerForIPC(const std::string& ev, EventHandler* ev_handler) {
+  if (ev_handler == nullptr) {
+    return;
+  }
+
+  std::unique_lock lock(callbackMutex_);
+  callbacks_.emplace_back(ev, ev_handler);
+}
+
+void IPC::unregisterForIPC(EventHandler* ev_handler) {
+  if (ev_handler == nullptr) {
+    return;
+  }
+
+  std::unique_lock lock(callbackMutex_);
+  for (auto it = callbacks_.begin(); it != callbacks_.end();) {
+    auto& [eventname, handler] = *it;
+    if (handler == ev_handler) {
+      it = callbacks_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+Json::Value IPC::send(const Json::Value& request) {
+  util::ScopedFd socketfd(connectToSocket());
+
+  auto unix_istream = Gio::UnixInputStream::create(socketfd, true);
+  auto unix_ostream = Gio::UnixOutputStream::create(socketfd, false);
+  auto istream = Gio::DataInputStream::create(unix_istream);
+  auto ostream = Gio::DataOutputStream::create(unix_ostream);
+
+  if (!ostream->put_string(serializeRequest(request)) || !ostream->flush()) {
+    throw std::runtime_error("error writing to Triad socket");
+  }
+
+  std::string line;
+  if (!istream->read_line(line)) throw std::runtime_error("error reading from Triad socket");
+
+  std::istringstream iss(std::move(line));
+  Json::Value response;
+  iss >> response;
+  return response;
+}
+
+Json::Value IPC::action(const std::string& action_name) {
+  Json::Value request = triadRequest("action");
+  request["triad"]["action"] = action_name;
+  return triadPayload(send(request));
+}
+
+Json::Value IPC::action(const std::string& action_name, const std::string& key,
+                        const Json::Value& value) {
+  Json::Value request = triadRequest("action");
+  request["triad"]["action"] = action_name;
+  request["triad"][key] = value;
+  return triadPayload(send(request));
+}
+
+}  // namespace waybar::modules::triad

--- a/src/modules/triad/language.cpp
+++ b/src/modules/triad/language.cpp
@@ -1,0 +1,125 @@
+#include "modules/triad/language.hpp"
+
+#include <spdlog/spdlog.h>
+#include <xkbcommon/xkbcommon.h>
+#include <xkbcommon/xkbregistry.h>
+
+#include "util/string.hpp"
+
+namespace waybar::modules::triad {
+
+Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
+    : ALabel(config, "language", id, "{}", 0, false), bar_(bar) {
+  label_.hide();
+
+  if (!gIPC) gIPC = std::make_unique<IPC>();
+
+  gIPC->registerForIPC("state-changed", this);
+
+  updateFromIPC();
+  dp.emit();
+}
+
+Language::~Language() {
+  gIPC->unregisterForIPC(this);
+  std::lock_guard<std::mutex> lock(mutex_);
+}
+
+void Language::updateFromIPC() {
+  std::lock_guard<std::mutex> lock(mutex_);
+  auto ipcLock = gIPC->lockData();
+
+  layouts_.clear();
+  layouts_.reserve(gIPC->keyboardLayoutNames().size());
+  for (const auto& fullName : gIPC->keyboardLayoutNames()) layouts_.push_back(getLayout(fullName));
+
+  current_idx_ = gIPC->keyboardLayoutCurrent();
+}
+
+void Language::doUpdate() {
+  std::lock_guard<std::mutex> lock(mutex_);
+
+  if (layouts_.size() <= current_idx_) {
+    spdlog::error("triad language layout index out of bounds");
+    label_.hide();
+    return;
+  }
+  const auto& layout = layouts_[current_idx_];
+
+  if (!last_short_name_.empty()) {
+    label_.get_style_context()->remove_class(last_short_name_);
+  }
+  if (!layout.short_name.empty()) {
+    label_.get_style_context()->add_class(layout.short_name);
+    last_short_name_ = layout.short_name;
+  } else {
+    last_short_name_.clear();
+  }
+
+  std::string layoutName = std::string{};
+  if (config_.isMember("format-" + layout.short_description + "-" + layout.variant)) {
+    const auto propName = "format-" + layout.short_description + "-" + layout.variant;
+    layoutName = fmt::format(fmt::runtime(format_), config_[propName].asString());
+  } else if (config_.isMember("format-" + layout.short_description)) {
+    const auto propName = "format-" + layout.short_description;
+    layoutName = fmt::format(fmt::runtime(format_), config_[propName].asString());
+  } else {
+    layoutName = trim(fmt::format(fmt::runtime(format_), fmt::arg("long", layout.full_name),
+                                  fmt::arg("short", layout.short_name),
+                                  fmt::arg("shortDescription", layout.short_description),
+                                  fmt::arg("variant", layout.variant)));
+  }
+
+  if (!format_.empty()) {
+    label_.show();
+    label_.set_markup(layoutName);
+  } else {
+    label_.hide();
+  }
+}
+
+void Language::update() {
+  doUpdate();
+  ALabel::update();
+}
+
+void Language::onEvent(const Json::Value& ev) {
+  updateFromIPC();
+  dp.emit();
+}
+
+Language::Layout Language::getLayout(const std::string& fullName) {
+  auto* const context = rxkb_context_new(RXKB_CONTEXT_LOAD_EXOTIC_RULES);
+  rxkb_context_parse_default_ruleset(context);
+
+  rxkb_layout* layout = rxkb_layout_first(context);
+  while (layout != nullptr) {
+    std::string nameOfLayout = rxkb_layout_get_description(layout);
+
+    if (nameOfLayout != fullName) {
+      layout = rxkb_layout_next(layout);
+      continue;
+    }
+
+    auto name = std::string(rxkb_layout_get_name(layout));
+    const auto* variantPtr = rxkb_layout_get_variant(layout);
+    std::string variant = variantPtr == nullptr ? "" : std::string(variantPtr);
+
+    const auto* descriptionPtr = rxkb_layout_get_brief(layout);
+    std::string description = descriptionPtr == nullptr ? "" : std::string(descriptionPtr);
+
+    Layout info = Layout{nameOfLayout, name, variant, description};
+
+    rxkb_context_unref(context);
+
+    return info;
+  }
+
+  rxkb_context_unref(context);
+
+  spdlog::debug("triad language didn't find matching layout for {}", fullName);
+
+  return Layout{fullName, fullName, "", fullName};
+}
+
+}  // namespace waybar::modules::triad

--- a/src/modules/triad/window.cpp
+++ b/src/modules/triad/window.cpp
@@ -1,0 +1,110 @@
+#include "modules/triad/window.hpp"
+
+#include <gtkmm/button.h>
+#include <gtkmm/label.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+
+#include "util/rewrite_string.hpp"
+#include "util/sanitize_str.hpp"
+
+namespace waybar::modules::triad {
+
+Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
+    : AAppIconLabel(config, "window", id, "{title}", 0, true), bar_(bar) {
+  if (!gIPC) gIPC = std::make_unique<IPC>();
+
+  gIPC->registerForIPC("layout-state-changed", this);
+  gIPC->registerForIPC("state-changed", this);
+  gIPC->registerForIPC("window-changed", this);
+
+  dp.emit();
+}
+
+Window::~Window() { gIPC->unregisterForIPC(this); }
+
+void Window::onEvent(const Json::Value& ev) { dp.emit(); }
+
+void Window::doUpdate() {
+  auto ipcLock = gIPC->lockData();
+
+  const auto& windows = gIPC->windows();
+  const auto& workspaces = gIPC->workspaces();
+
+  const auto separateOutputs = config_["separate-outputs"].asBool();
+  const auto ws_it = std::find_if(workspaces.cbegin(), workspaces.cend(), [&](const auto& ws) {
+    if (separateOutputs) {
+      return ws["is_output_visible"].asBool() && ws["output"].asString() == bar_.output->name;
+    }
+
+    return ws["is_active"].asBool();
+  });
+
+  std::vector<Json::Value>::const_iterator it;
+  if (ws_it == workspaces.cend() || (*ws_it)["focused_window_id"].isNull()) {
+    it = windows.cend();
+  } else {
+    const auto id = (*ws_it)["focused_window_id"].asUInt64();
+    it = std::find_if(windows.cbegin(), windows.cend(),
+                      [id](const auto& win) { return win["id"].asUInt64() == id; });
+  }
+
+  setClass("empty", ws_it == workspaces.cend() || (*ws_it)["focused_window_id"].isNull());
+
+  if (it != windows.cend()) {
+    const auto& window = *it;
+
+    const auto title = window["title"].asString();
+    const auto appId = window["app_id"].asString();
+    const auto sanitizedTitle = waybar::util::sanitize_string(title);
+    const auto sanitizedAppId = waybar::util::sanitize_string(appId);
+
+    label_.show();
+    label_.set_markup(waybar::util::rewriteString(
+        fmt::format(fmt::runtime(format_), fmt::arg("title", sanitizedTitle),
+                    fmt::arg("app_id", sanitizedAppId)),
+        config_["rewrite"]));
+
+    updateAppIconName(appId, "");
+
+    if (tooltipEnabled()) label_.set_tooltip_markup(title);
+
+    const auto id = window["id"].asUInt64();
+    const auto tagId = window["tag_id"].asUInt64();
+    const auto isSolo = std::none_of(windows.cbegin(), windows.cend(), [&](const auto& win) {
+      return win["id"].asUInt64() != id && win["tag_id"].asUInt64() == tagId;
+    });
+    setClass("solo", isSolo);
+    if (!appId.empty()) setClass(appId, isSolo);
+
+    if (oldAppId_ != appId) {
+      if (!oldAppId_.empty()) setClass(oldAppId_, false);
+      oldAppId_ = appId;
+    }
+  } else {
+    label_.hide();
+    updateAppIconName("", "");
+    setClass("solo", false);
+    if (!oldAppId_.empty()) setClass(oldAppId_, false);
+    oldAppId_.clear();
+  }
+}
+
+void Window::update() {
+  doUpdate();
+  AAppIconLabel::update();
+}
+
+void Window::setClass(const std::string& className, bool enable) {
+  auto styleContext = bar_.window.get_style_context();
+  if (enable) {
+    if (!styleContext->has_class(className)) {
+      styleContext->add_class(className);
+    }
+  } else {
+    styleContext->remove_class(className);
+  }
+}
+
+}  // namespace waybar::modules::triad

--- a/src/modules/triad/workspaces.cpp
+++ b/src/modules/triad/workspaces.cpp
@@ -1,0 +1,197 @@
+#include "modules/triad/workspaces.hpp"
+
+#include <gtkmm/button.h>
+#include <gtkmm/label.h>
+#include <spdlog/spdlog.h>
+
+#include <algorithm>
+
+namespace waybar::modules::triad {
+
+Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value& config)
+    : AModule(config, "workspaces", id, false, false), bar_(bar), box_(bar.orientation, 0) {
+  box_.set_name("workspaces");
+  if (!id.empty()) {
+    box_.get_style_context()->add_class(id);
+  }
+  box_.get_style_context()->add_class(MODULE_CLASS);
+  event_box_.add(box_);
+
+  if (!gIPC) gIPC = std::make_unique<IPC>();
+
+  gIPC->registerForIPC("layout-state-changed", this);
+  gIPC->registerForIPC("state-changed", this);
+
+  dp.emit();
+}
+
+Workspaces::~Workspaces() { gIPC->unregisterForIPC(this); }
+
+void Workspaces::onEvent(const Json::Value& ev) { dp.emit(); }
+
+bool Workspaces::isEmpty(const Json::Value& ws) {
+  if (ws["occupied"].isBool()) return !ws["occupied"].asBool();
+  return ws["focused_window_id"].isNull();
+}
+
+void Workspaces::doUpdate() {
+  auto ipcLock = gIPC->lockData();
+
+  const auto alloutputs = config_["all-outputs"].asBool();
+  std::vector<Json::Value> my_workspaces;
+  const auto& workspaces = gIPC->workspaces();
+  std::copy_if(workspaces.cbegin(), workspaces.cend(), std::back_inserter(my_workspaces),
+               [&](const auto& ws) {
+                 if (alloutputs) return true;
+                 return ws["output"].asString() == bar_.output->name;
+               });
+
+  for (auto it = buttons_.begin(); it != buttons_.end();) {
+    auto ws = std::find_if(my_workspaces.begin(), my_workspaces.end(),
+                           [it](const auto& ws) { return ws["tag_id"].asUInt64() == it->first; });
+    if (ws == my_workspaces.end()) {
+      it = buttons_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  for (const auto& ws : my_workspaces) {
+    auto bit = buttons_.find(ws["tag_id"].asUInt64());
+    auto& button = bit == buttons_.end() ? addButton(ws) : bit->second;
+    auto style_context = button.get_style_context();
+
+    if (ws["is_active"].asBool())
+      style_context->add_class("focused");
+    else
+      style_context->remove_class("focused");
+
+    if (ws["is_output_visible"].asBool())
+      style_context->add_class("active");
+    else
+      style_context->remove_class("active");
+
+    if (ws["is_urgent"].asBool())
+      style_context->add_class("urgent");
+    else
+      style_context->remove_class("urgent");
+
+    if (ws["output"]) {
+      if (ws["output"].asString() == bar_.output->name)
+        style_context->add_class("current_output");
+      else
+        style_context->remove_class("current_output");
+    } else {
+      style_context->remove_class("current_output");
+    }
+
+    if (isEmpty(ws))
+      style_context->add_class("empty");
+    else
+      style_context->remove_class("empty");
+
+    std::string name;
+    if (ws["name"].isString()) {
+      name = ws["name"].asString();
+    } else {
+      name = std::to_string(ws["workspace_idx"].asUInt());
+    }
+    button.set_name("triad-workspace-" + name);
+
+    if (config_["format"].isString()) {
+      auto format = config_["format"].asString();
+      name = fmt::format(
+          fmt::runtime(format), fmt::arg("icon", getIcon(name, ws)), fmt::arg("value", name),
+          fmt::arg("name", ws["name"].isString() ? ws["name"].asString() : ""),
+          fmt::arg("index", ws["workspace_idx"].asUInt()), fmt::arg("id", ws["tag_id"].asUInt()),
+          fmt::arg("output", ws["output"].asString()), fmt::arg("layout", ws["layout"].asString()));
+    }
+    if (!config_["disable-markup"].asBool()) {
+      static_cast<Gtk::Label*>(button.get_children()[0])->set_markup(name);
+    } else {
+      button.set_label(name);
+    }
+
+    if (config_["current-only"].asBool()) {
+      const auto* property = alloutputs ? "is_active" : "is_output_visible";
+      if (ws[property].asBool())
+        button.show();
+      else
+        button.hide();
+    } else if (config_["hide-empty"].asBool()) {
+      if (isEmpty(ws) && !ws["is_active"].asBool())
+        button.hide();
+      else
+        button.show();
+    } else {
+      button.show();
+    }
+  }
+
+  for (auto it = my_workspaces.cbegin(); it != my_workspaces.cend(); ++it) {
+    const auto& ws = *it;
+
+    auto pos = ws["workspace_idx"].asUInt() - 1;
+    if (alloutputs) pos = it - my_workspaces.cbegin();
+
+    auto& button = buttons_[ws["tag_id"].asUInt64()];
+    box_.reorder_child(button, pos);
+  }
+}
+
+void Workspaces::update() {
+  doUpdate();
+  AModule::update();
+}
+
+Gtk::Button& Workspaces::addButton(const Json::Value& ws) {
+  std::string name;
+  if (ws["name"].isString()) {
+    name = ws["name"].asString();
+  } else {
+    name = std::to_string(ws["workspace_idx"].asUInt());
+  }
+
+  auto pair = buttons_.emplace(ws["tag_id"].asUInt64(), name);
+  auto&& button = pair.first->second;
+  box_.pack_start(button, false, false, 0);
+  button.set_relief(Gtk::RELIEF_NONE);
+  if (!config_["disable-click"].asBool()) {
+    const auto id = ws["tag_id"].asUInt();
+    button.signal_pressed().connect([=] {
+      try {
+        IPC::action("focus-tag", "tag", id);
+      } catch (const std::exception& e) {
+        spdlog::error("Error switching Triad workspace: {}", e.what());
+      }
+    });
+  }
+  return button;
+}
+
+std::string Workspaces::getIcon(const std::string& value, const Json::Value& ws) {
+  const auto& icons = config_["format-icons"];
+  if (!icons) return value;
+
+  if (ws["is_urgent"].asBool() && icons["urgent"]) return icons["urgent"].asString();
+
+  if (ws["is_output_visible"].asBool() && icons["active"]) return icons["active"].asString();
+
+  if (ws["is_active"].asBool() && icons["focused"]) return icons["focused"].asString();
+
+  if (isEmpty(ws) && icons["empty"]) return icons["empty"].asString();
+
+  if (ws["name"].isString()) {
+    const auto& name = ws["name"].asString();
+    if (icons[name]) return icons[name].asString();
+  }
+
+  const auto idx = ws["workspace_idx"].asString();
+  if (icons[idx]) return icons[idx].asString();
+
+  if (icons["default"]) return icons["default"].asString();
+
+  return value;
+}
+
+}  // namespace waybar::modules::triad


### PR DESCRIPTION
Adds native Triad modules for Waybar.

Triad is a programmable Wayland window manager that runs on the River protocol. It has a small native IPC surface for shells and bars. This PR lets Waybar talk to that API directly, the same way it does for other compositor-specific modules, instead of depending on a compatibility layer whose shape is meant for another window manager.

The shared Waybar changes are small: a Meson option, module factory wiring, and manual page links. The Triad-specific code lives under its own module namespace and is only built when Triad support is enabled.

This adds:

- `triad/workspaces`
- `triad/window`
- `triad/language`

The backend connects to `$TRIAD_SOCKET`, or falls back to `${XDG_RUNTIME_DIR}/triad.sock`, reads the initial compositor state, and then follows Triad's native event stream for workspace, window, layout, and keyboard updates.

Tested on Triad with three monitors. Workspace switching, active and urgent workspace state, focused window updates, and keyboard layout updates work here.

Build and test commands run:

```sh
meson setup build -Dtriad=true -Dniri=true -Dtests=enabled
ninja -C build
meson test -C build --verbose --print-errorlogs --suite waybar
```

Triad: https://github.com/greenm01/triad
