### PR TITLE
feat(wlr/taskbar): add active-only option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ result-*
 .ccls-cache
 _codeql_detected_source_root
 heaptrack*
+PR_NOTES_WLR_TASKBAR_BAR_CSS_STATES.md

--- a/include/modules/wlr/taskbar.hpp
+++ b/include/modules/wlr/taskbar.hpp
@@ -102,6 +102,7 @@ class Task {
   bool minimized() const { return state_ & MINIMIZED; }
   bool active() const { return state_ & ACTIVE; }
   bool fullscreen() const { return state_ & FULLSCREEN; }
+  bool visible() const { return button_visible_; }
 
  public:
   /* Callbacks for the wlr protocol */

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -52,6 +52,11 @@ Addressed by *wlr/taskbar*
 	default: false ++
 	If set to true, always reorder the tasks in the taskbar so that the currently active one is first. Otherwise don't reorder.
 
+*active-only*: ++
+	typeof: bool ++
+	default: false ++
+	If set to true, only the currently active application button is shown. Other applications remain tracked and reappear when activated.
+
 *sort-by-app-id*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -293,7 +293,9 @@ void Task::handle_output_enter(struct wl_output* output) {
     button.signal_size_allocate().connect_notify(
         sigc::mem_fun(this, &Task::on_button_size_allocated));
     tbar_->add_button(button);
-    button.show();
+    if (!config_["active-only"].asBool() || active()) {
+      button.show();
+    }
     button_visible_ = true;
     spdlog::debug("{} now visible on {}", repr(), bar_.output->name);
   }
@@ -348,6 +350,14 @@ void Task::handle_done() {
     button.get_style_context()->add_class("fullscreen");
   } else if (!(state_ & FULLSCREEN)) {
     button.get_style_context()->remove_class("fullscreen");
+  }
+
+  if (button_visible_ && config_["active-only"].asBool()) {
+    if (active()) {
+      button.show();
+    } else {
+      button.hide();
+    }
   }
 
   if (config_["active-first"].isBool() && config_["active-first"].asBool() && active())


### PR DESCRIPTION
## Description

Add a new `active-only` configuration option to the `wlr/taskbar` module that, when set to `true`, only shows the currently active application button in the taskbar.

Other applications remain tracked internally and automatically reappear when they become active. This provides a cleaner UI for users who only want to see the focused window in their taskbar.

## Motivation

Some users prefer a minimalist taskbar that only shows the currently focused application. This feature allows hiding inactive windows while maintaining full tracking state, so windows seamlessly reappear when activated.

## Changes

- Add `visible()` getter to `Task` class for external visibility queries
- Modify `handle_output_enter()` to respect `active-only` setting when showing buttons
- Modify `handle_done()` to show/hide buttons based on active state when `active-only` is enabled
- Update man page documentation

## Configuration

```jsonc
"wlr/taskbar": {
    "active-only": true
}
```

## Testing

- Built with `meson setup -Dman-pages=enabled build`
- All existing tests pass
- Runtime tested on labwc compositor:
  - With `active-only: true`, only the focused window button is visible
  - Switching focus hides the previous window and shows the new one
  - Closing the active window shows the previously focused window
  - With `active-only: false` (default), behavior is unchanged

Signed-off-by: iamcheyan <iamcheyan@users.noreply.github.com>