### PR TITLE
temperature: add support for fan and power readings

### DIFF
--- a/include/modules/temperature.hpp
+++ b/include/modules/temperature.hpp
@@ -9,6 +9,8 @@
 
 namespace waybar::modules {
 
+enum SensorType { TEMPERATURE, FAN, POWER };
+
 class Temperature : public ALabel {
  public:
   Temperature(const std::string&, const Json::Value&);
@@ -18,11 +20,12 @@ class Temperature : public ALabel {
   void resume() override;
 
  private:
-  float getTemperature();
+  float getReadings();
   bool isCritical(uint16_t);
   bool isWarning(uint16_t);
 
   std::string file_path_;
+  SensorType sensor_type_{TEMPERATURE};
   util::SleeperThread thread_;
 };
 

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -6,7 +6,7 @@ waybar - temperature module
 
 # DESCRIPTION
 
-The *temperature* module displays the current temperature from a thermal zone.
+The *temperature* module displays the current temperature, fan, and power from sensors in hwmon or thermal zone.
 
 # CONFIGURATION
 
@@ -18,7 +18,7 @@ Addressed by *temperature*
 
 *hwmon-path*: ++
 	typeof: string ++
-	The temperature path to use, e.g. */sys/class/hwmon/hwmon2/temp1_input* instead of one in */sys/class/thermal/*.
+	The sensor path to use, e.g. */sys/class/hwmon/hwmon2/temp1_input* instead of one in */sys/class/thermal/*.
 	This can also be an array of strings. In this case, waybar will check each item in the array and use the first valid one.
 	This is suitable if you want to share the same configuration file among different machines with different hardware configurations.
 
@@ -35,7 +35,7 @@ Addressed by *temperature*
 
 *input-filename*: ++
 	typeof: string ++
-	The temperature filename of your *hwmon-path-abs* (also used by *hwmon-by-name*), e.g. *temp1_input*
+	The sensor filename of your *hwmon-path-abs* (also used by *hwmon-by-name*), e.g. *temp1_input*
 
 *hwmon-by-name*: ++
 	typeof: string ++
@@ -55,18 +55,29 @@ Addressed by *temperature*
 	default: 10 ++
 	The interval in which the information gets polled.
 
+*type*: ++
+	typeof: string ++
+	default: temperature ++
+	Type of the sensor. Can be one of: temperature, fan, power. Indicates how readings are interpreted.
+
 *format-warning*: ++
 	typeof: string ++
-	The format to use when temperature is considered warning
+	The format to use when reading is considered warning
 
 *format-critical*: ++
 	typeof: string ++
-	The format to use when temperature is considered critical
+	The format to use when reading is considered critical
 
 *format*: ++
 	typeof: string  ++
 	default: {temperatureC}°C ++
-	The format (Celsius/Fahrenheit/Kelvin) in which the temperature should be displayed.
+	The format in which the reading should be displayed. Depending on the type, accepted formats are:
+	- `temperatureC` for temperature in Celcius,
+	- `temperatureF` for temperature in Fahrenheit,
+	- `temperatureK` for temperature in Kelvin,
+	- `fan` for fan speed in RPM,
+	- `power` for power draw in Watts.
+	If a format specifier that is not relevant to the sensor type is used, value will be always 0. For example, if sensor type is `temperature` then `{fan}` and `{power}` format strings will always resolve to `0`.
 
 *format-icons*: ++
 	typeof: array ++
@@ -158,6 +169,10 @@ Addressed by *temperature*
 
 *{icon}*: Icon, as selected from *format-icons* based on the current temperature.
 
+*{fan}*: Fan speed in RPM.
+
+*{power}*: Power in Watts.
+
 # EXAMPLES
 
 ```
@@ -166,8 +181,32 @@ Addressed by *temperature*
 	// "hwmon-path": ["/sys/class/hwmon/hwmon2/temp1_input", "/sys/class/thermal/thermal_zone0/temp"],
 	// "critical-threshold": 80,
 	// "format-critical": "{temperatureC}°C ",
+	// "type": "temperature",
 	"format": "{temperatureC}°C "
 }
+```
+
+```
+"temperature#cpufan1": {
+	"hwmon-path-abs": "/sys/devices/platform/thinkpad_hwmon/hwmon",
+	"input-filename": "fan1_input",
+	"type": "fan",
+	"critical-threshold": 5000,
+	"interval": 3,
+	"format": "{icon}  {fan}",
+	"format-icons": [""],
+},
+```
+
+```
+"temperature#gpupower": {
+	"hwmon-path-abs": "/sys/devices/pci0000:00/0000:00:01.1/0000:01:00.0/0000:02:00.0/0000:03:00.0/hwmon",
+	"input-filename": "power1_average",
+	"type": "power",
+	"critical-threshold": 375,
+	"interval": 3,
+	"format": "{power}W",
+},
 ```
 
 # STYLE

--- a/src/modules/temperature.cpp
+++ b/src/modules/temperature.cpp
@@ -1,5 +1,7 @@
 #include "modules/temperature.hpp"
 
+#include <fmt/base.h>
+
 #include <filesystem>
 #include <optional>
 #include <stdexcept>
@@ -14,6 +16,17 @@ waybar::modules::Temperature::Temperature(const std::string& id, const Json::Val
 #if defined(__FreeBSD__)
 // FreeBSD uses sysctlbyname instead of read from a file
 #else
+  if (config_["type"].isString()) {
+    auto sensor_type_string = config_["type"].asString();
+    if (sensor_type_string.empty() || sensor_type_string == "temperature") {
+      sensor_type_ = SensorType::TEMPERATURE;
+    } else if (sensor_type_string == "fan") {
+      sensor_type_ = SensorType::FAN;
+    } else if (sensor_type_string == "power") {
+      sensor_type_ = SensorType::POWER;
+    }
+  }
+
   auto traverseAsArray = [](const Json::Value& value, auto&& check_set_path) {
     if (value.isString())
       check_set_path(value.asString());
@@ -103,7 +116,7 @@ waybar::modules::Temperature::Temperature(const std::string& id, const Json::Val
     file_path_ = hwmon->string() + "/" + config_["input-filename"].asString();
   }
 
-  if (file_path_.empty()) {
+  if (file_path_.empty() && sensor_type_ == SensorType::TEMPERATURE) {
     auto zone = config_["thermal-zone"].isInt() ? config_["thermal-zone"].asInt() : 0;
     file_path_ = fmt::format("/sys/class/thermal/thermal_zone{}/temp", zone);
   }
@@ -127,12 +140,9 @@ waybar::modules::Temperature::Temperature(const std::string& id, const Json::Val
 }
 
 auto waybar::modules::Temperature::update() -> void {
-  auto temperature = getTemperature();
-  uint16_t temperature_c = std::round(temperature);
-  uint16_t temperature_f = std::round(temperature * 1.8 + 32);
-  uint16_t temperature_k = std::round(temperature + 273.15);
-  auto critical = isCritical(temperature_c);
-  auto warning = isWarning(temperature_c);
+  uint16_t readings = std::round(getReadings());
+  auto critical = isCritical(readings);
+  auto warning = isWarning(readings);
   auto format = format_;
   if (critical) {
     format = config_["format-critical"].isString() ? config_["format-critical"].asString() : format;
@@ -154,17 +164,47 @@ auto waybar::modules::Temperature::update() -> void {
 
   event_box_.show();
 
-  auto max_temp = config_["critical-threshold"].isInt() ? config_["critical-threshold"].asInt() : 0;
-  updateLabelAndTooltip(format, "{temperatureC}°C", fmt::arg("temperatureC", temperature_c),
+  auto max_reading =
+      config_["critical-threshold"].isInt() ? config_["critical-threshold"].asInt() : 0;
+
+  uint16_t power = 0;
+  uint16_t fan_speed = 0;
+  uint16_t temperature_c = 0;
+  uint16_t temperature_f = 0;
+  uint16_t temperature_k = 0;
+  std::string tooltip_default = "";
+  switch (sensor_type_) {
+    case TEMPERATURE:
+      temperature_c = readings;
+      temperature_f = std::round((readings * 1.8) + 32);
+      temperature_k = std::round(readings + 273.15);
+      tooltip_default = "{temperatureC}°C";
+      break;
+    case FAN:
+      fan_speed = readings;
+      tooltip_default = "{fan} RPM";
+      break;
+    case POWER:
+      power = readings;
+      tooltip_default = "{power}W";
+      break;
+  }
+
+  updateLabelAndTooltip(format, tooltip_default, fmt::arg("temperatureC", temperature_c),
                         fmt::arg("temperatureF", temperature_f),
                         fmt::arg("temperatureK", temperature_k),
-                        fmt::arg("icon", getIcon(temperature_c, "", max_temp)));
+                        fmt::arg("icon", getIcon(readings, "", max_reading)),
+                        fmt::arg("fan", fan_speed), fmt::arg("power", power));
+
   // Call parent update
   ALabel::update();
 }
 
-float waybar::modules::Temperature::getTemperature() {
+float waybar::modules::Temperature::getReadings() {
 #if defined(__FreeBSD__)
+  if (sensor_type_ != SensorType::TEMPERATURE)
+    throw std::runtime_error("Only temperature sensor reading is supported in FreeBSD");
+
   int temp;
   size_t size = sizeof temp;
 
@@ -181,12 +221,12 @@ float waybar::modules::Temperature::getTemperature() {
 
   throw std::runtime_error(fmt::format(
       "sysctl hw.acpi.thermal.tz{}.temperature and dev.cpu.{}.temperature failed", zone, zone));
-
-#else  // Linux
+#else
   std::ifstream temp(file_path_);
   if (!temp.is_open()) {
     throw std::runtime_error("Can't open " + file_path_);
   }
+
   std::string line;
   if (temp.good()) {
     getline(temp, line);
@@ -195,19 +235,27 @@ float waybar::modules::Temperature::getTemperature() {
     throw std::runtime_error("Can't read from " + file_path_);
   }
   temp.close();
-  auto temperature_c = std::strtol(line.c_str(), nullptr, 10) / 1000.0;
-  return temperature_c;
+
+  auto reading = std::strtol(line.c_str(), nullptr, 10);
+  switch (sensor_type_) {
+    case TEMPERATURE:
+      return reading / 1000.0;
+    case FAN:
+      break;
+    case POWER:
+      return reading / 1000000.0;
+  }
+
+  return static_cast<float>(reading);
 #endif
 }
 
-bool waybar::modules::Temperature::isWarning(uint16_t temperature_c) {
-  return config_["warning-threshold"].isInt() &&
-         temperature_c >= config_["warning-threshold"].asInt();
+bool waybar::modules::Temperature::isWarning(uint16_t reading) {
+  return config_["warning-threshold"].isInt() && reading >= config_["warning-threshold"].asInt();
 }
 
-bool waybar::modules::Temperature::isCritical(uint16_t temperature_c) {
-  return config_["critical-threshold"].isInt() &&
-         temperature_c >= config_["critical-threshold"].asInt();
+bool waybar::modules::Temperature::isCritical(uint16_t reading) {
+  return config_["critical-threshold"].isInt() && reading >= config_["critical-threshold"].asInt();
 }
 
 void waybar::modules::Temperature::suspend() { thread_.pause(); }


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Add support for fan and power readings to the temperature module.

Instead of adding custom modules for my cpu & gpu fan readings and gpu power readings, i was experimenting if i could just add this to the existing temperature module as it already does the heavy lifting by parsing the hwmon path and reading the file.

I've been using my branch for around ~9-10 months now with [this config](https://github.com/umtdg/dotfiles/blob/5b57c230f5a0fcc76f556ff9bbf35173f3adb460/.config/waybar/config%23%23d.arch%2Ch.naboo#L29-L59) and [this config](https://github.com/umtdg/dotfiles/blob/5b57c230f5a0fcc76f556ff9bbf35173f3adb460/.config/waybar/config%23%23d.arch%2Ch.tatooine#L66-L137). This was meant to be a quick stitch up at the time and can probably be done better. Any suggestion or anything that i missed in testing/documentation is welcome.

I could only test this on Linux and i don't have the knowledge or environment to implement this for FreeBSD and test.

**Related issues**
Closes #4681

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)