### PR TITLE
refactor(ALabel): generic label+tooltip helper to remove per-module duplication

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -69,6 +69,26 @@ class ALabel : public AModule {
     updateLabelAndTooltipForState("", labelFormat, tooltipDefault, std::forward<Args>(args)...);
   }
 
+  // Overloads accepting a pre-built argument store, for modules that must
+  // assemble a dynamic set of format arguments (e.g. per-core CPU stats) that
+  // cannot be expressed through a fixed variadic call.
+  // A non-const reference is used so this overload is preferred over the
+  // variadic template above (which would otherwise bind the store as a single
+  // forwarded argument).
+  void updateLabelAndTooltipForState(const std::string& state, const std::string& labelFormat,
+                                     const std::string& tooltipDefault,
+                                     fmt::dynamic_format_arg_store<fmt::format_context>& store) {
+    setLabelMarkup(fmt::vformat(labelFormat, store));
+    if (tooltipEnabled()) {
+      setTooltipMarkup(fmt::vformat(resolveTooltipFormat(tooltipDefault, state), store));
+    }
+  }
+
+  void updateLabelAndTooltip(const std::string& labelFormat, const std::string& tooltipDefault,
+                             fmt::dynamic_format_arg_store<fmt::format_context>& store) {
+    updateLabelAndTooltipForState("", labelFormat, tooltipDefault, store);
+  }
+
   bool handleToggle(GdkEventButton* const& e) override;
   void copyToClipboard(const std::string&);
   virtual std::string getState(uint8_t value, bool lesser = false);

