### PR TITLE
fix(delayWorker): stop loop for static modules with no exec command

### DIFF
--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -49,6 +49,7 @@ void waybar::modules::Custom::delayWorker() {
       int status;
       waitpid(i, &status, 0);
     }
+
     this->pid_children_.clear();
 
     bool can_update = true;

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -39,12 +39,16 @@ waybar::modules::Custom::~Custom() {
 }
 
 void waybar::modules::Custom::delayWorker() {
+  if (!config_["exec"].isString() && !config_["exec-if"].isString()) {
+    dp.emit();
+    return;
+  }
+
   thread_ = [this] {
     for (int i : this->pid_children_) {
       int status;
       waitpid(i, &status, 0);
     }
-
     this->pid_children_.clear();
 
     bool can_update = true;
@@ -60,10 +64,6 @@ void waybar::modules::Custom::delayWorker() {
         output_ = util::command::exec(config_["exec"].asString(), output_name_);
       }
       dp.emit();
-    }
-    if (!config_["exec"].isString() && !config_["exec-if"].isString()) {
-      thread_.stop();
-      return;
     }
     thread_.sleep_for(interval_);
   };

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -61,6 +61,10 @@ void waybar::modules::Custom::delayWorker() {
       }
       dp.emit();
     }
+    if (!config_["exec"].isString() && !config_["exec-if"].isString()) {
+      thread_.stop();
+      return;
+    }
     thread_.sleep_for(interval_);
   };
 }


### PR DESCRIPTION
Hi! I am kind of new here.
I was customizing my Waybar for a couple of days and noticed a strange CPU usage spike when I add a custom separator to my config.jsonc file with interval set to 0:
`"custom/sep": {
	"format": "|",
	"interval": 0
}`.
This was the usage of the current v0.15.0:
`ps aux | grep waybar | grep -v grep`
`alex        1938  0.0  0.0   8516  3388 tty2     S+   06:40   0:00 /bin/sh -c waybar & swaync & hypridle & hyprpaper`
`alex       77380 11.6  0.1 788096 60124 pts/11   Sl+  09:24   0:01 ./build/waybar`
The usage spike was similar in two machines I have. Namely an ArmSoM Sige7 Pro Max and a Lenovo Ideapad Z400 Touch, both running Arch Linux, so Arm/x86 have the same behavior.

I then tracked the commits down, between v0.14.0 and v.0.15.0 and found out that commit 2b552f7f (https://github.com/Alexays/Waybar/commit/2b552f7f) produced a side effect on setting `interval = 0`. Instead of the earlier behavior where interval 0 was treated as "don't start a worker", since `interval_.count() == 0` skipped `delayWorker()` entirely, commit 2b552f7f forces a minimum of 1ms, which makes `delayWorker()` start and call `dp.emit()` in a continuous loop — even for modules with no exec command.

To have both of the new behavior of correcting sub-ms accidents and the "don't update when 0", I added the following check, so the delayWorker() function returns early if there is nothing to execute.:
`  if (!config_["exec"].isString() && !config_["exec-if"].isString()) {
    dp.emit();
    return;
  }
`