### PR TITLE
Consider format-<lang> and format-<lang>-<variant>

### DIFF
--- a/src/modules/sway/language.cpp
+++ b/src/modules/sway/language.cpp
@@ -20,7 +20,8 @@ const std::string Language::XKB_ACTIVE_LAYOUT_NAME_KEY = "xkb_active_layout_name
 Language::Language(const std::string& id, const Json::Value& config)
     : ALabel(config, "language", id, "{}", 0, true) {
   hide_single_ = config["hide-single-layout"].isBool() && config["hide-single-layout"].asBool();
-  is_variant_displayed = format_.find("{variant}") != std::string::npos;
+  is_variant_displayed =
+      format_.find("{}") != std::string::npos || format_.find("{variant}") != std::string::npos;
   if (format_.find("{}") != std::string::npos || format_.find("{short}") != std::string::npos) {
     displayed_short_flag |= static_cast<std::byte>(DisplayedShortFlag::ShortName);
   }
@@ -130,10 +131,36 @@ auto Language::update() -> void {
     event_box_.hide();
     return;
   }
-  auto display_layout = trim(fmt::format(
-      fmt::runtime(format_), fmt::arg("short", layout_.short_name),
-      fmt::arg("shortDescription", layout_.short_description), fmt::arg("long", layout_.full_name),
-      fmt::arg("variant", layout_.variant), fmt::arg("flag", layout_.country_flag())));
+
+  spdlog::debug("sway language update with full name {}", layout_.full_name);
+  spdlog::debug("sway language update with short name {}", layout_.short_name);
+  spdlog::debug("sway language update with short description {}", layout_.short_description);
+  spdlog::debug("sway language update with variant {}", layout_.variant);
+
+  std::string display_layout = std::string{};
+  if (const auto prop_name = "format-" + layout_.short_description + "-" + layout_.variant;
+      config_.isMember(prop_name)) {
+    display_layout =
+        trim(fmt::format(fmt::runtime(format_), config_[prop_name].asString(),
+                         fmt::arg("long", layout_.full_name), fmt::arg("short", layout_.short_name),
+                         fmt::arg("shortDescription", layout_.short_description),
+                         fmt::arg("variant", layout_.variant)));
+  } else if (const auto prop_name = "format-" + layout_.short_description;
+             config_.isMember(prop_name)) {
+    display_layout =
+        trim(fmt::format(fmt::runtime(format_), config_[prop_name].asString(),
+                         fmt::arg("long", layout_.full_name), fmt::arg("short", layout_.short_name),
+                         fmt::arg("shortDescription", layout_.short_description),
+                         fmt::arg("variant", layout_.variant)));
+  } else {
+    display_layout = trim(fmt::format(fmt::runtime(format_), fmt::arg("long", layout_.full_name),
+                                      fmt::arg("short", layout_.short_name),
+                                      fmt::arg("shortDescription", layout_.short_description),
+                                      fmt::arg("variant", layout_.variant)));
+  }
+
+  spdlog::debug("sway language formatted layout name {}", display_layout);
+
   setLabelMarkup(display_layout);
   if (tooltipEnabled()) {
     if (tooltip_format_ != "") {


### PR DESCRIPTION
**What does this PR do?**
Like for [hyprland/languages](https://github.com/Alexays/Waybar/wiki/Module:-Language#configuration-1) and [niri/languages](https://github.com/Alexays/Waybar/wiki/Module:-Language#nirilanguage) sway/languages can be configured for alternative languages and variant names:

Example:
```
"sway/language": {
	"format": "Lang: {}",
	"format-en": "AMERICA, HELL YEAH!",
	"format-tr": "As bayrakları"
}
```

This only works if `format` uses `{}`. I guess more work is required here, since all */languages plugins have different behavior. For the first approach I decided for the easiest solution. Maybe we should clarification the expected behavior and update the PR.

I also think that the code of all */languages modules can be merged to a common code base and only the glue code for each desktop environment can be separate. 

**Related issues**
*unknown*

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