--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -34,18 +34,7 @@ class ALabel : public AModule {
   bool setLabelMarkup(const Glib::ustring& markup);
   bool setTooltipMarkup(const Glib::ustring& markup);
 
-  // Resolve the tooltip format string: prefers `tooltip-format-<state>` (when a
-  // non-empty state is given), then `tooltip-format`, then `defaultFormat`.
-  std::string resolveTooltipFormat(const std::string& defaultFormat,
-                                   const std::string& state = "") const {
-    if (!state.empty() && config_["tooltip-format-" + state].isString()) {
-      return config_["tooltip-format-" + state].asString();
-    }
-    if (config_["tooltip-format"].isString()) {
-      return config_["tooltip-format"].asString();
-    }
-    return defaultFormat;
-  }
+  // resolveTooltipFormat() / resolveFormat() are inherited from AModule.
 
   // Combined label + tooltip helper. Builds a single fmt argument store from
   // `args`, renders `labelFormat` into the label and the resolved tooltip format

--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
+#include <fmt/args.h>
+#include <fmt/format.h>
 #include <glibmm/markup.h>
 #include <gtkmm/label.h>
 #include <json/json.h>
 
 #include <optional>
+#include <string>
+#include <utility>
 
 #include "AModule.hpp"
 
@@ -29,6 +33,41 @@ class ALabel : public AModule {
 
   bool setLabelMarkup(const Glib::ustring& markup);
   bool setTooltipMarkup(const Glib::ustring& markup);
+
+  // Resolve the tooltip format string: prefers `tooltip-format-<state>` (when a
+  // non-empty state is given), then `tooltip-format`, then `defaultFormat`.
+  std::string resolveTooltipFormat(const std::string& defaultFormat,
+                                   const std::string& state = "") const {
+    if (!state.empty() && config_["tooltip-format-" + state].isString()) {
+      return config_["tooltip-format-" + state].asString();
+    }
+    if (config_["tooltip-format"].isString()) {
+      return config_["tooltip-format"].asString();
+    }
+    return defaultFormat;
+  }
+
+  // Combined label + tooltip helper. Builds a single fmt argument store from
+  // `args`, renders `labelFormat` into the label and the resolved tooltip format
+  // into the tooltip, both through the dedup-aware setters. Honors the `tooltip`
+  // toggle. This replaces the label/tooltip formatting boilerplate that modules
+  // used to duplicate. `state` selects `tooltip-format-<state>` when non-empty.
+  template <typename... Args>
+  void updateLabelAndTooltipForState(const std::string& state, const std::string& labelFormat,
+                                     const std::string& tooltipDefault, Args&&... args) {
+    fmt::dynamic_format_arg_store<fmt::format_context> store;
+    (store.push_back(std::forward<Args>(args)), ...);
+    setLabelMarkup(fmt::vformat(labelFormat, store));
+    if (tooltipEnabled()) {
+      setTooltipMarkup(fmt::vformat(resolveTooltipFormat(tooltipDefault, state), store));
+    }
+  }
+
+  template <typename... Args>
+  void updateLabelAndTooltip(const std::string& labelFormat, const std::string& tooltipDefault,
+                             Args&&... args) {
+    updateLabelAndTooltipForState("", labelFormat, tooltipDefault, std::forward<Args>(args)...);
+  }
 
   bool handleToggle(GdkEventButton* const& e) override;
   void copyToClipboard(const std::string&);

--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -1,10 +1,15 @@
 #pragma once
 
+#include <fmt/args.h>
+#include <fmt/format.h>
 #include <glibmm/dispatcher.h>
 #include <glibmm/markup.h>
 #include <gtkmm.h>
 #include <gtkmm/eventbox.h>
 #include <json/json.h>
+
+#include <string>
+#include <utility>
 
 #include "IModule.hpp"
 
@@ -39,6 +44,40 @@ class AModule : public IModule {
 
   SCROLL_DIR getScrollDir(GdkEventScroll* e);
   bool tooltipEnabled() const;
+
+  // --- Generic format/tooltip resolution (config-only, usable by any module,
+  // ALabel-derived or not). Prefers `<key>-<state>`, then `<key>`, then default.
+  std::string resolveFormat(const std::string& defaultFormat, const std::string& state = "") const {
+    if (!state.empty() && config_["format-" + state].isString()) {
+      return config_["format-" + state].asString();
+    }
+    if (config_["format"].isString()) {
+      return config_["format"].asString();
+    }
+    return defaultFormat;
+  }
+  std::string resolveTooltipFormat(const std::string& defaultFormat,
+                                   const std::string& state = "") const {
+    if (!state.empty() && config_["tooltip-format-" + state].isString()) {
+      return config_["tooltip-format-" + state].asString();
+    }
+    if (config_["tooltip-format"].isString()) {
+      return config_["tooltip-format"].asString();
+    }
+    return defaultFormat;
+  }
+
+  // Generic tooltip for any widget: honors the `tooltip` toggle and
+  // `tooltip-format`, formats with the given args and applies it. Lets modules
+  // that are not ALabel-derived (e.g. gamemode) reuse the shared logic.
+  template <typename... Args>
+  void updateTooltip(Gtk::Widget& widget, const std::string& defaultFormat, Args&&... args) {
+    if (!tooltipEnabled()) {
+      return;
+    }
+    widget.set_tooltip_markup(
+        fmt::format(fmt::runtime(resolveTooltipFormat(defaultFormat)), std::forward<Args>(args)...));
+  }
 
   std::vector<int> pid_children_;
   const std::string name_;

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -55,24 +55,10 @@ auto waybar::modules::Backlight::update() -> void {
         }
       }
 
-      std::string desc =
-          fmt::format(fmt::runtime(current_format), fmt::arg("percent", percent),
-                      fmt::arg("percent_exp", percent_exp), fmt::arg("icon", getIcon(percent)),
-                      fmt::arg("icon_exp", getIcon(percent_exp)));
-      label_.set_markup(desc);
-      if (tooltipEnabled()) {
-        std::string tooltip_format;
-        if (config_["tooltip-format"].isString()) {
-          tooltip_format = config_["tooltip-format"].asString();
-        }
-        if (!tooltip_format.empty()) {
-          label_.set_tooltip_markup(fmt::format(fmt::runtime(tooltip_format),
-                                                fmt::arg("percent", percent),
-                                                fmt::arg("icon", getIcon(percent))));
-        } else {
-          label_.set_tooltip_markup(desc);
-        }
-      }
+      updateLabelAndTooltip(current_format, current_format, fmt::arg("percent", percent),
+                            fmt::arg("percent_exp", percent_exp),
+                            fmt::arg("icon", getIcon(percent)),
+                            fmt::arg("icon_exp", getIcon(percent_exp)));
     } else {
       event_box_.hide();
     }

--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -767,7 +767,7 @@ auto waybar::modules::Battery::update() -> void {
     } else if (config_["tooltip-format"].isString()) {
       tooltip_format = config_["tooltip-format"].asString();
     }
-    label_.set_tooltip_markup(
+    setTooltipMarkup(
         fmt::format(fmt::runtime(tooltip_format), fmt::arg("timeTo", tooltip_text_default),
                     fmt::arg("power", power), fmt::arg("capacity", capacity),
                     fmt::arg("time", time_remaining_formatted), fmt::arg("cycles", cycles),
@@ -790,7 +790,7 @@ auto waybar::modules::Battery::update() -> void {
   } else {
     event_box_.show();
     auto icons = std::vector<std::string>{status + "-" + state, status, state};
-    label_.set_markup(fmt::format(
+    setLabelMarkup(fmt::format(
         fmt::runtime(format), fmt::arg("capacity", capacity), fmt::arg("power", power),
         fmt::arg("icon", getIcon(capacity, icons)), fmt::arg("time", time_remaining_formatted),
         fmt::arg("cycles", cycles), fmt::arg("health", fmt::format("{:.3}", health))));

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -222,7 +222,7 @@ auto waybar::modules::Bluetooth::update() -> void {
     event_box_.hide();
   } else {
     event_box_.show();
-    label_.set_markup(fmt::format(
+    setLabelMarkup(fmt::format(
         fmt::runtime(format_), fmt::arg("status", state_),
         fmt::arg("num_connections", connected_devices_.size()),
         fmt::arg("controller_address", cur_controller_ ? cur_controller_->address : "null"),
@@ -267,7 +267,7 @@ auto waybar::modules::Bluetooth::update() -> void {
         device_enumerate_.erase(0, 1);
       }
     }
-    label_.set_tooltip_markup(fmt::format(
+    setTooltipMarkup(fmt::format(
         fmt::runtime(tooltip_format), fmt::arg("status", state_),
         fmt::arg("num_connections", connected_devices_.size()),
         fmt::arg("controller_address", cur_controller_ ? cur_controller_->address : "null"),

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -162,7 +162,7 @@ auto waybar::modules::Clock::update() -> void {
   const auto* tz = tzList_[tzCurrIdx_] != nullptr ? tzList_[tzCurrIdx_] : local_zone();
   const zoned_time now{tz, floor<seconds>(system_clock::now())};
 
-  label_.set_markup(fmt_lib::vformat(m_locale_, format_, fmt_lib::make_format_args(now)));
+  setLabelMarkup(fmt_lib::vformat(m_locale_, format_, fmt_lib::make_format_args(now)));
 
   if (tooltipEnabled()) {
     const year_month_day today{floor<days>(now.get_local_time())};

--- a/src/modules/cpu.cpp
+++ b/src/modules/cpu.cpp
@@ -62,21 +62,7 @@ auto waybar::modules::Cpu::update() -> void {
       store.push_back(fmt::arg(arg_names.back().c_str(), core_icon));
     }
     store.push_back(fmt::arg("icons", all_icons));
-    label_.set_markup(fmt::vformat(format, store));
-
-    if (tooltipEnabled()) {
-      std::string tooltip_format;
-      if (!state.empty() && config_["tooltip-format-" + state].isString()) {
-        tooltip_format = config_["tooltip-format-" + state].asString();
-      } else if (config_["tooltip-format"].isString()) {
-        tooltip_format = config_["tooltip-format"].asString();
-      }
-      if (!tooltip_format.empty()) {
-        label_.set_tooltip_markup(fmt::vformat(tooltip_format, store));
-      } else {
-        label_.set_tooltip_markup(tooltip);
-      }
-    }
+    updateLabelAndTooltipForState(state, format, tooltip, store);
   }
 
   // Call parent update

--- a/src/modules/cpu_frequency/common.cpp
+++ b/src/modules/cpu_frequency/common.cpp
@@ -32,24 +32,12 @@ auto waybar::modules::CpuFrequency::update() -> void {
   } else {
     event_box_.show();
     auto icons = std::vector<std::string>{state};
-    fmt::dynamic_format_arg_store<fmt::format_context> store;
-    store.push_back(fmt::arg("icon", getIcon(avg_frequency, icons)));
-    store.push_back(fmt::arg("max_frequency", max_frequency));
-    store.push_back(fmt::arg("min_frequency", min_frequency));
-    store.push_back(fmt::arg("avg_frequency", avg_frequency));
-    label_.set_markup(fmt::vformat(format, store));
-
-    if (tooltipEnabled()) {
-      std::string tooltip;
-      if (config_["tooltip-format"].isString()) {
-        tooltip = config_["tooltip-format"].asString();
-        label_.set_tooltip_markup(fmt::vformat(tooltip, store));
-      } else {
-        tooltip = "Minimum frequency: {}\nAverage frequency: {}\nMaximum frequency: {}\n";
-        label_.set_tooltip_markup(
-            fmt::format(fmt::runtime(tooltip), min_frequency, avg_frequency, max_frequency));
-      }
-    }
+    updateLabelAndTooltip(
+        format,
+        "Minimum frequency: {min_frequency}\nAverage frequency: {avg_frequency}\nMaximum "
+        "frequency: {max_frequency}\n",
+        fmt::arg("icon", getIcon(avg_frequency, icons)), fmt::arg("max_frequency", max_frequency),
+        fmt::arg("min_frequency", min_frequency), fmt::arg("avg_frequency", avg_frequency));
   }
 
   // Call parent update

--- a/src/modules/cpu_usage/common.cpp
+++ b/src/modules/cpu_usage/common.cpp
@@ -49,16 +49,7 @@ auto waybar::modules::CpuUsage::update() -> void {
       store.push_back(fmt::arg(arg_names.back().c_str(), core_icon));
     }
     store.push_back(fmt::arg("icons", all_icons));
-    label_.set_markup(fmt::vformat(format, store));
-
-    if (tooltipEnabled()) {
-      if (config_["tooltip-format"].isString()) {
-        tooltip = config_["tooltip-format"].asString();
-        label_.set_tooltip_markup(fmt::vformat(tooltip, store));
-      } else {
-        label_.set_tooltip_markup(tooltip);
-      }
-    }
+    updateLabelAndTooltip(format, tooltip, store);
   }
 
   // Call parent update

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -187,7 +187,7 @@ auto waybar::modules::Custom::update() -> void {
       if ((config_["hide-empty-text"].asBool() && text_.empty()) || str.empty()) {
         event_box_.hide();
       } else {
-        label_.set_markup(str);
+        setLabelMarkup(str);
         if (tooltipEnabled()) {
           std::string tooltip_markup;
           if (tooltip_format_enabled_) {
@@ -202,10 +202,7 @@ auto waybar::modules::Custom::update() -> void {
             tooltip_markup = tooltip_;
           }
 
-          if (last_tooltip_markup_ != tooltip_markup) {
-            label_.set_tooltip_markup(tooltip_markup);
-            last_tooltip_markup_ = std::move(tooltip_markup);
-          }
+          setTooltipMarkup(tooltip_markup);
         }
         auto style = label_.get_style_context();
         auto classes = style->list_classes();

--- a/src/modules/disk.cpp
+++ b/src/modules/disk.cpp
@@ -68,25 +68,13 @@ auto waybar::modules::Disk::update() -> void {
     event_box_.hide();
   } else {
     event_box_.show();
-    label_.set_markup(fmt::format(
-        fmt::runtime(format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
+    updateLabelAndTooltip(
+        format, "{used} used out of {total} on {path} ({percentage_used}%)",
+        stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
         fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
         fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),
         fmt::arg("path", path_), fmt::arg("specific_free", specific_free),
-        fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total)));
-  }
-
-  if (tooltipEnabled()) {
-    std::string tooltip_format = "{used} used out of {total} on {path} ({percentage_used}%)";
-    if (config_["tooltip-format"].isString()) {
-      tooltip_format = config_["tooltip-format"].asString();
-    }
-    label_.set_tooltip_markup(fmt::format(
-        fmt::runtime(tooltip_format), stats.f_bavail * 100 / stats.f_blocks, fmt::arg("free", free),
-        fmt::arg("percentage_free", stats.f_bavail * 100 / stats.f_blocks), fmt::arg("used", used),
-        fmt::arg("percentage_used", percentage_used), fmt::arg("total", total),
-        fmt::arg("path", path_), fmt::arg("specific_free", specific_free),
-        fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total)));
+        fmt::arg("specific_used", specific_used), fmt::arg("specific_total", specific_total));
   }
   // Call parent update
   ALabel::update();

--- a/src/modules/gamemode.cpp
+++ b/src/modules/gamemode.cpp
@@ -210,10 +210,7 @@ auto Gamemode::update() -> void {
   lastStatus = status;
 
   // Tooltip
-  if (tooltip) {
-    std::string text = fmt::format(fmt::runtime(tooltip_format), fmt::arg("count", gameCount));
-    box_.set_tooltip_markup(text);
-  }
+  updateTooltip(box_, tooltip_format, fmt::arg("count", gameCount));
 
   // Label format
   std::string str = fmt::format(fmt::runtime(showAltText ? format_alt : format),

--- a/src/modules/gps.cpp
+++ b/src/modules/gps.cpp
@@ -141,7 +141,7 @@ auto waybar::modules::Gps::update() -> void {
   // Show the module
   if (!event_box_.get_visible()) event_box_.set_visible(true);
 
-  std::string tooltip_format;
+  std::string tooltip_state;
 
   if (!alt_) {
     auto state = getFixModeName();
@@ -155,57 +155,27 @@ auto waybar::modules::Gps::update() -> void {
     } else {
       default_format_ = DEFAULT_FORMAT;
     }
-    if (config_["tooltip-format-" + state].isString()) {
-      tooltip_format = config_["tooltip-format-" + state].asString();
-    }
     if (!label_.get_style_context()->has_class(state)) {
       label_.get_style_context()->add_class(state);
     }
     format_ = default_format_;
     state_ = state;
+    tooltip_state = state;
   }
 
   auto format = format_;
 
-  fmt::dynamic_format_arg_store<fmt::format_context> store;
-  store.push_back(fmt::arg("mode", getFixModeString()));
-  store.push_back(fmt::arg("status", getFixStatusString()));
-
-  store.push_back(fmt::arg("latitude", gps_data_.fix.latitude));
-  store.push_back(fmt::arg("latitude_error", gps_data_.fix.epy));
-
-  store.push_back(fmt::arg("longitude", gps_data_.fix.longitude));
-  store.push_back(fmt::arg("longitude_error", gps_data_.fix.epx));
-
-  store.push_back(fmt::arg("altitude_hae", gps_data_.fix.altHAE));
-  store.push_back(fmt::arg("altitude_msl", gps_data_.fix.altMSL));
-  store.push_back(fmt::arg("altitude_error", gps_data_.fix.epv));
-
-  store.push_back(fmt::arg("speed", gps_data_.fix.speed));
-  store.push_back(fmt::arg("speed_error", gps_data_.fix.eps));
-
-  store.push_back(fmt::arg("climb", gps_data_.fix.climb));
-  store.push_back(fmt::arg("climb_error", gps_data_.fix.epc));
-
-  store.push_back(fmt::arg("satellites_used", gps_data_.satellites_used));
-  store.push_back(fmt::arg("satellites_visible", gps_data_.satellites_visible));
-
-  auto text = fmt::vformat(format, store);
-
-  if (tooltipEnabled()) {
-    if (tooltip_format.empty() && config_["tooltip-format"].isString()) {
-      tooltip_format = config_["tooltip-format"].asString();
-    }
-    if (!tooltip_format.empty()) {
-      auto tooltip_text = fmt::vformat(tooltip_format, store);
-      if (label_.get_tooltip_text() != tooltip_text) {
-        label_.set_tooltip_markup(tooltip_text);
-      }
-    } else if (label_.get_tooltip_text() != text) {
-      label_.set_tooltip_markup(text);
-    }
-  }
-  label_.set_markup(text);
+  updateLabelAndTooltipForState(
+      tooltip_state, format, format, fmt::arg("mode", getFixModeString()),
+      fmt::arg("status", getFixStatusString()), fmt::arg("latitude", gps_data_.fix.latitude),
+      fmt::arg("latitude_error", gps_data_.fix.epy), fmt::arg("longitude", gps_data_.fix.longitude),
+      fmt::arg("longitude_error", gps_data_.fix.epx),
+      fmt::arg("altitude_hae", gps_data_.fix.altHAE),
+      fmt::arg("altitude_msl", gps_data_.fix.altMSL), fmt::arg("altitude_error", gps_data_.fix.epv),
+      fmt::arg("speed", gps_data_.fix.speed), fmt::arg("speed_error", gps_data_.fix.eps),
+      fmt::arg("climb", gps_data_.fix.climb), fmt::arg("climb_error", gps_data_.fix.epc),
+      fmt::arg("satellites_used", gps_data_.satellites_used),
+      fmt::arg("satellites_visible", gps_data_.satellites_visible));
   // Call parent update
   ALabel::update();
 }

--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -77,9 +77,9 @@ auto Language::update() -> void {
 
   if (!format_.empty()) {
     label_.show();
-    label_.set_markup(layoutName);
+    setLabelMarkup(layoutName);
     if (tooltip_enabled) {
-      label_.set_tooltip_markup(tooltipContent);
+      setTooltipMarkup(tooltipContent);
     }
   } else {
     label_.hide();
@@ -93,12 +93,11 @@ auto Language::update() -> void {
     } else {
       tooltipFormat = "{long}";
     }
-    auto tooltipText = trim(fmt::format(
-        fmt::runtime(tooltipFormat),
-        fmt::arg("long", layout_.full_name),
-        fmt::arg("short", layout_.short_name),
-        fmt::arg("shortDescription", layout_.short_description),
-        fmt::arg("variant", layout_.variant)));
+    auto tooltipText =
+        trim(fmt::format(fmt::runtime(tooltipFormat), fmt::arg("long", layout_.full_name),
+                         fmt::arg("short", layout_.short_name),
+                         fmt::arg("shortDescription", layout_.short_description),
+                         fmt::arg("variant", layout_.variant)));
     label_.set_tooltip_text(tooltipText);
   } else {
     label_.set_tooltip_text("");
@@ -185,7 +184,8 @@ void Language::initLanguage() {
 
 auto Language::removeXkbLayoutCssClass() -> void {
   label_.get_style_context()->remove_class(layout_.short_name);
-  spdlog::debug("hyprland language try to remove currently short_name css class {}", layout_.short_name);
+  spdlog::debug("hyprland language try to remove currently short_name css class {}",
+                layout_.short_name);
 }
 auto Language::addXkbLayoutCssClass() -> void {
   label_.get_style_context()->add_class(layout_.short_name);

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -67,7 +67,7 @@ auto Window::update() -> void {
                     fmt::arg("class", windowData_.class_name),
                     fmt::arg("initialClass", windowData_.initial_class_name)),
         config_["rewrite"]);
-    label_.set_markup(label_text);
+    setLabelMarkup(label_text);
   } else {
     label_.hide();
   }
@@ -78,13 +78,12 @@ auto Window::update() -> void {
       tooltip_format = config_["tooltip-format"].asString();
     }
     if (!tooltip_format.empty()) {
-      label_.set_tooltip_markup(
-          fmt::format(fmt::runtime(tooltip_format), fmt::arg("title", windowName),
-                      fmt::arg("initialTitle", windowData_.initial_title),
-                      fmt::arg("class", windowData_.class_name),
-                      fmt::arg("initialClass", windowData_.initial_class_name)));
+      setTooltipMarkup(fmt::format(fmt::runtime(tooltip_format), fmt::arg("title", windowName),
+                                   fmt::arg("initialTitle", windowData_.initial_title),
+                                   fmt::arg("class", windowData_.class_name),
+                                   fmt::arg("initialClass", windowData_.initial_class_name)));
     } else if (!label_text.empty()) {
-      label_.set_tooltip_markup(label_text);
+      setTooltipMarkup(label_text);
     }
   }
 
@@ -222,9 +221,9 @@ void Window::queryActiveWorkspace() {
   std::vector<Json::Value> visibleWindows;
   std::ranges::copy_if(workspaceWindows, std::back_inserter(visibleWindows),
                        [&](const Json::Value& window) { return !window["hidden"].asBool(); });
-  solo_ = 1 == std::count_if(
-                   visibleWindows.begin(), visibleWindows.end(),
-                   [&](const Json::Value& window) { return !window["floating"].asBool(); });
+  solo_ =
+      1 == std::count_if(visibleWindows.begin(), visibleWindows.end(),
+                         [&](const Json::Value& window) { return !window["floating"].asBool(); });
   allFloating_ = std::ranges::all_of(
       visibleWindows, [&](const Json::Value& window) { return window["floating"].asBool(); });
   fullscreen_ = windowData_.fullscreen;

--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -63,16 +63,9 @@ auto waybar::modules::IdleInhibitor::update() -> void {
   }
 
   std::string status_text = status ? "activated" : "deactivated";
-  label_.set_markup(fmt::format(fmt::runtime(format_), fmt::arg("status", status_text),
-                                fmt::arg("icon", getIcon(0, status_text))));
+  updateLabelAndTooltipForState(status_text, format_, "{status}", fmt::arg("status", status_text),
+                                fmt::arg("icon", getIcon(0, status_text)));
   label_.get_style_context()->add_class(status_text);
-  if (tooltipEnabled()) {
-    auto config = config_[status ? "tooltip-format-activated" : "tooltip-format-deactivated"];
-    auto tooltip_format = config.isString() ? config.asString() : "{status}";
-    label_.set_tooltip_markup(fmt::format(fmt::runtime(tooltip_format),
-                                          fmt::arg("status", status_text),
-                                          fmt::arg("icon", getIcon(0, status_text))));
-  }
   // Call parent update
   ALabel::update();
 }

--- a/src/modules/jack.cpp
+++ b/src/modules/jack.cpp
@@ -72,19 +72,10 @@ auto JACK::update() -> void {
   } else
     format = "{load}%";
 
-  label_.set_markup(fmt::format(fmt::runtime(format), fmt::arg("load", std::round(load_)),
-                                fmt::arg("bufsize", bufsize_), fmt::arg("samplerate", samplerate_),
-                                fmt::arg("latency", fmt::format("{:.2f}", latency)),
-                                fmt::arg("xruns", xruns_)));
-
-  if (tooltipEnabled()) {
-    std::string tooltip_format = "{bufsize}/{samplerate} {latency}ms";
-    if (config_["tooltip-format"].isString()) tooltip_format = config_["tooltip-format"].asString();
-    label_.set_tooltip_markup(fmt::format(
-        fmt::runtime(tooltip_format), fmt::arg("load", std::round(load_)),
-        fmt::arg("bufsize", bufsize_), fmt::arg("samplerate", samplerate_),
-        fmt::arg("latency", fmt::format("{:.2f}", latency)), fmt::arg("xruns", xruns_)));
-  }
+  updateLabelAndTooltip(
+      format, "{bufsize}/{samplerate} {latency}ms", fmt::arg("load", std::round(load_)),
+      fmt::arg("bufsize", bufsize_), fmt::arg("samplerate", samplerate_),
+      fmt::arg("latency", fmt::format("{:.2f}", latency)), fmt::arg("xruns", xruns_));
 
   // Call parent update
   ALabel::update();

--- a/src/modules/memory/common.cpp
+++ b/src/modules/memory/common.cpp
@@ -1,16 +1,14 @@
 #include "modules/memory.hpp"
 
 namespace {
-const std::unordered_map<std::string, float> kUnits = {
-  {"kB", 1.000},
-  {"kiB", 1.024},
-  {"MB", 1.000 * 1000.0},
-  {"MiB", 1.024 * 1024.0},
-  {"GB", 1.000 * 1000.0 * 1000.0},
-  {"GiB", 1.024 * 1024.0 * 1024.0},
-  {"TB", 1.000 * 1000.0 * 1000.0 * 1000.0},
-  {"TiB", 1.024 * 1024.0 * 1024.0 * 1024.0}
-};
+const std::unordered_map<std::string, float> kUnits = {{"kB", 1.000},
+                                                       {"kiB", 1.024},
+                                                       {"MB", 1.000 * 1000.0},
+                                                       {"MiB", 1.024 * 1024.0},
+                                                       {"GB", 1.000 * 1000.0 * 1000.0},
+                                                       {"GiB", 1.024 * 1024.0 * 1024.0},
+                                                       {"TB", 1.000 * 1000.0 * 1000.0 * 1000.0},
+                                                       {"TiB", 1.024 * 1024.0 * 1024.0 * 1024.0}};
 }
 
 waybar::modules::Memory::Memory(const std::string& id, const Json::Value& config)
@@ -54,7 +52,7 @@ auto waybar::modules::Memory::update() -> void {
   if (memtotal > 0 && memfree >= 0) {
     int used_ram_percentage = 100 * (memtotal - memfree) / memtotal;
     int used_swap_percentage = 0;
-    if ((bool) swaptotal) {
+    if ((bool)swaptotal) {
       used_swap_percentage = 100 * (swaptotal - swapfree) / swaptotal;
     }
 
@@ -77,31 +75,14 @@ auto waybar::modules::Memory::update() -> void {
     } else {
       event_box_.show();
       auto icons = std::vector<std::string>{state};
-      label_.set_markup(fmt::format(
-          fmt::runtime(format), used_ram_percentage,
-          fmt::arg("icon", getIcon(used_ram_percentage, icons)),
-          fmt::arg("total", total_ram), fmt::arg("swapTotal", total_swap),
-          fmt::arg("percentage", used_ram_percentage),
+      updateLabelAndTooltip(
+          format, fmt::format("{:.{}f}{} used", used_ram, 1, unit_), used_ram_percentage,
+          fmt::arg("icon", getIcon(used_ram_percentage, icons)), fmt::arg("total", total_ram),
+          fmt::arg("swapTotal", total_swap), fmt::arg("percentage", used_ram_percentage),
           fmt::arg("swapState", swaptotal == 0 ? "Off" : "On"),
           fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram),
           fmt::arg("swapUsed", used_swap), fmt::arg("avail", available_ram),
-          fmt::arg("swapAvail", available_swap)));
-    }
-
-    if (tooltipEnabled()) {
-      if (config_["tooltip-format"].isString()) {
-        auto tooltip_format = config_["tooltip-format"].asString();
-        label_.set_tooltip_markup(fmt::format(
-            fmt::runtime(tooltip_format), used_ram_percentage,
-            fmt::arg("total", total_ram), fmt::arg("swapTotal", total_swap),
-            fmt::arg("percentage", used_ram_percentage),
-            fmt::arg("swapState", swaptotal == 0 ? "Off" : "On"),
-            fmt::arg("swapPercentage", used_swap_percentage), fmt::arg("used", used_ram),
-            fmt::arg("swapUsed", used_swap), fmt::arg("avail", available_ram),
-            fmt::arg("swapAvail", available_swap)));
-      } else {
-        label_.set_tooltip_markup(fmt::format("{:.{}f}{} used", used_ram, 1, unit_));
-      }
+          fmt::arg("swapAvail", available_swap));
     }
   } else {
     event_box_.hide();

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -735,7 +735,7 @@ auto Mpris::update() -> void {
     if (label_format.empty()) {
       label_.hide();
     } else {
-      label_.set_markup(label_format);
+      setLabelMarkup(label_format);
       label_.show();
     }
   } catch (fmt::format_error const& e) {
@@ -758,7 +758,7 @@ auto Mpris::update() -> void {
           fmt::arg("player_icon", getIconFromJson(config_["player-icons"], info.name)),
           fmt::arg("status_icon", getIconFromJson(config_["status-icons"], info.status_string)));
 
-      label_.set_tooltip_markup(tooltip_text);
+      setTooltipMarkup(tooltip_text);
     } catch (fmt::format_error const& e) {
       spdlog::warn("mpris: format error (tooltip): {}", e.what());
     }

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -350,32 +350,45 @@ auto waybar::modules::Network::update() -> void {
     final_ipaddr_ += ipaddr6_;
   }
 
-  auto text = fmt::format(
-      fmt::runtime(format_), fmt::arg("essid", essid_), fmt::arg("bssid", bssid_),
-      fmt::arg("signaldBm", signal_strength_dbm_), fmt::arg("signalStrength", signal_strength_),
-      fmt::arg("signalStrengthApp", signal_strength_app_), fmt::arg("ifname", ifname_),
-      fmt::arg("netmask", netmask_), fmt::arg("netmask6", netmask6_),
-      fmt::arg("ipaddr", final_ipaddr_), fmt::arg("gwaddr", gwaddr_), fmt::arg("cidr", cidr_),
-      fmt::arg("cidr6", cidr6_), fmt::arg("frequency", fmt::format("{:.1f}", frequency_)),
-      fmt::arg("icon", getIcon(signal_strength_, state_)),
-      fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / elapsed_seconds, "b/s")),
-      fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / elapsed_seconds, "b/s")),
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  store.push_back(fmt::arg("essid", essid_));
+  store.push_back(fmt::arg("bssid", bssid_));
+  store.push_back(fmt::arg("signaldBm", signal_strength_dbm_));
+  store.push_back(fmt::arg("signalStrength", signal_strength_));
+  store.push_back(fmt::arg("signalStrengthApp", signal_strength_app_));
+  store.push_back(fmt::arg("ifname", ifname_));
+  store.push_back(fmt::arg("netmask", netmask_));
+  store.push_back(fmt::arg("netmask6", netmask6_));
+  store.push_back(fmt::arg("ipaddr", final_ipaddr_));
+  store.push_back(fmt::arg("gwaddr", gwaddr_));
+  store.push_back(fmt::arg("cidr", cidr_));
+  store.push_back(fmt::arg("cidr6", cidr6_));
+  store.push_back(fmt::arg("frequency", fmt::format("{:.1f}", frequency_)));
+  store.push_back(fmt::arg("icon", getIcon(signal_strength_, state_)));
+  store.push_back(
+      fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / elapsed_seconds, "b/s")));
+  store.push_back(
+      fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / elapsed_seconds, "b/s")));
+  store.push_back(
       fmt::arg("bandwidthTotalBits",
-               pow_format((bandwidth_up + bandwidth_down) * 8ull / elapsed_seconds, "b/s")),
-      fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / elapsed_seconds, "o/s")),
-      fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / elapsed_seconds, "o/s")),
-      fmt::arg("bandwidthTotalOctets",
-               pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "o/s")),
-      fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / elapsed_seconds, "B/s")),
-      fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / elapsed_seconds, "B/s")),
-      fmt::arg("bandwidthDownBytesCompact",
-               pow_format(bandwidth_down / elapsed_seconds, "B", false, 2)),
-      fmt::arg("bandwidthUpBytesCompact",
-               pow_format(bandwidth_up / elapsed_seconds, "B", false, 2)),
-      fmt::arg("bandwidthTotalBytes",
-               pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "B/s")));
-  if (text.compare(label_.get_label()) != 0) {
-    label_.set_markup(text);
+               pow_format((bandwidth_up + bandwidth_down) * 8ull / elapsed_seconds, "b/s")));
+  store.push_back(
+      fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / elapsed_seconds, "o/s")));
+  store.push_back(fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / elapsed_seconds, "o/s")));
+  store.push_back(fmt::arg("bandwidthTotalOctets",
+                           pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "o/s")));
+  store.push_back(
+      fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / elapsed_seconds, "B/s")));
+  store.push_back(fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / elapsed_seconds, "B/s")));
+  store.push_back(fmt::arg("bandwidthDownBytesCompact",
+                           pow_format(bandwidth_down / elapsed_seconds, "B", false, 2)));
+  store.push_back(fmt::arg("bandwidthUpBytesCompact",
+                           pow_format(bandwidth_up / elapsed_seconds, "B", false, 2)));
+  store.push_back(fmt::arg("bandwidthTotalBytes",
+                           pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "B/s")));
+
+  auto text = fmt::vformat(format_, store);
+  if (setLabelMarkup(text)) {
     if (text.empty()) {
       event_box_.hide();
     } else {
@@ -387,35 +400,9 @@ auto waybar::modules::Network::update() -> void {
       tooltip_format = config_["tooltip-format"].asString();
     }
     if (!tooltip_format.empty()) {
-      auto tooltip_text = fmt::format(
-          fmt::runtime(tooltip_format), fmt::arg("essid", essid_), fmt::arg("bssid", bssid_),
-          fmt::arg("signaldBm", signal_strength_dbm_), fmt::arg("signalStrength", signal_strength_),
-          fmt::arg("signalStrengthApp", signal_strength_app_), fmt::arg("ifname", ifname_),
-          fmt::arg("netmask", netmask_), fmt::arg("netmask6", netmask6_),
-          fmt::arg("ipaddr", final_ipaddr_), fmt::arg("gwaddr", gwaddr_), fmt::arg("cidr", cidr_),
-          fmt::arg("cidr6", cidr6_), fmt::arg("frequency", fmt::format("{:.1f}", frequency_)),
-          fmt::arg("icon", getIcon(signal_strength_, state_)),
-          fmt::arg("bandwidthDownBits", pow_format(bandwidth_down * 8ull / elapsed_seconds, "b/s")),
-          fmt::arg("bandwidthUpBits", pow_format(bandwidth_up * 8ull / elapsed_seconds, "b/s")),
-          fmt::arg("bandwidthTotalBits",
-                   pow_format((bandwidth_up + bandwidth_down) * 8ull / elapsed_seconds, "b/s")),
-          fmt::arg("bandwidthDownOctets", pow_format(bandwidth_down / elapsed_seconds, "o/s")),
-          fmt::arg("bandwidthUpOctets", pow_format(bandwidth_up / elapsed_seconds, "o/s")),
-          fmt::arg("bandwidthTotalOctets",
-                   pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "o/s")),
-          fmt::arg("bandwidthDownBytes", pow_format(bandwidth_down / elapsed_seconds, "B/s")),
-          fmt::arg("bandwidthUpBytes", pow_format(bandwidth_up / elapsed_seconds, "B/s")),
-          fmt::arg("bandwidthDownBytesCompact",
-                   pow_format(bandwidth_down / elapsed_seconds, "B", false, 2)),
-          fmt::arg("bandwidthUpBytesCompact",
-                   pow_format(bandwidth_up / elapsed_seconds, "B", false, 2)),
-          fmt::arg("bandwidthTotalBytes",
-                   pow_format((bandwidth_up + bandwidth_down) / elapsed_seconds, "B/s")));
-      if (label_.get_tooltip_text() != tooltip_text) {
-        label_.set_tooltip_markup(tooltip_text);
-      }
-    } else if (label_.get_tooltip_text() != text) {
-      label_.set_tooltip_markup(text);
+      setTooltipMarkup(fmt::vformat(tooltip_format, store));
+    } else {
+      setTooltipMarkup(text);
     }
   }
 

