### PR TITLE
Add tooltip-format to hyprland language module

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,16 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how layout should be displayed in the tooltip. Uses the same replacements as *format*.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +70,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config_["tooltip-format"].isString()) {
+    tooltip_format_ = config_["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -56,6 +60,19 @@ auto Language::update() -> void {
     label_.set_markup(layoutName);
   } else {
     label_.hide();
+  }
+
+  if (tooltipEnabled()) {
+    if (!tooltip_format_.empty()) {
+      auto tooltip = trim(fmt::format(fmt::runtime(tooltip_format_),
+                                      fmt::arg("long", layout_.full_name),
+                                      fmt::arg("short", layout_.short_name),
+                                      fmt::arg("shortDescription", layout_.short_description),
+                                      fmt::arg("variant", layout_.variant)));
+      label_.set_tooltip_markup(tooltip);
+    } else {
+      label_.set_tooltip_markup(layoutName);
+    }
   }
 
   ALabel::update();


### PR DESCRIPTION
Fixes #3693

This adds tooltip formatting support to `hyprland/language`, matching the behavior users already have in similar language modules.

Changes:

- read optional `tooltip-format` from the module config
- format the tooltip with `{long}`, `{short}`, `{shortDescription}`, and `{variant}`
- fall back to the displayed layout text when no custom tooltip format is configured
- document `tooltip-format` and `tooltip` in `waybar-hyprland-language(5)`

Validation:

- `git diff --check`

Notes:

- I could not run a full local build in my Windows environment because Meson and the Linux/GTK/Wayland dependency stack are unavailable here.