### PR TITLE
Replace lone tab character in style.css with spaces for consistency

### DIFF
--- a/resources/style.css
+++ b/resources/style.css
@@ -302,7 +302,7 @@ label:focus {
 }
 
 #scratchpad.empty {
-	background-color: transparent;
+    background-color: transparent;
 }
 
 #privacy {


### PR DESCRIPTION
**What does this PR do?**

Hi !
Just a small whitespace inconsistency that I just noticed while reading this file, and that's driving me crazy :)

**Checklist**
- [ ] Code is formatted with `clang-format`
- [ ] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [ ] Tested against the affected module(s)
