### PR TITLE
feat(ALabel): allow custom percentage thresholds in format-icons

### DIFF
--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -150,7 +150,26 @@ std::string ALabel::getIcon(uint16_t percentage, const std::string& alt, uint16_
   }
   if (format_icons.isArray()) {
     auto size = format_icons.size();
-    if (size != 0U) {
+    if (size != 0U && format_icons[0].isObject()) {
+      std::string last_icon;
+      for (const auto& threshold : format_icons) {
+        if (!threshold.isObject() || !threshold["icon"].isString() || !threshold["max"].isUInt()) {
+          static bool warned = false;
+          if (!warned) {
+            spdlog::warn("format-icons: skipping invalid threshold object, expected {\"icon\": \"...\", \"max\": N}");
+            warned = true;
+          }
+          continue;
+        }
+        last_icon = threshold["icon"].asString();
+        if (percentage <= threshold["max"].asUInt()) {
+          return last_icon;
+        }
+      }
+      if (!last_icon.empty()) {
+        return last_icon;
+      }
+    } else if (size != 0U) {
       auto divisor = std::max(1U, (max == 0 ? 100U : static_cast<unsigned>(max)) / size);
       auto idx = std::clamp(percentage / divisor, 0U, size - 1);
       format_icons = format_icons[idx];
@@ -177,7 +196,26 @@ std::string ALabel::getIcon(uint16_t percentage, const std::vector<std::string>&
   }
   if (format_icons.isArray()) {
     auto size = format_icons.size();
-    if (size != 0U) {
+    if (size != 0U && format_icons[0].isObject()) {
+      std::string last_icon;
+      for (const auto& threshold : format_icons) {
+        if (!threshold.isObject() || !threshold["icon"].isString() || !threshold["max"].isUInt()) {
+          static bool warned = false;
+          if (!warned) {
+            spdlog::warn("format-icons: skipping invalid threshold object, expected {\"icon\": \"...\", \"max\": N}");
+            warned = true;
+          }
+          continue;
+        }
+        last_icon = threshold["icon"].asString();
+        if (percentage <= threshold["max"].asUInt()) {
+          return last_icon;
+        }
+      }
+      if (!last_icon.empty()) {
+        return last_icon;
+      }
+    } else if (size != 0U) {
       auto divisor = std::max(1U, (max == 0 ? 100U : static_cast<unsigned>(max)) / size);
       auto idx = std::clamp(percentage / divisor, 0U, size - 1);
       format_icons = format_icons[idx];


### PR DESCRIPTION
The current `format-icons` behavior divides the 0-100 range into _N_ equal parts when _N_ icons are provided. This makes it impossible to define custom ranges like 0%, 1-69%, 70-100%. 

So, I added a new feature where you can customize the ranges yourself. What if I wanted an specific icon to appear when my battery is 67%? Well, now I can.
```
"format-icons": [
    {"icon": "󰁺", "max": 10},
    {"icon": "󰁻", "max": 20},
    {"icon": "󰁼", "max": 30},
    {"icon": "󰁽", "max": 40},
    {"icon": "󰁾", "max": 50},
    {"icon": "󰁿", "max": 60},
    {"icon": "󰂀", "max": 66},
    {"icon": "🫪", "max": 67},
    {"icon": "󰂀", "max": 70},
    {"icon": "󰂁", "max": 80},
    {"icon": "󰂂", "max": 90},
    {"icon": "󰁹", "max": 100}
]
```
<div align="center">
<img width="500" height="31" alt="waybar-demo" src="https://github.com/user-attachments/assets/b21724e5-3406-43af-b072-05e2f66457c6" />
</div>

> [!NOTE]
> This feature is additive, the code just adds a new possibility where the user can set custom thresholds. The current configurations still work.

### Syntax:
```
"format-icons": [
    {"icon": icon, "max": N},
    {"icon": icon, "max": N},
    ...
]
```
>[!IMPORTANT]
> It's important that the array is ascendant, anyway if no threshold matches the current percentage, the last icon in the array is used as fallback. Invalid objects (missing icon or max) are skipped with a warning in the logs.

It works with all modules with `format-icons` but I just tested it with **battery**, **network** and **pulseaudio** and it goes great!
<img width="1920" height="25" alt="Image" src="https://github.com/user-attachments/assets/a811bbca-0d81-4f20-8a22-2201834a587f" />
Closes #5150 
