### PR TITLE
Fallback formatting when format-paused is missing uses ALabel

### DIFF
--- a/src/modules/mpd/mpd.cpp
+++ b/src/modules/mpd/mpd.cpp
@@ -137,8 +137,9 @@ void waybar::modules::MPD::setLabel() {
       label_.get_style_context()->add_class("playing");
       label_.get_style_context()->remove_class("paused");
     } else if (paused()) {
-      format = config_["format-paused"].isString() ? config_["format-paused"].asString()
-                                                   : config_["format"].asString();
+      if (config_["format-paused"].isString()) {
+        format = config_["format-paused"].asString();
+      }
       label_.get_style_context()->add_class("paused");
       label_.get_style_context()->remove_class("playing");
     }


### PR DESCRIPTION
With the minimal change the paused state, if format-paused state is not set, will show the Alabel if the Alabel was active.
Current behaviour jumps to format even if it was in format-alt state beforehand