### PR TITLE
Fix (memory): Fix tooltip showing incorrect unit and add proper unit initialization

### DIFF
--- a/include/modules/memory.hpp
+++ b/include/modules/memory.hpp
@@ -19,8 +19,6 @@ class Memory : public ALabel {
  private:
   void parseMeminfo();
 
-  static float calc_divisor(const std::string& divisor);
-
   std::unordered_map<std::string, unsigned long> meminfo_;
 
   util::SleeperThread thread_;

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -1,5 +1,18 @@
 #include "modules/memory.hpp"
 
+namespace {
+const std::unordered_map<std::string, float> kUnits = {
+  {"kB", 1.000},
+  {"kiB", 1.024},
+  {"MB", 1.000 * 1000.0},
+  {"MiB", 1.024 * 1024.0},
+  {"GB", 1.000 * 1000.0 * 1000.0},
+  {"GiB", 1.024 * 1024.0 * 1024.0},
+  {"TB", 1.000 * 1000.0 * 1000.0 * 1000.0},
+  {"TiB", 1.024 * 1024.0 * 1024.0 * 1024.0}
+};
+}
+
 waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config)
     : ALabel(config, "memory", id, "{}%", 30) {
   thread_ = [this] {
@@ -8,6 +21,11 @@ waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config
   };
   if (config["unit"].isString()) {
     unit_ = config["unit"].asString();
+    if (!kUnits.contains(unit_)) {
+      unit_ = "GiB";
+    }
+  } else {
+    unit_ = "GiB";
   }
 }
 
@@ -40,7 +58,7 @@ auto waybar::modules::Memory::update() -> void {
       used_swap_percentage = 100 * (swaptotal - swapfree) / swaptotal;
     }
 
-    float divisor = calc_divisor(unit_);
+    float divisor = kUnits.at(unit_);
     float total_ram = memtotal / divisor;
     float total_swap = swaptotal / divisor;
     float used_ram = (memtotal - memfree) / divisor;
@@ -82,7 +100,7 @@ auto waybar::modules::Memory::update() -> void {
             fmt::arg("swapUsed", used_swap), fmt::arg("avail", available_ram),
             fmt::arg("swapAvail", available_swap)));
       } else {
-        label_.set_tooltip_markup(fmt::format("{:.{}f}GiB used", used_ram, 1));
+        label_.set_tooltip_markup(fmt::format("{:.{}f}{} used", used_ram, 1, unit_));
       }
     }
   } else {
@@ -90,26 +108,4 @@ auto waybar::modules::Memory::update() -> void {
   }
   // Call parent update
   ALabel::update();
-}
-
-float waybar::modules::Memory::calc_divisor(const std::string& divisor) {
-  if (divisor == "kB") {
-    return 1.0;
-  } else if (divisor == "kiB") {
-    return 1.024;
-  } else if (divisor == "MB") {
-    return 1.000 * 1000.0;
-  } else if (divisor == "MiB") {
-    return 1.024 * 1024.0;
-  } else if (divisor == "GB") {
-    return 1.000 * 1000.0 * 1000.0;
-  } else if (divisor == "GiB") {
-    return 1.024 * 1024.0 * 1024.0;
-  } else if (divisor == "TB") {
-    return 1.000 * 1000.0 * 1000.0 * 1000.0;
-  } else if (divisor == "TiB") {
-    return 1.024 * 1024.0 * 1024.0 * 1024.0;
-  } else {  // default to GiB if it is anything that we don't recongnise
-    return 1.024 * 1024.0 * 1024.0;
-  }
 }


### PR DESCRIPTION
## Waybar version
`Waybar v0.15.0`

## Bug Description
The tooltip was not using the unit that the user supplied through the configuration file.

The following changes seemed to have solved that issue, in these changes I have removed the static function to calculate divisors and added a static const unordered_map with the units and the divisors. 

This allows checking the validity of the unit and getting the divisor with the same variable. If the user passes an invalid unit, the unit_ member will default to GiB, whereas before the unit_ member could have been an invalid unit.