### PR TITLE
fix(wireplumber): correct linear→cubic volume conversion (0% on Bluetooth) + source-muted state

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -547,8 +547,11 @@ auto waybar::modules::Wireplumber::update() -> void {
     label_.get_style_context()->remove_class("source-muted");
   }
 
-  double vol_cube = pow(volume_, 3);
-  double source_vol_cube = pow(source_volume_, 3);
+  // mixer-api is configured with the linear scale, so volume_ holds the raw linear gain. The
+  // perceptual "cubic" value shown by wpctl and used for {volume} is cbrt(linear), not linear^3.
+  // Cubing here drives small linear gains (typical for Bluetooth sinks) to 0%.
+  double vol_cube = cbrt(volume_);
+  double source_vol_cube = cbrt(source_volume_);
 
   int vol = round(vol_cube * 100.0);
   int source_vol = round(source_vol_cube * 100.0);
@@ -622,10 +625,10 @@ bool waybar::modules::Wireplumber::handleScroll(GdkEventScroll* e) {
     step = config_["scroll-step"].asDouble();
   }
   if (config_["max-volume"].isDouble()) {
-    // {volume} is displayed as cubic-percent (pow(volume_, 3) * 100), while volume_/newVol are
+    // {volume} is displayed as cubic-percent (cbrt(volume_) * 100), while volume_/newVol are
     // linear gains. Map the documented cubic-percent ceiling into the linear domain the clamp
-    // operates in, restoring the 0.15.0 cap semantics (e.g. 130 -> cbrt(1.3) linear -> 130%).
-    maxVolume = cbrt(config_["max-volume"].asDouble() / 100.0);
+    // operates in, restoring the 0.15.0 cap semantics (e.g. 130 -> pow(1.3, 3) linear -> 130%).
+    maxVolume = pow(config_["max-volume"].asDouble() / 100.0, 3);
   }
 
   double vol = volume_;
@@ -635,11 +638,11 @@ bool waybar::modules::Wireplumber::handleScroll(GdkEventScroll* e) {
   }
 
   if (scale == "cubic") {
-    vol = pow(vol, 3);
+    vol = cbrt(vol);
   } else if (scale == "db") {
     vol = log10(vol) * 20.0;
   } else if (scale == "cubic_percent") {
-    vol = pow(vol, 3) * 100.0;
+    vol = cbrt(vol) * 100.0;
   }
 
   double newVol = vol;
@@ -650,11 +653,11 @@ bool waybar::modules::Wireplumber::handleScroll(GdkEventScroll* e) {
   }
 
   if (scale == "cubic") {
-    newVol = cbrt(newVol);
+    newVol = pow(newVol, 3);
   } else if (scale == "db") {
     newVol = exp10(newVol / 20.0);
   } else if (scale == "cubic_percent") {
-    newVol = cbrt(newVol / 100.0);
+    newVol = pow(newVol / 100.0, 3);
   }
 
   if (dir == SCROLL_DIR::UP) {

--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -527,24 +527,39 @@ auto waybar::modules::Wireplumber::update() -> void {
     label_.get_style_context()->remove_class("bluetooth");
   }
 
-  // Handle sink mute state
+  // A module configured with node-type "Audio/Source" tracks a source as its primary node, so its
+  // primary mute state (muted_) must drive the source-muted class rather than the sink classes.
+  const bool is_source_type = g_strcmp0(type_, "Audio/Source") == 0;
+
+  // Handle primary node mute state
   if (muted_) {
     // Check muted bluetooth format exists, otherwise fall back to default muted format.
     if (format_name != "format" && !config_[format_name + "-muted"].isString())
       format_name = "format";
     format_name += "-muted";
-    label_.get_style_context()->add_class("muted");
-    label_.get_style_context()->add_class("sink-muted");
+    if (is_source_type) {
+      label_.get_style_context()->add_class("source-muted");
+    } else {
+      label_.get_style_context()->add_class("muted");
+      label_.get_style_context()->add_class("sink-muted");
+    }
   } else {
-    label_.get_style_context()->remove_class("muted");
-    label_.get_style_context()->remove_class("sink-muted");
+    if (is_source_type) {
+      label_.get_style_context()->remove_class("source-muted");
+    } else {
+      label_.get_style_context()->remove_class("muted");
+      label_.get_style_context()->remove_class("sink-muted");
+    }
   }
 
-  // Handle source mute state
-  if (source_muted_) {
-    label_.get_style_context()->add_class("source-muted");
-  } else {
-    label_.get_style_context()->remove_class("source-muted");
+  // Handle the secondary source mute state (only relevant for sink modules, which additionally
+  // track the default source for {format_source}). A source module already owns source-muted above.
+  if (!is_source_type) {
+    if (source_muted_) {
+      label_.get_style_context()->add_class("source-muted");
+    } else {
+      label_.get_style_context()->remove_class("source-muted");
+    }
   }
 
   // mixer-api is configured with the linear scale, so volume_ holds the raw linear gain. The


### PR DESCRIPTION
Two WirePlumber fixes. The first is a **volume-scale correction that affects every user's `{volume}` reading**, so please sanity-check it against a real device before merging — I couldn't runtime-test it.

## `{volume}` reads too low / 0% on Bluetooth (#5159, regression)

The mixer-api is configured with the **linear** scale (`onMixerApiLoaded` → `g_object_set(..., "scale", 0 /* linear */)`, wireplumber.cpp:469), so `volume_` holds the raw **linear gain**. WirePlumber's perceptual value (what `wpctl` shows and what `{volume}` should display) is `cbrt(linear)`. But `update()` computed the percentage as `pow(volume_, 3)` — it **cubed** where it must take the **cube root**, which under-reads every volume and collapses the small linear gains typical of Bluetooth sinks to 0%.

Verified against the reporter's numbers: `wpctl` 0.55 (cubic) → linear 0.166 → buggy `pow(0.166,3)·100 = 0%`; fixed `cbrt(0.166)·100 = 55%` (matches `wpctl`). Analog is affected too (an 80%-set sink displayed ~13%), but only Bluetooth hits a visible 0%. (`f72f84e0`'s device.id guard only touched the form-factor lookup, never the volume path.)

The fix swaps the inverted `pow(x,3)` ↔ `cbrt(x)` in the three places that share this convention and stay mutually consistent: the display computation, the `scroll-scale` `cubic`/`cubic_percent` forward+inverse conversions in `handleScroll` (exact inverses, so scrolling still round-trips), and the `max-volume` ceiling mapping.

## `source-muted` state never applied for source modules (#4523)

For a module configured `node-type: "Audio/Source"`, `update()` applied `muted`/`sink-muted` instead of `source-muted`. Now the mute-class selection is node-type aware: a source module drives `source-muted` from its primary mute state; a sink module keeps `muted`/`sink-muted` for its sink plus `source-muted` for the secondary default source it tracks for `{format_source}`. (`{volume}` still comes from the primary node, so source-module volume rendering is unchanged.)
