### PR TITLE
refactor(cava): fix thread-safety, resource leaks, and style violations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,3 +43,145 @@ add its man page and a line in [`.github/wiki/mapping.json`](.github/wiki/mappin
 - Build and test against the module(s) you touched.
 
 Have fun :)
+
+---
+
+# Coding Conventions
+
+## 1. Language & Build
+- **Standard**: C++20.
+- **Build system**: Meson (`meson.build`). Project version is defined there.
+- **Compiler flags**: Added via `add_project_arguments()` in Meson. Feature flags use `HAVE_*` / `WANT_*` prefixes (e.g. `-DHAVE_NIRI`, `-DHAVE_HYPRLAND`, `-DHAVE_LIBUDEV`).
+
+## 2. Formatting
+- **Tool**: `.clang-format` is checked in. **Never bypass it.**
+- **Style**: Google base style.
+- **Indent**: 2 spaces. No tabs.
+- **Column limit**: 100.
+- **Braces**: K&R (opening brace on the same line).
+- **Declaration alignment**: Disabled (`AlignConsecutiveDeclarations: false`).
+- **Pointer/reference alignment**: Left (`const Json::Value& config`, `int* ptr`, not `int *ptr`).
+
+## 3. Naming
+
+### Files
+- Match the primary exported class exactly: `AAppIconLabel.hpp`, `workspaces.cpp`, `backlight_backend.hpp`.
+- Corresponding header and source should live in predictable paths:
+  - `include/<module/path>.hpp`
+  - `src/<module/path>.cpp`
+
+### Types
+- **Classes / Structs**: `PascalCase`.
+  - Abstract base classes are prefixed with `A` (e.g., `AModule`, `ALabel`, `AIconLabel`, `AAppIconLabel`).
+- **Enums / Enum classes**: `PascalCase` name.
+  - Enumerators: `UPPER_SNAKE_CASE` (e.g., `SCROLL_DIR::NONE`, `KillSignalAction::RELOAD`, `ChangeType::Increase`).
+- **Concepts / Type aliases**: `PascalCase`.
+
+### Variables
+- **Member variables**: `snake_case_` with a **trailing underscore**.
+  - Examples: `config_`, `bar_`, `label_`, `app_icon_size_`, `distance_scrolled_y_`, `on_updated_cb_`.
+- **Function parameters & locals**: `snake_case` (no trailing underscore).
+  - Examples: `workspace_data`, `should_refresh`, `app_identifier`, `preferred_device`.
+- **Static / constexpr constants**: `UPPER_SNAKE_CASE` or descriptive `kPascalCase`.
+  - Examples: `MODULE_CLASS`, `EPOLL_MAX_EVENTS`, `kExecFailureExitCode`.
+
+### Functions & Methods
+- **Free functions**: `snake_case`.
+  - Examples: `sanitize_string()`, `rewrite_string()`, `get_total_memory()`, `best_device()`.
+- **Class methods**: `lowerCamelCase`.
+  - Examples: `update()`, `tooltipEnabled()`, `handleScroll()`, `getScrollDir()`, `resolveFormat()`, `setBrightness()`.
+- **Virtual overrides**: Mark with `override` (and `final` where applicable). Header signatures often use a trailing return type:
+  ```cpp
+  auto update() -> void override;
+  auto refresh(int should_refresh) -> void;
+  ```
+
+### Namespaces
+- All lowercase, nested by module path:
+  ```cpp
+  namespace waybar { }
+  namespace waybar::modules::niri { }
+  namespace waybar::util { }
+  ```
+- Close every namespace with a comment:
+  ```cpp
+  }  // namespace waybar::modules::niri
+  ```
+
+## 4. Includes & Headers
+- Use `#pragma once` in all project headers.
+- Include order in `.cpp` files:
+  1. Corresponding header first.
+  2. Blank line.
+  3. External library headers (`<fmt/...>`, `<spdlog/...>`, `<gtkmm/...>`, `<json/json.h>`).
+  4. Standard library headers (`<algorithm>`, `<vector>`, `<memory>`).
+  5. Blank line.
+  6. Other project headers (`"util/..."`, `"modules/..."`).
+- Do not use `using namespace` in headers. In `.cpp` files it is acceptable for narrow scopes (e.g., `using namespace std::literals::chrono_literals;`).
+- Headers that expose standard-library types in their public interface (e.g. `std::chrono::milliseconds` as a return type or `std::vector<T>` as a member) must `#include` the corresponding standard header directly. Do not rely on transitive includes from other headers.
+
+## 5. Class & Module Design
+
+### Base Class Patterns
+- All UI modules ultimately derive from `AModule` (and often `ALabel` or `AIconLabel`).
+- Accept configuration in constructors:
+  ```cpp
+  MyModule(const Json::Value& config, const std::string& name, const std::string& id, ...);
+  ```
+
+### Signals & Threading
+- Use `Glib::Dispatcher` (via `waybar::SafeSignal`) to marshal work to the GTK main thread.
+- Use `sigc::signal` for normal GTK++ signals.
+- If a scope must not be interrupted by `pthread_cancel`, guard it with `waybar::util::CancellationGuard`.
+
+### State / IPC
+- Modules that talk to a compositor often implement a small `EventHandler` interface (`onEvent(...)`) and delegate to a singleton backend (e.g., `gIPC`).
+
+### RAII
+- Prefer `std::unique_ptr` with custom deleters over raw `new/delete` for C-API resources (see `ScopedFd`, `UdevDeleter`, `UdevDeviceDeleter`, `ScopeGuard`).
+
+## 6. JSON Configuration
+- Every module receives `const Json::Value& config` (usually as the first constructor argument).
+- Always validate node type before reading:
+  ```cpp
+  if (config_["sort-by-id"].isBool()) { ... }
+  if (config.isMember("window-rewrite-default") && config["window-rewrite-default"].isString()) { ... }
+  ```
+- Use `waybar::util::JsonParser` if you need to pre-process JSON with non-standard escape sequences.
+
+## 7. String & UI Formatting
+- Use `fmt::format` / `fmt::join` for all string composition.
+- Use `fmt::dynamic_format_arg_store<fmt::format_context>` when building arguments dynamically.
+- Custom `fmt::formatter` specializations are allowed for domain types (e.g., `Glib::ustring`, project enums).
+- Sanitize arbitrary text before inserting into Pango markup with `waybar::util::sanitize_string`.
+- Use `waybar::util::rewriteString` for user-configurable regex rewrites.
+- Truncate UTF-8 safely with `waybar::util::utf8_truncate` / `utf8_width`.
+
+## 8. Error Handling & Logging
+- Use `spdlog` for all logging:
+  - `spdlog::error("Context: {}", e.what());`
+  - `spdlog::warn("Deprecated key '{}', prefer '{}'", old, replacement);`
+  - `spdlog::debug("State changed to {}", value);`
+- Throw `std::runtime_error` (or similar) for fatal initialization failures that should bubble up to `main()`.
+
+## 9. GTK / Glib Patterns
+- Prefer gtkmm-3.0 types (`Gtk::Button`, `Gtk::Label`, `Gdk::Pixbuf`, `Glib::RefPtr`, `Glib::ustring`) over raw C GTK APIs.
+- Access the default icon theme through thread-safe wrappers if off the main thread (`DefaultGtkIconThemeWrapper`).
+- Tooltips and labels should respect the module `tooltip` toggle (see `tooltipEnabled()` in `AModule`).
+
+## 10. Platform Portability
+- Isolate platform-specific code in dedicated files (e.g., `linux.cpp`, `bsd.cpp`).
+- Use preprocessor guards for platform differences (`#if defined(__FreeBSD__)`, `#if defined(HAVE_LIBNL)`).
+- Keep the common interface in a shared header or base class.
+
+## 11. Thread Safety & Cross-Thread Communication
+- GTK is strictly single-threaded. Never emit raw `sigc::signal` from background threads.
+- Use `waybar::SafeSignal<T...>` to marshal events from worker threads to the GTK main loop.
+- When a module manages background threads, use `std::mutex`, `std::recursive_mutex`, or atomic variables to protect shared state, and ensure the destructor joins or synchronizes with those threads before destroying resources.
+
+## 12. Unsafe Patterns to Avoid
+- Do not use `strcpy`, `strcat`, or `sprintf` into fixed-size buffers (e.g. `char buf[PATH_MAX]`). Prefer `std::string`, `std::vector<char>`, or `std::array` with bounds-safe operations.
+- When passing a `std::vector<char>` buffer to a C API that expects a mutable `char*` string, always ensure the buffer is null-terminated and clamp the written length to `size() - 1`. Never use `std::copy` from an unbounded source into a fixed-size buffer.
+
+## 13. Singleton Lifetime
+- Singletons or objects with process-wide lifetime must not store references (`&`) or pointers to objects with shorter lifetime (e.g., configuration trees, GTK widgets, or bar instances) unless they are explicitly notified of destruction. Prefer storing configuration by value (`Json::Value`, `std::string`, etc.) if the singleton outlives the config loader.

--- a/include/modules/cava/cavaGLSL.hpp
+++ b/include/modules/cava/cavaGLSL.hpp
@@ -1,36 +1,64 @@
 #pragma once
 
 #include <epoxy/gl.h>
