### PR TITLE
Fix empty layout display for custom XKB layouts in sway/language module

### DIFF
--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -124,9 +124,31 @@ auto Language::update() -> void {
   ALabel::update();
 }
 
+static std::string fallback_layout_short_name(std::string_view full_name) {
+  const size_t n = std::min<size_t>(2, full_name.size());
+  return std::string(full_name.substr(0, n));
+}
+
 auto Language::set_current_layout(const std::string& current_layout) -> void {
   label_.get_style_context()->remove_class(layout_.short_name);
-  layout_ = layouts_map_[current_layout];
+
+  auto it = layouts_map_.find(current_layout);
+
+  if (it != layouts_map_.end()) {
+    layout_ = it->second;
+  } else {
+    spdlog::debug("Language: using fallback for unknown layout '{}'", current_layout);
+
+    auto short_name = fallback_layout_short_name(current_layout);
+
+    layout_ = Layout{
+      current_layout,
+      short_name,
+      "",
+      short_name
+    };
+  }
+
   label_.get_style_context()->add_class(layout_.short_name);
 }
 


### PR DESCRIPTION
## Problem

Custom XKB layouts (e.g. defined in _~/.config/xkb/symbols/_) are not present in **libxkbregistry**.  
When such a layout is active, sway/language module fails to resolve it in layouts_map_, resulting in empty output for all layout placeholders ({short}, {long}, {shortDescription}).

## Cause

The code previously used `layouts_map_[current_layout]`, which assumes every active layout exists in `layouts_map_`:

`layout_ = layouts_map_[current_layout];`

For unknown layouts, this produces a default Layout with empty fields.

## Fix

Add a fallback for unknown layouts instead of relying on `map::operator[]`.

```cpp
static std::string fallback_layout_short_name(std::string_view full_name) {
  const size_t n = std::min<size_t>(2, full_name.size());
  return std::string(full_name.substr(0, n));
}

auto Language::set_current_layout(const std::string& current_layout) -> void {
  label_.get_style_context()->remove_class(layout_.short_name);

  auto it = layouts_map_.find(current_layout);

  if (it != layouts_map_.end()) {
    layout_ = it->second;
  } else {
    spdlog::debug("Language: using fallback for unknown layout '{}'", current_layout);

    auto short_name = fallback_layout_short_name(current_layout);

    layout_ = Layout{
      current_layout,
      short_name,
      "",
      short_name
    };
  }

  label_.get_style_context()->add_class(layout_.short_name);
}
```

## Notes

- No change for layouts found in **libxkbregistry**
- Fixes empty output for all layout format fields
- Improves handling of custom XKB configurations
