### PR TITLE
Add tooltip-format support for hyprland/language

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -23,6 +23,8 @@ class Language : public waybar::ALabel, public EventHandler {
 
   void initLanguage();
 
+  auto formatLayout(const std::string& format) const -> std::string;
+
   struct Layout {
     std::string full_name;
     std::string short_name;

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -17,6 +17,16 @@ Addressed by *hyprland/language*
 	default: {} ++
 	The format, how information should be displayed.
 
+*tooltip-format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how information should be displayed in the tooltip.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *format-<lang>* ++
 	typeof: string++
 	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
@@ -60,6 +70,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "{shortDescription}: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -27,6 +27,13 @@ Language::~Language() {
   std::lock_guard<std::mutex> lg(mutex_);
 }
 
+auto Language::formatLayout(const std::string& format) const -> std::string {
+  return trim(fmt::format(fmt::runtime(format), fmt::arg("long", layout_.full_name),
+                          fmt::arg("short", layout_.short_name),
+                          fmt::arg("shortDescription", layout_.short_description),
+                          fmt::arg("variant", layout_.variant)));
+}
+
 auto Language::update() -> void {
   std::lock_guard<std::mutex> lg(mutex_);
 
@@ -43,10 +50,7 @@ auto Language::update() -> void {
     const auto propName = "format-" + layout_.short_description;
     layoutName = fmt::format(fmt::runtime(format_), config_[propName].asString());
   } else {
-    layoutName = trim(fmt::format(fmt::runtime(format_), fmt::arg("long", layout_.full_name),
-                                  fmt::arg("short", layout_.short_name),
-                                  fmt::arg("shortDescription", layout_.short_description),
-                                  fmt::arg("variant", layout_.variant)));
+    layoutName = formatLayout(format_);
   }
 
   spdlog::debug("hyprland language formatted layout name {}", layoutName);
@@ -56,6 +60,16 @@ auto Language::update() -> void {
     label_.set_markup(layoutName);
   } else {
     label_.hide();
+  }
+
+  if (tooltipEnabled()) {
+    const auto tooltipFormat =
+        config_["tooltip-format"].isString() ? config_["tooltip-format"].asString() : "";
+    if (!tooltipFormat.empty()) {
+      label_.set_tooltip_markup(formatLayout(tooltipFormat));
+    } else if (!layoutName.empty()) {
+      label_.set_tooltip_markup(layoutName);
+    }
   }
 
   ALabel::update();


### PR DESCRIPTION
## Summary

Adds tooltip support to the Hyprland language module via a new tooltip-format option.

The implementation mirrors the existing text format path, falls back to the visible label when tooltip-format is not configured, and updates the module man page with the new option.

## Context

Related issue: #3693

## Verification

- git diff --check HEAD~1..HEAD

I could not run a full Waybar build in this Windows environment because the local toolchain does not include meson/ninja/clang-format.

## Payout

If this helps close the bounty or saves review time, payout wallet: 0xB167296811544B429D17990E687548F7d552008C