+#include <gtkmm/glarea.h>
+#include <map>
+#include <string>
+#include <array>
+
+#include <sigc++/connection.h>
 
 #include "AModule.hpp"
 #include "cava_backend.hpp"
 
 namespace waybar::modules::cava {
 
-class CavaGLSL final : public AModule, public Gtk::GLArea {
+class CavaGLSL final : public AModule {
  public:
   CavaGLSL(const std::string&, const Json::Value&);
-  ~CavaGLSL() = default;
+  ~CavaGLSL();
+  auto doAction(const std::string& name) -> void override;
 
  private:
+  using Action = void (CavaGLSL::*)();
+
+  Gtk::GLArea gl_area_;
   std::shared_ptr<CavaBackend> backend_;
-  struct ::cava::config_params prm_;
-  int frame_counter{0};
+  // Cached config params (deep-copied strings to avoid dangling char* on backend reload)
+  int sdl_width_{0};
+  int sdl_height_{0};
+  int bar_width_{0};
+  int bar_spacing_{0};
+  int gradient_count_{0};
+  std::string vertex_shader_;
+  std::string fragment_shader_;
+  std::string bcolor_;
+  std::string color_;
+  std::array<std::string, 8> gradient_colors_;
+  int frame_counter_{0};
   bool silence_{false};
   bool hide_on_silence_{false};
+  bool mapped_{false};
   // Cava method
-  auto onUpdate(const ::cava::audio_raw& input) -> void;
+  void pauseResume();
+  auto onUpdate(const CavaBackend::AudioRaw& input) -> void;
   auto onSilence() -> void;
-  // Member variable to store the shared pointer
-  std::shared_ptr<::cava::audio_raw> m_data_;
-  GLuint shaderProgram_;
+  auto onBackendConfigChanged() -> void;
+  void cacheConfigParams(const ::cava::config_params& src);
+  // Member variable to store audio data
+  CavaBackend::AudioRaw m_data_;
+  GLuint shaderProgram_{0};
   // OpenGL variables
-  GLuint fbo_;
-  GLuint texture_;
+  GLuint fbo_{0};
+  GLuint texture_{0};
+  GLuint vbo_{0};
+  GLuint ibo_{0};
+  GLuint vao_{0};
   GLint uniform_bars_;
   GLint uniform_previous_bars_;
   GLint uniform_bars_count_;
   GLint uniform_time_;
+  GLint uniform_input_texture_;
   // Methods
   void onRealize();
   bool onRender(const Glib::RefPtr<Gdk::GLContext>& context);
@@ -39,5 +67,13 @@ class CavaGLSL final : public AModule, public Gtk::GLArea {
   void initSurface();
   void initGLSL();
   GLuint loadShader(const std::string& fileName, GLenum type);
+  void cleanupGL();
+
+  // ModuleActionMap
+  static const std::map<std::string, Action> actionMap_;
+
+  sigc::connection audio_raw_update_conn_;
+  sigc::connection silence_conn_;
+  sigc::connection config_changed_conn_;
 };
 }  // namespace waybar::modules::cava

--- a/include/modules/cava/cavaRaw.hpp
+++ b/include/modules/cava/cavaRaw.hpp
@@ -1,30 +1,38 @@
 #pragma once
 
+#include <map>
+#include <string>
+
+#include <sigc++/connection.h>
+
 #include "ALabel.hpp"
 #include "cava_backend.hpp"
 
 namespace waybar::modules::cava {
 
-class Cava final : public ALabel, public sigc::trackable {
+class CavaRaw final : public ALabel {
  public:
-  Cava(const std::string&, const Json::Value&);
-  ~Cava() = default;
+  CavaRaw(const std::string&, const Json::Value&);
+  ~CavaRaw();
   auto doAction(const std::string& name) -> void override;
 
  private:
+  using Action = void (CavaRaw::*)();
+
   std::shared_ptr<CavaBackend> backend_;
   // Text to display
-  Glib::ustring label_text_{""};
+  Glib::ustring label_text_;
   bool silence_{false};
   bool hide_on_silence_{false};
-  std::string format_silent_{""};
-  int ascii_range_{0};
+  std::string format_silent_;
   // Cava method
-  void pause_resume();
+  void pauseResume();
   auto onUpdate(const std::string& input) -> void;
   auto onSilence() -> void;
   // ModuleActionMap
-  static inline std::map<const std::string, void (waybar::modules::cava::Cava::* const)()>
-      actionMap_{{"mode", &waybar::modules::cava::Cava::pause_resume}};
+  static const std::map<std::string, Action> actionMap_;
+
+  sigc::connection update_conn_;
+  sigc::connection silence_conn_;
 };
 }  // namespace waybar::modules::cava

--- a/include/modules/cava/cava_backend.hpp
+++ b/include/modules/cava/cava_backend.hpp
@@ -1,8 +1,17 @@
 #pragma once
 
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
 #include <json/json.h>
 #include <sigc++/sigc++.h>
 
+#include "util/SafeSignal.hpp"
 #include "util/sleeper_thread.hpp"
 
 namespace cava {
@@ -21,7 +30,6 @@ extern "C" {
 }  // namespace cava
 
 namespace waybar::modules::cava {
-using namespace std::literals::chrono_literals;
 
 class CavaBackend final {
  public:
@@ -29,19 +37,38 @@ class CavaBackend final {
 
   virtual ~CavaBackend();
   // Methods
-  int getAsciiRange();
+  int getAsciiRange() const;
   void doPauseResume();
-  void Update();
-  const struct ::cava::config_params* getPrm();
-  std::chrono::milliseconds getFrameTimeMilsec();
+  void update();
+  const ::cava::config_params& getPrm() const;
+  std::chrono::milliseconds getFrameTimeMilsec() const;
+
+  struct AudioRaw {
+    std::vector<float> bars_raw;
+    std::vector<float> previous_bars_raw;
+    int number_of_bars = 0;
+
+    AudioRaw() = default;
+    explicit AudioRaw(const ::cava::audio_raw& raw) {
+      number_of_bars = raw.number_of_bars;
+      if (raw.bars_raw != nullptr && number_of_bars > 0) {
+        bars_raw.assign(raw.bars_raw, raw.bars_raw + number_of_bars);
+      }
+      if (raw.previous_bars_raw != nullptr && number_of_bars > 0) {
+        previous_bars_raw.assign(raw.previous_bars_raw, raw.previous_bars_raw + number_of_bars);
+      }
+    }
+  };
 
   // Signal accessor
-  using type_signal_update = sigc::signal<void(const std::string&)>;
-  type_signal_update signal_update();
-  using type_signal_audio_raw_update = sigc::signal<void(const ::cava::audio_raw&)>;
-  type_signal_audio_raw_update signal_audio_raw_update();
-  using type_signal_silence = sigc::signal<void()>;
-  type_signal_silence signal_silence();
+  using SignalUpdate = SafeSignal<const std::string&>;
+  SignalUpdate& signalUpdate();
+  using SignalAudioRawUpdate = SafeSignal<AudioRaw>;
+  SignalAudioRawUpdate& signalAudioRawUpdate();
+  using SignalSilence = SafeSignal<>;
+  SignalSilence& signalSilence();
+  using SignalConfigChanged = SafeSignal<>;
+  SignalConfigChanged& signalConfigChanged();
 
  private:
   CavaBackend(const Json::Value& config);
@@ -49,36 +76,78 @@ class CavaBackend final {
   util::SleeperThread out_thread_;
 
   // Cava API to read audio source
-  ::cava::ptr input_source_{NULL};
+  ::cava::ptr input_source_{nullptr};
 
   struct ::cava::error_s error_{};          // cava errors
   struct ::cava::config_params prm_{};      // cava parameters
   struct ::cava::audio_raw audio_raw_{};    // cava handled raw audio data(is based on audio_data)
   struct ::cava::audio_data audio_data_{};  // cava audio data
-  struct ::cava::cava_plan* plan_{NULL};    //{new cava_plan{}};
+  struct ::cava::cava_plan* plan_{nullptr};    //{new cava_plan{}};
 
   std::chrono::seconds fetch_input_delay_{4};
-  // Delay to handle audio source
-  std::chrono::milliseconds frame_time_milsec_{1s};
 
-  const Json::Value& config_;
+  struct AdaptiveDelay {
+    std::chrono::milliseconds delay;
+    std::chrono::seconds delta{0};
+
+    explicit AdaptiveDelay(std::chrono::milliseconds initial = std::chrono::seconds(1))
+        : delay(initial) {}
+
+    bool increase() {
+      if (delta == std::chrono::seconds{0}) {
+        delta += std::chrono::seconds{1};
+        delay += delta;
+        return true;
+      }
+      return false;
+    }
+
+    bool decrease() {
+      if (delta > std::chrono::seconds{0}) {
+        delay -= delta;
+        delta -= std::chrono::seconds{1};
+        return true;
+      }
+      return false;
+    }
+
+    std::chrono::milliseconds current() const { return delay; }
+
+    void reset(std::chrono::milliseconds new_delay) {
+      delay = new_delay;
+      delta = std::chrono::seconds{0};
+    }
+  };
+
+  AdaptiveDelay adaptive_delay_;
+
+  Json::Value config_;
   int re_paint_{0};
   bool silence_{false};
   bool silence_prev_{false};
-  std::chrono::seconds suspend_silence_delay_{0};
   int sleep_counter_{0};
   std::string output_{};
   // Methods
   void invoke();
   void execute();
-  bool isSilence();
+  bool isSilent();
   void doUpdate(bool force = false);
   void loadConfig();
   void freeBackend();
 
   // Signal
-  type_signal_update m_signal_update_;
-  type_signal_audio_raw_update m_signal_audio_raw_;
-  type_signal_silence m_signal_silence_;
+  SignalUpdate m_signal_update_;
+  SignalAudioRawUpdate m_signal_audio_raw_;
+  SignalSilence m_signal_silence_;
+  SignalConfigChanged m_signal_config_changed_;
+
+  std::atomic<bool> shutdown_{false};
+  bool audio_raw_initialized_{false};
+  mutable std::recursive_mutex state_mutex_;
+
+  // Synchronization for joining read_thread_ during destruction
+  bool read_thread_exited_{false};
+  mutable std::mutex read_thread_exit_mutex_;
+  std::condition_variable read_thread_exit_cv_;
 };
 }  // namespace waybar::modules::cava

--- a/include/modules/cava/cava_frontend.hpp
+++ b/include/modules/cava/cava_frontend.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #ifdef HAVE_LIBCAVA
 #include "cavaRaw.hpp"
 #include "cava_backend.hpp"
@@ -9,16 +11,16 @@
 #endif
 
 namespace waybar::modules::cava {
-AModule* getModule(const std::string& id, const Json::Value& config) {
+inline std::unique_ptr<AModule> getModule(const std::string& id, const Json::Value& config) {
 #ifdef HAVE_LIBCAVA
   const std::shared_ptr<CavaBackend> backend_{waybar::modules::cava::CavaBackend::inst(config)};
-  switch (backend_->getPrm()->output) {
+  switch (backend_->getPrm().output) {
 #ifdef HAVE_LIBCAVAGLSL
     case ::cava::output_method::OUTPUT_SDL_GLSL:
-      return new waybar::modules::cava::CavaGLSL(id, config);
+      return std::make_unique<waybar::modules::cava::CavaGLSL>(id, config);
 #endif
     default:
-      return new waybar::modules::cava::Cava(id, config);
+      return std::make_unique<waybar::modules::cava::CavaRaw>(id, config);
   }
 #else
   throw std::runtime_error("Unknown module");

--- a/man/waybar-cava.5.scd
+++ b/man/waybar-cava.5.scd
@@ -6,10 +6,10 @@ waybar - cava module
 
 # DESCRIPTION
 
-*cava* module for karlstav/cava project. See it on github: https://github.com/karlstav/cava.
-
-Module supports two different frontends starting from the 0.15.0 release. The frontend that
-will be used is managed by the method parameter in the [output] section of the cava configuration file.
+The *cava* module integrates the *karlstav/cava* audio visualizer into Waybar.
+It supports two frontends: a text-based *raw* frontend and a GPU-based *GLSL*
+frontend. The active frontend is selected by the *method* option in the
+*[output]* section of the cava configuration file.
 
 # FILES
 
@@ -27,185 +27,186 @@ libcava lives in:
 # CONFIGURATION
 
 [- *Option*
-:- *Typeof*
-:- *Default*
-:- *Description*
+:[ *Type*
+:[ *Default*
+:[ *Description*
 |[ *cava_config*
 :[ string
 :[
-:< Path where cava configuration file is placed to
-|[ *method* \[output\]
-:[ string
-:[
-:< Manages which frontend Waybar cava module should use. Values: raw, sdl_glsl. Not a waybar JSON key: it is set through the *method* option in the *\[output\]* section of the cava configuration file (*cava_config*)
+:[ Path to the cava configuration file. When provided, cava settings are read from it first.
 |[ *framerate*
 :[ integer
 :[ 30
-:[ Frames per second. Is used as a replacement for *interval*
+:[ Target frames per second. Replaces the generic *interval* option.
 |[ *autosens*
 :[ integer
 :[ 1
-:[ Will attempt to decrease sensitivity if the bars peak
+:[ Automatically decrease sensitivity when the bars peak.
 |[ *sensitivity*
 :[ integer
 :[ 100
-:[ Manual sensitivity in %. If autosens is enabled, this will only be the initial value. 200 means double height. Accepts only non-negative values
+:[ Manual sensitivity in %. If *autosens* is enabled, this is only the initial value. 200 means double height. Accepts only non-negative values.
 |[ *bars*
 :[ integer
 :[ 12
-:[ The number of bars
+:[ The number of bars.
 |[ *lower_cutoff_freq*
 :[ long integer
 :[ 50
-:[ Lower cutoff frequencies for lowest bars the bandwidth of the visualizer
+:[ Lower cutoff frequency for the visualizer bandwidth.
 |[ *higher_cutoff_freq*
 :[ long integer
 :[ 10000
-:[ Higher cutoff frequencies for highest bars the bandwidth of the visualizer
+:[ Higher cutoff frequency for the visualizer bandwidth.
 |[ *sleep_timer*
 :[ integer
 :[ 5
-:[ Seconds with no input before cava main thread goes to sleep mode
+:[ Seconds of silence before cava enters sleep mode.
 |[ *hide_on_silence*
 :[ bool
 :[ false
-:[ Hides the widget if no input (after sleep_timer elapsed)
+:[ Hide the widget when silence lasts longer than *sleep_timer*.
 |[ *format_silent*
 :[ string
 :[
-:[ Widget's text after sleep_timer elapsed (hide_on_silence has to be false)
+:[ Text shown when the module is silent and *hide_on_silence* is false. **Raw frontend only.**
+|[ *format-icons*
+:[ array
+:[
+:[ Array of characters used to render bar levels in the raw frontend. The number of items determines the dynamic range.
 |[ *method* \[input\]
 :[ string
 :[ pulse
-:[ Audio capturing method. Possible methods are: pipewire, pulse, alsa, fifo, sndio or shmem
+:[ Audio capture backend. Supported values: pipewire, pulse, alsa, fifo, sndio, shmem.
 |[ *source*
 :[ string
 :[ auto
-:[ See cava configuration
+:[ Audio source identifier. See the cava documentation for details.
 |[ *sample_rate*
 :[ long integer
 :[ 44100
-:[ See cava configuration
+:[ See the cava documentation.
 |[ *sample_bits*
 :[ integer
 :[ 16
-:[ See cava configuration
+:[ See the cava documentation.
 |[ *stereo*
 :[ bool
 :[ true
-:[ Visual channels
+:[ Enable stereo visualization.
 |[ *reverse*
 :[ bool
 :[ false
-:[ Displays frequencies the other way around
+:[ Reverse the bar order (highest frequencies on the left).
 |[ *bar_delimiter*
 :[ integer
 :[ 0
-:[ Each bar is separated by a delimiter. Use decimal value in ascii table(i.e. 59 = ";"). 0 means no delimiter
+:[ Delimiter placed between bars in the raw output. Use a decimal ASCII value (e.g. 59 = ";"). 0 means no delimiter.
 |[ *monstercat*
 :[ bool
 :[ false
-:[ Disables or enables the so-called "Monstercat smoothing" with or without "waves"
+:[ Enable Monstercat smoothing.
 |[ *waves*
 :[ bool
 :[ false
-:[ Disables or enables the so-called "Monstercat smoothing" with or without "waves"
+:[ Enable the waves effect alongside Monstercat smoothing.
 |[ *noise_reduction*
 :[ double
 :[ 0.77
-:[ Fractional value between 0.0 - 1.0. The raw visualization is very noisy, this factor adjusts the integral and gravity filters to keep the signal smooth. Values near 1.0 will be very slow and smooth, near 0.0 will be fast but noisy
+:[ Smoothing factor between 0.0 and 1.0. Higher values produce slower, smoother animation; lower values are more reactive but noisy.
 |[ *gravity*
 :[ integer
 :[
-:[ Gravity smoothing filter. Higher values make the bars drop faster. Adjusted by *noise_reduction* when set
+:[ Gravity factor. Higher values make bars fall faster. When *noise_reduction* is set, this is derived automatically.
 |[ *integral*
 :[ integer
 :[
-:[ Integral smoothing filter. Higher values make the visualization smoother but less precise. Adjusted by *noise_reduction* when set
+:[ Integral smoothing factor. Higher values produce smoother but less precise animation. When *noise_reduction* is set, this is derived automatically.
 |[ *input_delay*
 :[ integer
 :[ 4
-:[ Sets the delay before fetching audio source thread start working. On author's machine, Waybar starts much faster than pipewire audio server, and without a little delay cava module fails because pipewire is not ready
-|[ *ascii_max_range*
-:[ integer
-:[ 7
-:[ It's impossible to set it directly. The value is dictated by the number of icons in the array *format-icons*
-|[ *data_format*
-:[ string
-:[ ascii
-:[ Raw data format. Can be 'binary' or 'ascii'
-|[ *raw_target*
-:[ string
-:[ /dev/stdout
-:[ Raw output target. A fifo will be created if target does not exist
-|[ *menu*
-:[ string
-:[
-:[ Action that popups the menu.
-|[ *menu-file*
-:[ string
-:[
-:[ Location of the menu descriptor file. There need to be an element of type GtkMenu with id *menu*
-|[ *menu-actions*
-:[ array
-:[
-:[ The actions corresponding to the buttons of the menu.
-|[ *bar_spacing*
-:[ integer
-:[
-:[ Bars' space between bars in number of characters
+:[ Delay in seconds before starting audio capture. Increase this if Waybar starts before the audio server (e.g. PipeWire).
 |[ *bar_width*
 :[ integer
 :[
-:[ Bars' width between bars in number of characters
+:[ Bar width in pixels. **Used by the GLSL frontend.**
+|[ *bar_spacing*
+:[ integer
+:[
+:[ Space between bars in pixels. **Used by the GLSL frontend.**
 |[ *bar_height*
 :[ integer
 :[
-:[ Useless. bar_height is only used for output in "noritake" format
-|[ *background*
+:[ Ignored by Waybar. Used only by cava's "noritake" output format.
+|[ *menu*
 :[ string
 :[
-:[ GLSL actual. Support hex code colors only. Must be within ''. Not a waybar JSON key: set it as *background* in the *\[color\]* section of the cava configuration file (*cava_config*)
-|[ *foreground*
+:[ Action that opens the menu.
+|[ *menu-file*
 :[ string
 :[
-:[ GLSL actual. Support hex code colors only. Must be within ''. Not a waybar JSON key: set it as *foreground* in the *\[color\]* section of the cava configuration file (*cava_config*)
-|[ *gradient*
-:[ integer
-:[ 0
-:[ GLSL actual. Gradient mode(0/1 - on/off)
-|[ *gradient_count*
-:[ integer
-:[ 0
-:[ GLSL actual. The count of colors for the gradient
-|[ *gradient_color_N*
-:[ string
+:[ Location of the menu descriptor file. There must be a GtkMenu element with id *menu*.
+|[ *menu-actions*
+:[ array
 :[
-:[ GLSL actual. N - the number of the gradient color between 1 and 8. Only hex defined colors are supported. Must be within ''
+:[ Actions corresponding to the buttons of the menu.
+|[ *method* \[output\]
+:[ string
+:[ raw
+:[ Cava output method. Set to *raw* for the text frontend or *sdl_glsl* for the GPU frontend. **This is set inside the *[output]* section of the cava configuration file, not in Waybar's JSON.**
 |[ *sdl_width*
 :[ integer
 :[
-:[ GLSL actual. Manages the width of the waybar cava GLSL frontend module
+:[ GLSL frontend width in pixels. **GLSL only.**
 |[ *sdl_height*
 :[ integer
 :[
-:[ GLSL actual. Manages the height of the waybar cava GLSL frontend module
+:[ GLSL frontend height in pixels. **GLSL only.**
+|[ *vertex_shader*
+:[ string
+:[
+:[ Path to the vertex shader. **GLSL only; set in the *[output]* section of the cava configuration file.**
+|[ *fragment_shader*
+:[ string
+:[
+:[ Path to the fragment shader. **GLSL only; set in the *[output]* section of the cava configuration file.**
 |[ *continuous_rendering*
 :[ integer
 :[ 0
-:[ GLSL actual. Keep rendering even if no audio. Recommended to set to 1. Not a waybar JSON key: set it as *continuous_rendering* in the *\[output\]* section of the cava configuration file (*cava_config*)
+:[ Continue rendering when silent. Set to 1 for smooth animation. **GLSL only; set in the *[output]* section of the cava configuration file.**
+|[ *background*
+:[ string
+:[
+:[ Background color as a '#RRGGBB' hex string (must be quoted). **GLSL only; set in the *[color]* section of the cava configuration file.**
+|[ *foreground*
+:[ string
+:[
+:[ Foreground color as a '#RRGGBB' hex string (must be quoted). **GLSL only; set in the *[color]* section of the cava configuration file.**
+|[ *gradient*
+:[ integer
+:[ 0
+:[ Enable gradient mode (0 = off, 1 = on). **GLSL only; set in the *[color]* section of the cava configuration file.**
+|[ *gradient_count*
+:[ integer
+:[ 0
+:[ Number of gradient colors (up to 8). **GLSL only; set in the *[color]* section of the cava configuration file.**
+|[ *gradient_color_N*
+:[ string
+:[
+:[ Gradient color N (1–8) as a '#RRGGBB' hex string (must be quoted). **GLSL only; set in the *[color]* section of the cava configuration file.**
 
-Configuration can be provided as:
-- The only cava configuration file which is provided through *cava_config*. The rest configuration can be skipped
-- Without cava configuration file. In such case cava should be configured through provided list of the configuration option
-- Mix. When provided both And cava configuration file And configuration options. In such case, waybar applies configuration file first and then overrides particular options by the provided list of configuration options
+Configuration can be provided in three ways:
+
+- **Cava config only**: set *cava_config* to a cava configuration file and omit all other options.
+- **Waybar JSON only**: leave out *cava_config* and set every option in Waybar's module configuration.
+- **Mixed**: provide a *cava_config* and also set specific options in Waybar's JSON. Waybar reads the file first, then overrides any values present in the JSON.
 
 # ACTIONS
 
 [- *String*
-:- *Action*
+:[ *Action*
 |[ *mode*
-:< Switch main cava thread and fetch audio source thread from/to pause/resume
+:[ Toggle pause/resume for the audio capture and output threads.
 
 # DEPENDENCIES
 
@@ -215,30 +216,31 @@ Configuration can be provided as:
 
 # SOLVING ISSUES
 
-. On start Waybar throws an exception "error while loading shared libraries: libcava.so: cannot open shared object file: No such file or directory".
-  It might happen when libcava for some reason hasn't been registered in the system. sudo ldconfig should help.
-  It might also happen when Waybar was installed into /usr/local while libcava lives elsewhere. In that case:
-   1. Drop the local cava library: sudo rm -rfv /usr/local/include/cava /usr/local/lib64/pkgconfig/cava.pc /usr/local/lib64/libcava.so
-   2. Set the prefix where Waybar should be installed: meson configure build -Dprefix="/usr"
-   3. Build Waybar: make
-   4. Install Waybar into the system: sudo meson install -C build
-. Waybar is starting but cava module doesn't react to the music
-   1. In such cases at first need to make sure usual cava application is working as well
-   2. If so, need to comment all configuration options. Uncomment cava_config and provide the path to the working cava config
-   3. You might set too huge or too small input_delay. Try to setup to 4 seconds, restart waybar, and check again 4 seconds past. Usual even on weak machines it should be enough
-   4. You might accidentally switch action mode to pause mode
+. At startup Waybar fails with *"error while loading shared libraries: libcava.so: cannot open shared object file: No such file or directory"*.
+  This happens when libcava has not been registered in the system library cache. Run *sudo ldconfig* to refresh the cache.
+  This can also occur when Waybar is installed under */usr/local* but libcava is elsewhere. To fix it:
+   1. Remove the local libcava installation: *sudo rm -rfv /usr/local/include/cava /usr/local/lib64/pkgconfig/cava.pc /usr/local/lib64/libcava.so*
+   2. Reconfigure Waybar to use the system prefix: *meson configure build -Dprefix="/usr"*
+   3. Rebuild Waybar: *ninja -C build*
+   4. Install Waybar: *sudo meson install -C build*
 
-# RISING ISSUES
+. Waybar starts but the cava module does not react to audio.
+   1. First, verify that standalone cava works correctly.
+   2. If it does, comment out all Waybar cava options, uncomment *cava_config*, and point it to the working cava configuration file.
+   3. The *input_delay* may be too large or too small. Try setting it to 4 seconds, restart Waybar, and check again after that delay. This is usually sufficient, even on slower machines.
+   4. You may have accidentally toggled pause mode via an action.
 
-For clear understanding: this module is a cava API's consumer. So for any bugs related to cava engine you should contact Cava upstream(https://github.com/karlstav/cava) ++
-with the one Exception. Cava upstream doesn't provide cava as a shared library. For that, this module author made a fork libcava(https://github.com/LukashonakV/cava). ++
-So the order is:
-. cava upstream
-. libcava upstream.
-In case when cava releases new version and you're wanna get it, it should be raised an issue to libcava(https://github.com/LukashonakV/cava) with title ++
-\[Bump\]x.x.x where x.x.x is cava release version.
+# REPORTING ISSUES
+
+This module is a consumer of the cava API. For bugs in the cava engine itself, please report them to [cava upstream](https://github.com/karlstav/cava) first.
+
+Upstream cava does not provide a shared library. The Waybar cava module uses [libcava](https://github.com/LukashonakV/cava), a fork maintained by the module author, to provide one. If the issue is specific to the shared library packaging, report it to libcava.
+
+When requesting a new upstream cava release to be packaged in libcava, open an issue at libcava with the title `[Bump] x.x.x`, where `x.x.x` is the desired cava version.
 
 # EXAMPLES
+
+## Raw frontend
 
 ```
 "cava": {
@@ -253,7 +255,6 @@ In case when cava releases new version and you're wanna get it, it should be rai
 	"source": "auto",
 	"stereo": true,
 	"reverse": false,
-	"bar_delimiter": 0,
 	"monstercat": false,
 	"waves": false,
 	"noise_reduction": 0.77,
@@ -263,39 +264,6 @@ In case when cava releases new version and you're wanna get it, it should be rai
 		"on-click-right": "mode"
 	}
 },
-```
-# STYLE
-
-- *#cava* Raw frontend widget
-- *#cava.silent* Applied after no sound has been detected for sleep_timer seconds
-- *#cava.updated* Applied when a new frame is shown
-- *#cavaGLSL* GLSL frontend widget (used instead of *#cava* when the cava *method* is *sdl_glsl*)
-- *#cavaGLSL.silent* Applied after no sound has been detected for sleep_timer seconds
-- *#cavaGLSL.updated* Applied when a new frame is shown
-# FRONTENDS
-
-## RAW
-The cava raw frontend uses ASCII characters to visualize incoming audio data. Each ASCII symbol position corresponds to the value of the audio power pulse.
-
-Under the hood:
-```
-. Incoming audio power pulse list is : 12684
-. Configured array of ASCII codes is: ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" ]. See `format-icons` https://github.com/Alexays/Waybar/wiki/Module:-Cava#example 
-```
-As a result cava frontend will give ▁▂▆█▄
-
-Examples:
-
-waybar config
-```
-"cava": {
-        "cava_config": "$XDG_CONFIG_HOME/cava/waybar_raw.conf",
-        "input_delay": 2,
-        "format-icons" : ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█" ],
-        "actions": {
-                   "on-click-right": "mode"
-                   }
-        },
 ```
 
 waybar_raw.conf
@@ -366,6 +334,7 @@ sleep_timer = 5
 # For jack 'source' will be the name of the JACK server to connect to, e.g. 'foobar'. Default: 'default'.
 # README.md contains further information on how to setup CAVA for JACK.
 #
+
 
 # The options 'sample_rate', 'sample_bits', 'channels' and 'autoconnect' can be configured for some input methods:
 #   sample_rate: fifo, pipewire, sndio, oss
@@ -468,7 +437,7 @@ bar_delimiter = 0
 
 # Noise reduction, int 0 - 100. default 77
 # the raw visualization is very noisy, this factor adjusts the integral and gravity filters to keep the signal smooth
-# 100 will be very slow and smooth, 0 will be fast but noisy.
+# 100 will be very slow and smooth, 0 will be fast and noisy.
 
 
 [eq]
@@ -477,33 +446,32 @@ bar_delimiter = 0
 # Remember to uncomment more than one key! More keys = more precision.
 # Look at readme.md on github for further explanations and examples.
 ```
-## GLSL
-The Cava GLSL frontend delegates the visualization of incoming audio data to the GPU via OpenGL.
 
-There are some mandatory dependencies that need to be satisfied in order for Cava GLSL to be built and function properly:
+## GLSL frontend
 
-. epoxy library must be installed on the system
-. Vertex and fragment shaders from the original project must be used. They should be downloaded, and the file paths must be configured correctly in the Waybar Cava configuration:
-   1. cava shaders [cava shaders](https://github.com/karlstav/cava/tree/master/output/shaders)
-   2. libcava shaders [libcava shaders](https://github.com/LukashonakV/cava/tree/master/output/shaders)
-. It is highly recommended to have a separate cava configuration for the Waybar Cava GLSL module and to use this as the cava_config in the Waybar configuration.
-. It is common for cava configurations to be placed in the XDG_CONFIG_HOME directory, including shaders as well. Consider keeping them in the $XDG_CONFIG_HOME/cava/shaders folder.
+The GLSL frontend requires:
 
-Key configuration options:
+. The *epoxy* library.
+. Vertex and fragment shaders from the cava project. Download them and place under _$XDG_CONFIG_HOME/cava/shaders_, then reference them in the cava configuration:
+  1. [cava shaders](https://github.com/karlstav/cava/tree/master/output/shaders)
+  2. [libcava shaders](https://github.com/LukashonakV/cava/tree/master/output/shaders)
+. A separate cava configuration file is highly recommended.
 
-. bars. The more values the parameter has, the more interesting the visualization becomes.
-. method in output section must be set to sdl_glsl
-. sdl_width and sdl_height manage the size of the module. Adjust them according to your needs.
-. Shaders for sdl_glsl, located in $HOME/.config/cava/shaders. Example: "vertex_shader" = "pass_through.vert" "fragment_shader" = "spectrogram.frag"
-. Set continuous_rendering to 1 to enable smooth rendering; set it to 0 otherwise. It is recommended to keep it set to 1.
-. background, foreground, and gradient_color_N (where N is a number between 1 and 8) must be defined using hex code
+Key cava configuration options for GLSL:
+
+. *bars* — higher values produce more detailed visualization.
+. *method* in *[output]* must be set to *sdl_glsl*.
+. *sdl_width* and *sdl_height* control the module size.
+. *vertex_shader* and *fragment_shader* point to the shader files under _$HOME/.config/cava/shaders_.
+. *continuous_rendering* — set to 1 for smooth animation.
+. *background*, *foreground*, and *gradient_color_N* must use hex codes inside single quotes.
 
 Example:
 
 waybar config
 ```
 "cava": {
-        "cava_config": "$XDG_CONFIG_HOME/cava/waybar_cava#3.conf",
+        "cava_config": "$XDG_CONFIG_HOME/cava/waybar_cava.conf",
         "input_delay": 2,
         "actions": {
                    "on-click-right": "mode"
@@ -511,7 +479,7 @@ waybar config
         },
 ```
 
-waybar_raw.conf
+waybar_cava.conf
 ```
 ## Configuration file for CAVA.
 # Remove the ; to change parameters.
@@ -721,4 +689,21 @@ gradient_color_2 = '#45475A'
 # Look at readme.md on github for further explanations and examples.
 ```
 
-Different waybar_cava#N.conf see at [cava GLSL](https://github.com/Alexays/Waybar/wiki/Module:-Cava:-GLSL)
+More GLSL examples are available on the [cava GLSL wiki page](https://github.com/Alexays/Waybar/wiki/Module:-Cava:-GLSL).
+
+# STYLE
+
+- *#cava* Raw frontend widget
+- *#cava.silent* Applied after no sound has been detected for *sleep_timer* seconds
+- *#cava.updated* Applied when a new frame is shown
+- *#cavaGLSL* GLSL frontend widget (used instead of *#cava* when the cava *method* is *sdl_glsl*)
+- *#cavaGLSL.silent* Applied after no sound has been detected for *sleep_timer* seconds
+- *#cavaGLSL.updated* Applied when a new frame is shown
+
+# FRONTENDS
+
+## RAW
+The raw frontend maps each bar's amplitude to a character from *format-icons*. The final widget text is the concatenation of all characters, optionally separated by *bar_delimiter*. See the EXAMPLES section above for a complete configuration.
+
+## GLSL
+The GLSL frontend renders the visualization with OpenGL ES using user-provided shaders. It is selected by setting *method = sdl_glsl* in the cava configuration. See the EXAMPLES section above for a complete configuration.

--- a/src/factory.cpp
+++ b/src/factory.cpp
@@ -372,7 +372,7 @@ waybar::AModule* waybar::Factory::makeModule(const std::string& name,
     }
 #endif
     if (ref == "cava") {
-      return waybar::modules::cava::getModule(id, config_[name]);
+      return waybar::modules::cava::getModule(id, config_[name]).release();
     }
 #ifdef HAVE_SYSTEMD_MONITOR
     if (ref == "systemd-failed-units") {

--- a/src/modules/cava/cavaGLSL.cpp
+++ b/src/modules/cava/cavaGLSL.cpp
@@ -2,88 +2,214 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
+#include <cstdio>
+#include <cstring>
 #include <fstream>
+#include <sstream>
+#include <vector>
+
+const std::map<std::string, waybar::modules::cava::CavaGLSL::Action>
+    waybar::modules::cava::CavaGLSL::actionMap_{{"mode", &CavaGLSL::pauseResume}};
 
 waybar::modules::cava::CavaGLSL::CavaGLSL(const std::string& id, const Json::Value& config)
     : AModule(config, "cavaGLSL", id, false, false),
       backend_{waybar::modules::cava::CavaBackend::inst(config)} {
-  set_name(name_);
+  gl_area_.set_name(name_);
   if (config_["hide_on_silence"].isBool()) hide_on_silence_ = config_["hide_on_silence"].asBool();
   if (!id.empty()) {
-    get_style_context()->add_class(id);
+    gl_area_.get_style_context()->add_class(id);
   }
-  get_style_context()->add_class(MODULE_CLASS);
+  gl_area_.get_style_context()->add_class(MODULE_CLASS);
 
-  set_use_es(true);
-  //  set_auto_render(true);
-  signal_realize().connect(sigc::mem_fun(*this, &CavaGLSL::onRealize));
-  signal_render().connect(sigc::mem_fun(*this, &CavaGLSL::onRender), false);
+  gl_area_.set_use_es(true);
+  gl_area_.signal_realize().connect(sigc::mem_fun(*this, &CavaGLSL::onRealize));
+  gl_area_.signal_render().connect(sigc::mem_fun(*this, &CavaGLSL::onRender), false);
+  gl_area_.signal_map().connect([this]() { mapped_ = true; });
+  gl_area_.signal_unmap().connect([this]() { mapped_ = false; });
 
-  // Get parameters_config struct from the backend
-  prm_ = *backend_->getPrm();
+  cacheConfigParams(backend_->getPrm());
 
-  // Set widget length
   int length{0};
   if (config_["min-length"].isUInt())
     length = config_["min-length"].asUInt();
   else if (config_["max-length"].isUInt())
     length = config_["max-length"].asUInt();
   else
-    length = prm_.sdl_width;
+    length = sdl_width_;
 
-  set_size_request(length, prm_.sdl_height);
+  gl_area_.set_size_request(length, sdl_height_);
 
-  // Subscribe for changes
-  backend_->signal_audio_raw_update().connect(sigc::mem_fun(*this, &CavaGLSL::onUpdate));
-  // Subscribe for silence
-  backend_->signal_silence().connect(sigc::mem_fun(*this, &CavaGLSL::onSilence));
-  event_box_.add(*this);
+  audio_raw_update_conn_ =
+      backend_->signalAudioRawUpdate().connect(sigc::mem_fun(*this, &CavaGLSL::onUpdate));
+  silence_conn_ = backend_->signalSilence().connect(sigc::mem_fun(*this, &CavaGLSL::onSilence));
+  config_changed_conn_ =
+      backend_->signalConfigChanged().connect(sigc::mem_fun(*this, &CavaGLSL::onBackendConfigChanged));
+  event_box_.add(gl_area_);
 }
 
-auto waybar::modules::cava::CavaGLSL::onUpdate(const ::cava::audio_raw& input) -> void {
-  Glib::signal_idle().connect_once([this, input]() {
-    m_data_ = std::make_shared<::cava::audio_raw>(input);
-    if (silence_) {
-      get_style_context()->remove_class("silent");
-      if (!get_style_context()->has_class("updated")) get_style_context()->add_class("updated");
-      show();
-      silence_ = false;
-    }
+waybar::modules::cava::CavaGLSL::~CavaGLSL() {
+  audio_raw_update_conn_.disconnect();
+  silence_conn_.disconnect();
+  config_changed_conn_.disconnect();
 
-    queue_render();
-  });
+  if (gl_area_.get_realized()) {
+    gl_area_.make_current();
+    cleanupGL();
+  }
+}
+
+void waybar::modules::cava::CavaGLSL::cleanupGL() {
+  if (shaderProgram_ != 0) {
+    glDeleteProgram(shaderProgram_);
+    shaderProgram_ = 0;
+  }
+  if (fbo_ != 0) {
+    glDeleteFramebuffers(1, &fbo_);
+    fbo_ = 0;
+  }
+  if (texture_ != 0) {
+    glDeleteTextures(1, &texture_);
+    texture_ = 0;
+  }
+  if (vbo_ != 0) {
+    glDeleteBuffers(1, &vbo_);
+    vbo_ = 0;
+  }
+  if (ibo_ != 0) {
+    glDeleteBuffers(1, &ibo_);
+    ibo_ = 0;
+  }
+  if (vao_ != 0) {
+    glDeleteVertexArrays(1, &vao_);
+    vao_ = 0;
+  }
+}
+
+auto waybar::modules::cava::CavaGLSL::doAction(const std::string& name) -> void {
+  auto it = actionMap_.find(name);
+  if (it != actionMap_.end() && it->second) {
+    (this->*it->second)();
+  } else {
+    spdlog::error("CavaGLSL. Unsupported action \"{0}\"", name);
+  }
+}
+
+void waybar::modules::cava::CavaGLSL::pauseResume() { backend_->doPauseResume(); }
+
+auto waybar::modules::cava::CavaGLSL::onUpdate(const CavaBackend::AudioRaw& input) -> void {
+  m_data_ = input;
+  if (silence_) {
+    gl_area_.get_style_context()->remove_class("silent");
+    if (!gl_area_.get_style_context()->has_class("updated"))
+      gl_area_.get_style_context()->add_class("updated");
+    gl_area_.show();
+    silence_ = false;
+  }
+
+  if (mapped_) {
+    gl_area_.queue_render();
+  }
 }
 
 auto waybar::modules::cava::CavaGLSL::onSilence() -> void {
-  Glib::signal_idle().connect_once([this]() {
-    if (!silence_) {
-      if (get_style_context()->has_class("updated")) get_style_context()->remove_class("updated");
+  if (!silence_) {
+    if (gl_area_.get_style_context()->has_class("updated"))
+      gl_area_.get_style_context()->remove_class("updated");
 
-      if (hide_on_silence_) hide();
-      silence_ = true;
-      get_style_context()->add_class("silent");
-      // Set clear color to black
-      glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
-      queue_render();
+    if (hide_on_silence_) gl_area_.hide();
+    silence_ = true;
+    gl_area_.get_style_context()->add_class("silent");
+  }
+}
+
+void waybar::modules::cava::CavaGLSL::cacheConfigParams(const ::cava::config_params& src) {
+  sdl_width_ = src.sdl_width;
+  sdl_height_ = src.sdl_height;
+  bar_width_ = src.bar_width;
+  bar_spacing_ = src.bar_spacing;
+  gradient_count_ = src.gradient_count;
+  vertex_shader_ = src.vertex_shader ? src.vertex_shader : "";
+  fragment_shader_ = src.fragment_shader ? src.fragment_shader : "";
+  bcolor_ = src.bcolor ? src.bcolor : "";
+  color_ = src.color ? src.color : "";
+  for (size_t i = 0; i < gradient_colors_.size(); ++i) {
+    gradient_colors_[i] = (src.gradient_colors[i] ? src.gradient_colors[i] : "");
+  }
+}
+
+auto waybar::modules::cava::CavaGLSL::onBackendConfigChanged() -> void {
+  auto new_prm = backend_->getPrm();
+
+  bool dimensions_changed =
+      (new_prm.sdl_width != sdl_width_) || (new_prm.sdl_height != sdl_height_);
+
+  bool shaders_changed = false;
+  std::string new_vertex = new_prm.vertex_shader ? new_prm.vertex_shader : "";
+  std::string new_fragment = new_prm.fragment_shader ? new_prm.fragment_shader : "";
+  shaders_changed = (vertex_shader_ != new_vertex) || (fragment_shader_ != new_fragment);
+
+  bool surface_changed = false;
+  if (new_prm.bar_width != bar_width_) surface_changed = true;
+  if (new_prm.bar_spacing != bar_spacing_) surface_changed = true;
+  if (new_prm.gradient_count != gradient_count_) surface_changed = true;
+  std::string new_bcolor = new_prm.bcolor ? new_prm.bcolor : "";
+  if (bcolor_ != new_bcolor) surface_changed = true;
+  std::string new_color = new_prm.color ? new_prm.color : "";
+  if (color_ != new_color) surface_changed = true;
+  for (size_t i = 0; i < gradient_colors_.size(); ++i) {
+    std::string new_grad = new_prm.gradient_colors[i] ? new_prm.gradient_colors[i] : "";
+    if (gradient_colors_[i] != new_grad) {
+      surface_changed = true;
+      break;
     }
-  });
+  }
+
+  cacheConfigParams(new_prm);
+
+  if ((dimensions_changed || shaders_changed) && gl_area_.get_realized()) {
+    gl_area_.make_current();
+    cleanupGL();
+    initShaders();
+    if (shaderProgram_ != 0) {
+      initGLSL();
+      initSurface();
+    }
+  } else if (surface_changed && gl_area_.get_realized()) {
+    gl_area_.make_current();
+    glUseProgram(shaderProgram_);
+    initSurface();
+  }
+
+  int length{0};
+  if (config_["min-length"].isUInt())
+    length = config_["min-length"].asUInt();
+  else if (config_["max-length"].isUInt())
+    length = config_["max-length"].asUInt();
+  else
+    length = sdl_width_;
+
+  gl_area_.set_size_request(length, sdl_height_);
 }
 
 bool waybar::modules::cava::CavaGLSL::onRender(const Glib::RefPtr<Gdk::GLContext>& context) {
-  if (!m_data_) return true;
+  if (m_data_.bars_raw.empty() || shaderProgram_ == 0) return true;
+
+  glUseProgram(shaderProgram_);
+  glBindVertexArray(vao_);
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
   glActiveTexture(GL_TEXTURE0);
   glBindTexture(GL_TEXTURE_2D, texture_);
-  glUniform1i(glGetUniformLocation(shaderProgram_, "inputTexture"), 0);
+  glUniform1i(uniform_input_texture_, 0);
 
-  glUniform1fv(uniform_bars_, m_data_->number_of_bars, m_data_->bars_raw);
-  glUniform1fv(uniform_previous_bars_, m_data_->number_of_bars, m_data_->previous_bars_raw);
-  glUniform1i(uniform_bars_count_, m_data_->number_of_bars);
-  ++frame_counter;
-  glUniform1f(uniform_time_, (frame_counter / backend_->getFrameTimeMilsec().count()) / 1e3);
+  glUniform1fv(uniform_bars_, m_data_.number_of_bars, m_data_.bars_raw.data());
+  glUniform1fv(uniform_previous_bars_, m_data_.number_of_bars, m_data_.previous_bars_raw.data());
+  glUniform1i(uniform_bars_count_, m_data_.number_of_bars);
+  ++frame_counter_;
+  glUniform1f(uniform_time_,
+              static_cast<float>(frame_counter_) * backend_->getFrameTimeMilsec().count() / 1000.0f);
 
-  //  glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glDrawElements(GL_TRIANGLE_FAN, 4, GL_UNSIGNED_INT, nullptr);
 
   glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
@@ -94,21 +220,35 @@ bool waybar::modules::cava::CavaGLSL::onRender(const Glib::RefPtr<Gdk::GLContext
 }
 
 void waybar::modules::cava::CavaGLSL::onRealize() {
-  make_current();
+  gl_area_.make_current();
+  cleanupGL();
   initShaders();
+  if (shaderProgram_ == 0) {
+    return;
+  }
   initGLSL();
   initSurface();
 }
 
-struct colors {
+struct Colors {
   uint16_t R;
   uint16_t G;
   uint16_t B;
 };
 
-static void parse_color(char* color_string, struct colors* color) {
-  if (color_string[0] == '#') {
-    sscanf(++color_string, "%02hx%02hx%02hx", &color->R, &color->G, &color->B);
+static void parse_color(const char* color_string, struct Colors* color) {
+  if (color_string == nullptr) {
+    return;
+  }
+  if (color_string[0] != '#') {
+    return;
+  }
+  if (std::strlen(color_string) < 7) {
+    spdlog::warn("Invalid color string '{}': expected #RRGGBB", color_string);
+    return;
+  }
+  if (std::sscanf(color_string + 1, "%02hx%02hx%02hx", &color->R, &color->G, &color->B) != 3) {
+    spdlog::warn("Failed to parse color string '{}'", color_string);
   }
 }
 
@@ -123,49 +263,44 @@ void waybar::modules::cava::CavaGLSL::initGLSL() {
   GLfloat vertexData[]{-1.0f, -1.0f, 1.0f, -1.0f, 1.0f, 1.0f, -1.0f, 1.0f};
   GLint indexData[]{0, 1, 2, 3};
 
-  GLuint gVBO{0};
-  glGenBuffers(1, &gVBO);
-  glBindBuffer(GL_ARRAY_BUFFER, gVBO);
+  glGenBuffers(1, &vbo_);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
   glBufferData(GL_ARRAY_BUFFER, 2 * 4 * sizeof(GLfloat), vertexData, GL_STATIC_DRAW);
 
-  GLuint gIBO{0};
-  glGenBuffers(1, &gIBO);
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, gIBO);
+  glGenBuffers(1, &ibo_);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibo_);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER, 4 * sizeof(GLuint), indexData, GL_STATIC_DRAW);
 
-  GLuint gVAO{0};
-  glGenVertexArrays(1, &gVAO);
-  glBindVertexArray(gVAO);
+  glGenVertexArrays(1, &vao_);
+  glBindVertexArray(vao_);
   glEnableVertexAttribArray(gVertexPos2DLocation);
 
-  glBindBuffer(GL_ARRAY_BUFFER, gVBO);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo_);
   glVertexAttribPointer(gVertexPos2DLocation, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(GLfloat), nullptr);
 
-  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, gIBO);
+  glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibo_);
 
   glGenFramebuffers(1, &fbo_);
   glBindFramebuffer(GL_FRAMEBUFFER, fbo_);
 
-  // Create a texture to attach the framebuffer
   glGenTextures(1, &texture_);
   glBindTexture(GL_TEXTURE_2D, texture_);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, prm_.sdl_width, prm_.sdl_height, 0, GL_RGBA,
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, sdl_width_, sdl_height_, 0, GL_RGBA,
                GL_UNSIGNED_BYTE, nullptr);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
   glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
   glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture_, 0);
 
-  // Check is framebuffer is complete
   if (glCheckFramebufferStatus(GL_FRAMEBUFFER) != GL_FRAMEBUFFER_COMPLETE) {
     spdlog::error("{0}. Framebuffer not complete", name_);
   }
 
-  // Unbind the framebuffer
   glBindFramebuffer(GL_FRAMEBUFFER, 0);
   uniform_bars_ = glGetUniformLocation(shaderProgram_, "bars");
   uniform_previous_bars_ = glGetUniformLocation(shaderProgram_, "previous_bars");
   uniform_bars_count_ = glGetUniformLocation(shaderProgram_, "bars_count");
   uniform_time_ = glGetUniformLocation(shaderProgram_, "shader_time");
+  uniform_input_texture_ = glGetUniformLocation(shaderProgram_, "inputTexture");
 
   GLuint err{glGetError()};
   if (err != 0) {
@@ -174,32 +309,32 @@ void waybar::modules::cava::CavaGLSL::initGLSL() {
 }
 
 void waybar::modules::cava::CavaGLSL::initSurface() {
-  colors color = {0};
+  Colors color = {0};
   GLint uniform_bg_col{glGetUniformLocation(shaderProgram_, "bg_color")};
-  parse_color(prm_.bcolor, &color);
-  glUniform3f(uniform_bg_col, (float)color.R / 255.0, (float)color.G / 255.0,
-              (float)color.B / 255.0);
+  parse_color(bcolor_.c_str(), &color);
+  glUniform3f(uniform_bg_col, static_cast<float>(color.R) / 255.0f, static_cast<float>(color.G) / 255.0f,
+              static_cast<float>(color.B) / 255.0f);
   GLint uniform_fg_col{glGetUniformLocation(shaderProgram_, "fg_color")};
-  parse_color(prm_.color, &color);
-  glUniform3f(uniform_fg_col, (float)color.R / 255.0, (float)color.G / 255.0,
-              (float)color.B / 255.0);
+  parse_color(color_.c_str(), &color);
+  glUniform3f(uniform_fg_col, static_cast<float>(color.R) / 255.0f, static_cast<float>(color.G) / 255.0f,
+              static_cast<float>(color.B) / 255.0f);
   GLint uniform_res{glGetUniformLocation(shaderProgram_, "u_resolution")};
-  glUniform3f(uniform_res, (float)prm_.sdl_width, (float)prm_.sdl_height, 0.0f);
+  glUniform3f(uniform_res, static_cast<float>(sdl_width_), static_cast<float>(sdl_height_), 0.0f);
   GLint uniform_bar_width{glGetUniformLocation(shaderProgram_, "bar_width")};
-  glUniform1i(uniform_bar_width, prm_.bar_width);
+  glUniform1i(uniform_bar_width, bar_width_);
   GLint uniform_bar_spacing{glGetUniformLocation(shaderProgram_, "bar_spacing")};
-  glUniform1i(uniform_bar_spacing, prm_.bar_spacing);
+  glUniform1i(uniform_bar_spacing, bar_spacing_);
   GLint uniform_gradient_count{glGetUniformLocation(shaderProgram_, "gradient_count")};
-  glUniform1i(uniform_gradient_count, prm_.gradient_count);
+  glUniform1i(uniform_gradient_count, std::max(0, gradient_count_));
   GLint uniform_gradient_colors{glGetUniformLocation(shaderProgram_, "gradient_colors")};
-  GLfloat gradient_colors[8][3];
-  for (int i{0}; i < prm_.gradient_count; ++i) {
-    parse_color(prm_.gradient_colors[i], &color);
-    gradient_colors[i][0] = (float)color.R / 255.0;
-    gradient_colors[i][1] = (float)color.G / 255.0;
-    gradient_colors[i][2] = (float)color.B / 255.0;
+  GLfloat gradient_colors[8][3] = {};
+  for (int i{0}; i < gradient_count_; ++i) {
+    parse_color(gradient_colors_[i].c_str(), &color);
+    gradient_colors[i][0] = static_cast<float>(color.R) / 255.0f;
+    gradient_colors[i][1] = static_cast<float>(color.G) / 255.0f;
+    gradient_colors[i][2] = static_cast<float>(color.B) / 255.0f;
   }
-  glUniform3fv(uniform_gradient_colors, 8, (const GLfloat*)gradient_colors);
+  glUniform3fv(uniform_gradient_colors, std::max(0, std::min(gradient_count_, 8)), &gradient_colors[0][0]);
 
   glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
   glDrawElements(GL_TRIANGLE_FAN, 4, GL_UNSIGNED_INT, nullptr);
@@ -207,9 +342,23 @@ void waybar::modules::cava::CavaGLSL::initSurface() {
 
 void waybar::modules::cava::CavaGLSL::initShaders() {
   shaderProgram_ = glCreateProgram();
+  if (shaderProgram_ == 0) {
+    spdlog::error("{0}. Failed to create shader program", name_);
+    gl_area_.hide();
+    return;
+  }
 
-  GLuint vertexShader{loadShader(prm_.vertex_shader, GL_VERTEX_SHADER)};
-  GLuint fragmentShader{loadShader(prm_.fragment_shader, GL_FRAGMENT_SHADER)};
+  GLuint vertexShader{loadShader(vertex_shader_, GL_VERTEX_SHADER)};
+  GLuint fragmentShader{loadShader(fragment_shader_, GL_FRAGMENT_SHADER)};
+
+  if (vertexShader == 0 || fragmentShader == 0) {
+    if (vertexShader != 0) glDeleteShader(vertexShader);
+    if (fragmentShader != 0) glDeleteShader(fragmentShader);
+    glDeleteProgram(shaderProgram_);
+    shaderProgram_ = 0;
+    gl_area_.hide();
+    return;
+  }
 
   glAttachShader(shaderProgram_, vertexShader);
   glAttachShader(shaderProgram_, fragmentShader);
@@ -219,14 +368,18 @@ void waybar::modules::cava::CavaGLSL::initShaders() {
   glDeleteShader(vertexShader);
   glDeleteShader(fragmentShader);
 
-  // Check for linking errors
-  GLint success, len;
+  GLint success{0};
   glGetProgramiv(shaderProgram_, GL_LINK_STATUS, &success);
   if (!success) {
+    GLint len{0};
     glGetProgramiv(shaderProgram_, GL_INFO_LOG_LENGTH, &len);
-    GLchar* infoLog{(char*)'\0'};
-    glGetProgramInfoLog(shaderProgram_, len, &len, infoLog);
-    spdlog::error("{0}. Shader linking error: {1}", name_, infoLog);
+    std::vector<GLchar> infoLog(len + 1);
+    glGetProgramInfoLog(shaderProgram_, len, nullptr, infoLog.data());
+    spdlog::error("{0}. Shader linking error: {1}", name_, infoLog.data());
+    glDeleteProgram(shaderProgram_);
+    shaderProgram_ = 0;
+    gl_area_.hide();
+    return;
   }
 
   glReleaseShaderCompiler();
@@ -236,35 +389,37 @@ void waybar::modules::cava::CavaGLSL::initShaders() {
 GLuint waybar::modules::cava::CavaGLSL::loadShader(const std::string& fileName, GLenum type) {
   spdlog::debug("{0}. loadShader: {1}", name_, fileName);
 
-  // Read shader source code from the file
   std::ifstream shaderFile{fileName};
-
   if (!shaderFile.is_open()) {
     spdlog::error("{0}. Could not open shader file: {1}", name_, fileName);
+    return 0;
   }
 
   std::ostringstream buffer;
-  buffer << shaderFile.rdbuf();  // read file content into stringstream
+  buffer << shaderFile.rdbuf();
   std::string str{buffer.str()};
-  const char* shaderSource = str.c_str();
   shaderFile.close();
 
   GLuint shaderID{glCreateShader(type)};
-  if (shaderID == 0) spdlog::error("{0}. Error creating shader type: {0}", type);
+  if (shaderID == 0) {
+    spdlog::error("{0}. Error creating shader type: {1}", name_, type);
+    return 0;
+  }
+
+  const char* shaderSource = str.c_str();
   glShaderSource(shaderID, 1, &shaderSource, nullptr);
   glCompileShader(shaderID);
 
-  // Check for compilation errors
-  GLint success, len;
-
+  GLint success{0};
   glGetShaderiv(shaderID, GL_COMPILE_STATUS, &success);
-
   if (!success) {
+    GLint len{0};
     glGetShaderiv(shaderID, GL_INFO_LOG_LENGTH, &len);
-
-    GLchar* infoLog{(char*)'\0'};
-    glGetShaderInfoLog(shaderID, len, nullptr, infoLog);
-    spdlog::error("{0}. Shader compilation error in {1}: {2}", name_, fileName, infoLog);
+    std::vector<GLchar> infoLog(len + 1);
+    glGetShaderInfoLog(shaderID, len, nullptr, infoLog.data());
+    spdlog::error("{0}. Shader compilation error in {1}: {2}", name_, fileName, infoLog.data());
+    glDeleteShader(shaderID);
+    return 0;
   }
 
   return shaderID;

--- a/src/modules/cava/cavaRaw.cpp
+++ b/src/modules/cava/cavaRaw.cpp
@@ -2,59 +2,68 @@
 
 #include <spdlog/spdlog.h>
 
-waybar::modules::cava::Cava::Cava(const std::string& id, const Json::Value& config)
+const std::map<std::string, waybar::modules::cava::CavaRaw::Action>
+    waybar::modules::cava::CavaRaw::actionMap_{{"mode", &CavaRaw::pauseResume}};
+
+waybar::modules::cava::CavaRaw::CavaRaw(const std::string& id, const Json::Value& config)
     : ALabel(config, "cava", id, "{}", 60, false, false, false),
       backend_{waybar::modules::cava::CavaBackend::inst(config)} {
   if (config_["hide_on_silence"].isBool()) hide_on_silence_ = config_["hide_on_silence"].asBool();
   if (config_["format_silent"].isString()) format_silent_ = config_["format_silent"].asString();
 
-  ascii_range_ = backend_->getAsciiRange();
-  backend_->signal_update().connect(sigc::mem_fun(*this, &Cava::onUpdate));
-  backend_->signal_silence().connect(sigc::mem_fun(*this, &Cava::onSilence));
-  backend_->Update();
+  update_conn_ = backend_->signalUpdate().connect(sigc::mem_fun(*this, &CavaRaw::onUpdate));
+  silence_conn_ = backend_->signalSilence().connect(sigc::mem_fun(*this, &CavaRaw::onSilence));
+  backend_->update();
 }
 
-auto waybar::modules::cava::Cava::doAction(const std::string& name) -> void {
-  if ((actionMap_[name])) {
-    (this->*actionMap_[name])();
-  } else
+waybar::modules::cava::CavaRaw::~CavaRaw() {
+  update_conn_.disconnect();
+  silence_conn_.disconnect();
+}
+
+auto waybar::modules::cava::CavaRaw::doAction(const std::string& name) -> void {
+  auto it = actionMap_.find(name);
+  if (it != actionMap_.end() && it->second) {
+    (this->*it->second)();
+  } else {
     spdlog::error("Cava. Unsupported action \"{0}\"", name);
+  }
 }
 
 // Cava actions
-void waybar::modules::cava::Cava::pause_resume() { backend_->doPauseResume(); }
-auto waybar::modules::cava::Cava::onUpdate(const std::string& input) -> void {
-  Glib::signal_idle().connect_once([this, input]() {
-    if (silence_) {
-      silence_ = false;
-      label_.get_style_context()->remove_class("silent");
-      if (!label_.get_style_context()->has_class("updated"))
-        label_.get_style_context()->add_class("updated");
-    }
-    label_text_.clear();
-    for (auto& ch : input)
-      label_text_.append(getIcon((ch > ascii_range_) ? ascii_range_ : ch, "", ascii_range_ + 1));
+void waybar::modules::cava::CavaRaw::pauseResume() { backend_->doPauseResume(); }
+auto waybar::modules::cava::CavaRaw::onUpdate(const std::string& input) -> void {
+  if (silence_) {
+    silence_ = false;
+    label_.get_style_context()->remove_class("silent");
+    if (!label_.get_style_context()->has_class("updated"))
+      label_.get_style_context()->add_class("updated");
+  }
+  label_text_.clear();
+  auto ascii_range = backend_->getAsciiRange();
+  for (auto& ch : input) {
+    auto uch = static_cast<unsigned char>(ch);
+    label_text_.append(getIcon((uch > ascii_range) ? ascii_range : uch, "", ascii_range + 1));
+  }
 
-    label_.set_markup(label_text_);
-    label_.show();
-    ALabel::update();
-  });
+  label_.set_markup(label_text_);
+  label_.show();
+  ALabel::update();
 }
 
-auto waybar::modules::cava::Cava::onSilence() -> void {
-  Glib::signal_idle().connect_once([this]() {
-    if (!silence_) {
-      if (label_.get_style_context()->has_class("updated"))
-        label_.get_style_context()->remove_class("updated");
+auto waybar::modules::cava::CavaRaw::onSilence() -> void {
+  if (!silence_) {
+    if (label_.get_style_context()->has_class("updated"))
+      label_.get_style_context()->remove_class("updated");
 
-      if (hide_on_silence_) {
-        // Clear the label markup before hiding to prevent GTK from rendering a NULL Pango layout
-        label_.set_markup("");
-        label_.hide();
-      } else if (config_["format_silent"].isString())
-        label_.set_markup(format_silent_);
-      silence_ = true;
-      label_.get_style_context()->add_class("silent");
+    if (hide_on_silence_) {
+      // Clear the label markup before hiding to prevent GTK from rendering a NULL Pango layout
+      label_.set_markup("");
+      label_.hide();
+    } else if (!format_silent_.empty()) {
+      label_.set_markup(format_silent_);
     }
-  });
+    silence_ = true;
+    label_.get_style_context()->add_class("silent");
+  }
 }

--- a/src/modules/cava/cava_backend.cpp
+++ b/src/modules/cava/cava_backend.cpp
@@ -2,7 +2,22 @@
 
 #include <spdlog/spdlog.h>
 
+#include <algorithm>
 #include <stdexcept>
+
+namespace {
+struct CavaConfigGuard {
+  ::cava::config_params* prm;
+  bool released = false;
+  explicit CavaConfigGuard(::cava::config_params* p) : prm(p) {}
+  ~CavaConfigGuard() {
+    if (!released && prm) {
+      free_config(prm);
+    }
+  }
+  void release() { released = true; }
+};
+}  // namespace
 
 std::shared_ptr<waybar::modules::cava::CavaBackend> waybar::modules::cava::CavaBackend::inst(
     const Json::Value& config) {
@@ -12,69 +27,84 @@ std::shared_ptr<waybar::modules::cava::CavaBackend> waybar::modules::cava::CavaB
 }
 
 waybar::modules::cava::CavaBackend::CavaBackend(const Json::Value& config) : config_(config) {
-  // Load waybar module config
   loadConfig();
-  // Read audio source trough cava API. Cava orginizes this process via infinity loop
   read_thread_ = [this] {
-    try {
-      input_source_(&audio_data_);
-    } catch (const std::runtime_error& e) {
-      spdlog::warn("Cava backend. Read source error: {0}", e.what());
+    while (read_thread_.isRunning()) {
+      try {
+        if (input_source_) {
+          input_source_(&audio_data_);
+        }
+      } catch (const std::exception& e) {
+        spdlog::warn("Cava backend. Read source error: {0}", e.what());
+      }
+      if (!read_thread_.isRunning()) break;
+      read_thread_.sleep_for(fetch_input_delay_);
+      if (!read_thread_.isRunning()) break;
+      try {
+        loadConfig();
+      } catch (const std::exception& e) {
+        spdlog::error("{}", e.what());
+      }
     }
-    read_thread_.sleep_for(fetch_input_delay_);
-    // loadConfig() now throws on failure; contain it so a runtime config error
-    // logs instead of terminating the process (#4456).
-    try {
-      loadConfig();
-    } catch (const std::exception& e) {
-      spdlog::error("{}", e.what());
+    {
+      std::lock_guard<std::mutex> lk(read_thread_exit_mutex_);
+      read_thread_exited_ = true;
     }
+    read_thread_exit_cv_.notify_one();
   };
-  // Write outcoming data. Emit signals
   out_thread_ = [this] {
-    doUpdate(false);
-    out_thread_.sleep_for(frame_time_milsec_);
+    try {
+      doUpdate(false);
+    } catch (const std::exception& e) {
+      spdlog::error("Cava backend. Output thread error: {0}", e.what());
+    }
+    out_thread_.sleep_for(adaptive_delay_.current());
   };
 }
 
 waybar::modules::cava::CavaBackend::~CavaBackend() {
+  {
+    std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+    shutdown_ = true;
+  }
+
+  pthread_mutex_lock(&audio_data_.lock);
+  audio_data_.terminate = 1;
+  pthread_mutex_unlock(&audio_data_.lock);
+
   out_thread_.stop();
   read_thread_.stop();
 
+  std::unique_lock<std::mutex> lk(read_thread_exit_mutex_);
+  if (!read_thread_exit_cv_.wait_for(lk, std::chrono::milliseconds(100),
+                                     [this] { return read_thread_exited_; })) {
+    spdlog::debug(
+        "Cava backend: read thread still blocked in input_source() on shutdown. "
+        "Proceeding with cleanup.");
+  }
+
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
   freeBackend();
 }
 
-static bool upThreadDelay(std::chrono::milliseconds& delay, std::chrono::seconds& delta) {
-  if (delta == std::chrono::seconds{0}) {
-    delta += std::chrono::seconds{1};
-    delay += delta;
-    return true;
-  }
-  return false;
-}
-
-static bool downThreadDelay(std::chrono::milliseconds& delay, std::chrono::seconds& delta) {
-  if (delta > std::chrono::seconds{0}) {
-    delay -= delta;
-    delta -= std::chrono::seconds{1};
-    return true;
-  }
-  return false;
-}
-
-bool waybar::modules::cava::CavaBackend::isSilence() {
+bool waybar::modules::cava::CavaBackend::isSilent() {
+  pthread_mutex_lock(&audio_data_.lock);
+  bool silent = true;
   for (int i{0}; i < audio_data_.input_buffer_size; ++i) {
     if (audio_data_.cava_in[i]) {
-      return false;
+      silent = false;
+      break;
     }
   }
-
-  return true;
+  pthread_mutex_unlock(&audio_data_.lock);
+  return silent;
 }
 
-int waybar::modules::cava::CavaBackend::getAsciiRange() { return prm_.ascii_range; }
+int waybar::modules::cava::CavaBackend::getAsciiRange() const {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  return prm_.ascii_range;
+}
 
-// Process: execute cava
 void waybar::modules::cava::CavaBackend::invoke() {
   pthread_mutex_lock(&audio_data_.lock);
   ::cava::cava_execute(audio_data_.cava_in, audio_data_.samples_counter, audio_raw_.cava_out,
@@ -83,7 +113,6 @@ void waybar::modules::cava::CavaBackend::invoke() {
   pthread_mutex_unlock(&audio_data_.lock);
 }
 
-// Do transformation under raw data
 void waybar::modules::cava::CavaBackend::execute() {
   invoke();
   audio_raw_fetch(&audio_raw_, &prm_, &re_paint_, plan_);
@@ -99,183 +128,228 @@ void waybar::modules::cava::CavaBackend::execute() {
 }
 
 void waybar::modules::cava::CavaBackend::doPauseResume() {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
   pthread_mutex_lock(&audio_data_.lock);
   if (audio_data_.suspendFlag) {
     audio_data_.suspendFlag = false;
     pthread_cond_broadcast(&audio_data_.resumeCond);
-    downThreadDelay(frame_time_milsec_, suspend_silence_delay_);
+    adaptive_delay_.decrease();
   } else {
     audio_data_.suspendFlag = true;
-    upThreadDelay(frame_time_milsec_, suspend_silence_delay_);
+    adaptive_delay_.increase();
   }
   pthread_mutex_unlock(&audio_data_.lock);
-  Update();
+  update();
 }
 
-waybar::modules::cava::CavaBackend::type_signal_update
-waybar::modules::cava::CavaBackend::signal_update() {
+waybar::modules::cava::CavaBackend::SignalUpdate&
+waybar::modules::cava::CavaBackend::signalUpdate() {
   return m_signal_update_;
 }
 
-waybar::modules::cava::CavaBackend::type_signal_audio_raw_update
-waybar::modules::cava::CavaBackend::signal_audio_raw_update() {
+waybar::modules::cava::CavaBackend::SignalAudioRawUpdate&
+waybar::modules::cava::CavaBackend::signalAudioRawUpdate() {
   return m_signal_audio_raw_;
 }
 
-waybar::modules::cava::CavaBackend::type_signal_silence
-waybar::modules::cava::CavaBackend::signal_silence() {
+waybar::modules::cava::CavaBackend::SignalSilence&
+waybar::modules::cava::CavaBackend::signalSilence() {
   return m_signal_silence_;
 }
 
-void waybar::modules::cava::CavaBackend::Update() { doUpdate(true); }
+waybar::modules::cava::CavaBackend::SignalConfigChanged&
+waybar::modules::cava::CavaBackend::signalConfigChanged() {
+  return m_signal_config_changed_;
+}
+
+void waybar::modules::cava::CavaBackend::update() { doUpdate(true); }
 
 void waybar::modules::cava::CavaBackend::doUpdate(bool force) {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  if (!plan_ || !input_source_) return;
   if (audio_data_.suspendFlag && !force) return;
 
-  silence_ = isSilence();
+  silence_ = isSilent();
   if (!silence_) sleep_counter_ = 0;
 
   if (silence_ && prm_.sleep_timer != 0) {
     if (sleep_counter_ <=
-        (int)(std::chrono::milliseconds(prm_.sleep_timer * 1s) / frame_time_milsec_)) {
+        static_cast<int>(std::chrono::milliseconds(prm_.sleep_timer * std::chrono::seconds(1)) /
+              adaptive_delay_.current())) {
       ++sleep_counter_;
       silence_ = false;
     }
   }
 
   if (!silence_ || prm_.sleep_timer == 0) {
-    if (downThreadDelay(frame_time_milsec_, suspend_silence_delay_)) Update();
+    while (adaptive_delay_.decrease()) {}
     execute();
     if (re_paint_ == 1 || force || prm_.continuous_rendering) {
       m_signal_update_.emit(output_);
-      m_signal_audio_raw_.emit(audio_raw_);
+      m_signal_audio_raw_.emit(AudioRaw{audio_raw_});
     }
   } else {
-    if (upThreadDelay(frame_time_milsec_, suspend_silence_delay_)) Update();
+    while (adaptive_delay_.increase()) {}
     if (silence_ != silence_prev_ || force) m_signal_silence_.emit();
   }
   silence_prev_ = silence_;
 }
 
 void waybar::modules::cava::CavaBackend::freeBackend() {
-  if (plan_ != NULL) {
+  input_source_ = nullptr;
+
+  if (plan_ != nullptr) {
     cava_destroy(plan_);
-    plan_ = NULL;
+    plan_ = nullptr;
   }
 
-  audio_raw_clean(&audio_raw_);
+  if (audio_raw_initialized_) {
+    audio_raw_clean(&audio_raw_);
+    audio_raw_initialized_ = false;
+  }
   pthread_mutex_lock(&audio_data_.lock);
   audio_data_.terminate = 1;
   pthread_mutex_unlock(&audio_data_.lock);
   free_config(&prm_);
+  prm_ = {};
   free(audio_data_.source);
+  audio_data_.source = nullptr;
   free(audio_data_.cava_in);
+  audio_data_.cava_in = nullptr;
 }
 
 void waybar::modules::cava::CavaBackend::loadConfig() {
-  freeBackend();
-  // Load waybar module config
-  char cfgPath[PATH_MAX];
-  cfgPath[0] = '\0';
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  if (shutdown_.load()) {
+    return;
+  }
 
-  if (config_["cava_config"].isString()) strcpy(cfgPath, config_["cava_config"].asString().data());
-  // Load cava config
+  const Json::Value& cfg = config_;
+
+  struct ::cava::config_params new_prm{};
+  CavaConfigGuard new_prm_guard(&new_prm);
+  std::vector<char> cfgPath(PATH_MAX, '\0');
+  if (cfg["cava_config"].isString()) {
+    const std::string& s = cfg["cava_config"].asString();
+    auto len = std::min(s.size(), static_cast<size_t>(PATH_MAX - 1));
+    std::copy_n(s.begin(), len, cfgPath.begin());
+    cfgPath[len] = '\0';
+  }
   error_.length = 0;
 
-  if (!load_config(cfgPath, &prm_, &error_)) {
-    // Throw, don't exit(): a bad config must disable only the cava module, not
-    // kill the whole bar (#4456). Caught by the factory (ctor) / read_thread_.
+  if (!load_config(cfgPath.data(), &new_prm, &error_)) {
     throw std::runtime_error(std::string{"cava backend: error loading config: "} + error_.message);
   }
 
-  // Override cava parameters by the user config
-  prm_.inAtty = 0;
-  auto const output{prm_.output};
-  // prm_.output = ::cava::output_method::OUTPUT_RAW;
-  if (prm_.data_format) free(prm_.data_format);
-  // Default to ascii for format-icons output; allow user override
-  prm_.data_format = strdup(
-      config_["data_format"].isString() ? config_["data_format"].asString().c_str() : "ascii");
-  if (config_["raw_target"].isString()) {
-    if (prm_.raw_target) free(prm_.raw_target);
-    prm_.raw_target = strdup(config_["raw_target"].asString().c_str());
+  new_prm.inAtty = 0;
+  auto const output{new_prm.output};
+  if (new_prm.data_format) free(new_prm.data_format);
+  new_prm.data_format = strdup(
+      cfg["data_format"].isString() ? cfg["data_format"].asString().c_str() : "ascii");
+  if (cfg["raw_target"].isString()) {
+    if (new_prm.raw_target) free(new_prm.raw_target);
+    new_prm.raw_target = strdup(cfg["raw_target"].asString().c_str());
   }
-  prm_.ascii_range = config_["format-icons"].size() - 1;
-
-  if (config_["bar_spacing"].isInt()) prm_.bar_spacing = config_["bar_spacing"].asInt();
-  if (config_["bar_width"].isInt()) prm_.bar_width = config_["bar_width"].asInt();
-  if (config_["bar_height"].isInt()) prm_.bar_height = config_["bar_height"].asInt();
-  prm_.orientation = ::cava::ORIENT_TOP;
-  prm_.xaxis = ::cava::xaxis_scale::NONE;
-  prm_.mono_opt = ::cava::AVERAGE;
-  prm_.autobars = 0;
-  if (config_["gravity"].isInt()) prm_.gravity = config_["gravity"].asInt();
-  if (config_["integral"].isInt()) prm_.integral = config_["integral"].asInt();
-
-  if (config_["framerate"].isInt()) prm_.framerate = config_["framerate"].asInt();
-  // Calculate delay for Update() thread
-  frame_time_milsec_ = std::chrono::milliseconds((int)(1e3 / prm_.framerate));
-  if (config_["autosens"].isInt()) prm_.autosens = config_["autosens"].asInt();
-  if (config_["sensitivity"].isInt()) prm_.sens = config_["sensitivity"].asInt();
-  if (config_["bars"].isInt()) prm_.fixedbars = config_["bars"].asInt();
-  if (config_["lower_cutoff_freq"].isNumeric())
-    prm_.lower_cut_off = config_["lower_cutoff_freq"].asLargestInt();
-  if (config_["higher_cutoff_freq"].isNumeric())
-    prm_.upper_cut_off = config_["higher_cutoff_freq"].asLargestInt();
-  if (config_["sleep_timer"].isInt()) prm_.sleep_timer = config_["sleep_timer"].asInt();
-  if (config_["method"].isString())
-    prm_.input = ::cava::input_method_by_name(config_["method"].asString().c_str());
-  if (config_["source"].isString()) {
-    if (prm_.audio_source) free(prm_.audio_source);
-    prm_.audio_source = strdup(config_["source"].asString().c_str());
-  }
-  if (config_["sample_rate"].isNumeric()) prm_.samplerate = config_["sample_rate"].asLargestInt();
-  if (config_["sample_bits"].isInt()) prm_.samplebits = config_["sample_bits"].asInt();
-  if (config_["stereo"].isBool()) prm_.stereo = config_["stereo"].asBool();
-  if (config_["reverse"].isBool()) prm_.reverse = config_["reverse"].asBool();
-  if (config_["bar_delimiter"].isInt()) prm_.bar_delim = config_["bar_delimiter"].asInt();
-  if (config_["monstercat"].isBool()) prm_.monstercat = config_["monstercat"].asBool();
-  if (config_["waves"].isBool()) prm_.waves = config_["waves"].asBool();
-  if (config_["noise_reduction"].isDouble())
-    prm_.noise_reduction = config_["noise_reduction"].asDouble();
-  if (config_["input_delay"].isInt())
-    fetch_input_delay_ = std::chrono::seconds(config_["input_delay"].asInt());
-  if (config_["gradient"].isInt()) prm_.gradient = config_["gradient"].asInt();
-  if (prm_.gradient == 0)
-    prm_.gradient_count = 0;
-  else if (config_["gradient_count"].isInt())
-    prm_.gradient_count = config_["gradient_count"].asInt();
-  if (config_["sdl_width"].isInt()) prm_.sdl_width = config_["sdl_width"].asInt();
-  if (config_["sdl_height"].isInt()) prm_.sdl_height = config_["sdl_height"].asInt();
-
-  audio_raw_.height = prm_.ascii_range;
-  audio_data_.format = -1;
-  audio_data_.rate = 0;
-  audio_data_.samples_counter = 0;
-  audio_data_.channels = 2;
-  audio_data_.IEEE_FLOAT = 0;
-  audio_data_.input_buffer_size = BUFFER_SIZE * audio_data_.channels;
-  audio_data_.cava_buffer_size = audio_data_.input_buffer_size * 8;
-  audio_data_.terminate = 0;
-  audio_data_.suspendFlag = false;
-  input_source_ = get_input(&audio_data_, &prm_);
-
-  if (!input_source_) {
-    throw std::runtime_error("cava backend: API didn't provide an input audio source");
+  {
+    auto icon_count = cfg["format-icons"].size();
+    new_prm.ascii_range = (icon_count > 0) ? static_cast<int>(icon_count) - 1 : 0;
   }
 
-  prm_.output = ::cava::output_method::OUTPUT_RAW;
+  if (cfg["bar_spacing"].isInt()) new_prm.bar_spacing = cfg["bar_spacing"].asInt();
+  if (cfg["bar_width"].isInt()) new_prm.bar_width = cfg["bar_width"].asInt();
+  if (cfg["bar_height"].isInt()) new_prm.bar_height = cfg["bar_height"].asInt();
+  new_prm.orientation = ::cava::ORIENT_TOP;
+  new_prm.xaxis = ::cava::xaxis_scale::NONE;
+  new_prm.mono_opt = ::cava::AVERAGE;
+  new_prm.autobars = 0;
+  if (cfg["gravity"].isInt()) new_prm.gravity = cfg["gravity"].asInt();
+  if (cfg["integral"].isInt()) new_prm.integral = cfg["integral"].asInt();
 
-  // Make cava parameters configuration
-  // Init cava plan, audio_raw structure
-  audio_raw_init(&audio_data_, &audio_raw_, &prm_, &plan_);
-  if (!plan_) spdlog::error("cava backend plan is not provided");
-  audio_raw_.previous_frame[0] = -1;  // For first Update() call need to rePaint text message
+  if (cfg["framerate"].isInt()) new_prm.framerate = cfg["framerate"].asInt();
+  if (cfg["autosens"].isInt()) new_prm.autosens = cfg["autosens"].asInt();
+  if (cfg["sensitivity"].isInt()) new_prm.sens = cfg["sensitivity"].asInt();
+  if (cfg["bars"].isInt()) new_prm.fixedbars = cfg["bars"].asInt();
+  if (cfg["lower_cutoff_freq"].isNumeric())
+    new_prm.lower_cut_off = cfg["lower_cutoff_freq"].asLargestInt();
+  if (cfg["higher_cutoff_freq"].isNumeric())
+    new_prm.upper_cut_off = cfg["higher_cutoff_freq"].asLargestInt();
+  if (cfg["sleep_timer"].isInt()) new_prm.sleep_timer = cfg["sleep_timer"].asInt();
+  if (cfg["method"].isString())
+    new_prm.input = ::cava::input_method_by_name(cfg["method"].asString().c_str());
+  if (cfg["source"].isString()) {
+    if (new_prm.audio_source) free(new_prm.audio_source);
+    new_prm.audio_source = strdup(cfg["source"].asString().c_str());
+  }
+  if (cfg["sample_rate"].isNumeric()) new_prm.samplerate = cfg["sample_rate"].asLargestInt();
+  if (cfg["sample_bits"].isInt()) new_prm.samplebits = cfg["sample_bits"].asInt();
+  if (cfg["stereo"].isBool()) new_prm.stereo = cfg["stereo"].asBool();
+  if (cfg["reverse"].isBool()) new_prm.reverse = cfg["reverse"].asBool();
+  if (cfg["bar_delimiter"].isInt()) new_prm.bar_delim = cfg["bar_delimiter"].asInt();
+  if (cfg["monstercat"].isBool()) new_prm.monstercat = cfg["monstercat"].asBool();
+  if (cfg["waves"].isBool()) new_prm.waves = cfg["waves"].asBool();
+  if (cfg["noise_reduction"].isDouble())
+    new_prm.noise_reduction = cfg["noise_reduction"].asDouble();
+  if (cfg["input_delay"].isInt())
+    fetch_input_delay_ = std::chrono::seconds(cfg["input_delay"].asInt());
+  if (cfg["gradient"].isInt()) new_prm.gradient = cfg["gradient"].asInt();
+  if (new_prm.gradient == 0)
+    new_prm.gradient_count = 0;
+  else if (cfg["gradient_count"].isInt())
+    new_prm.gradient_count = cfg["gradient_count"].asInt();
+  if (cfg["sdl_width"].isInt()) new_prm.sdl_width = cfg["sdl_width"].asInt();
+  if (cfg["sdl_height"].isInt()) new_prm.sdl_height = cfg["sdl_height"].asInt();
 
+  if (new_prm.framerate <= 0) {
+    throw std::runtime_error(std::string{"cava backend: framerate must be positive, got: "} +
+                             std::to_string(new_prm.framerate));
+  }
+
+  adaptive_delay_.reset(std::chrono::milliseconds(static_cast<int>(1e3 / new_prm.framerate)));
+  freeBackend();
+
+  try {
+    audio_raw_.height = new_prm.ascii_range;
+    audio_data_.format = -1;
+    audio_data_.rate = 0;
+    audio_data_.samples_counter = 0;
+    audio_data_.channels = 2;
+    audio_data_.IEEE_FLOAT = 0;
+    audio_data_.input_buffer_size = BUFFER_SIZE * audio_data_.channels;
+    audio_data_.cava_buffer_size = audio_data_.input_buffer_size * 8;
+    audio_data_.terminate = 0;
+    audio_data_.suspendFlag = false;
+
+    input_source_ = get_input(&audio_data_, &new_prm);
+    if (!input_source_) {
+      throw std::runtime_error("cava backend: API didn't provide an input audio source");
+    }
+
+    new_prm.output = ::cava::output_method::OUTPUT_RAW;
+
+    audio_raw_init(&audio_data_, &audio_raw_, &new_prm, &plan_);
+    if (!plan_) {
+      throw std::runtime_error("cava backend plan is not provided");
+    }
+    audio_raw_.previous_frame[0] = -1;
+    audio_raw_initialized_ = true;
+  } catch (...) {
+    freeBackend();
+    throw;
+  }
+
+  prm_ = new_prm;
+  new_prm_guard.release();
   prm_.output = output;
+
+  m_signal_config_changed_.emit();
 }
 
-const struct ::cava::config_params* waybar::modules::cava::CavaBackend::getPrm() { return &prm_; }
-std::chrono::milliseconds waybar::modules::cava::CavaBackend::getFrameTimeMilsec() {
-  return frame_time_milsec_;
-};
+const ::cava::config_params& waybar::modules::cava::CavaBackend::getPrm() const {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  return prm_;
+}
+
+std::chrono::milliseconds waybar::modules::cava::CavaBackend::getFrameTimeMilsec() const {
+  std::lock_guard<std::recursive_mutex> lock(state_mutex_);
+  return adaptive_delay_.current();
+}


### PR DESCRIPTION
Hi @Alexays ,

This MR was created using the deep kimi-k2.6 support. I used it for the first time to identify what could be improved or fixed for the CAVA module. While I don’t fully agree with some of the criticisms (for example, the “high risk” points), I would still say that the AI is quite useful for reviewing existing functionality, improving it, and polishing it.

Even so, the AI helped me find some race conditions, and the fix improved the CAVA module’s performance.

All proposed changes were reviewed by me.

To outline the process:
    Using the AI tool, I inspected the project at a high level to gather the necessary information, which I documented in the [CONVENTION.md](https://github.com/user-attachments/files/29975387/CONVENTION.md).
    Based on that convention, I used the plan in [cava_module_refactor_plan.md](https://github.com/user-attachments/files/29975409/cava_module_refactor_plan.md) to construct this MR.

If it’s useful for the project, I can also push the commit for CONVENTION.md.

Please see the commit overview below.

# Cava Module Refactor

## Summary
This MR addresses all outstanding style violations, architectural risks, thread-safety bugs, and resource leaks in the `cava` module.

## What changed

### Code Style & Naming
- Renamed class `Cava` -> `CavaRaw` to match filename convention
- Renamed methods to `lowerCamelCase` (`update()`, `pauseResume()`, etc.)
- Renamed signal aliases to `PascalCase` (`SignalUpdate`, `SignalAudioRawUpdate`)
- Replaced `NULL` with `nullptr` throughout the backend
- Replaced all C-style casts with `static_cast`
- Added missing explicit includes: `<memory>`, `<string>`, `<chrono>`
- Fixed member variable naming (`frame_counter_`, etc.)

### Architecture
- `CavaGLSL` no longer multiply-inherits from `Gtk::GLArea`; it composes a private `GLArea` child widget
- Factory returns `std::unique_ptr<AModule>` instead of raw `new`
- Added `doAction()` / `actionMap_` support to the GLSL frontend
- Encapsulated delay arithmetic in `CavaBackend::AdaptiveDelay`

### Thread Safety & Correctness
- Backend worker threads now emit `waybar::SafeSignal` instead of raw `sigc::signal`, marshalling events safely to the GTK main thread
- Fixed critical data race between `loadConfig()` and `out_thread_` via `std::recursive_mutex` + atomic `shutdown_` flag
- Fixed `audio_raw` shallow-copy / use-after-free in GLSL frontend by introducing a deep-copy `AudioRaw` payload
- `loadConfig()` is now fully exception-safe: validates into a temporary `new_prm`, tears down old state, then runs risky init inside a `try` block. On failure `freeBackend()` scrubs partial allocations and the exception is rethrown
- Destructor now waits up to 100 ms for the blocking `read_thread_` to exit before cleanup
- `isSilent()` now acquires `audio_data_.lock`
- Replaced recursive `doUpdate()` with iteration
- Guarded `audio_raw_clean()` against uninitialized state
- Fixed `format-icons` underflow and `cava_config` buffer overflow
- Backend stores `Json::Value` by value, eliminating dangling references on Waybar config reload
- Frontends cache config safely and refresh on runtime changes
- Fixed signed-char icon lookup bug (`unsigned char` cast before `getIcon`)
- Fixed unbounded `Json::Value` growth by performing lookups through a `const` reference
- Worker threads now catch `const std::exception&` instead of only `std::runtime_error`

### Resource Management & OpenGL Robustness
- Persisted VBO/IBO/VAO IDs as members; explicit destructor calls `glDelete*`
- Fixed shader info-log crash (null pointer write)
- Cached `inputTexture` uniform location instead of querying every frame
- Zero-initialized gradient color stack array and clamped count to `[0, 8]`
- Fixed shader time uniform integer division bug (now uses float arithmetic)
- Added explicit `glBindVertexArray(vao_)` in `onRender()`
- Runtime changes to bar width, spacing, colors, and gradients are now detected independently of dimension/shader changes and re-uploaded via `initSurface()`
- Clamped negative `gradient_count_` to `0` before `glUniform1i`

## Testing
- Compiled with GCC 15 / `-std=c++20`
- Runtime tested with PulseAudio input, FIFO input, and GLSL output
- Graceful shutdown verified even when the input backend is blocked in a system call

## Follow-up work (out of scope)
| Item | Reason |
|------|--------|
| **Split singleton config API** | Requires changing the public `inst()` contract and deciding how multi-module config reloading should behave. Best handled in a standalone PR. |

## Related issues
Fixes style violations, thread-safety bugs, and resource leaks identified in the cava module audit.
