### PR TITLE
feat(custom): add image

### DIFF
--- a/include/modules/custom.hpp
+++ b/include/modules/custom.hpp
@@ -5,14 +5,14 @@
 #include <csignal>
 #include <string>
 
-#include "ALabel.hpp"
+#include "AIconLabel.hpp"
 #include "util/command.hpp"
 #include "util/json.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace waybar::modules {
 
-class Custom : public ALabel {
+class Custom : public AIconLabel {
  public:
   Custom(const std::string&, const std::string&, const Json::Value&, const std::string&);
   virtual ~Custom();
@@ -36,6 +36,9 @@ class Custom : public ALabel {
   std::string alt_;
   std::string tooltip_;
   std::string last_tooltip_markup_;
+  std::string image_path_;
+  std::string image_name_;
+  unsigned app_icon_size_{24};
   const bool tooltip_format_enabled_;
   std::vector<std::string> class_;
   int percentage_;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -193,7 +193,8 @@ auto waybar::modules::Custom::update() -> void {
       auto str = fmt::format(fmt::runtime(format_), fmt::arg("text", text_), fmt::arg("alt", alt_),
                              fmt::arg("icon", getIcon(percentage_, alt_)),
                              fmt::arg("percentage", percentage_));
-      if ((config_["hide-empty-text"].asBool() && text_.empty()) || (str.empty() && image_path_.empty() && image_name_.empty())) {
+      if ((config_["hide-empty-text"].asBool() && text_.empty()) ||
+          (str.empty() && image_path_.empty() && image_name_.empty())) {
         event_box_.hide();
       } else {
         label_.set_markup(str);
@@ -231,17 +232,16 @@ auto waybar::modules::Custom::update() -> void {
         auto image_style = image_.get_style_context();
         image_style->add_class("image-button");
         event_box_.show();
-        if (!image_path_.empty()) {            
-            auto pixbuf = Gdk::Pixbuf::create_from_file(image_path_, app_icon_size_, app_icon_size_);
-            image_.set(pixbuf);
-        } else if (!image_name_.empty()) {            
-            image_.set_from_icon_name(image_name_, Gtk::ICON_SIZE_INVALID);
-            image_.set_pixel_size(app_icon_size_);
-        } 
+        if (!image_path_.empty()) {
+          auto pixbuf = Gdk::Pixbuf::create_from_file(image_path_, app_icon_size_, app_icon_size_);
+          image_.set(pixbuf);
+        } else if (!image_name_.empty()) {
+          image_.set_from_icon_name(image_name_, Gtk::ICON_SIZE_INVALID);
+          image_.set_pixel_size(app_icon_size_);
+        }
 
         image_.set_visible(!image_name_.empty() || !image_path_.empty());
         label_.set_visible(!str.empty());
-        
       }
     } catch (const fmt::format_error& e) {
       if (std::strcmp(e.what(), "cannot switch from manual to automatic argument indexing") != 0)
@@ -251,9 +251,6 @@ auto waybar::modules::Custom::update() -> void {
           "mixing manual and automatic argument indexing is no longer supported; "
           "try replacing \"{}\" with \"{text}\" in your format specifier");
     }
-    
-    
-    
   }
   // Call parent update
   AIconLabel::update();
@@ -322,7 +319,7 @@ void waybar::modules::Custom::parseOutputJson() {
         class_.push_back(c.asString());
       }
     }
-    
+
     if (!parsed["percentage"].asString().empty() && parsed["percentage"].isNumeric()) {
       percentage_ = (int)lround(parsed["percentage"].asFloat());
     } else {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -8,7 +8,7 @@
 
 waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
                                 const Json::Value& config, const std::string& output_name)
-    : ALabel(config, "custom-" + name, id, "{}"),
+    : AIconLabel(config, "custom-" + name, id, "{}"),
       name_(name),
       output_name_(output_name),
       id_(id),
@@ -27,6 +27,15 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
     delayWorker();
   } else if (config_["exec"].isString()) {
     continuousWorker();
+  }
+  if (config_["image-path"].isString()) {
+    image_path_ = config_["image-path"].asString();
+  }
+  if (config_["image-name"].isString()) {
+    image_name_ = config_["image-name"].asString();
+  }
+  if (config["icon-size"].isUInt()) {
+    app_icon_size_ = config["icon-size"].asUInt();
   }
 }
 
@@ -177,7 +186,7 @@ auto waybar::modules::Custom::update() -> void {
       auto str = fmt::format(fmt::runtime(format_), fmt::arg("text", text_), fmt::arg("alt", alt_),
                              fmt::arg("icon", getIcon(percentage_, alt_)),
                              fmt::arg("percentage", percentage_));
-      if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
+      if ((config_["hide-empty-text"].asBool() && text_.empty()) || (str.empty() && image_path_.empty() && image_name_.empty())) {
         event_box_.hide();
       } else {
         label_.set_markup(str);
@@ -212,7 +221,20 @@ auto waybar::modules::Custom::update() -> void {
         style->add_class("flat");
         style->add_class("text-button");
         style->add_class(MODULE_CLASS);
+        auto image_style = image_.get_style_context();
+        image_style->add_class("image-button");
         event_box_.show();
+        if (!image_path_.empty()) {            
+            auto pixbuf = Gdk::Pixbuf::create_from_file(image_path_, app_icon_size_, app_icon_size_);
+            image_.set(pixbuf);
+        } else if (!image_name_.empty()) {            
+            image_.set_from_icon_name(image_name_, Gtk::ICON_SIZE_INVALID);
+            image_.set_pixel_size(app_icon_size_);
+        } 
+
+        image_.set_visible(!image_name_.empty() || !image_path_.empty());
+        label_.set_visible(!str.empty());
+        
       }
     } catch (const fmt::format_error& e) {
       if (std::strcmp(e.what(), "cannot switch from manual to automatic argument indexing") != 0)
@@ -222,9 +244,12 @@ auto waybar::modules::Custom::update() -> void {
           "mixing manual and automatic argument indexing is no longer supported; "
           "try replacing \"{}\" with \"{text}\" in your format specifier");
     }
+    
+    
+    
   }
   // Call parent update
-  ALabel::update();
+  AIconLabel::update();
 }
 
 void waybar::modules::Custom::parseOutputRaw() {
@@ -290,6 +315,7 @@ void waybar::modules::Custom::parseOutputJson() {
         class_.push_back(c.asString());
       }
     }
+    
     if (!parsed["percentage"].asString().empty() && parsed["percentage"].isNumeric()) {
       percentage_ = (int)lround(parsed["percentage"].asFloat());
     } else {


### PR DESCRIPTION
Proposed to change a custom module parent to AIconLabel in order make launcher button more easily.
Added "image-name" and "image-path" config options to specify image through icon name or through path to icon file. 
Config also may contain "icon-size" parameter to specify desired icon size, which defaults to 24.
Added CSS class "image-button" to image tune it via style.css.