### PR TITLE
fix(hyprland/workspaces): respect enable-bar-scroll config option

### DIFF
--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -55,8 +55,8 @@ void Workspaces::init() {
   if (m_scrollEventConnection_.connected()) {
     m_scrollEventConnection_.disconnect();
   }
-  bool hasScrollConfig = config_["on-scroll-up"].isString() || config_["on-scroll-down"].isString();
-  if (barScroll() || hasScrollConfig) {
+
+  if (barScroll()) {
     auto& window = const_cast<Bar&>(m_bar).window;
     window.add_events(Gdk::SCROLL_MASK | Gdk::SMOOTH_SCROLL_MASK);
     m_scrollEventConnection_ =


### PR DESCRIPTION
**What does this PR do?**
Removed `hasScrollConfig` boolean variable in Workspaces init function. It was OR'd with `barScroll()` and overriding when enable-bar-scroll is declared false in waybar config. Setting any scroll up or down events caused enable-bar-scroll to be ignored.

Tested on Arch/Hyprland, removing `hasScrollConfig` and the or condition restored expected behavior.

**Related issues**
Closes #5229 

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
