### PR TITLE
hyprland/language: add tooltip-format support

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,16 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how layout should be displayed in tooltip.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +70,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config["tooltip-format"].isString()) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,18 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        auto tooltipLayoutName = trim(
+            fmt::format(fmt::runtime(tooltip_format_), fmt::arg("long", layout_.full_name),
+                        fmt::arg("short", layout_.short_name),
+                        fmt::arg("shortDescription", layout_.short_description),
+                        fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltipLayoutName);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Adds tooltip support for the `hyprland/language` module so users can configure a tooltip with the same layout replacement fields used by the module format.

Example:

```json
"hyprland/language": {
  "format": "Layout: {short}",
  "tooltip": true,
  "tooltip-format": "Layout: {long}"
}
```

The module keeps the existing behavior when `tooltip-format` is not configured by using the visible label text as the tooltip.

Verification:
- `git diff --check`

I could not run the full Waybar Meson build or clang-format locally because `meson` and `clang-format` are not installed in this workspace.

Closes #3693.
