### PR TITLE
hyprland/language: add tooltip-format support

### DIFF
--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -21,6 +21,10 @@ Addressed by *hyprland/language*
 	typeof: string++
 	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. This option uses the same replacements as *format*.
+
 *keyboard-name*: ++
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
@@ -60,6 +64,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -51,6 +51,14 @@ auto Language::update() -> void {
 
   spdlog::debug("hyprland language formatted layout name {}", layoutName);
 
+  if (tooltipEnabled() && config_["tooltip-format"].isString()) {
+    const auto tooltip_format = config_["tooltip-format"].asString();
+    label_.set_tooltip_markup(trim(fmt::format(
+        fmt::runtime(tooltip_format), fmt::arg("long", layout_.full_name),
+        fmt::arg("short", layout_.short_name),
+        fmt::arg("shortDescription", layout_.short_description), fmt::arg("variant", layout_.variant))));
+  }
+
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);


### PR DESCRIPTION
Fixes #3693.

Adds optional tooltip formatting for the hyprland/language module.

Changes:
- Reads `tooltip-format` when tooltips are enabled.
- Uses the same replacements as the label format: `{long}`, `{short}`, `{shortDescription}`, and `{variant}`.
- Documents `tooltip-format` in `waybar-hyprland-language(5)` and adds it to the example config.

Verification:
- Ran `git diff --check` successfully.

Limitations:
- I did not run a full Waybar build in this Windows workspace because the Linux/Wayland/Hyprland dependency stack is not available here.