### PR TITLE
config: add min-brightness to backlight example

### DIFF
--- a/resources/config.jsonc
+++ b/resources/config.jsonc
@@ -154,7 +154,8 @@
     "backlight": {
         // "device": "acpi_video1",
         "format": "{percent}% {icon}",
-        "format-icons": ["", "", "", "", "", "", "", "", ""]
+        "format-icons": ["", "", "", "", "", "", "", "", ""],
+        "min-brightness": 1
     },
     "battery": {
         "states": {


### PR DESCRIPTION
**What does this PR do?**
The backlight module has supported `min-brightness` since #3637, but the shipped `config.jsonc` doesn't set it. Without it, scrolling over the backlight widget can take the screen to full black. Adding `"min-brightness": 1` to the example config means anyone copying it gets safe defaults out of the box.

Note: there is a related bug where a scroll step that crosses `min-brightness` isn't clamped (e.g. scrolling from 5% with `scroll-step: 5` and `min-brightness: 1` still reaches 0%). That is fixed separately in #5210. This PR and #5210 are complementary.

**Related issues**
Closes #2275

**Checklist**
- [ ] Code is formatted with `clang-format`
- [ ] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)