### PR TITLE
feat(hyprland): add language tooltip format

### DIFF
--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -21,6 +21,15 @@ Addressed by *hyprland/language*
 	typeof: string++
 	Provide an alternative name to display per language where <lang> is the language of your choosing. Can be passed multiple times with multiple languages as shown by the example below.
 
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
+*tooltip-format*: ++
+	typeof: string ++
+	The format, how information should be displayed in the tooltip. Uses the same replacements as *format*.
+
 *keyboard-name*: ++
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
@@ -60,6 +69,8 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip": true,
+	"tooltip-format": "Layout: {long}",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -58,6 +58,20 @@ auto Language::update() -> void {
     label_.hide();
   }
 
+  if (tooltipEnabled()) {
+    if (config_["tooltip-format"].isString()) {
+      const auto tooltipFormat = config_["tooltip-format"].asString();
+      const auto tooltipLayoutName = trim(fmt::format(
+          fmt::runtime(tooltipFormat), fmt::arg("long", layout_.full_name),
+          fmt::arg("short", layout_.short_name),
+          fmt::arg("shortDescription", layout_.short_description),
+          fmt::arg("variant", layout_.variant)));
+      label_.set_tooltip_markup(tooltipLayoutName);
+    } else {
+      label_.set_tooltip_markup(layoutName);
+    }
+  }
+
   ALabel::update();
 }
 


### PR DESCRIPTION
Closes #3693

This adds tooltip support to `hyprland/language`.

- supports `tooltip-format`
- uses the same replacements as `format`: `{long}`, `{short}`, `{shortDescription}`, `{variant}`
- falls back to the visible layout text when `tooltip-format` is not set
- documents `tooltip` and `tooltip-format` in `waybar-hyprland-language(5)`

I could not compile Waybar in this Windows environment because no C++ compiler is installed here, but the implementation follows the existing `sway/language` tooltip pattern and the patch is limited to the Hyprland language module plus documentation.