### PR TITLE
feat(niri/workspaces): add {total} format token to workspaces

### DIFF
--- a/man/waybar-niri-workspaces.5.scd
+++ b/man/waybar-niri-workspaces.5.scd
@@ -63,6 +63,8 @@ as defined by niri.
 
 *{output}*: Output where the workspace is located.
 
+*{total}*: The total number of workspaces.
+
 # ICONS
 
 Additional to workspace name matching, the following *format-icons* can be set.

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -100,7 +100,8 @@ void Workspaces::doUpdate() {
       name = fmt::format(fmt::runtime(format), fmt::arg("icon", getIcon(name, ws)),
                          fmt::arg("value", name), fmt::arg("name", ws["name"].asString()),
                          fmt::arg("index", ws["idx"].asUInt()),
-                         fmt::arg("output", ws["output"].asString()));
+                         fmt::arg("output", ws["output"].asString()),
+                         fmt::arg("total", my_workspaces.size()));
     }
     if (!config_["disable-markup"].asBool()) {
       static_cast<Gtk::Label*>(button.get_children()[0])->set_markup(name);


### PR DESCRIPTION
Currently, the `niri/workspaces` module provides tokens such as `{index}`, `{name}`, and `{value}`, but it lacks a native way to fetch the total number of workspaces. This metric is especially useful when a user wants to display a minimalist indicator by setting `"current-only": true` (e.g., rendering a clean `1 / 3` text pagination counter instead of a row of buttons).