### PR TITLE
feat(cursor): use cursor-shape-v1 cursor names instead of Gdk::CursorType

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -41,7 +41,7 @@ class AModule : public IModule {
   const Json::Value& config_;
   Gtk::EventBox event_box_;
 
-  virtual void setCursor(Gdk::CursorType const& c);
+  virtual void setCursor(std::string const& c);
 
   virtual bool handleToggle(GdkEventButton* const& ev);
   virtual bool handleMouseEnter(GdkEventCrossing* const& ev);

--- a/man/waybar-styles.5.scd.in
+++ b/man/waybar-styles.5.scd.in
@@ -43,18 +43,17 @@ You can apply special styling to any module for when the cursor hovers it.
 
 Most, if not all, module types support setting the `cursor` option. This is
 configured in your `config.jsonc`. If set to `false`, when hovering the module a
-"pointer"(as commonly known from web CSS styling `cursor: pointer`) style cursor
+"pointer" (as commonly known from web CSS styling `cursor: pointer`) style cursor
 will not be shown. Default behavior is to indicate an interaction event is
 available.
 
-There are more cursor types to choose from by setting the `cursor` option to
-a number, see Gdk3 official docs for all possible cursor types:
-https://docs.gtk.org/gdk3/enum.CursorType.html.
-However, note that not all cursor options listed may be available on
-your system. If you attempt to use a cursor which is not available, the
-application will crash.
+If set to a string value, it must be a valid cursor name
+(e.g. `"pointer"`, `"default"`, `"grab"`, `"text"`, `"crosshair"`, etc.),
+see the cursor-shape-v1 protocol for all possible cursor types:
+https://wayland.app/protocols/cursor-shape-v1#wp_cursor_shape_device_v1:enum:shape.
+Depending on the compositor and cursor theme used, cursors not listed in the protocol may also work.
 
-Example of disabling pointer(`Gdk::Hand2`) cursor type on a custom module:
+Example of disabling the cursor on a custom module:
 
 ```
 "custom/my-custom-module": {
@@ -63,13 +62,12 @@ Example of disabling pointer(`Gdk::Hand2`) cursor type on a custom module:
 }
 ```
 
-Example of setting cursor type to `Gdk::Boat`(according to
-https://docs.gtk.org/gdk3/enum.CursorType.html#boat):
+Example of setting the cursor type to `"grab"`:
 
 ```
 "custom/my-custom-module": {
     ...
-    "cursor": 8,
+    "cursor": "grab",
 }
 ```
 

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -73,9 +73,9 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
   // Respect user configuration of cursor
   if (config_.isMember("cursor")) {
     if (config_["cursor"].isBool() && config_["cursor"].asBool()) {
-      setCursor(Gdk::HAND2);
-    } else if (config_["cursor"].isInt()) {
-      setCursor(Gdk::CursorType(config_["cursor"].asInt()));
+        setCursor("pointer");
+    } else if (config_["cursor"].isString()) {
+      setCursor(config_["cursor"].asString());
     } else {
       spdlog::warn("unknown cursor option configured on module {}", name_);
     }
@@ -110,10 +110,10 @@ auto AModule::doAction(const std::string& name) -> void {
   }
 }
 
-void AModule::setCursor(Gdk::CursorType const& c) {
+void AModule::setCursor(std::string const& c) {
   auto gdk_window = event_box_.get_window();
   if (gdk_window) {
-    auto cursor = Gdk::Cursor::create(c);
+    auto cursor = Gdk::Cursor::create(gdk_window->get_display(), c);
     gdk_window->set_cursor(cursor);
   } else {
     // window may not be accessible yet, in this case,
@@ -134,7 +134,7 @@ bool AModule::handleMouseEnter(GdkEventCrossing* const& e) {
 
   // Default behavior indicating event availability
   if (hasUserEvents_ && !config_.isMember("cursor")) {
-    setCursor(Gdk::HAND2);
+    setCursor("pointer");
   }
 
   return false;
@@ -147,7 +147,7 @@ bool AModule::handleMouseLeave(GdkEventCrossing* const& e) {
 
   // Default behavior indicating event availability
   if (hasUserEvents_ && !config_.isMember("cursor")) {
-    setCursor(Gdk::ARROW);
+    setCursor("default");
   }
 
   return false;

--- a/src/modules/user.cpp
+++ b/src/modules/user.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <chrono>
 
-#include "gdkmm/cursor.h"
 #include "gdkmm/event.h"
 #include "gdkmm/types.h"
 #include "glibmm/fileutils.h"


### PR DESCRIPTION
Replace `Gdk::CursorType` enum values used for setting cursors with CSS cursor name strings (e.g. "default", "grab").

Background: 
- in [!8247](https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8257)  support for the `cursor_shape_v1` protocol was backported to gtk3
- a cursor is set using a `Gdk::CursorType` enum value, GTK does not map that value to the corresponding `cursor_shape_v1` cursor name
- As a result, GTK falls back to its own cursor theme instead of using the cursor provided by the compositor through `cursor_shape_v1`

<img width="400" alt="image" src="https://github.com/user-attachments/assets/5ab4acbd-70cf-4120-9a73-62488e31525d" />


Breaking changes:
- "cursor" now accepts a CSS cursor name string:
```
"custom/my-custom-module": {
    ...
    "cursor": "grab",
}
```
- Integer values (e.g. "cursor": 8) are no longer supported
