### PR TITLE
perf(mpd): avoid duplicate playing-state updates

### DIFF
--- a/include/modules/mpd/mpd.hpp
+++ b/include/modules/mpd/mpd.hpp
@@ -54,7 +54,6 @@ class MPD : public ALabel {
   void tryConnect();
   void checkErrors(mpd_connection* conn);
   void fetchState();
-  void queryMPD();
 
   inline bool stopped() const { return connection_ && state_ == MPD_STATE_STOP; }
   inline bool playing() const { return connection_ && state_ == MPD_STATE_PLAY; }

--- a/include/modules/mpd/state.hpp
+++ b/include/modules/mpd/state.hpp
@@ -197,7 +197,6 @@ class Context {
   void tryConnect() const;
   void checkErrors(mpd_connection*) const;
   void do_update();
-  void queryMPD() const;
   void fetchState() const;
   constexpr mpd_state state() const;
   void emit() const;

--- a/include/modules/mpd/state.inl.hpp
+++ b/include/modules/mpd/state.inl.hpp
@@ -15,7 +15,6 @@ constexpr inline mpd_state Context::state() const { return mpd_module_->state_; 
 inline void Context::do_update() { mpd_module_->setLabel(); }
 
 inline void Context::checkErrors(mpd_connection* conn) const { mpd_module_->checkErrors(conn); }
-inline void Context::queryMPD() const { mpd_module_->queryMPD(); }
 inline void Context::fetchState() const { mpd_module_->fetchState(); }
 inline void Context::emit() const { mpd_module_->emit(); }
 

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -51,21 +51,6 @@ auto waybar::modules::MPD::update() -> void {
   ALabel::update();
 }
 
-void waybar::modules::MPD::queryMPD() {
-  if (connection_ != nullptr) {
-    spdlog::trace("{}: fetching state information", module_name_);
-    try {
-      fetchState();
-      spdlog::trace("{}: fetch complete", module_name_);
-    } catch (std::exception const& e) {
-      spdlog::error("{}: {}", module_name_, e.what());
-      state_ = MPD_STATE_UNKNOWN;
-    }
-
-    dp.emit();
-  }
-}
-
 std::string waybar::modules::MPD::getTag(mpd_tag_type type, unsigned idx) const {
   std::string result =
       config_["unknown-tag"].isString() ? config_["unknown-tag"].asString() : "N/A";

--- a/src/modules/mpd/state.cpp
+++ b/src/modules/mpd/state.cpp
@@ -152,7 +152,6 @@ bool Playing::on_timer() {
       return false;
     }
 
-    ctx_->queryMPD();
     ctx_->emit();
   } catch (std::exception const& e) {
     spdlog::warn("mpd: Playing: error: {}", e.what());


### PR DESCRIPTION
## Summary

- Remove the unused `queryMPD()` wrapper from the MPD state path.
- Let the playing timer reuse its existing `fetchState()` result and emit one update.

## Why

`Playing::on_timer()` already fetches MPD state before checking whether playback is still active. Calling `queryMPD()` immediately afterward fetched the same state again and emitted an extra update on every playing tick.

## Testing

- `ninja -C build`
- `meson test -C build`
