### PR TITLE
fix(mpris): sanitize metadata to prevent multiline UI expansion

### DIFF
--- a/src/modules/mpris/mpris.cpp
+++ b/src/modules/mpris/mpris.cpp
@@ -543,34 +543,40 @@ auto Mpris::getPlayerInfo() -> std::optional<PlayerInfo> {
       .length = std::nullopt,
   };
 
-  if (auto* artist_ = playerctl_player_get_artist(last_active_player_, &error)) {
-    spdlog::debug("mpris[{}]: artist = {}", info.name, artist_);
-    info.artist = artist_;
-    g_free(artist_);
-  }
-  if (error) goto errorexit;
+  auto sanitize = [ ]( char* raw_str ) {
+      std::string s( raw_str );
+      std::replace( s.begin(), s.end(), '\n', ' ' );
+      std::replace( s.begin(), s.end(), '\r', ' ' );
+      return s;
+    };
 
-  if (auto* album_artist_ =
-          playerctl_player_print_metadata_prop(last_active_player_, "xesam:albumArtist", &error)) {
-    spdlog::debug("mpris[{}]: albumArtist = {}", info.name, album_artist_);
-    info.album_artist = album_artist_;
-    g_free(album_artist_);
+if(auto* artist_ = playerctl_player_get_artist( last_active_player_, &error )) {
+    spdlog::debug( "mpris[{}]: artist = {}", info.name, artist_ );
+    info.artist = sanitize( artist_ );
+    g_free( artist_ );
   }
-  if (error) goto errorexit;
+  if(error) goto errorexit;
 
-  if (auto* album_ = playerctl_player_get_album(last_active_player_, &error)) {
-    spdlog::debug("mpris[{}]: album = {}", info.name, album_);
-    info.album = album_;
-    g_free(album_);
+  if(auto* album_artist_ = playerctl_player_print_metadata_prop( last_active_player_, "xesam:albumArtist", &error )) {
+    spdlog::debug( "mpris[{}]: albumArtist = {}", info.name, album_artist_ );
+    info.album_artist = sanitize( album_artist_ );
+    g_free( album_artist_ );
   }
-  if (error) goto errorexit;
+  if(error) goto errorexit;
 
-  if (auto* title_ = playerctl_player_get_title(last_active_player_, &error)) {
-    spdlog::debug("mpris[{}]: title = {}", info.name, title_);
-    info.title = title_;
-    g_free(title_);
+  if(auto* album_ = playerctl_player_get_album( last_active_player_, &error )) {
+    spdlog::debug( "mpris[{}]: album = {}", info.name, album_ );
+    info.album = sanitize( album_ );
+    g_free( album_ );
   }
-  if (error) goto errorexit;
+  if(error) goto errorexit;
+
+  if(auto* title_ = playerctl_player_get_title( last_active_player_, &error )) {
+    spdlog::debug( "mpris[{}]: title = {}", info.name, title_ );
+    info.title = sanitize( title_ );
+    g_free( title_ );
+  }
+  if(error) goto errorexit;
 
   if (auto* length_ =
           playerctl_player_print_metadata_prop(last_active_player_, "mpris:length", &error)) {


### PR DESCRIPTION

**What does this PR do?**
I introduced a local sanitizer lambda in src/modules/mpris/mpris.cpp inside the getPlayerInfo() function. Before assigning the raw D-Bus C-strings to the PlayerInfo struct, the sanitizer converts them to std::string and uses std::replace to swap any \n or \r characters with standard spaces.

**Related issues**
Closes #4971

**Checklist**
- [ x ] Code is formatted with `clang-format`
- [ x ] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [ x ] Tested against the affected module(s)
