### PR TITLE
fix(tray): segfault due to use-after-free from iterating children

### DIFF
--- a/include/modules/sni/tray.hpp
+++ b/include/modules/sni/tray.hpp
@@ -28,6 +28,7 @@ class Tray : public AModule {
   SNI::Watcher::singleton watcher_;
   std::vector<std::string> ignore_list_;
   SNI::Host host_;
+  std::vector<Item*> items_;
 };
 
 }  // namespace waybar::modules::SNI

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -68,6 +68,7 @@ void Tray::onAdd(std::unique_ptr<Item>& item) {
   } else {
     box_.pack_start(item->event_box);
   }
+  items_.push_back(item.get());
 
   spdlog::debug("Tray::onAdd deferred check - checking ignore list");
   host_.checkIgnoreList(ignore_list_, std::bind(&Tray::onRemove, this, std::placeholders::_1));
@@ -79,6 +80,7 @@ void Tray::onAdd(std::unique_ptr<Item>& item) {
 
 void Tray::onRemove(std::unique_ptr<Item>& item) {
   box_.remove(item->event_box);
+  items_.erase(std::remove(items_.begin(), items_.end(), item.get()), items_.end());
   dp.emit();
 }
 
@@ -89,9 +91,11 @@ auto Tray::update() -> void {
     host_.checkIgnoreList(ignore_list_, std::bind(&Tray::onRemove, this, std::placeholders::_1));
   }
 
-  std::vector<Gtk::Widget*> children = box_.get_children();
-  event_box_.set_visible(std::any_of(children.begin(), children.end(),
-                                     [](Gtk::Widget* child) { return child->get_visible(); }));
+  // Show tray only when items are visible. Iterate the managed items_ list
+  // instead of box_.get_children() to avoid a use-after-free on raw widget
+  // pointers that may dangle after items are destroyed asynchronously.
+  event_box_.set_visible(std::any_of(items_.begin(), items_.end(),
+                                     [](Item* item) { return item->event_box.get_visible(); }));
   AModule::update();
 }
 


### PR DESCRIPTION
Hi, waybar was crashing for me when I was using the tray module. My LLM wrote the below description for me and debugged it for me.

### Problem

Waybar segfaults when configured with the tray module. The crash occurs in Tray::update() when iterating over widget children returned by box_.get_children().

### Root cause

`box_.get_children()` returns raw pointers to GtkWidget objects. When tray items are removed/destroyed asynchronously (e.g., via DBus), these raw pointers become dangling. The `update()` function then attempts to call `get_style_context()` on these invalid pointers, causing use-after-free segfaults.

Solution: Instead of iterating over raw widget pointers from GTK's internal widget list, maintain a separate list of managed Item pointers. Item objects are owned by the Host class as `std::unique_ptr<Item>`, ensuring they have a well-defined lifetime and won't become dangling.