### PR TITLE
fix(hyprland/workspaces): only deduplicate taskbar icons when max-icons is set

### DIFF
--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -527,35 +527,36 @@ void Workspace::updateTaskbar(const std::string& workspace_icon) {
     }
   }
 
-  // Build a list of windows to display, removing duplicates by window_class
-  // and respecting max-icons limit
+  // Build a list of windows to display. Duplicate window classes are only
+  // collapsed to make room for the max-icons limit, so with the limit unset
+  // every window is shown.
+  int maxIcons = m_workspaceManager.taskbarMaxIcons();
+  const bool deduplicate = maxIcons > 0;
+
   std::vector<const WindowRepr*> windowsToShow;
   std::set<std::string> seenClasses;
 
-  auto addWindowIfUnique = [&](const WindowRepr& window_repr) {
+  auto addWindow = [&](const WindowRepr& window_repr) {
     if (shouldSkipWindow(window_repr)) {
       return;
     }
-    // Deduplicate by window_class
-    if (seenClasses.find(window_repr.window_class) != seenClasses.end()) {
+    if (deduplicate && !seenClasses.insert(window_repr.window_class).second) {
       return;
     }
-    seenClasses.insert(window_repr.window_class);
     windowsToShow.push_back(&window_repr);
   };
 
   if (m_workspaceManager.taskbarReverseDirection()) {
     for (auto it = m_windowMap.rbegin(); it != m_windowMap.rend(); ++it) {
-      addWindowIfUnique(*it);
+      addWindow(*it);
     }
   } else {
     for (const auto& window_repr : m_windowMap) {
-      addWindowIfUnique(window_repr);
+      addWindow(window_repr);
     }
   }
 
   // Apply max-icons limit if configured
-  int maxIcons = m_workspaceManager.taskbarMaxIcons();
   if (maxIcons > 0 && static_cast<int>(windowsToShow.size()) > maxIcons) {
     windowsToShow.resize(maxIcons);
   }


### PR DESCRIPTION
**What does this PR do?**

The workspace taskbar collapsed every window whose class had already been shown, whatever `max-icons` was set to. Since the default is `0`, meaning unlimited, three terminals on a workspace rendered as one entry.

`updateTaskbar` deduplicated unconditionally, and the `maxIcons > 0` check only guarded the trimming that came afterwards:

```cpp
auto addWindowIfUnique = [&](const WindowRepr& window_repr) {
  if (shouldSkipWindow(window_repr)) return;
  if (seenClasses.find(window_repr.window_class) != seenClasses.end()) return;   // always
  ...
};

int maxIcons = m_workspaceManager.taskbarMaxIcons();
if (maxIcons > 0 && ...) windowsToShow.resize(maxIcons);                         // conditional
```

The deduplication is meant to belong to `max-icons`. It arrived in the same commit as the limit (#4694), and that commit's own man page text describes the pairing:

> *max-icons* — default: 0 (unlimited). **When set**, duplicate icons (windows with the same class) are removed first, then the list is trimmed to this limit. Set to 0 for unlimited icons.

So this hoists `maxIcons` above the loop and gates deduplication on it. With the limit unset every window is listed, and with it set the behaviour is unchanged: duplicates collapse first, then the list is trimmed. The lambda is renamed to `addWindow` because it no longer always adds unique windows.

The man page already documents the intended behaviour, so it needs no edit.

**Related issues**

Closes #5220

**Testing**

Built at 30610d3b and compared the same config against the same desktop, changing only the binary. Seven workspaces, three of which held two `kitty` windows each:

before

```
[⠂ Execute prio] [✳ Build MVP pa] [Manet — Onboar] [⠂ Investigate ] [✳ Update onboa] [YouTube - (83)] [ZapZap]
```

after

```
[⠂ Execute prio] [cloud-sql-prox] [⠂ Build MVP pa] [⠄ anir] [Manet — Onboar] [⠂ Investigate ] [✳ Investigate ] [⠂ Update onboa] [YouTube - (83)] [ZapZap]
```

| workspace | windows | before | after |
| --- | --- | --- | --- |
| 4 | 2 × kitty | 1 | 2 |
| 6 | 2 × kitty | 1 | 2 |
| 10 | 2 × kitty | 1 | 2 |
| 9, 11, 12, 13 | 1 each | 1 | 1 |

The three workspaces holding two terminals now show both, and the single window workspaces are untouched.

I set `active-only` to `false` for this. My first attempt used `active-only: true` and I switched workspaces between the two captures, so the comparison was worthless. Showing every workspace at once makes the result independent of which one is focused.

Also checked with `max-icons` set, where deduplication still applies as before.

Environment: Hyprland 0.55.4, Wayland.

**Checklist**
- [x] Code is formatted with `clang-format` (22.1.8, no changes to make)
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option — not needed, the documented behaviour is what this restores
- [x] Tested against the affected module(s) — plus `meson test -C build`, 3/3 passing
