### PR TITLE
Force layer-shell commit after configure

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -99,6 +99,7 @@ class Bar : public sigc::trackable {
   void setMode(const bar_mode&);
   void setPassThrough(bool passthrough);
   void setPosition(Gtk::PositionType position);
+  void forceLayerCommit();
   void onConfigure(GdkEventConfigure* ev);
   void configureGlobalOffset(int width, int height);
   void onOutputGeometryChanged();

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -309,6 +309,19 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   setupWidgets();
   window.show_all();
 
+  /*
+   * If gtk-layer-shell's synchronous wait for the initial configure timed out, show_all() can
+   * return with a configured but not-yet-presented surface. Kick GTK/layer-shell once control has
+   * returned to the main loop, when any late initial configure has been dispatched and widgets have
+   * had a chance to allocate/draw.
+   */
+  Glib::signal_idle().connect(sigc::track_obj([this] {
+    window.queue_resize();
+    window.queue_draw();
+    forceLayerCommit();
+    return false;
+  }, *this));
+
   if (spdlog::should_log(spdlog::level::debug)) {
     // Unfortunately, this function isn't in the C++ bindings, so we have to call the C version.
     char* gtk_tree = gtk_style_context_to_string(
@@ -374,7 +387,14 @@ void waybar::Bar::setMode(const struct bar_mode& mode) {
    * gtk-layer-shell schedules a commit on the next frame event in GTK, but this could fail in
    * certain scenarios, such as fully occluded bar.
    */
-  gtk_layer_try_force_commit(gtk_window);
+  forceLayerCommit();
+}
+
+void waybar::Bar::forceLayerCommit() {
+  auto* gtk_window = window.gobj();
+  if (gtk_window != nullptr && gtk_widget_get_realized(GTK_WIDGET(gtk_window))) {
+    gtk_layer_try_force_commit(gtk_window);
+  }
   wl_display_flush(Client::inst()->wl_display);
 }
 
@@ -652,6 +672,17 @@ void waybar::Bar::onConfigure(GdkEventConfigure* ev) {
 
   configureGlobalOffset(ev->width, ev->height);
   spdlog::info(BAR_SIZE_MSG, ev->width, ev->height, output->name);
+
+  /*
+   * gtk-layer-shell waits for the compositor's initial configure while realizing the window. On a
+   * busy compositor (common during session startup) that wait can time out even though the initial
+   * configure arrives shortly afterwards. In that case GTK may not schedule the frame commit that
+   * presents the first layer-surface buffer, leaving an otherwise configured bar invisible. Force a
+   * commit after every configure so late initial configures, and later compositor-driven resizes,
+   * always result in a submitted surface state.
+   */
+  window.queue_draw();
+  forceLayerCommit();
 }
 
 void waybar::Bar::configureGlobalOffset(int width, int height) {


### PR DESCRIPTION
## Summary

This adds a defensive layer-shell commit after Waybar receives configure events, plus a one-shot startup idle recovery after `show_all()`.

The goal is to recover from cases where `gtk-layer-shell` times out waiting for the initial configure:

```text
   Timed out waiting for initial .configure
```

In observed cases, the compositor may still send the configure immediately afterwards and Waybar logs:

 ```text
Bar configured (width: ..., height: ...) for output: ...
 ```

but the bar can remain invisible. Forcing a draw/commit after configure gives GTK/gtk-layer-shell another opportunity to submit the visible surface state.

Related work

This is related to, but different from, PR https://github.com/Alexays/Waybar/pull/4984:

That PR is probably the more correct/root-cause fix for the gtk-layer-shell 0.10.1 startup timeout, because it avoids creating bars directly from output .done handling and instead batches/defer bar creation.

This PR is a smaller defensive recovery path: even if a configure arrives late after the initial wait timed out, Waybar forces a layer-shell commit so the configured bar is more likely to become visible.

The two approaches seem complementary to me.

While my own setup (MangoWM) is different, related issues likely include:

- https://github.com/Alexays/Waybar/issues/4978
- https://github.com/Alexays/Waybar/issues/4361
- https://github.com/Alexays/Waybar/issues/4864
- https://github.com/Alexays/Waybar/issues/3742
- https://github.com/Alexays/Waybar/issues/2176

It would be good if author's of above issues could test this patch too.

### Testing 
Built successfully with:

```sh
meson compile -C build
 ```

Locally, this improved the startup case where Waybar logged the initial configure timeout followed by a successful Bar configured ... message but did not display.  I also haven't seen waybar disappearing again after this patch.

Note: I used the pi coding agent with gpt-5.5 to dig into this issue - the patch seems straight-forward, and it also solves my problem.