### PR TITLE
Add tooltip format for Hyprland language

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_ = "";
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,16 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how layout should be displayed in tooltip.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +70,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config.isMember("tooltip-format")) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,18 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        auto tooltip_layout = trim(fmt::format(
+            fmt::runtime(tooltip_format_), fmt::arg("long", layout_.full_name),
+            fmt::arg("short", layout_.short_name),
+            fmt::arg("shortDescription", layout_.short_description),
+            fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltip_layout);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Summary

- Add `tooltip-format` support to `hyprland/language`
- Format tooltip text with the same layout placeholders used by `format`
- Document the new option in the Hyprland language man page

 Problem

`hyprland/language` can format the visible label with `{long}`, `{short}`, `{shortDescription}`, and `{variant}`, but there is no separate tooltip format. This addresses #3693.

 Fix

The module now reads `tooltip-format` from config and applies it on update when tooltips are enabled. If `tooltip-format` is not configured, the tooltip falls back to the displayed label text, matching the behavior used by similar language modules.


Verification:
- Ran `git diff --check`.
- Full build was not run locally because the workspace does not have Meson/Ninja/C++ build dependencies.
- Runtime Hyprland check was not run locally because the workspace does not have a Hyprland session.

Risk

Low. The change is limited to `hyprland/language` tooltip rendering and documentation. Existing label formatting is unchanged.