### PR TITLE
refactor: rm direct dp.emit() call in constructor.

### DIFF
--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -624,6 +624,7 @@ void waybar::Bar::getModules(const Factory& factory, const std::string& pos,
             spdlog::error("{}: {}", ref, e.what());
           }
         });
+        module->dp.emit();
       } catch (const std::exception& e) {
         spdlog::warn("module {}: {}", name.asString(), e.what());
       }

--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -17,8 +17,6 @@ waybar::modules::Backlight::Backlight(const std::string& id, const Json::Value& 
     : ALabel(config, "backlight", id, "{percent}%", 2),
       preferred_device_(config["device"].isString() ? config["device"].asString() : ""),
       backend(interval_, [this] { dp.emit(); }) {
-  dp.emit();
-
   // Set up scroll handler
   event_box_.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
   event_box_.signal_scroll_event().connect(sigc::mem_fun(*this, &Backlight::handleScroll));

--- a/src/modules/bluetooth.cpp
+++ b/src/modules/bluetooth.cpp
@@ -213,8 +213,6 @@ waybar::modules::Bluetooth::Bluetooth(const std::string& id, const Json::Value& 
 #ifdef WANT_RFKILL
   rfkill_.on_update.connect(sigc::hide(sigc::mem_fun(*this, &Bluetooth::update)));
 #endif
-
-  dp.emit();
 }
 
 auto waybar::modules::Bluetooth::update() -> void {

--- a/src/modules/custom.cpp
+++ b/src/modules/custom.cpp
@@ -17,7 +17,7 @@ waybar::modules::Custom::Custom(const std::string& name, const std::string& id,
   if (config.isNull()) {
     spdlog::warn("There is no configuration for 'custom/{}', element will be hidden", name);
   }
-  dp.emit();
+
   if (!config_["signal"].empty() && config_["interval"].empty() &&
       config_["restart-interval"].empty()) {
     waitingWorker();

--- a/src/modules/custom_graph.cpp
+++ b/src/modules/custom_graph.cpp
@@ -22,7 +22,7 @@ waybar::modules::CustomGraph::CustomGraph(const std::string& name, const std::st
   if (config.isNull()) {
     spdlog::warn("There is no configuration for 'custom-graph/{}', element will be hidden", name);
   }
-  dp.emit();
+
   if (!config_["signal"].empty() && config_["interval"].empty() &&
       config_["restart-interval"].empty()) {
     waitingWorker();

--- a/src/modules/hyprland/submap.cpp
+++ b/src/modules/hyprland/submap.cpp
@@ -20,7 +20,6 @@ Submap::Submap(const std::string& id, const Bar& bar, const Json::Value& config)
 
   // register for hyprland ipc
   m_ipc.registerForIPC("submap", this);
-  dp.emit();
 
   if (config["icons"].isObject()) {
     const Json::Value& icons = config["icons"];

--- a/src/modules/hyprland/window.cpp
+++ b/src/modules/hyprland/window.cpp
@@ -32,8 +32,6 @@ Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
   m_ipc.registerForIPC("changefloatingmode", this);
   m_ipc.registerForIPC("fullscreen", this);
   windowIpcUniqueLock.unlock();
-
-  dp.emit();
 }
 
 Window::~Window() {

--- a/src/modules/hyprland/windowcount.cpp
+++ b/src/modules/hyprland/windowcount.cpp
@@ -19,7 +19,6 @@ WindowCount::WindowCount(const std::string& id, const Bar& bar, const Json::Valu
 
   queryActiveWorkspace();
   update();
-  dp.emit();
 
   // register for hyprland ipc
   m_ipc.registerForIPC("fullscreen", this);

--- a/src/modules/inhibitor.cpp
+++ b/src/modules/inhibitor.cpp
@@ -104,7 +104,6 @@ Inhibitor::Inhibitor(const std::string& id, const Bar& bar, const Json::Value& c
       inhibitors_(::getInhibitors(config)) {
   event_box_.add_events(Gdk::BUTTON_PRESS_MASK);
   event_box_.signal_button_press_event().connect(sigc::mem_fun(*this, &Inhibitor::handleToggle));
-  dp.emit();
 }
 
 Inhibitor::~Inhibitor() {

--- a/src/modules/mango/keymode.cpp
+++ b/src/modules/mango/keymode.cpp
@@ -7,7 +7,6 @@ namespace waybar::modules::mango {
 Keymode::Keymode(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "keymode", id, "{}", 0, false), bar_(bar) {
   IPC::getInstance().registerForIPC("monitor", this);
-  dp.emit();
 }
 
 Keymode::~Keymode() { IPC::getInstance().unregisterForIPC(this); }

--- a/src/modules/mango/language.cpp
+++ b/src/modules/mango/language.cpp
@@ -17,7 +17,6 @@ Language::Language(const std::string& id, const Bar& bar, const Json::Value& con
 
   IPC::getInstance().registerForIPC("monitor", this);
   updateFromIPC();
-  dp.emit();
 }
 
 Language::~Language() {

--- a/src/modules/mango/layout.cpp
+++ b/src/modules/mango/layout.cpp
@@ -7,7 +7,6 @@ namespace waybar::modules::mango {
 Layout::Layout(const std::string& id, const Bar& bar, const Json::Value& config)
     : ALabel(config, "layout", id, "{}", 0, false), bar_(bar) {
   IPC::getInstance().registerForIPC("monitor", this);
-  dp.emit();
 }
 
 Layout::~Layout() { IPC::getInstance().unregisterForIPC(this); }

--- a/src/modules/mango/window.cpp
+++ b/src/modules/mango/window.cpp
@@ -10,7 +10,6 @@ namespace waybar::modules::mango {
 Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
     : AAppIconLabel(config, "window", id, "{title}", 0, true), bar_(bar) {
   IPC::getInstance().registerForIPC("monitor", this);
-  dp.emit();
 }
 
 Window::~Window() { IPC::getInstance().unregisterForIPC(this); }

--- a/src/modules/mango/workspaces.cpp
+++ b/src/modules/mango/workspaces.cpp
@@ -29,7 +29,6 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
   }
 
   IPC::getInstance().registerForIPC("monitor", this);
-  dp.emit();
 }
 
 Workspaces::~Workspaces() {

--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -177,9 +177,6 @@ Mpris::Mpris(const std::string& id, const Json::Value& config)
       thread_.sleep_for(interval_);
     };
   }
-
-  // trigger initial update
-  dp.emit();
 }
 
 Mpris::~Mpris() {

--- a/src/modules/network.cpp
+++ b/src/modules/network.cpp
@@ -140,7 +140,6 @@ waybar::modules::Network::Network(const std::string& id, const Json::Value& conf
   createEventSocket();
   createInfoSocket();
 
-  dp.emit();
   // Ask for a dump of interfaces and then addresses to populate our
   // information. First the interface dump, and once done, the callback
   // will be called again which will ask for addresses dump.

--- a/src/modules/niri/language.cpp
+++ b/src/modules/niri/language.cpp
@@ -18,7 +18,6 @@ Language::Language(const std::string& id, const Bar& bar, const Json::Value& con
   gIPC->registerForIPC("KeyboardLayoutSwitched", this);
 
   updateFromIPC();
-  dp.emit();
 }
 
 Language::~Language() {

--- a/src/modules/niri/window.cpp
+++ b/src/modules/niri/window.cpp
@@ -18,8 +18,6 @@ Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
   gIPC->registerForIPC("WindowClosed", this);
   gIPC->registerForIPC("WindowFocusChanged", this);
   gIPC->registerForIPC("WindowLayoutsChanged", this);
-
-  dp.emit();
 }
 
 Window::~Window() { gIPC->unregisterForIPC(this); }

--- a/src/modules/niri/workspaces.cpp
+++ b/src/modules/niri/workspaces.cpp
@@ -82,8 +82,6 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
     window.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     window.signal_scroll_event().connect(sigc::mem_fun(*this, &Workspaces::handleScroll));
   }
-
-  dp.emit();
 }
 
 Workspaces::~Workspaces() { gIPC->unregisterForIPC(this); }

--- a/src/modules/power_profiles_daemon.cpp
+++ b/src/modules/power_profiles_daemon.cpp
@@ -44,8 +44,6 @@ PowerProfilesDaemon::PowerProfilesDaemon(const std::string& id, const Json::Valu
   Gio::DBus::Proxy::create_for_bus(Gio::DBus::BusType::BUS_TYPE_SYSTEM, "net.hadess.PowerProfiles",
                                    "/net/hadess/PowerProfiles", "net.hadess.PowerProfiles",
                                    sigc::mem_fun(*this, &PowerProfilesDaemon::busConnectedCb));
-  // Schedule update to set the initial visibility
-  dp.emit();
 }
 
 void PowerProfilesDaemon::busConnectedCb(Glib::RefPtr<Gio::AsyncResult>& r) {

--- a/src/modules/privacy/privacy.cpp
+++ b/src/modules/privacy/privacy.cpp
@@ -117,8 +117,6 @@ Privacy::Privacy(const std::string& id, const Json::Value& config, Gtk::Orientat
   geoclue_backend = util::GeoClueBackend::GeoClueBackend::getInstance();
   geoclue_backend->in_use_changed_signal_event.connect(
       sigc::mem_fun(*this, &Privacy::onGeoCluePrivacyNodesChanged));
-
-  dp.emit();
 }
 
 void Privacy::onPWPrivacyNodesChanged() {

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -49,7 +49,6 @@ Tray::Tray(const std::string& id, const Bar& bar, const Json::Value& config)
     box_.set_spacing(config_["spacing"].asUInt());
   }
   nb_hosts_ += 1;
-  dp.emit();
 }
 
 void Tray::checkIgnoreList(std::unique_ptr<Item>* item_ptr) {

--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -42,7 +42,6 @@ Language::Language(const std::string& id, const Json::Value& config)
       spdlog::error("Language: {}", e.what());
     }
   });
-  dp.emit();
 }
 
 void Language::onCmd(const struct Ipc::ipc_response& res) {

--- a/src/modules/sway/mode.cpp
+++ b/src/modules/sway/mode.cpp
@@ -16,7 +16,6 @@ Mode::Mode(const std::string& id, const Json::Value& config)
       spdlog::error("Mode: {}", e.what());
     }
   });
-  dp.emit();
 }
 
 void Mode::onEvent(const struct Ipc::ipc_response& res) {

--- a/src/modules/systemd_failed_units.cpp
+++ b/src/modules/systemd_failed_units.cpp
@@ -88,8 +88,6 @@ SystemdFailedUnits::SystemdFailedUnits(const std::string& id, const Json::Value&
     throw std::runtime_error("Neither system nor user status is requested.");
 
   updateData();
-  /* Always update for the first time. */
-  dp.emit();
 }
 
 auto SystemdFailedUnits::notify_cb(const Glib::ustring& sender_name,

--- a/src/modules/upower.cpp
+++ b/src/modules/upower.cpp
@@ -79,8 +79,6 @@ UPower::UPower(const std::string& id, const Json::Value& config)
 
   resetDevices();
   setDisplayDevice();
-  // Update the widget
-  dp.emit();
 }
 
 UPower::~UPower() {

--- a/src/modules/wayfire/window.cpp
+++ b/src/modules/wayfire/window.cpp
@@ -20,8 +20,6 @@ Window::Window(const std::string& id, const Bar& bar, const Json::Value& config)
   ipc->register_handler("view-app-id-changed", handler);
 
   ipc->register_handler("window-rules/get-focused-view", handler);
-
-  dp.emit();
 }
 
 Window::~Window() { ipc->unregister_handler(handler); }

--- a/src/modules/wayfire/workspaces.cpp
+++ b/src/modules/wayfire/workspaces.cpp
@@ -44,9 +44,6 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
   ipc->register_handler("window-rules/list-outputs", handler);
   ipc->register_handler("window-rules/list-wsets", handler);
   ipc->register_handler("window-rules/get-focused-output", handler);
-
-  // initial render
-  dp.emit();
 }
 
 Workspaces::~Workspaces() { ipc->unregister_handler(handler); }


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Remove the `dp.emit()` call in constructor, at this time, the `dp` isn't connect to callback, so it make no sense.

**Related issues**
N/A

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
