### PR TITLE
[feat] `sway/workspaces`: refer to outputs by their monitor identifier in `persistent-workspaces`

### DIFF
--- a/man/waybar-sway-workspaces.5.scd
+++ b/man/waybar-sway-workspaces.5.scd
@@ -147,6 +147,7 @@ an empty list denoting all outputs.
 		"3": [], // Always show a workspace with name '3', on all outputs if it does not exist
 		"4": ["eDP-1"], // Always show a workspace with name '4', on output 'eDP-1' if it does not exist
 		"5": ["eDP-1", "DP-2"] // Always show a workspace with name '5', on outputs 'eDP-1' and 'DP-2' if it does not exist
+		"6": ["MonitorMaker 3000 ABC0123"], // Always show a workspace with name '6' on outputs with an identifier 'MonitorMaker 3000 ABC0123' (usually a triple of vendor/model/serial)
 	}
 }
 ```

--- a/src/modules/sway/workspaces.cpp
+++ b/src/modules/sway/workspaces.cpp
@@ -143,7 +143,8 @@ void Workspaces::onCmd(const struct Ipc::ipc_response& res) {
             if (p_w.isArray() && !p_w.empty()) {
               // Adding to target outputs
               for (const Json::Value& output : p_w) {
-                if (output.asString() == bar_.output->name) {
+                auto output_name = output.asString();
+                if (output_name == bar_.output->name || output_name == bar_.output->identifier) {
                   Json::Value v;
                   v["name"] = p_w_name;
                   v["target_output"] = bar_.output->name;


### PR DESCRIPTION
This PR extends the `persistent-workspaces` functionality in `sway/workspaces` with an option of pinning workspaces to displays by their output identifiers (basically, the monitor's "make and model", usually given as a vendor/model/serial triple) in addition to their output name (e.g. `DP-3`, which is unstable and can change between reboots).

That means instead of this:

```json
{
    ...
    "sway/workspaces": {
        ...
        "persistent-workspaces": {
            "1:main": ["DP-2"],
            "2:code": ["DP-2"],
            "3:secondary": ["DP-3"],
            "0:TV": ["HDMI-A-1"]
        }
    },
    ...
}
```

we can now write this:

```json
{
    ...
    "sway/workspaces": {
        ...
        "persistent-workspaces": {
            "1:main": ["Dell Inc. Dell AW2518H #ASM0cCiovard"],
            "2:code": ["Dell Inc. Dell AW2518H #ASM0cCiovard"],
            "3:secondary": ["AOC 24P4CV XL9RAHA000298"],
            "0:TV": ["Philips Consumer Electronics Company Philips FTV 0x01010101"]
        }
    },
    ...
}
```

and even if the outputs are renamed after a reboot the workspaces will still be assigned to correct displays.