### PR TITLE
ci(smoke): fix state tier hang from bare wait on a lingering daemon

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -29,6 +29,10 @@ env:
 jobs:
   smoke:
     runs-on: ubuntu-latest
+    # Safety net: the whole smoke job is minutes of work. Cap it so a hung tier
+    # (e.g. a daemon left running under a bare `wait`) fails fast instead of
+    # burning the default 6h runner budget.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 

--- a/test/smoke/lib.sh
+++ b/test/smoke/lib.sh
@@ -194,5 +194,12 @@ smoke::assert_clean_exit() {
 smoke::stop() {
     kill "$WAYBAR_PID" 2>/dev/null || true
     swaymsg -q exit 2>/dev/null || kill "$COMP_PID" 2>/dev/null || true
-    wait 2>/dev/null || true
+    # Wait only on the processes we own. A bare `wait` reaps *every* background
+    # job of the caller's shell, so a tier that leaves an unrelated daemon
+    # running (state.sh's mpd, killed later in its own cleanup) would deadlock
+    # here until GitHub's 6h job timeout.
+    local p
+    for p in "$WAYBAR_PID" "$COMP_PID"; do
+        [ -n "$p" ] && wait "$p" 2>/dev/null || true
+    done
 }

--- a/test/smoke/state.sh
+++ b/test/smoke/state.sh
@@ -20,9 +20,11 @@ MPD_PID=""
 PA_STARTED=""
 
 cleanup() {
-    smoke::stop
+    # Tear our daemons down first: smoke::stop waits on the compositor/waybar,
+    # and a still-running mpd/pulseaudio must not be left for anything to block on.
     [ -n "$MPD_PID" ] && kill "$MPD_PID" 2>/dev/null || true
     [ -n "$PA_STARTED" ] && pulseaudio --kill 2>/dev/null || true
+    smoke::stop
     return 0
 }
 


### PR DESCRIPTION
## Problem

The `smoke` job on `master` hung (e.g. [run 28754189481](https://github.com/Alexays/Waybar/actions/runs/28754189481)) at **State transitions (mpd / pulseaudio)** — not slow, *stuck*: the tests finished but teardown never returned, so the job would run until GitHub's 6h timeout.

`74f0d33` made the mpd tier actually start `mpd` for the first time (its config was previously broken, so mpd never ran). That exposed a latent deadlock:

- `state.sh` launches `mpd --no-daemon &` and never kills it during the tier.
- Its `cleanup()` called `smoke::stop` **before** killing mpd.
- `smoke::stop` ended in a **bare `wait`**, which reaps *every* background job of the shell — including the still-running mpd — so it blocked forever.

`continue-on-error: true` doesn't help here: it catches step *failures*, not *hangs*.

## Fix

- **`lib.sh`** — `smoke::stop` now waits only on the PIDs it owns (`WAYBAR_PID`, `COMP_PID`). Root-cause fix: no tier can deadlock teardown by leaving an unrelated daemon running.
- **`state.sh`** — `cleanup()` tears down mpd/pulseaudio before `smoke::stop`.
- **`smoke.yml`** — `timeout-minutes: 20` so any future hang fails fast instead of burning the 6h runner budget.

## Verification

- `bash -n` passes on both scripts.
- Reproduced the deadlock in isolation: a bare `wait` blocks on a lingering background "daemon"; the targeted `wait` returns immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)