### PR TITLE
fix(mpd): avoid false no-song warning when stopped

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -124,8 +124,9 @@ void waybar::modules::MPD::setLabel() {
 
   std::string stateIcon = "";
   bool no_song = song_.get() == nullptr;
-  if (stopped() || no_song) {
-    if (no_song) spdlog::warn("Bug in mpd: no current song but state is not stopped.");
+  bool is_stopped = stopped();
+  if (is_stopped || no_song) {
+    if (no_song && !is_stopped) spdlog::warn("mpd: no current song while state is not stopped");
     format =
         config_["format-stopped"].isString() ? config_["format-stopped"].asString() : "stopped";
     label_.get_style_context()->add_class("stopped");


### PR DESCRIPTION
## Summary

- Only warn about a missing current song when MPD is not stopped.
- Keep the existing stopped-format fallback for missing song data.

## Why

MPD can legitimately report no current song while stopped. The old condition logged `Bug in mpd` for any missing song, including the normal stopped state, which made routine MPD idle/stopped states look like bugs.

## Testing

- `ninja -C build`
- `meson test -C build`
