### PR TITLE
Document light and dark stylesheets in `man`ual

### DIFF
--- a/man/waybar-styles.5.scd.in
+++ b/man/waybar-styles.5.scd.in
@@ -8,13 +8,27 @@ waybar-styles - using stylesheets for waybar
 
 Waybar uses Cascading Style Sheets (CSS) to configure its appearance.
 
-It uses the first file found in this search order:
+When the system appearance is light, Waybar first looks for *style-light.css*.
+When the system appearance is dark, Waybar first looks for *style-dark.css*.
+If no appearance-specific stylesheet is found, it falls back to *style.css*.
 
-- *$XDG_CONFIG_HOME/waybar/style.css*
-- *~/.config/waybar/style.css*
-- *~/waybar/style.css*
-- */etc/xdg/waybar/style.css*
-- *@sysconfdir@/xdg/waybar/style.css*
+Waybar uses the first file found in this search order for each stylesheet name:
+
+- *$XDG_CONFIG_HOME/waybar/<stylesheet>*
+- *~/.config/waybar/<stylesheet>*
+- *~/waybar/<stylesheet>*
+- */etc/xdg/waybar/<stylesheet>*
+- *@sysconfdir@/xdg/waybar/<stylesheet>*
+
+For example, a light theme is loaded from the first available file among:
+
+- *$XDG_CONFIG_HOME/waybar/style-light.css*
+- *~/.config/waybar/style-light.css*
+- *~/waybar/style-light.css*
+- */etc/xdg/waybar/style-light.css*
+- *@sysconfdir@/xdg/waybar/style-light.css*
+
+If no file is found there, Waybar repeats the same search using *style.css*.
 
 # EXAMPLE
 

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -19,7 +19,7 @@ Valid locations for this file are:
 A good starting point is the default configuration found at https://github.com/Alexays/Waybar/blob/master/resources/config.jsonc
 Also, a minimal example configuration can be found at the bottom of this man page.
 
-The visual display elements for waybar use a CSS stylesheet, see *waybar-styles(5)* for details.
+The visual display elements for waybar use a CSS stylesheet. Waybar supports *style.css* and the appearance-specific *style-light.css* and *style-dark.css* files; see *waybar-styles(5)* for details.
 
 # BAR CONFIGURATION
 


### PR DESCRIPTION
This PR documents the usage of `style-[dark|light].css` in the `man` pages.

As far as I can tell, it wasn't documented anywhere other than the Wiki, and I for one like browsing the `man`ual far more than I do the GitHub Wiki.