### PR TITLE
Add tooltip-format support to hyprland language

### DIFF
--- a/include/modules/hyprland/language.hpp
+++ b/include/modules/hyprland/language.hpp
@@ -37,6 +37,7 @@ class Language : public waybar::ALabel, public EventHandler {
   util::JsonParser parser_;
 
   Layout layout_;
+  std::string tooltip_format_;
 
   IPC& m_ipc;
 };

--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -21,6 +21,16 @@ Addressed by *hyprland/language*
 	typeof: string++
 	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
 
+*tooltip-format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how layout should be displayed in tooltip.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *keyboard-name*: ++
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
@@ -60,6 +70,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -11,6 +11,10 @@ namespace waybar::modules::hyprland {
 
 Language::Language(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true), bar_(bar), m_ipc(IPC::inst()) {
+  if (config_["tooltip-format"].isString()) {
+    tooltip_format_ = config_["tooltip-format"].asString();
+  }
+
   // get the active layout when open
   initLanguage();
 
@@ -54,6 +58,18 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      if (!tooltip_format_.empty()) {
+        auto tooltip = trim(fmt::format(fmt::runtime(tooltip_format_),
+                                        fmt::arg("long", layout_.full_name),
+                                        fmt::arg("short", layout_.short_name),
+                                        fmt::arg("shortDescription", layout_.short_description),
+                                        fmt::arg("variant", layout_.variant)));
+        label_.set_tooltip_markup(tooltip);
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
Fixes #3693.

Adds tooltip-format support to the hyprland/language module using the same layout replacements already available to format:

- {short}
- {shortDescription}
- {long}
- {variant}

Also falls back to the displayed layout text when tooltip-format is not configured, matching the sway/language behavior, and documents tooltip plus tooltip-format in the manpage.

Verification:
- git diff --check
- Compared the three committed fork files against the local patched files

Not run:
- meson build/test; meson is not installed on this macOS host
- clang-format; clang-format is not installed on this macOS host