### PR TITLE
Add tooltip-format for Hyprland language module

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -35,6 +35,7 @@ class Language : public waybar::ALabel, public EventHandler {
   std::mutex mutex_;
   const Bar& bar_;
   util::JsonParser parser_;
+  std::string tooltip_format_;
 
   Layout layout_;
 

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,10 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. Uses the same replacements as *format*.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +64,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config["tooltip-format"].isString()) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,18 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        const auto tooltip =
+            trim(fmt::format(fmt::runtime(tooltip_format_), fmt::arg("long", layout_.full_name),
+                             fmt::arg("short", layout_.short_name),
+                             fmt::arg("shortDescription", layout_.short_description),
+                             fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltip);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Closes #3693.

This adds `tooltip-format` support to `hyprland/language`, matching the existing `sway/language` behavior:

- reads `tooltip-format` from config
- formats the tooltip with `{short}`, `{shortDescription}`, `{long}`, and `{variant}`
- falls back to the displayed layout text when `tooltip-format` is not set
- documents the option in `waybar-hyprland-language(5)`

Verification:

- `git diff --check`

I could not run the full Meson build in this Windows environment because `meson` is not installed here.