### PR TITLE
(Fix) (sway workspace module) persistent workspaces always removed

### DIFF
--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -229,7 +229,10 @@ bool Workspaces::filterButtons() {
     auto ws = std::find_if(workspaces_.begin(), workspaces_.end(),
                            [it](const auto& node) { return node["name"].asString() == it->first; });
     if (ws == workspaces_.end() ||
-        (!config_["all-outputs"].asBool() && (*ws)["output"].asString() != bar_.output->name)) {
+        ((*ws).isMember("target_output") ? (*ws)["target_output"].asString() != bar_.output->name &&
+                                               (*ws)["target_output"].asString() != ""
+                                         : !config_["all-outputs"].asBool() &&
+                                               (*ws)["output"].asString() != bar_.output->name)) {
       it = buttons_.erase(it);
       needReorder = true;
     } else {


### PR DESCRIPTION
Previously the logic in `filter_buttons` did not check for and handle persistent workspaces properly, with the result that persistent workspaces were erased every time the function was called, then immediately recreated because they were missing.

Obviously that's a bit inefficient. But far worse, this was messing with my rice because it broke any transitions that were meant to play.