### PR TITLE
fix(hyprland/workspaces): skip taskbar rebuild when content is unchanged

### DIFF
--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -100,6 +100,10 @@ class Workspace {
   Gtk::Label m_labelBefore;
   Gtk::Label m_labelAfter;
 
+  // Signature of the last taskbar render, used to skip redundant rebuilds that
+  // otherwise leak GtkCssStaticStyle on every refresh (Alexays/Waybar#5186).
+  std::string m_lastTaskbarSignature;
+
   bool isEmpty() const;
   void updateTaskbar(const std::string& workspace_icon);
   bool handleClick(const GdkEventButton* event_button, WindowAddress const& addr) const;

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -521,13 +521,7 @@ bool Workspace::isEmpty() const {
 }
 
 void Workspace::updateTaskbar(const std::string& workspace_icon) {
-  for (auto child : m_content.get_children()) {
-    if (child != &m_labelBefore) {
-      m_content.remove(*child);
-    }
-  }
-
-  // Build a list of windows to display, removing duplicates by window_class
+  // Build the list of windows to display, removing duplicates by window_class
   // and respecting max-icons limit
   std::vector<const WindowRepr*> windowsToShow;
   std::set<std::string> seenClasses;
@@ -564,6 +558,37 @@ void Workspace::updateTaskbar(const std::string& workspace_icon) {
   int maxWindows = m_workspaceManager.maxWindows();
   if (maxWindows > 0 && static_cast<int>(windowsToShow.size()) > maxWindows) {
     windowsToShow.resize(maxWindows);
+  }
+
+  // Skip the rebuild when nothing this function renders has changed. With
+  // 'update-active-window' the taskbar is refreshed on every activewindowv2
+  // event, but most focus changes leave a given workspace's taskbar identical.
+  // Tearing it down and recreating every button/label/icon each time leaks a
+  // GtkCssStaticStyle per gtk_widget_show() that GTK never frees, so unchanged
+  // rebuilds accumulate memory unbounded (Alexays/Waybar#5186). Compare a
+  // signature of everything rendered below and bail out early when it matches.
+  std::string signature = name();
+  signature.push_back('\x1f');
+  signature.append(workspace_icon);
+  for (const auto* window_repr : windowsToShow) {
+    signature.push_back('\x1e');
+    signature.append(window_repr->window_class);
+    signature.push_back('\x1f');
+    signature.append(window_repr->window_title);
+    signature.push_back('\x1f');
+    signature.append(window_repr->address);
+    signature.push_back(window_repr->isActive ? '\x01' : '\x02');
+  }
+  if (signature == m_lastTaskbarSignature) {
+    return;
+  }
+  m_lastTaskbarSignature = signature;
+
+  // Content changed: tear down the previous taskbar widgets and rebuild.
+  for (auto child : m_content.get_children()) {
+    if (child != &m_labelBefore) {
+      m_content.remove(*child);
+    }
   }
 
   bool isFirst = true;


### PR DESCRIPTION
## Summary

First, thanks for Waybar — it's what I run every day. I went digging into the
memory growth reported in #5186 and think I found where a lot of it comes from,
so I wanted to share what I have along with a small change that helped a lot on
my setup. I'm not a Waybar/GTK expert, so please read the analysis below as
"here's what I measured" rather than the final word — I'm very happy to rework
the approach into whatever fits the codebase best.

## What seems to be happening

`Workspace::updateTaskbar()` rebuilds the whole per-window taskbar subtree
(buttons, labels, icons) on every call, and with `update-active-window` it is
called for every workspace on every `activewindowv2` event. From what I can
tell, most focus changes leave a given workspace's taskbar identical, so many of
those rebuilds don't change anything on screen.

Profiling with heaptrack (master `98b2a56`, 3 monitors, `update-active-window:
true`, driving 500 focus changes) pointed at the recreated widgets: each one,
when shown, appears to make GTK compute a `GtkCssStaticStyle` that isn't
released. ~75 MB accumulated over the 500 events (~143 KB each), almost all via:

    gtk_css_static_style_new_compute
      ... gtk_widget_show / gtk_widget_map / gtk_widget_realize ...
      Workspace::updateTaskbar()
      Workspace::update()
      Workspaces::updateWorkspaceStates()
      Workspaces::doUpdate()

(I could be misreading the GTK side of this — but the widget churn from the
rebuilds is clearly what triggers it.)

## What the change does

Compute the window list first, then skip the teardown+rebuild when a signature
of what the function renders (per-window class/title/address/active-state, plus
the workspace name and icon) hasn't changed since the last render. When nothing
visible changed, the existing widgets are already correct. Genuine changes
rebuild exactly as before. I tried to keep it small and match the surrounding
style, but I'm glad to take a different approach if this isn't the shape you'd
want.

## What it helps with

The redundant rebuilds — a workspace's taskbar being torn down and rebuilt when
its content didn't actually change. With `update-active-window` that was
happening on every focus event, for every workspace, on every monitor.

| | accumulated / 500 events | per event |
|---|---|---|
| before | ~73 MB | ~143 KB |
| after | ~0.36 MB | ~0.7 KB |

On my machine (NixOS, Hyprland, 3 monitors) waybar used to reach ~2 GB in
~7.5 h; with this change it stays around ~130 MB over a comparable stretch.

## What it does not solve (being upfront)

I don't think this addresses the underlying allocation — GTK still seems to hold
onto a `GtkCssStaticStyle` per widget shown; the change only avoids showing new
widgets when nothing changed. So genuine taskbar changes still rebuild and still
grow memory by their share:

- a window opening, closing, or moving between workspaces
- the active-window highlight moving within a strip
- a window title changing (browser tabs, terminals, editors) — titles are part
  of the rendered content, so they count as a change

So growth should now track real taskbar activity rather than the raw focus-event
rate — a big drop for most workloads, though not zero, and a title-churn-heavy
session would still creep up slowly. A complete fix probably lives either in
GTK's style lifetime, or in reusing the taskbar widgets in place instead of
recreating the subtree; both felt bigger than I wanted to attempt without your
input. I'd be happy to take a run at the widget-reuse version if you think
that's the better direction.

## Testing

- heaptrack before/after on master with the reported config
- A/B on an identical 500-focus-change run (with an idle control): +73 MB → +0.36 MB
- `clang-format` clean; builds with `meson setup` + `ninja -C build`
- Running it live (NixOS, Hyprland, 3 monitors); the taskbar still renders and
  updates correctly on window open/close and focus changes

Refs #5186 — I left it as a reference rather than an auto-close, since there's
still the residual above. Totally your call whether to close it or keep it open
to track the GTK side.

## Checklist

- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option — N/A, no
      user-facing option added or changed
- [x] Tested against the affected module(s) — `hyprland/workspaces` taskbar]