### PR TITLE
Add tooltip support for hyprland language

### DIFF
--- a/man/waybar-hyprland-language.5.scd
+++ b/man/waybar-hyprland-language.5.scd
@@ -25,6 +25,16 @@ Addressed by *hyprland/language*
 	typeof: string ++
 	Specifies which keyboard to use from hyprctl devices output. Using the option that begins with "at-translated-set..." is recommended.
 
+*tooltip-format*: ++
+	typeof: string ++
+	default: {} ++
+	The format, how layout should be displayed in tooltip.
+
+*tooltip*: ++
+	typeof: bool ++
+	default: true ++
+	Option to disable tooltip on hover.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.
@@ -60,6 +70,7 @@ Addressed by *hyprland/language*
 ```
 "hyprland/language": {
 	"format": "Lang: {long}",
+	"tooltip-format": "{shortDescription} ({short})",
 	"format-en": "AMERICA, HELL YEAH!",
 	"format-tr": "As bayrakları",
 	"keyboard-name": "at-translated-set-2-keyboard"

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -54,6 +54,18 @@ auto Language::update() -> void {
   if (!format_.empty()) {
     label_.show();
     label_.set_markup(layoutName);
+    if (tooltipEnabled()) {
+      if (config_["tooltip-format"].isString()) {
+        const auto tooltipFormat = config_["tooltip-format"].asString();
+        label_.set_tooltip_markup(
+            trim(fmt::format(fmt::runtime(tooltipFormat), fmt::arg("long", layout_.full_name),
+                             fmt::arg("short", layout_.short_name),
+                             fmt::arg("shortDescription", layout_.short_description),
+                             fmt::arg("variant", layout_.variant))));
+      } else {
+        label_.set_tooltip_markup(layoutName);
+      }
+    }
   } else {
     label_.hide();
   }


### PR DESCRIPTION
## Summary
- add tooltip support to `hyprland/language`
- support `tooltip-format` with the same layout placeholders used by `format`
- document `tooltip` and `tooltip-format` in the module man page

Closes #3693

## Testing
- `git diff --check`

Note: I could not run a full local build in this Windows environment because `meson`, `ninja`, and `clang-format` are not installed here.