### PR TITLE
feat(hyprland/language): add tooltip-format support

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -18,12 +18,16 @@ Addressed by *hyprland/language*
 	The format, how information should be displayed.
 
 *format-<lang>* ++
-	typeof: string++
-	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
+    typeof: string++
+    Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
+
+*tooltip-format*: ++
+    typeof: string ++
+    The format displayed in the tooltip.
 
 *keyboard-name*: ++
-	typeof: string ++
-	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
+    typeof: string ++
+    Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
 *menu*: ++
 	typeof: string ++
@@ -59,10 +63,11 @@ Addressed by *hyprland/language*
 
 ```
 "hyprland/language": {
-	"format": "Lang: {long}",
-	"format-en": "AMERICA, HELL YEAH!",
-	"format-tr": "As bayrakları",
-	"keyboard-name": "at-translated-set-2-keyboard"
+    "format": "Lang: {long}",
+    "tooltip-format": "{short} ({variant})",
+    "format-en": "AMERICA, HELL YEAH!",
+    "format-tr": "As bayrakları",
+    "keyboard-name": "at-translated-set-2-keyboard"
 }
 ```
 

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config.isMember("tooltip-format")) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,19 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        auto tooltip = trim(fmt::format(fmt::runtime(tooltip_format_),
+                                        fmt::arg("long", layout_.full_name),
+                                        fmt::arg("short", layout_.short_name),
+                                        fmt::arg("shortDescription", layout_.short_description),
+                                        fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltip);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Adds `tooltip-format` support to `hyprland/language`.

Changes:
- read `tooltip-format` from module config
- render tooltip with the same language fields as the main format
- fall back to the displayed label when `tooltip-format` is not configured
- update the module man page and example config

Supported placeholders:
- {long}
- {short}
- {shortDescription}
- {variant}
