### PR TITLE
Add tooltip support to hyprland language module

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -21,6 +21,15 @@ Addressed by *hyprland/language*
 	typeof: string++
 	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how layout should be displayed in tooltip.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *keyboard-name*: ++
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config.isMember("tooltip-format")) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -56,6 +60,19 @@ auto Language::update() -> void {
     label_.set_markup(layoutName);
   } else {
     label_.hide();
+  }
+
+  if (tooltipEnabled()) {
+    if (!tooltip_format_.empty()) {
+      auto tooltip = trim(fmt::format(fmt::runtime(tooltip_format_),
+                                      fmt::arg("long", layout_.full_name),
+                                      fmt::arg("short", layout_.short_name),
+                                      fmt::arg("shortDescription", layout_.short_description),
+                                      fmt::arg("variant", layout_.variant)));
+      label_.set_tooltip_markup(tooltip);
+    } else {
+      label_.set_tooltip_markup(layoutName);
+    }
   }
 
   ALabel::update();


### PR DESCRIPTION
## Summary
- add tooltip and tooltip-format handling to hyprland/language
- reuse the existing language format replacements for tooltip text
- document tooltip options for waybar-hyprland-language

Closes #3693

## Testing
- git diff --check
- not run: meson/ninja build unavailable in this Windows environment