### PR TITLE
fix(sni): ignore name/pixmap updates for custom icons

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -46,6 +46,7 @@ class Item : public sigc::trackable {
   std::string title;
   std::string icon_name;
   Glib::RefPtr<Gdk::Pixbuf> icon_pixmap;
+  bool has_custom_icon_ = false;
   Glib::RefPtr<Gtk::IconTheme> icon_theme;
   std::string overlay_icon_name;
   Glib::RefPtr<Gdk::Pixbuf> overlay_icon_pixmap;

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -190,9 +190,17 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
     } else if (name == "Status") {
       setStatus(get_variant<Glib::ustring>(value));
     } else if (name == "IconName") {
-      icon_name = get_variant<std::string>(value);
+      if (has_custom_icon_) {
+        spdlog::trace("Item '{}': ignoring IconName update, custom icon is set", id);
+      } else {
+        icon_name = get_variant<std::string>(value);
+      }
     } else if (name == "IconPixmap") {
-      icon_pixmap = this->extractPixBuf(value.gobj());
+      if (has_custom_icon_) {
+        spdlog::trace("Item '{}': ignoring IconPixmap update, custom icon is set", id);
+      } else {
+        icon_pixmap = this->extractPixBuf(value.gobj());
+      }
     } else if (name == "OverlayIconName") {
       overlay_icon_name = get_variant<std::string>(value);
     } else if (name == "OverlayIconPixmap") {
@@ -270,11 +278,13 @@ void Item::setCustomIcon(const std::string& id) {
         Glib::RefPtr<Gdk::Pixbuf> custom_pixbuf = Gdk::Pixbuf::create_from_file(custom_icon);
         icon_name = "";  // icon_name has priority over pixmap
         icon_pixmap = custom_pixbuf;
+        has_custom_icon_ = true;
       } catch (const Glib::Error& e) {
         spdlog::error("Failed to load custom icon {}: {}", custom_icon, e.what());
       }
     } else {  // if file doesn't exist it's most likely an icon_name
       icon_name = custom_icon;
+      has_custom_icon_ = true;
     }
   }
 }


### PR DESCRIPTION
A user that sets a custom icon likely does not want the application to override it. (There's one particular application that atrociously *blinks* its tray icon when there are notifications; this allows using custom icons to override such behavior.)