### PR TITLE
fix(idle_inhibitor.cpp): Fix build for systems without SIGRTMIN/SIGRTMAX

### DIFF
--- a/src/modules/idle_inhibitor.cpp
+++ b/src/modules/idle_inhibitor.cpp
@@ -103,6 +103,7 @@ auto waybar::modules::IdleInhibitor::update() -> void {
 }
 
 auto waybar::modules::IdleInhibitor::refresh(int sig) -> void {
+#ifdef SIGRTMIN
   if (config_["signal"].isInt() && sig == SIGRTMIN + config_["signal"].asInt()) {
     toggleStatus();
 
@@ -111,6 +112,7 @@ auto waybar::modules::IdleInhibitor::refresh(int sig) -> void {
       module->update();
     }
   }
+#endif
 }
 
 void waybar::modules::IdleInhibitor::toggleStatus(int force_status) {


### PR DESCRIPTION
Follow-up to https://github.com/Alexays/Waybar/pull/4992 addressing newly introduced usage of ```SIGRTMIN``` 