### PR TITLE
fix(backlight): clamp scroll step to min-brightness

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -120,9 +120,15 @@ bool waybar::modules::Backlight::handleScroll(GdkEventScroll* e) {
   if (config_["min-brightness"].isDouble()) {
     min_brightness = config_["min-brightness"].asDouble();
   }
-  if (backend.get_scaled_brightness(preferred_device_) <= min_brightness &&
-      ct == util::ChangeType::Decrease) {
-    return true;
+  if (ct == util::ChangeType::Decrease) {
+    const double current = backend.get_scaled_brightness(preferred_device_);
+    if (current <= min_brightness) {
+      return true;
+    }
+    if (current - step < min_brightness) {
+      backend.set_scaled_brightness(preferred_device_, static_cast<int>(std::round(min_brightness)));
+      return true;
+    }
   }
   backend.set_brightness(preferred_device_, ct, step);
 


### PR DESCRIPTION
**What does this PR do?**

When `min-brightness` is set, a scroll step that would *cross* it wasn't being clamped. Only scrolling while already at or below the minimum was blocked. With `scroll-step: 5` and `min-brightness: 1`, scrolling from 5% passes the guard (5 > 1) and sets brightness to 0%.

The check in `handleScroll` in [src/modules/backlight.cpp](https://github.com/Alexays/Waybar/blob/7f732f055316d3b0ab89f57e4347d24c1cc96167/src/modules/backlight.cpp#L123) was:

```cpp
if (backend.get_scaled_brightness(preferred_device_) <= min_brightness &&
    ct == util::ChangeType::Decrease) {
  return true;
}
backend.set_brightness(preferred_device_, ct, step);
```

This blocks further decrease once you're already at the minimum, but doesn't prevent a step from landing below it.

The fix computes whether the post-step value would fall below `min-brightness` and, if so, sets exactly `min-brightness` instead of applying the full step.

**Why does this matter?**

On `intel_backlight` (type `raw`, no kernel-enforced minimum), the kernel and logind both accept brightness 0, which on most laptop panels is a completely black screen. This makes the issue a real usability problem rather than just a cosmetic one. Users setting `min-brightness: 1` to prevent this are silently unprotected when scrolling in steps larger than 1.

Tested on `intel_backlight`, max_brightness 7500. Confirmed bug on unpatched master, confirmed fix on this branch.

Relates to #5209 (which adds `min-brightness` to the default config, which is complementary, but without this fix the protection has gaps whenever `scroll-step > 1`).