### PR TITLE
hyprland/language: add tooltip-format support

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -17,6 +17,10 @@ Addressed by *hyprland/language*
 	default: {} ++
 	The format, how information should be displayed.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. This format supports the same replacements as *format*.
+
 *format-<lang>* ++
 	typeof: string++
 	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
@@ -60,6 +64,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "{long} ({short})",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config["tooltip-format"].isString()) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -35,6 +39,14 @@ auto Language::update() -> void {
   spdlog::debug("hyprland language update with short description {}", layout_.short_description);
   spdlog::debug("hyprland language update with variant {}", layout_.variant);
 
+  const auto formatLayout = [this](const std::string& format) {
+    return trim(fmt::format(fmt::runtime(format), layout_.short_name,
+                            fmt::arg("long", layout_.full_name),
+                            fmt::arg("short", layout_.short_name),
+                            fmt::arg("shortDescription", layout_.short_description),
+                            fmt::arg("variant", layout_.variant)));
+  };
+
   std::string layoutName = std::string{};
   if (config_.isMember("format-" + layout_.short_description + "-" + layout_.variant)) {
     const auto propName = "format-" + layout_.short_description + "-" + layout_.variant;
@@ -43,10 +55,7 @@ auto Language::update() -> void {
     const auto propName = "format-" + layout_.short_description;
     layoutName = fmt::format(fmt::runtime(format_), config_[propName].asString());
   } else {
-    layoutName = trim(fmt::format(fmt::runtime(format_), fmt::arg("long", layout_.full_name),
-                                  fmt::arg("short", layout_.short_name),
-                                  fmt::arg("shortDescription", layout_.short_description),
-                                  fmt::arg("variant", layout_.variant)));
+    layoutName = formatLayout(format_);
   }
 
   spdlog::debug("hyprland language formatted layout name {}", layoutName);
@@ -54,6 +63,10 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      label_.set_tooltip_markup(
+          tooltip_format_.empty() ? layoutName : formatLayout(tooltip_format_));
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
## Summary

- add `tooltip-format` support to the `hyprland/language` module
- format tooltip text with the same layout placeholders as `format`: `{}`, `{long}`, `{short}`, `{shortDescription}`, and `{variant}`
- document the new option in `waybar-hyprland-language(5)`

Closes #3693

## Validation

- `git diff --check HEAD~1..HEAD`

I could not run a full Meson/Ninja build in this Windows workspace because the required Linux build tools and Waybar system dependencies were not installed; Docker image setup timed out before completing.