### PR TITLE
Add tooltip-format support to hyprland language

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_ = "";
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,10 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. Uses the same replacements as *format*.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +64,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config.isMember("tooltip-format")) {
+    tooltip_format_ = config["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,19 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        auto tooltip = trim(fmt::format(fmt::runtime(tooltip_format_),
+                                        fmt::arg("long", layout_.full_name),
+                                        fmt::arg("short", layout_.short_name),
+                                        fmt::arg("shortDescription", layout_.short_description),
+                                        fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltip);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Closes #3693

## Summary
- Adds `tooltip-format` support to `hyprland/language`.
- Uses the same replacements as `format`: `{short}`, `{shortDescription}`, `{long}`, and `{variant}`.
- Falls back to the displayed layout text when tooltip is enabled but no custom tooltip format is configured.
- Documents the new option in `waybar-hyprland-language(5)`.

## Verification
- Static checked the implementation against the existing `sway/language` tooltip-format pattern.
- Confirmed `tooltip-format`, `tooltipEnabled()`, and `set_tooltip_markup()` are present in the Hyprland language module.
- Confirmed the manpage documents `tooltip-format` and includes an example.

## Bounty
This PR addresses the BOSS bounty attached to #3693.