### PR TITLE
fix(label): compare markup cache by raw bytes, not collation

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -87,8 +87,11 @@ class ALabel : public AModule {
   static void handleGtkMenuEvent(GtkMenuItem* menuitem, gpointer data);
 
  private:
-  std::optional<Glib::ustring> last_label_markup_;
-  std::optional<Glib::ustring> last_tooltip_markup_;
+  // Raw UTF-8 bytes, not Glib::ustring: ustring::operator== collates with
+  // g_utf8_collate(), which gives private-use codepoints (nerd-font icons)
+  // no collation weight, so two different icons compare equal.
+  std::optional<std::string> last_label_markup_;
+  std::optional<std::string> last_tooltip_markup_;
 };
 
 }  // namespace waybar

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -147,22 +147,22 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
 auto ALabel::update() -> void { AModule::update(); }
 
 bool ALabel::setLabelMarkup(const Glib::ustring& markup) {
-  if (last_label_markup_ == markup) {
+  if (last_label_markup_ == markup.raw()) {
     return false;
   }
 
   label_.set_markup(markup);
-  last_label_markup_ = markup;
+  last_label_markup_ = markup.raw();
   return true;
 }
 
 bool ALabel::setTooltipMarkup(const Glib::ustring& markup) {
-  if (last_tooltip_markup_ == markup) {
+  if (last_tooltip_markup_ == markup.raw()) {
     return false;
   }
 
   label_.set_tooltip_markup(markup);
-  last_tooltip_markup_ = markup;
+  last_tooltip_markup_ = markup.raw();
   return true;
 }
 


### PR DESCRIPTION
**What does this PR do?**
Fixes the markup-skip cache in `ALabel` treating labels that differ only by a nerd-font icon as identical, which made `idle_inhibitor` (and any other module whose consecutive updates differ only by an icon glyph) never visually update.

The cache from 2190871a compares `Glib::ustring`s, whose `operator==` goes through `g_utf8_collate()`. Under the UTF-8 locale GTK sets at startup, private-use-area codepoints — where all nerd-font icons live — carry no collation weight, so e.g. `󰒳` and `󰒲` compare *equal* and `set_markup()` is skipped. That's why the reporter saw the state CSS class toggle (highlight changes) while the icon stayed frozen, and why plain-text icons like `"YES"`/`"NO"` kept working. `idle_inhibitor` only started routing through this cache when db4941ef moved it onto the shared `setLabelMarkup()`/`setTooltipMarkup()` helpers, which matches "stopped working after the latest round of commits".

The fix stores the cache as raw UTF-8 bytes (`ustring::raw()`) and compares those, so the redundant-update skip only triggers on byte-identical markup.

Reproduced under a nested niri session with the issue's exact config: sending `SIGRTMIN+8` (same `toggleStatus()` + `update()` path as a click) toggled the `activated` class but left the glyph unchanged before the fix, and flips it correctly after. `g_utf8_collate("\U000F04B3", "\U000F04B2")` returning 0 under `en_US.UTF-8` confirmed the root cause directly.

**Related issues**
Closes #5169

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`) — not applicable, no user-facing option changed
- [x] Tested against the affected module(s)