### PR TITLE
fix(battery): prevent crash when removing a hot-plugged device

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -153,7 +153,7 @@ void waybar::modules::Battery::refreshBatteries() {
       }
     }
   } catch (fs::filesystem_error& e) {
-    throw std::runtime_error(e.what());
+    spdlog::warn("Battery directory tracking failed: {}", e.what());
   }
   if (warnFirstTime_ && batteries_.empty()) {
     if (config_["bat"].isString()) {


### PR DESCRIPTION
Fixes a bug where removing a hot-plugged device mid-loop causes a filesystem error that turns into a fatal runtime error that crashes waybar entirely, changed to warning instead of runtime error.