--- a/src/modules/power_profiles_daemon.cpp
+++ b/src/modules/power_profiles_daemon.cpp
@@ -187,18 +187,14 @@ void PowerProfilesDaemon::switchToProfile(std::string const& str) {
 auto PowerProfilesDaemon::update() -> void {
   if (connected_ && activeProfile_ != availableProfiles_.end()) {
     auto profile = (*activeProfile_);
-    // Set label
-    fmt::dynamic_format_arg_store<fmt::format_context> store;
-    store.push_back(fmt::arg("profile", profile.name));
-    // Legacy placeholder, kept for backward compatibility with existing configs.
-    store.push_back(fmt::arg("driver", profile.driver));
-    store.push_back(fmt::arg("cpu_driver", profile.cpuDriver));
-    store.push_back(fmt::arg("platform_driver", profile.platformDriver));
-    store.push_back(fmt::arg("icon", getIcon(0, profile.name)));
-    label_.set_markup(fmt::vformat(format_, store));
-    if (tooltipEnabled()) {
-      label_.set_tooltip_markup(fmt::vformat(tooltipFormat_, store));
-    }
+    // Set label and tooltip
+    updateLabelAndTooltip(format_, tooltipFormat_, fmt::arg("profile", profile.name),
+                          // Legacy placeholder, kept for backward compatibility with existing
+                          // configs.
+                          fmt::arg("driver", profile.driver),
+                          fmt::arg("cpu_driver", profile.cpuDriver),
+                          fmt::arg("platform_driver", profile.platformDriver),
+                          fmt::arg("icon", getIcon(0, profile.name)));
 
     // Set CSS class
     if (!currentStyle_.empty()) {

--- a/src/modules/pulseaudio.cpp
+++ b/src/modules/pulseaudio.cpp
@@ -72,7 +72,6 @@ const std::vector<std::string> waybar::modules::Pulseaudio::getPulseIcon() const
 
 auto waybar::modules::Pulseaudio::update() -> void {
   auto format = format_;
-  std::string tooltip_format;
   auto sink_volume = backend->getSinkVolume();
   if (!alt_) {
     std::string format_name = "format";
@@ -120,29 +119,29 @@ auto waybar::modules::Pulseaudio::update() -> void {
   auto source_desc = backend->getSourceDesc();
 
   format_source = fmt::format(fmt::runtime(format_source), fmt::arg("volume", source_volume));
-  auto text = fmt::format(
-      fmt::runtime(format), fmt::arg("desc", sink_desc), fmt::arg("volume", sink_volume),
-      fmt::arg("format_source", format_source), fmt::arg("source_volume", source_volume),
-      fmt::arg("source_desc", source_desc), fmt::arg("icon", getIcon(sink_volume, getPulseIcon())));
+
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  store.push_back(fmt::arg("desc", sink_desc));
+  store.push_back(fmt::arg("volume", sink_volume));
+  store.push_back(fmt::arg("format_source", format_source));
+  store.push_back(fmt::arg("source_volume", source_volume));
+  store.push_back(fmt::arg("source_desc", source_desc));
+  store.push_back(fmt::arg("icon", getIcon(sink_volume, getPulseIcon())));
+
+  auto text = fmt::vformat(format, store);
   if (text.empty()) {
     label_.hide();
   } else {
-    label_.set_markup(text);
+    setLabelMarkup(text);
     label_.show();
   }
 
   if (tooltipEnabled()) {
-    if (tooltip_format.empty() && config_["tooltip-format"].isString()) {
-      tooltip_format = config_["tooltip-format"].asString();
-    }
+    auto tooltip_format = resolveTooltipFormat("");
     if (!tooltip_format.empty()) {
-      label_.set_tooltip_markup(fmt::format(
-          fmt::runtime(tooltip_format), fmt::arg("desc", sink_desc),
-          fmt::arg("volume", sink_volume), fmt::arg("format_source", format_source),
-          fmt::arg("source_volume", source_volume), fmt::arg("source_desc", source_desc),
-          fmt::arg("icon", getIcon(sink_volume, getPulseIcon()))));
+      setTooltipMarkup(fmt::vformat(tooltip_format, store));
     } else {
-      label_.set_tooltip_markup(sink_desc);
+      setTooltipMarkup(sink_desc);
     }
   }
 

--- a/src/modules/simpleclock.cpp
+++ b/src/modules/simpleclock.cpp
@@ -18,18 +18,7 @@ auto waybar::modules::Clock::update() -> void {
   tzset();  // Update timezone information
   auto now = std::chrono::system_clock::now();
   auto localtime = fmt::localtime(std::chrono::system_clock::to_time_t(now));
-  auto text = fmt::format(fmt::runtime(format_), localtime);
-  label_.set_markup(text);
-
-  if (tooltipEnabled()) {
-    if (config_["tooltip-format"].isString()) {
-      auto tooltip_format = config_["tooltip-format"].asString();
-      auto tooltip_text = fmt::format(fmt::runtime(tooltip_format), localtime);
-      label_.set_tooltip_markup(tooltip_text);
-    } else {
-      label_.set_tooltip_markup(text);
-    }
-  }
+  updateLabelAndTooltip(format_, format_, localtime);
   // Call parent update
   ALabel::update();
 }

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -124,7 +124,7 @@ auto Language::update() -> void {
       fmt::runtime(format_), fmt::arg("short", layout_.short_name),
       fmt::arg("shortDescription", layout_.short_description), fmt::arg("long", layout_.full_name),
       fmt::arg("variant", layout_.variant), fmt::arg("flag", layout_.country_flag())));
-  label_.set_markup(display_layout);
+  setLabelMarkup(display_layout);
   if (tooltipEnabled()) {
     if (tooltip_format_ != "") {
       auto tooltip_display_layout = trim(
@@ -132,9 +132,9 @@ auto Language::update() -> void {
                       fmt::arg("shortDescription", layout_.short_description),
                       fmt::arg("long", layout_.full_name), fmt::arg("variant", layout_.variant),
                       fmt::arg("flag", layout_.country_flag())));
-      label_.set_tooltip_markup(tooltip_display_layout);
+      setTooltipMarkup(tooltip_display_layout);
     } else {
-      label_.set_tooltip_markup(display_layout);
+      setTooltipMarkup(display_layout);
     }
   }
 

--- a/src/modules/sway/scratchpad.cpp
+++ b/src/modules/sway/scratchpad.cpp
@@ -31,12 +31,12 @@ Scratchpad::Scratchpad(const std::string& id, const Json::Value& config)
 auto Scratchpad::update() -> void {
   if (count_ || show_empty_) {
     event_box_.show();
-    label_.set_markup(
+    setLabelMarkup(
         fmt::format(fmt::runtime(format_),
                     fmt::arg("icon", getIcon(count_, "", config_["format-icons"].size())),
                     fmt::arg("count", count_)));
     if (tooltip_enabled_) {
-      label_.set_tooltip_markup(tooltip_text_);
+      setTooltipMarkup(tooltip_text_);
     }
   } else {
     event_box_.hide();

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -281,7 +281,7 @@ auto SystemdFailedUnits::update() -> void {
 
   last_status_ = overall_state_;
 
-  label_.set_markup(fmt::format(
+  setLabelMarkup(fmt::format(
       fmt::runtime(nr_failed_ == 0 ? format_ok_ : format_), fmt::arg("nr_failed", nr_failed_),
       fmt::arg("nr_failed_system", nr_failed_system_), fmt::arg("nr_failed_user", nr_failed_user_),
       fmt::arg("system_state", system_state_), fmt::arg("user_state", user_state_),
@@ -290,14 +290,14 @@ auto SystemdFailedUnits::update() -> void {
     std::string failed_list = BuildTooltipFailedList();
     auto tooltip_template = overall_state_ == "ok" ? tooltip_format_ok_ : tooltip_format_;
     if (!tooltip_template.empty()) {
-      label_.set_tooltip_markup(fmt::format(
+      setTooltipMarkup(fmt::format(
           fmt::runtime(tooltip_template), fmt::arg("nr_failed", nr_failed_),
           fmt::arg("nr_failed_system", nr_failed_system_),
           fmt::arg("nr_failed_user", nr_failed_user_), fmt::arg("system_state", system_state_),
           fmt::arg("user_state", user_state_), fmt::arg("overall_state", overall_state_),
           fmt::arg("failed_units_list", failed_list)));
     } else {
-      label_.set_tooltip_markup("");
+      setTooltipMarkup("");
     }
   }
   ALabel::update();

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -155,19 +155,10 @@ auto waybar::modules::Temperature::update() -> void {
   event_box_.show();
 
   auto max_temp = config_["critical-threshold"].isInt() ? config_["critical-threshold"].asInt() : 0;
-  label_.set_markup(fmt::format(fmt::runtime(format), fmt::arg("temperatureC", temperature_c),
-                                fmt::arg("temperatureF", temperature_f),
-                                fmt::arg("temperatureK", temperature_k),
-                                fmt::arg("icon", getIcon(temperature_c, "", max_temp))));
-  if (tooltipEnabled()) {
-    std::string tooltip_format = "{temperatureC}°C";
-    if (config_["tooltip-format"].isString()) {
-      tooltip_format = config_["tooltip-format"].asString();
-    }
-    label_.set_tooltip_markup(fmt::format(
-        fmt::runtime(tooltip_format), fmt::arg("temperatureC", temperature_c),
-        fmt::arg("temperatureF", temperature_f), fmt::arg("temperatureK", temperature_k)));
-  }
+  updateLabelAndTooltip(format, "{temperatureC}°C", fmt::arg("temperatureC", temperature_c),
+                        fmt::arg("temperatureF", temperature_f),
+                        fmt::arg("temperatureK", temperature_k),
+                        fmt::arg("icon", getIcon(temperature_c, "", max_temp)));
   // Call parent update
   ALabel::update();
 }

--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -223,7 +223,7 @@ auto UPower::update() -> void {
     return;
   }
 
-  label_.set_markup(getText(upDevice_, format_));
+  setLabelMarkup(getText(upDevice_, format_));
   // Set icon
   if (upDevice_.icon_name == NULL || !gtkTheme_->has_icon(upDevice_.icon_name))
     upDevice_.icon_name = (char*)NO_BATTERY.c_str();

--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -432,7 +432,6 @@ void waybar::modules::Wireplumber::asyncLoadRequiredApiModules() {
 
 auto waybar::modules::Wireplumber::update() -> void {
   auto format = format_;
-  std::string tooltipFormat;
 
   // Handle sink mute state
   if (muted_) {
@@ -486,32 +485,28 @@ auto waybar::modules::Wireplumber::update() -> void {
   std::string formatted_source =
       fmt::format(fmt::runtime(format_source), fmt::arg("volume", source_vol));
 
-  std::string markup =
-      fmt::format(fmt::runtime(format), fmt::arg("node_name", node_name_), fmt::arg("volume", vol),
-                  fmt::arg("icon", getIcon(vol)), fmt::arg("format_source", formatted_source),
-                  fmt::arg("source_volume", source_vol), fmt::arg("source_desc", source_name_),
-                  fmt::arg("volume_linear", volume_), fmt::arg("volume_cubic", vol_cube),
-                  fmt::arg("volume_db", vol_db), fmt::arg("source_volume_linear", source_volume_),
-                  fmt::arg("source_volume_cubic", source_vol_cube),
-                  fmt::arg("source_volume_db", source_vol_db));
-  label_.set_markup(markup);
+  fmt::dynamic_format_arg_store<fmt::format_context> store;
+  store.push_back(fmt::arg("node_name", node_name_));
+  store.push_back(fmt::arg("volume", vol));
+  store.push_back(fmt::arg("icon", getIcon(vol)));
+  store.push_back(fmt::arg("format_source", formatted_source));
+  store.push_back(fmt::arg("source_volume", source_vol));
+  store.push_back(fmt::arg("source_desc", source_name_));
+  store.push_back(fmt::arg("volume_linear", volume_));
+  store.push_back(fmt::arg("volume_cubic", vol_cube));
+  store.push_back(fmt::arg("volume_db", vol_db));
+  store.push_back(fmt::arg("source_volume_linear", source_volume_));
+  store.push_back(fmt::arg("source_volume_cubic", source_vol_cube));
+  store.push_back(fmt::arg("source_volume_db", source_vol_db));
+
+  setLabelMarkup(fmt::vformat(format, store));
 
   if (tooltipEnabled()) {
-    if (tooltipFormat.empty() && config_["tooltip-format"].isString()) {
-      tooltipFormat = config_["tooltip-format"].asString();
-    }
-
+    auto tooltipFormat = resolveTooltipFormat("");
     if (!tooltipFormat.empty()) {
-      label_.set_tooltip_markup(fmt::format(
-          fmt::runtime(tooltipFormat), fmt::arg("node_name", node_name_), fmt::arg("volume", vol),
-          fmt::arg("icon", getIcon(vol)), fmt::arg("format_source", formatted_source),
-          fmt::arg("source_volume", source_vol), fmt::arg("source_desc", source_name_),
-          fmt::arg("volume_linear", volume_), fmt::arg("volume_cubic", vol_cube),
-          fmt::arg("volume_db", vol_db), fmt::arg("source_volume_linear", source_volume_),
-          fmt::arg("source_volume_cubic", source_vol_cube),
-          fmt::arg("source_volume_db", source_vol_db)));
+      setTooltipMarkup(fmt::vformat(tooltipFormat, store));
     } else {
-      label_.set_tooltip_markup(node_name_);
+      setTooltipMarkup(node_name_);
     }
   }
 


### PR DESCRIPTION
## Motivation
~29 modules duplicate the same boilerplate to format their label and tooltip: read `tooltip-format`, `fmt::format`, `set_tooltip_markup`. The tooltip-format resolution and the shared fmt argument store are copy-pasted everywhere.

## Change
Adds to `ALabel`:
- `resolveTooltipFormat(default, state="")` — centralizes `tooltip-format-<state>` → `tooltip-format` → default resolution.
- `updateLabelAndTooltip(labelFormat, tooltipDefault, args...)` — builds a **single** fmt arg store, renders the label and the resolved tooltip through the existing dedup-aware setters (`setLabelMarkup`/`setTooltipMarkup`), honoring the `tooltip` toggle.
- `updateLabelAndTooltipForState(state, ...)` — state-aware variant.

Each module's label+tooltip block collapses from ~8 lines to 1 call. State-based format selection stays in the module (genuinely module-specific); the module passes the selected format.

## Migrated so far
- temperature, disk (proof of concept).

Remaining modules migrate incrementally in follow-ups. Modules with fully custom tooltips (clock calendar, custom, mpris) keep their direct `setTooltipMarkup` calls.