### PR TITLE
perf(json): parse directly from string buffers

### DIFF
--- a/include/util/json.hpp
+++ b/include/util/json.hpp
@@ -7,6 +7,7 @@
 #include <codecvt>
 #include <iostream>
 #include <locale>
+#include <memory>
 #include <regex>
 
 #if (FMT_VERSION >= 90000)
@@ -26,14 +27,19 @@ class JsonParser {
     Json::Value root;
 
     // replace all occurrences of "\x" with "\u00", because JSON doesn't allow "\x" escape sequences
-    std::string modifiedJsonStr = replaceHexadecimalEscape(jsonStr);
+    std::string modifiedJsonStr;
+    const std::string* json = &jsonStr;
+    if (jsonStr.find("\\x") != std::string::npos) {
+      modifiedJsonStr = replaceHexadecimalEscape(jsonStr);
+      json = &modifiedJsonStr;
+    }
 
-    std::istringstream jsonStream(modifiedJsonStr);
     std::string errs;
     // Use local CharReaderBuilder for thread safety - the IPC singleton's
     // parser can be called concurrently from multiple module threads
     Json::CharReaderBuilder readerBuilder;
-    if (!Json::parseFromStream(readerBuilder, jsonStream, &root, &errs)) {
+    auto reader = std::unique_ptr<Json::CharReader>(readerBuilder.newCharReader());
+    if (!reader->parse(json->data(), json->data() + json->size(), &root, &errs)) {
       throw std::runtime_error("Error parsing JSON: " + errs);
     }
     return root;


### PR DESCRIPTION
## Summary

- Parse `JsonParser` input with JsonCpp `CharReader` directly from the existing string buffer.
- Keep `\x` escape compatibility, but only allocate and run `regex_replace` when that escape is present.

## Why this was needed

`baseline.perf.data` showed the JSON utility paying a large common-case regex tax before parsing:

- `std::regex` search/replace: about **1.10B child cycles**
- `std::regex::_M_dfs`: **743M self cycles**
- Json parse path: **834M child cycles**

## Change

Parse from the existing string buffer with JsonCpp's `CharReader`. Preserve the `\x` compatibility repair, but first check whether the escape is present so the common path avoids allocating a modified string and running regex replacement.

## Effect in comparison

The regex path disappears from visible hot symbols. Json parse work drops from **834M** to **188M** cycles, and the overall JsonCpp bucket drops from roughly **700M** to **186M** cycles.

## Testing

- `ninja -C build`
- `meson test -C build`

