### PR TITLE
fix(sway/ipc): don't mistake events for the subscribe reply

### DIFF
--- a/src/modules/sway/ipc/client.cpp
+++ b/src/modules/sway/ipc/client.cpp
@@ -193,6 +193,13 @@ void Ipc::sendCmd(uint32_t type, const std::string& payload) {
 
 void Ipc::subscribe(const std::string& payload) {
   auto res = Ipc::send(fd_event_, IPC_SUBSCRIBE, payload);
+  // Events subscribed to by a previous subscribe() call may arrive on the
+  // socket before the reply to this one; deliver them and keep reading until
+  // the subscribe reply is found.
+  while ((res.type >> 31) != 0U) {
+    signal_event.emit(res);
+    res = Ipc::recv(fd_event_);
+  }
   if (res.payload != "{\"success\": true}") {
     throw std::runtime_error("Unable to subscribe ipc event");
   }


### PR DESCRIPTION
**What does this PR do?**
It fixes the invisible workspaces bug reported in #5218 . I've been running this patch for some weeks now and it works nicely to avoid the hotplug event error.

Please see more details in the commit message.

**Related issues**
Closes #5218

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- ~~[ ] Man page updated for any new/changed user-facing option (`man/`)~~
- [x] Tested against the affected module(s)
