### PR TITLE
Add tooltip format to Hyprland language module

### DIFF
--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,10 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. Uses the same replacements as *format*.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +64,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -58,6 +58,19 @@ auto Language::update() -> void {
     label_.hide();
   }
 
+  if (tooltipEnabled()) {
+    if (config_["tooltip-format"].isString()) {
+      const auto tooltip = trim(fmt::format(fmt::runtime(config_["tooltip-format"].asString()),
+                                            fmt::arg("long", layout_.full_name),
+                                            fmt::arg("short", layout_.short_name),
+                                            fmt::arg("shortDescription", layout_.short_description),
+                                            fmt::arg("variant", layout_.variant)));
+      label_.set_tooltip_markup(tooltip);
+    } else {
+      label_.set_tooltip_markup(layoutName);
+    }
+  }
+
   ALabel::update();
 }
 


### PR DESCRIPTION
## Summary

Adds tooltip support to the `hyprland/language` module.

When tooltips are enabled:

- `tooltip-format` is formatted with the same layout placeholders already used by `format`: `{short}`, `{shortDescription}`, `{long}`, and `{variant}`.
- If `tooltip-format` is not configured, the tooltip falls back to the visible formatted layout text.

Also documents `tooltip-format` in `waybar-hyprland-language(5)`.

## Motivation

Fixes Alexays/Waybar#3693.

## Testing

- `git diff --check`
- Applied `clang-format` to `src/modules/hyprland/language.cpp`

I could not run the full Waybar build locally in this Windows workspace because `meson`, `ninja`, and Docker are not installed. The project CI should cover Linux/FreeBSD builds.
