### PR TITLE
Add tooltip-format support to hyprland language

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,10 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The tooltip format. Uses the same replacements as *format*. When unset, the tooltip matches the displayed format output.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +64,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config.isMember("tooltip-format")) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,18 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        auto tooltipLayoutName =
+            trim(fmt::format(fmt::runtime(tooltip_format_), fmt::arg("long", layout_.full_name),
+                             fmt::arg("short", layout_.short_name),
+                             fmt::arg("shortDescription", layout_.short_description),
+                             fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltipLayoutName);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
## Summary
- add `tooltip-format` support to `hyprland/language`
- render tooltip text with the same `{short}`, `{shortDescription}`, `{long}`, and `{variant}` replacements as `format`
- fall back to the displayed layout text when `tooltip-format` is not configured
- document the new option in the Hyprland language man page

Fixes #3693

## Testing
- `git diff --check`

I could not run the full Meson build in this Windows/WSL environment because `meson` and `ninja` are not installed here.