### PR TITLE
[hyprland/workspaces] add window-sort-by to order windows by on-screen position

### DIFF
--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -25,6 +25,19 @@ using WindowAddress = std::string;
 
 namespace waybar::modules::hyprland {
 
+// Where a window sits in the layout, as reported by the "clients" IPC reply.
+struct WindowPosition {
+  bool floating = false;
+  int x = 0;
+  int y = 0;
+
+  bool operator==(const WindowPosition& other) const = default;
+};
+
+// Keyed by address with the "0x" prefix stripped, to match WindowRepr::address
+// (see WindowCreationPayload::clearAddr).
+using WindowPositions = std::map<WindowAddress, WindowPosition>;
+
 class Workspaces;
 class Workspace {
  public:
@@ -69,6 +82,7 @@ class Workspace {
   };
   void insertWindow(WindowCreationPayload create_window_payload);
   void initializeWindowMap(const Json::Value& clients_data);
+  void sortWindowsByPosition(WindowPositions const& positions, bool floating_last);
   void setActiveWindow(WindowAddress const& addr);
 
   bool onWindowOpened(WindowCreationPayload const& create_window_payload);

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -92,6 +92,7 @@ class Workspaces : public AModule, public EventHandler {
   static auto populateBoolConfig(const Json::Value& config, const std::string& key, bool& member)
       -> void;
   auto populateSortByConfig(const Json::Value& config) -> void;
+  auto populateWindowSortByConfig(const Json::Value& config) -> void;
   auto populateIgnoreWorkspacesConfig(const Json::Value& config) -> void;
   auto populateFormatWindowSeparatorConfig(const Json::Value& config) -> void;
   auto populateWindowRewriteConfig(const Json::Value& config) -> void;
@@ -142,6 +143,12 @@ class Workspaces : public AModule, public EventHandler {
   void updateWorkspaceStates();
   bool updateWindowsToCreate();
 
+  // Window position sorting. Hyprland emits no event when windows are rearranged within a
+  // workspace (layoutmsg swapcol, movewindow, drag-moves), so this has to be polled.
+  WindowPositions queryWindowPositions() const;
+  bool checkWindowPositions();
+  bool sortsWindowsByPosition() const { return m_windowSortBy != WindowSortMethod::INSERTION; }
+
   void extendOrphans(int workspaceId, Json::Value const& clientsJson);
   void registerOrphanWindow(WindowCreationPayload create_window_payload);
 
@@ -175,6 +182,19 @@ class Workspaces : public AModule, public EventHandler {
                                                  {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
                                                  {"DEFAULT", SortMethod::DEFAULT}};
 
+  // How the windows *within* a workspace are ordered. INSERTION is Hyprland's creation order,
+  // the historical behaviour; the POSITION variants follow the on-screen layout.
+  enum class WindowSortMethod { INSERTION, POSITION, POSITION_FLOATING_LAST };
+  util::EnumParser<WindowSortMethod> m_windowSortEnumParser;
+  WindowSortMethod m_windowSortBy = WindowSortMethod::INSERTION;
+  std::map<std::string, WindowSortMethod> m_windowSortMap = {
+      {"INSERTION", WindowSortMethod::INSERTION},
+      {"POSITION", WindowSortMethod::POSITION},
+      {"POSITION-FLOATING-LAST", WindowSortMethod::POSITION_FLOATING_LAST}};
+  int m_windowSortInterval = 500;
+  WindowPositions m_lastWindowPositions;
+  sigc::connection m_windowPositionPoll;
+
   std::string m_formatBefore;
   std::string m_formatAfter;
 
@@ -188,6 +208,7 @@ class Workspaces : public AModule, public EventHandler {
   std::string m_windowRewriteGroupFormat = "{icon}×{count}";
 
   bool m_withIcon;
+  bool m_withWindows = false;
   uint64_t m_monitorId;
   int m_activeWorkspaceId;
   std::string m_activeSpecialWorkspaceName;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -196,6 +196,20 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	If set to special-centered, workspaces will sort by default with special workspaces in the center.
 	If none of those, workspaces will sort with default behavior.
 
+*window-sort-by*: ++
+	typeof: string ++
+	default: "insertion" ++
+	Controls the order of the windows *within* a workspace. Applies both to the *{windows}* replacement and to *workspace-taskbar*.
+	If set to insertion, windows appear in the order Hyprland created them. This is the historical behavior.
+	If set to position, windows appear in on-screen layout order: left to right, then top to bottom. Floating windows are ordered inline with tiled ones.
+	If set to position-floating-last, the same as position, except floating windows are placed after all tiled ones.
+	When combined with *workspace-taskbar*'s *active-window-position*, windows are sorted by position first and the active window is then moved to the requested end, so both options apply.
+
+*window-sort-interval*: ++
+	typeof: integer ++
+	default: 500 ++
+	How often, in milliseconds, to check for changes in window positions. Only used when *window-sort-by* orders by position. Hyprland emits no event when windows are rearranged within a workspace (for example *layoutmsg swapcol*, *movewindow*, or a drag-move), so this is polled. A redraw only happens when a position actually changed. Values below 50 are clamped.
+
 *tooltip*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -4,9 +4,11 @@
 
 #include <algorithm>
 #include <cctype>
+#include <climits>
 #include <memory>
 #include <set>
 #include <string>
+#include <tuple>
 #include <utility>
 
 #include "modules/hyprland/workspaces.hpp"
@@ -237,6 +239,24 @@ void Workspace::initializeWindowMap(const Json::Value& clients_data) {
       insertWindow({client});
     }
   }
+}
+
+// Order the windows the way they are laid out on screen: left to right, then top to bottom.
+// Hyprland reports windows in creation order, which under a tiling layout says nothing about
+// where they actually are.
+void Workspace::sortWindowsByPosition(WindowPositions const& positions, bool floating_last) {
+  // A window with no reported position (opened between the query and this call) sorts last and,
+  // thanks to stable_sort, keeps its insertion order relative to other such windows.
+  static constexpr WindowPosition UNKNOWN{.floating = true, .x = INT_MAX, .y = INT_MAX};
+
+  auto key = [&positions, floating_last](const WindowRepr& window) {
+    auto it = positions.find(window.address);
+    const WindowPosition& position = it == positions.end() ? UNKNOWN : it->second;
+    return std::tuple{floating_last && position.floating, position.x, position.y};
+  };
+
+  std::ranges::stable_sort(
+      m_windowMap, [&key](const auto& lhs, const auto& rhs) { return key(lhs) < key(rhs); });
 }
 
 void Workspace::setActiveWindow(WindowAddress const& addr) {

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1,5 +1,6 @@
 #include "modules/hyprland/workspaces.hpp"
 
+#include <glibmm/main.h>
 #include <json/value.h>
 #include <spdlog/spdlog.h>
 
@@ -31,6 +32,12 @@ Workspaces::Workspaces(const std::string& id, const Bar& bar, const Json::Value&
   setCurrentMonitorId();
   init();
   registerIpc();
+
+  // Only worth polling if this module actually renders windows.
+  if (sortsWindowsByPosition() && (m_withWindows || m_enableTaskbar)) {
+    m_windowPositionPoll = Glib::signal_timeout().connect(
+        sigc::mem_fun(*this, &Workspaces::checkWindowPositions), m_windowSortInterval);
+  }
 }
 
 Workspaces::~Workspaces() {
@@ -41,6 +48,9 @@ Workspaces::~Workspaces() {
   // Runs on the main thread, same as where the timer is armed.
   if (m_debounceTimer.connected()) {
     m_debounceTimer.disconnect();
+  }
+  if (m_windowPositionPoll.connected()) {
+    m_windowPositionPoll.disconnect();
   }
   m_ipc.unregisterForIPC(this);
   // wait for possible event handler to finish
@@ -610,7 +620,7 @@ auto Workspaces::parseConfig(const Json::Value& config) -> void {
   const auto& configFormat = config["format"];
   m_formatBefore = configFormat.isString() ? configFormat.asString() : "{name}";
   m_withIcon = m_formatBefore.find("{icon}") != std::string::npos;
-  auto withWindows = m_formatBefore.find("{windows}") != std::string::npos;
+  m_withWindows = m_formatBefore.find("{windows}") != std::string::npos;
 
   if (m_withIcon && m_iconsMap.empty()) {
     populateIconsMap(config["format-icons"]);
@@ -637,6 +647,7 @@ auto Workspaces::parseConfig(const Json::Value& config) -> void {
 
   m_persistentWorkspaceConfig = config.get("persistent-workspaces", Json::Value());
   populateSortByConfig(config);
+  populateWindowSortByConfig(config);
   populateIgnoreWorkspacesConfig(config);
   populateFormatWindowSeparatorConfig(config);
 
@@ -652,7 +663,7 @@ auto Workspaces::parseConfig(const Json::Value& config) -> void {
   populateWindowRewriteConfig(config);
   populateMaxWindowsConfig(config);
 
-  if (withWindows) {
+  if (m_withWindows) {
     populateWorkspaceTaskbarConfig(config);
   }
   if (m_enableTaskbar) {
@@ -688,6 +699,24 @@ auto Workspaces::populateSortByConfig(const Json::Value& config) -> void {
       spdlog::warn(
           "Invalid string representation for sort-by. Falling back to default sort method.");
     }
+  }
+}
+
+auto Workspaces::populateWindowSortByConfig(const Json::Value& config) -> void {
+  const auto& configWindowSortBy = config["window-sort-by"];
+  if (configWindowSortBy.isString()) {
+    auto windowSortByStr = configWindowSortBy.asString();
+    try {
+      m_windowSortBy = m_windowSortEnumParser.parseStringToEnum(windowSortByStr, m_windowSortMap);
+    } catch (const std::invalid_argument& e) {
+      m_windowSortBy = WindowSortMethod::INSERTION;
+      spdlog::warn("Invalid string representation for window-sort-by. Falling back to insertion.");
+    }
+  }
+
+  const auto& configInterval = config["window-sort-interval"];
+  if (configInterval.isInt()) {
+    m_windowSortInterval = std::max(configInterval.asInt(), 50);
   }
 }
 
@@ -1101,6 +1130,10 @@ void Workspaces::updateWorkspaceStates() {
   std::string currentWorkspaceName =
       currentWorkspace.isMember("name") ? currentWorkspace["name"].asString() : "";
 
+  if (sortsWindowsByPosition()) {
+    m_lastWindowPositions = queryWindowPositions();
+  }
+
   for (auto& workspace : m_workspaces) {
     bool isActiveByName =
         !currentWorkspaceName.empty() && workspace->name() == currentWorkspaceName;
@@ -1127,8 +1160,53 @@ void Workspaces::updateWorkspaceStates() {
     if (updatedWorkspace != updatedWorkspaces.end()) {
       workspace->setOutput((*updatedWorkspace)["monitor"].asString());
     }
+    if (sortsWindowsByPosition()) {
+      workspace->sortWindowsByPosition(m_lastWindowPositions,
+                                       m_windowSortBy == WindowSortMethod::POSITION_FLOATING_LAST);
+      // Sorting rewrites the order active-window-position established, so re-apply it on top.
+      // Skipped until an active window is known, so this never clears the active flag.
+      if (m_activeWindowPosition != ActiveWindowPosition::NONE &&
+          !m_currentActiveWindowAddress.empty()) {
+        workspace->setActiveWindow(m_currentActiveWindowAddress);
+      }
+    }
     workspace->update(workspaceIcon, workspaceTooltip);
   }
+}
+
+WindowPositions Workspaces::queryWindowPositions() const {
+  WindowPositions positions;
+  for (const auto& client : m_ipc.getSocket1JsonReply("clients")) {
+    const auto& at = client["at"];
+    if (!at.isArray() || at.size() < 2) {
+      continue;
+    }
+    auto address = client["address"].asString();
+    if (address.starts_with("0x")) {
+      address = address.substr(2);
+    }
+    positions.emplace(std::move(address), WindowPosition{.floating = client["floating"].asBool(),
+                                                         .x = at[0].asInt(),
+                                                         .y = at[1].asInt()});
+  }
+  return positions;
+}
+
+// Hyprland emits no event when windows are rearranged within a workspace, so poll for it.
+// Redraw only when something actually moved, which keeps an idle desktop free of updates.
+bool Workspaces::checkWindowPositions() {
+  try {
+    auto positions = queryWindowPositions();
+    if (positions != m_lastWindowPositions) {
+      m_lastWindowPositions = std::move(positions);
+      dp.emit();
+    }
+  } catch (const std::exception& e) {
+    // Hyprland may be gone while this bar is still shutting down; keep the timer alive rather
+    // than letting the exception escape into the GLib main loop.
+    spdlog::debug("Failed to poll window positions: {}", e.what());
+  }
+  return true;
 }
 
 int Workspaces::windowRewritePriorityFunction(std::string const& window_rule) {

--- a/src/util/enum.cpp
+++ b/src/util/enum.cpp
@@ -41,6 +41,7 @@ EnumType EnumParser<EnumType>::parseStringToEnum(const std::string& str,
 // Explicit instantiations for specific EnumType types you intend to use
 // Add explicit instantiations for all relevant EnumType types
 template struct EnumParser<modules::hyprland::Workspaces::SortMethod>;
+template struct EnumParser<modules::hyprland::Workspaces::WindowSortMethod>;
 template struct EnumParser<modules::hyprland::Workspaces::ActiveWindowPosition>;
 template struct EnumParser<util::KillSignalAction>;
 


### PR DESCRIPTION
This feature was developed using Claude. However, I've run through the code to ensure the following things: 1. This, of course, works as expected 2. The code is minimal 3. This should have no interactions with other features 4. This has minimal overhead. Polling is necessary, but is minimal, and the refresh rate can be edited. Let me know if any changes would be useful.

## Problem

In `hyprland/workspaces`, the windows rendered by `{windows}` and by `workspace-taskbar`
come out of `Workspace::m_windowMap`, a `std::vector<WindowRepr>` that is filled in
`hyprctl clients` reply order and `emplace_back`-appended on `openwindow`. That is
creation order, which under a tiling layout tells you nothing about where a window
actually is — so the leftmost icon routinely belongs to the rightmost window.

There is currently no way to change this: `sort-by` sorts *workspaces*,
`workspace-taskbar.active-window-position` only pins the active window, and
`workspace-taskbar.reverse-direction` only flips the iteration order.

Closes #4782.

Four windows on one workspace — vivaldi, kitty, lutris and steam, left to right on screen:

| | rendered |
| --- | --- |
| before (creation order) | `2｜S L K V` |
| after (`window-sort-by: position`) | `2｜V K L S` |

## What this adds

One option, `window-sort-by`, applying to both `{windows}` and `workspace-taskbar`
(they render from the same vector):

| value | sort key | behaviour |
| --- | --- | --- |
| `insertion` | — | creation order. **Default, current behaviour, unchanged** |
| `position` | `(x, y)` | layout order; floating windows inline |
| `position-floating-last` | `(isFloating, x, y)` | layout order; floating windows after tiled ones |

`(x, y)` gives exactly what #4782 describes: leftmost-topmost first, a vertically split
left column appearing as the second icon, rightmost-bottom-most last. The issue also asks
for floating windows at the end, hence the third value — kept separate so people who
prefer them inline are not forced either way.

Plus `window-sort-interval` (ms, default 500, clamped to ≥50), see below.

```jsonc
"hyprland/workspaces": {
    "format": "{name}: {windows}",
    "window-sort-by": "position",
    // optional, this is the default
    "window-sort-interval": 500
}
```

## Why it polls

**Hyprland emits no IPC event when windows are rearranged within a workspace.** I verified
this rather than assuming it: a debug-log capture spanning two `layoutmsg swapcol`
dispatches recorded no relevant event at all — only `activewindow`, `workspace`,
`windowtitle` and layer events. `movewindowv2` fires when a window changes *workspace*, not
when it moves inside one, and the focused window does not change either. So there is nothing
to subscribe to, and ordering by position cannot be event-driven.

The obvious objection to a timer is redraw churn, so the poll is built to answer it: each
tick queries `clients`, builds an address→position map, and compares it with the previous
map. If nothing moved it returns immediately, without touching GTK. An idle desktop
produces no updates at all — confirmed in the logs.

Two things I'd flag for your judgement:

- The timer is per module instance, so two instances across two bars poll independently.
  The no-op-on-no-change comparison keeps that cheap, but if you'd rather, the natural
  follow-up is to hoist the query into the `IPC` singleton and share it. I left that out to
  keep this diff small.
- If Hyprland ever grows an event for intra-workspace movement, the timer can be dropped
  and this becomes purely event-driven with no config change.

## Why it should not affect anyone else

The option is opt-in and defaults to `insertion`. With it unset, every added path is
guarded and the change is behaviourally inert:

| path | when `window-sort-by` is unset |
| --- | --- |
| constructor | `sortsWindowsByPosition()` false → no timer armed |
| destructor | `disconnect()` on an unconnected `sigc::connection`, a no-op |
| `updateWorkspaceStates()` | guarded → no `clients` query, no sort, vector order untouched |
| `parseConfig()` | reads two absent keys once at startup |
| `src/util/enum.cpp` | one explicit template instantiation, no runtime effect |

Everything is under `modules/hyprland/`, so no other compositor backend or module is
touched. Window counts, `isEmpty()`, `ignore-list`, urgency and click handling all key off
fields other than order, so reordering cannot affect them, and
`workspace-taskbar.reverse-direction` still composes — it reverses whatever order the
vector holds.

The timer is additionally only armed when the module actually renders windows (`{windows}`
present or the taskbar enabled), so a stray `window-sort-by` cannot cause background
polling for no reason.

## Interactions handled

- **`active-window-position`.** This hoists the active window to the front/back of the same
  vector from `onActiveWindowChanged()`. A naive sort silently undoes that on the next
  update, turning a documented option into a no-op. Instead, the hoist is re-applied after
  sorting (reusing `setActiveWindow`), so windows are ordered by position and the active one
  is then moved to the requested end — both options apply. Skipped while no active window is
  known, so it never clears the active flag.
- **`workspace-taskbar`.** Taskbar mode renders from the same vector and is ordered
  consistently, which is what #4782 originally asked about.
- **IPC failure.** `getSocket1JsonReply` throws if the socket is unreachable. Since a timer
  would keep hitting that after Hyprland exits, the poll body is wrapped in `try/catch` and
  logs at debug rather than letting an exception escape into the GLib main loop.

## Testing

Built against master, `meson test --suite waybar` passes (3/3). The `hyprland` suite
asserts that no compositor is reachable, so running it from a live Hyprland session needs
`HYPRLAND_INSTANCE_SIGNATURE` unset and `XDG_RUNTIME_DIR` pointed somewhere empty; it passes
under those conditions.

Verified live on Hyprland with the built-in `scrolling` layout, on a workspace holding four
windows whose creation order and on-screen order disagree. Every expected result below was
computed from `hyprctl clients -j` at the moment of the screenshot:

- `insertion` renders `S L K V`; `position` renders `V K L S`, matching the `(x, y)` order.
- After `layoutmsg swapcol` — which emits no event — the bar reorders on the next poll.
- With a floating window parked left of the tiled ones, `position` renders `K V L S` and
  `position-floating-last` renders `V L S K`.
- With `active-window-position: first`, focusing a window hoists it to the front while the
  remaining windows stay in position order; verified for two different focus targets.
- Six seconds idle produced zero additional log output, i.e. no redraws from the poll.

## Open question

I put `window-sort-by` at the top level, matching its nearest neighbour `sort-by`. It
governs `{windows}` as well as the taskbar, so nesting it under `workspace-taskbar` seemed
wrong — but happy to move or rename it if you'd prefer it grouped.
