### PR TITLE
Fix (wayfire/backend): Fixed unhandled exception (out_of_range) after…

### DIFF
--- a/src/modules/wayfire/backend.cpp
+++ b/src/modules/wayfire/backend.cpp
@@ -347,10 +347,13 @@ auto IPC::update_state_handler(const std::string& event, const Json::Value& data
 
   if (event == "output-wset-changed") {
     // data: { event, new-wset: wset.name, output: id, new-wset-data: wset, output-data: output }
-    auto& output = state.outputs.at(data["output-data"]["name"].asString());
-    auto wset_idx = data["new-wset-data"]["index"].asUInt();
-    state.wsets.at(wset_idx).output = output;
-    output.wset_idx = wset_idx;
+    try {
+	  auto& output = state.outputs.at(data["output-data"]["name"].asString());
+	  auto wset_idx = data["new-wset-data"]["index"].asUInt();
+	  state.wsets.at(wset_idx).output = output;
+	  output.wset_idx = wset_idx;
+	} catch (const std::exception&) {
+	} 
     return;
   }
 


### PR DESCRIPTION
## Waybar version & Setup Info
`Waybar v0.15.0`
`Waybar v05945748 (branch 'master')`

I am launching waybar using wayfire's autostart plugin.

## Explanation of the Bug
Waybar crashes with an unhandled exception after i put my laptop in idle.

After examining the logs, i found an unhandled exception in the backend code of wayfire.

Related logs:
```
[2026-05-27 23:06:32.550] [debug] Wayfire IPC: received event "output-wset-changed"
[2026-05-27 23:06:32.552] [debug] Output removed: Chimei Innolux Corporation 0x15E6
terminate called after throwing an instance of 'std::out_of_range'
  what():  unordered_map::at
```

Simply adding a try-catch clause could have unintended side effects, i apologize in advance for my lack of knowledge about the codebase.
The patch seems to work when trying to recreate the bug.
There may be a way where the proper wset might not get set and crash the program with a different unhandled exception.

I unfortunately do not have the hardware to test this with multiple outputs.
Please do point out if there are any faults within my solution as I consider myself rather inexperienced.