### PR TITLE
perf(label): skip redundant markup updates

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -4,6 +4,8 @@
 #include <gtkmm/label.h>
 #include <json/json.h>
 
+#include <optional>
+
 #include "AModule.hpp"
 
 namespace waybar {
@@ -25,12 +27,19 @@ class ALabel : public AModule {
   bool alt_ = false;
   std::string default_format_;
 
+  bool setLabelMarkup(const Glib::ustring& markup);
+  bool setTooltipMarkup(const Glib::ustring& markup);
+
   bool handleToggle(GdkEventButton* const& e) override;
   virtual std::string getState(uint8_t value, bool lesser = false);
 
   std::map<std::string, GtkMenuItem*> submenus_;
   std::map<std::string, std::string> menuActionsMap_;
   static void handleGtkMenuEvent(GtkMenuItem* menuitem, gpointer data);
+
+ private:
+  std::optional<Glib::ustring> last_label_markup_;
+  std::optional<Glib::ustring> last_tooltip_markup_;
 };
 
 }  // namespace waybar

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -139,6 +139,26 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
 
 auto ALabel::update() -> void { AModule::update(); }
 
+bool ALabel::setLabelMarkup(const Glib::ustring& markup) {
+  if (last_label_markup_ == markup) {
+    return false;
+  }
+
+  label_.set_markup(markup);
+  last_label_markup_ = markup;
+  return true;
+}
+
+bool ALabel::setTooltipMarkup(const Glib::ustring& markup) {
+  if (last_tooltip_markup_ == markup) {
+    return false;
+  }
+
+  label_.set_tooltip_markup(markup);
+  last_tooltip_markup_ = markup;
+  return true;
+}
+
 std::string ALabel::getIcon(uint16_t percentage, const std::string& alt, uint16_t max) {
   auto format_icons = config_["format-icons"];
   if (format_icons.isObject()) {

--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -98,7 +98,7 @@ void waybar::modules::MPD::setLabel() {
                       ? config_["format-disconnected"].asString()
                       : "disconnected";
     if (format.empty()) {
-      label_.set_markup(format);
+      setLabelMarkup(format);
       label_.show();
     } else {
       label_.hide();
@@ -110,7 +110,7 @@ void waybar::modules::MPD::setLabel() {
                            ? config_["tooltip-format-disconnected"].asString()
                            : "MPD (disconnected)";
       // Nothing to format
-      label_.set_tooltip_markup(tooltip_format);
+      setTooltipMarkup(tooltip_format);
     }
     return;
   }
@@ -190,7 +190,7 @@ void waybar::modules::MPD::setLabel() {
       label_.hide();
     } else {
       label_.show();
-      label_.set_markup(text);
+      setLabelMarkup(text);
     }
   } catch (fmt::format_error const& e) {
     spdlog::warn("mpd: format error: {}", e.what());
@@ -210,7 +210,7 @@ void waybar::modules::MPD::setLabel() {
           fmt::arg("stateIcon", stateIcon), fmt::arg("consumeIcon", consumeIcon),
           fmt::arg("randomIcon", randomIcon), fmt::arg("repeatIcon", repeatIcon),
           fmt::arg("singleIcon", singleIcon), fmt::arg("filename", filename), fmt::arg("uri", uri));
-      label_.set_tooltip_markup(tooltip_text);
+      setTooltipMarkup(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpd: format error (tooltip): {}", e.what());
     }

--- a/src/modules/sway/window.cpp
+++ b/src/modules/sway/window.cpp
@@ -94,12 +94,12 @@ auto Window::update() -> void {
     old_app_id_ = app_id_;
   }
 
-  label_.set_markup(waybar::util::rewriteString(
+  setLabelMarkup(waybar::util::rewriteString(
       fmt::format(fmt::runtime(format_), fmt::arg("title", window_), fmt::arg("app_id", app_id_),
                   fmt::arg("shell", shell_), fmt::arg("marks", marks_)),
       config_["rewrite"]));
   if (tooltipEnabled()) {
-    label_.set_tooltip_markup(window_);
+    setTooltipMarkup(window_);
   }
 
   updateAppIcon();


### PR DESCRIPTION
## Summary

- Add `ALabel` helpers that skip identical label and tooltip markup writes.
- Use them in hot `sway/window` and `mpd` label paths.

## Why this was needed

`baseline.perf.data` had visible GTK/UI update work. The GTK layout/draw-ish path accounted for about **213M cycles**, which is avoidable when a module writes identical markup repeatedly.

## Change

Cache the last label and tooltip markup in `ALabel`. Skip `Gtk::Label::set_markup()` and `set_tooltip_markup()` when the new markup is unchanged.

## Effect in comparison

GTK layout/draw-ish work drops from **213M** to **17M** cycles, indicating fewer no-op relayout/redraw paths.

## Testing

- `ninja -C build`
- `meson test -C build`
