### PR TITLE
feat(wlr/taskbar): add scroll wheel support and discrete minimize act…

### DIFF
--- a/include/modules/wlr/taskbar.hpp
+++ b/include/modules/wlr/taskbar.hpp
@@ -130,6 +130,7 @@ class Task {
   /* Callbacks for Gtk events */
   bool handle_clicked(GdkEventButton*);
   bool handle_button_release(GdkEventButton*);
+  bool handle_scroll(GdkEventScroll* e);
   bool handle_motion_notify(GdkEventMotion*);
   void handle_drag_data_get(const Glib::RefPtr<Gdk::DragContext>& context,
                             Gtk::SelectionData& selection_data, guint info, guint time);

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -101,6 +101,14 @@ Addressed by *wlr/taskbar*
 	typeof: string ++
 	The action which should be triggered when clicking on the application button with the right mouse button.
 
+*on-scroll-up*: ++
+	typeof: string ++
+	The action which should be triggered when scrolling up on the application button.
+
+*on-scroll-down*: ++
+	typeof: string ++
+	The action which should be triggered when scrolling down on the application button.
+
 *on-update*: ++
 	typeof: string ++
 	Command to execute when the module is updated.
@@ -145,6 +153,10 @@ value that must be escaped in XML.
 *activate*: Bring the application into foreground.
 
 *minimize*: Toggle application's minimized state.
+
+*minimize-only*: Minimize the application, one-way does not toggle.
+
+*unminimize*: Restore the application from its minimized state.
 
 *minimize-raise*: Bring the application into foreground or toggle its minimized state.
 

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -541,11 +541,11 @@ bool Task::handle_clicked(GdkEventButton* bt) {
   else if (action == "close")
     close();
   else if (action == "unminimize") {
-      set_minimize_hint();
-      minimize(false);
+    set_minimize_hint();
+    minimize(false);
   } else if (action == "minimize-only") {
-      set_minimize_hint();
-      minimize(true);
+    set_minimize_hint();
+    minimize(true);
   } else
     spdlog::warn("Unknown action {}", action);
 
@@ -555,17 +555,16 @@ bool Task::handle_clicked(GdkEventButton* bt) {
 
 bool Task::handle_scroll(GdkEventScroll* e) {
   std::string action;
-  
-  if ((e->direction == GDK_SCROLL_UP || (e->direction == GDK_SCROLL_SMOOTH && e->delta_y < 0)) && 
+
+  if ((e->direction == GDK_SCROLL_UP || (e->direction == GDK_SCROLL_SMOOTH && e->delta_y < 0)) &&
       config_["on-scroll-up"].isString()) {
     action = config_["on-scroll-up"].asString();
-  } 
-  else if ((e->direction == GDK_SCROLL_DOWN || (e->direction == GDK_SCROLL_SMOOTH && e->delta_y > 0)) && 
-           config_["on-scroll-down"].isString()) {
+  } else if ((e->direction == GDK_SCROLL_DOWN ||
+              (e->direction == GDK_SCROLL_SMOOTH && e->delta_y > 0)) &&
+             config_["on-scroll-down"].isString()) {
     action = config_["on-scroll-down"].asString();
   }
-  if (action.empty())
-    return false;
+  if (action.empty()) return false;
 
   if (action == "activate")
     activate();
@@ -587,11 +586,11 @@ bool Task::handle_scroll(GdkEventScroll* e) {
   else if (action == "close")
     close();
   else if (action == "unminimize") {
-      set_minimize_hint();
-      minimize(false);
+    set_minimize_hint();
+    minimize(false);
   } else if (action == "minimize-only") {
-      set_minimize_hint();
-      minimize(true);
+    set_minimize_hint();
+    minimize(true);
   } else
     spdlog::warn("Unknown action {}", action);
 
@@ -772,10 +771,11 @@ Taskbar::Taskbar(const std::string& id, const waybar::Bar& bar, const Json::Valu
   // commands (issue #3284). Values that are not built-in actions are left alone
   // and still run as user shell commands.
   const auto is_builtin_action = [](const std::string& v) {
-    return v == "activate" || v == "minimize" || v == "minimize-only" || v == "unminimize" || v == "minimize-raise" || v == "maximize" ||
-           v == "fullscreen" || v == "close";
+    return v == "activate" || v == "minimize" || v == "minimize-only" || v == "unminimize" ||
+           v == "minimize-raise" || v == "maximize" || v == "fullscreen" || v == "close";
   };
-  for (const auto* event : {"on-click", "on-click-middle", "on-click-right", "on-scroll-up", "on-scroll-down"}) {
+  for (const auto* event :
+       {"on-click", "on-click-middle", "on-click-right", "on-scroll-up", "on-scroll-down"}) {
     if (config_[event].isString() && is_builtin_action(config_[event].asString())) {
       eventActionMap_.insert({event, config_[event].asString()});
     }

--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -188,8 +188,9 @@ Task::Task(const waybar::Bar& bar, const Json::Value& config, Taskbar* tbar,
       config_["on-click-right"].isString()) {
   }
 
-  button.add_events(Gdk::BUTTON_PRESS_MASK);
+  button.add_events(Gdk::BUTTON_PRESS_MASK | Gdk::SCROLL_MASK);
   button.signal_button_release_event().connect(sigc::mem_fun(*this, &Task::handle_clicked), false);
+  button.signal_scroll_event().connect(sigc::mem_fun(*this, &Task::handle_scroll), false);
 
   button.signal_motion_notify_event().connect(sigc::mem_fun(*this, &Task::handle_motion_notify),
                                               false);
@@ -539,10 +540,61 @@ bool Task::handle_clicked(GdkEventButton* bt) {
     fullscreen(!fullscreen());
   else if (action == "close")
     close();
-  else
+  else if (action == "unminimize") {
+      set_minimize_hint();
+      minimize(false);
+  } else if (action == "minimize-only") {
+      set_minimize_hint();
+      minimize(true);
+  } else
     spdlog::warn("Unknown action {}", action);
 
   drag_start_button = -1;
+  return true;
+}
+
+bool Task::handle_scroll(GdkEventScroll* e) {
+  std::string action;
+  
+  if ((e->direction == GDK_SCROLL_UP || (e->direction == GDK_SCROLL_SMOOTH && e->delta_y < 0)) && 
+      config_["on-scroll-up"].isString()) {
+    action = config_["on-scroll-up"].asString();
+  } 
+  else if ((e->direction == GDK_SCROLL_DOWN || (e->direction == GDK_SCROLL_SMOOTH && e->delta_y > 0)) && 
+           config_["on-scroll-down"].isString()) {
+    action = config_["on-scroll-down"].asString();
+  }
+  if (action.empty())
+    return false;
+
+  if (action == "activate")
+    activate();
+  else if (action == "minimize") {
+    set_minimize_hint();
+    minimize(!minimized());
+  } else if (action == "minimize-raise") {
+    set_minimize_hint();
+    if (minimized())
+      minimize(false);
+    else if (active())
+      minimize(true);
+    else
+      activate();
+  } else if (action == "maximize")
+    maximize(!maximized());
+  else if (action == "fullscreen")
+    fullscreen(!fullscreen());
+  else if (action == "close")
+    close();
+  else if (action == "unminimize") {
+      set_minimize_hint();
+      minimize(false);
+  } else if (action == "minimize-only") {
+      set_minimize_hint();
+      minimize(true);
+  } else
+    spdlog::warn("Unknown action {}", action);
+
   return true;
 }
 
@@ -720,10 +772,10 @@ Taskbar::Taskbar(const std::string& id, const waybar::Bar& bar, const Json::Valu
   // commands (issue #3284). Values that are not built-in actions are left alone
   // and still run as user shell commands.
   const auto is_builtin_action = [](const std::string& v) {
-    return v == "activate" || v == "minimize" || v == "minimize-raise" || v == "maximize" ||
+    return v == "activate" || v == "minimize" || v == "minimize-only" || v == "unminimize" || v == "minimize-raise" || v == "maximize" ||
            v == "fullscreen" || v == "close";
   };
-  for (const auto* event : {"on-click", "on-click-middle", "on-click-right"}) {
+  for (const auto* event : {"on-click", "on-click-middle", "on-click-right", "on-scroll-up", "on-scroll-down"}) {
     if (config_[event].isString() && is_builtin_action(config_[event].asString())) {
       eventActionMap_.insert({event, config_[event].asString()});
     }


### PR DESCRIPTION
**What does this PR do?**
This PR adds the ability to use the scroll wheel on taskbar buttons (e.g., scrolling up to minimize, scrolling down to restore).

While testing this, I realized that using the standard minimize toggle action with a scroll wheel causes the window to flicker too much, since a single swipe of a mouse wheel or touchpad sends dozens of rapid events. To fix this, I added two new one-way actions, minimize-only and unminimize.

**Related issues**
This feature was mentioned in issue #5071 

**Checklist**
- [ x ] Code is formatted with `clang-format`
- [ x ] Builds locally (`ninja -C build`)
- [ x ] Man page updated for any new/changed user-facing option (`man/`)
- [ x ] Tested against the affected module(s)
