### PR TITLE
fix(tooltips): keep dynamic tooltips from resetting hover delay

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -4,6 +4,7 @@
 #include <fmt/format.h>
 #include <glibmm/markup.h>
 #include <gtkmm/label.h>
+#include <gtkmm/tooltip.h>
 #include <json/json.h>
 
 #include <optional>
@@ -92,6 +93,7 @@ class ALabel : public AModule {
   // no collation weight, so two different icons compare equal.
   std::optional<std::string> last_label_markup_;
   std::optional<std::string> last_tooltip_markup_;
+  Glib::RefPtr<Gtk::Tooltip> active_tooltip_;
 };
 
 }  // namespace waybar

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -42,6 +42,26 @@ ALabel::ALabel(const Json::Value& config, const std::string& name, const std::st
   }
   label_.get_style_context()->add_class(MODULE_CLASS);
   event_box_.add(label_);
+  if (tooltipEnabled()) {
+    // Keep dynamic tooltip contents out of GtkWidget's tooltip-markup property.
+    // Setting that property queues a display-wide tooltip query, which restarts
+    // GTK's hover delay when modules update faster than the delay can expire.
+    label_.set_has_tooltip(true);
+    label_.signal_query_tooltip().connect(
+        [this](int, int, bool, const Glib::RefPtr<Gtk::Tooltip>& tooltip) {
+          if (!last_tooltip_markup_.has_value() || last_tooltip_markup_->empty()) {
+            active_tooltip_.reset();
+            return false;
+          }
+          active_tooltip_ = tooltip;
+          tooltip->set_markup(*last_tooltip_markup_);
+          return true;
+        });
+    event_box_.signal_leave_notify_event().connect([this](GdkEventCrossing*) {
+      active_tooltip_.reset();
+      return false;
+    });
+  }
   if (config_["max-length"].isUInt()) {
     label_.set_max_width_chars(config_["max-length"].asInt());
     label_.set_ellipsize(Pango::EllipsizeMode::ELLIPSIZE_END);
@@ -162,8 +182,10 @@ bool ALabel::setTooltipMarkup(const Glib::ustring& markup) {
     return false;
   }
 
-  label_.set_tooltip_markup(markup);
   last_tooltip_markup_ = markup.raw();
+  if (active_tooltip_) {
+    active_tooltip_->set_markup(markup);
+  }
   return true;
 }
 


### PR DESCRIPTION
Cache ALabel tooltip markup and provide it through query-tooltip instead of repeatedly setting GtkWidget's tooltip-markup property. This prevents frequently updating modules from restarting GTK's display-wide tooltip timer.

Keep the active tooltip updated directly so dynamic tooltip contents continue refreshing while the pointer remains stationary.

## Problem

  Setting `tooltip-markup` queues a display-wide GTK tooltip query. A
  module updating more frequently than GTK's hover delay continually
  restarts that delay, preventing its own tooltip—and potentially other
  modules' tooltips—from appearing.

  ## Testing

  Tested with a custom module updating its displayed text and tooltip every
  250 ms, alongside a static control module.

  Verified that:

  - Both tooltips appear normally.
  - The rapidly updating tooltip refreshes while the pointer remains still.
  - The rapidly updating module no longer prevents the control tooltip
    from appearing.
  - The patched production build compiles and runs with the existing
    Waybar configuration.

  ## Related issues

  Related to #4801, #4519, and #4842.

  #4812 restored dynamic tooltip synchronization by repeatedly setting
  `tooltip-markup`, but was reverted because doing so resets GTK's hover
  state. #4900 subsequently avoided redundant property assignments by
  deduplicating identical markup.

  That does not cover genuinely dynamic tooltip content: when the value
  changes on every update, every assignment is non-redundant and GTK's
  display-wide tooltip delay is still continually restarted. This change
  provides tooltip content through `query-tooltip` and updates an already
  active tooltip directly, preserving both initial display and live
  updates.

  **Checklist**
  - [x] Code is formatted with `clang-format`
  - [x] Builds locally (`ninja -C build`)
  - [x] N/A, no user-facing option
  changed
  - [x] Tested against the affected module(s)