### PR TITLE
waybar.service: Use sway-session.target instead of graphical-session.target

### DIFF
--- a/resources/waybar.service.in
+++ b/resources/waybar.service.in
@@ -11,4 +11,4 @@ ExecReload=kill -SIGUSR2 $MAINPID
 Restart=on-failure
 
 [Install]
-WantedBy=graphical-session.target
+WantedBy=sway-session.target


### PR DESCRIPTION
graphical-session.target is now activated by multiple desktop environments
including GNOME and Cinnamon. waybar only functions under wlroots-based
Wayland compositors so WantedBy=graphical-session.target causes it to be
started unconditionally in any graphical session.

Use WantedBy=sway-session.target to scope waybar to Sway sessions only.
Users of other wlroots compositors can enable it manually against their
own session target.