### PR TITLE
fix(tray): fall back when dbus menu is unavailable

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -94,6 +94,8 @@ class Item : public sigc::trackable {
   Glib::RefPtr<Gdk::Pixbuf> getIconByName(const std::string& name, int size);
   double getScaledIconSize();
   static void onMenuDestroyed(Item* self, GObject* old_menu_pointer);
+  void validateMenu();
+  void menuProbeReady(Glib::RefPtr<Gio::AsyncResult>& result, const std::string& menu_path);
   void makeMenu();
   bool handleClick(GdkEventButton* const& /*ev*/);
   bool handleScroll(GdkEventScroll* const&);
@@ -118,6 +120,7 @@ class Item : public sigc::trackable {
 
   Glib::RefPtr<Gio::DBus::Proxy> proxy_;
   Glib::RefPtr<Gio::Cancellable> cancellable_;
+  bool has_dbus_menu_ = false;
   std::set<std::string_view> update_pending_;
 
   Host& host_;

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -40,6 +40,7 @@ namespace waybar::modules::SNI {
 
 static const Glib::ustring SNI_INTERFACE_NAME = sn_item_interface_info()->name;
 static const unsigned UPDATE_DEBOUNCE_TIME = 10;
+static const char DBUSMENU_INTERFACE[] = "com.canonical.dbusmenu";
 
 Item::Item(const std::string& bn, const std::string& op, const Json::Value& config, const Bar& bar,
            const std::function<void(Item&)>& on_ready,
@@ -237,7 +238,7 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
       }
     } else if (name == "Menu") {
       menu = get_variant<std::string>(value);
-      makeMenu();
+      validateMenu();
     } else if (name == "ItemIsMenu") {
       item_is_menu = get_variant<bool>(value);
     }
@@ -571,8 +572,33 @@ void Item::onMenuDestroyed(Item* self, GObject* old_menu_pointer) {
   }
 }
 
+void Item::validateMenu() {
+  has_dbus_menu_ = false;
+  if (menu.empty() || !proxy_) {
+    return;
+  }
+
+  auto parameters =
+      Glib::VariantContainerBase(g_variant_new("(ss)", DBUSMENU_INTERFACE, "Version"));
+  proxy_->get_connection()->call(menu, "org.freedesktop.DBus.Properties", "Get", parameters,
+                                 sigc::bind(sigc::mem_fun(*this, &Item::menuProbeReady), menu),
+                                 cancellable_, bus_name);
+}
+
+void Item::menuProbeReady(Glib::RefPtr<Gio::AsyncResult>& result, const std::string& menu_path) {
+  if (menu != menu_path) {
+    return;
+  }
+
+  try {
+    proxy_->get_connection()->call_finish(result);
+    has_dbus_menu_ = true;
+  } catch (const Glib::Error&) {
+  }
+}
+
 void Item::makeMenu() {
-  if (gtk_menu == nullptr && !menu.empty()) {
+  if (gtk_menu == nullptr && has_dbus_menu_) {
     dbus_menu = dbusmenu_gtkmenu_new(bus_name.data(), menu.data());
     if (dbus_menu != nullptr) {
       g_object_ref_sink(G_OBJECT(dbus_menu));


### PR DESCRIPTION
**What does this PR do?**
Some SNI items advertise a menu object path without exporting the com.canonical.dbusmenu interface. Creating a GTK dbus menu for those items prevents their native context menu from being used.

Probe the mandatory dbusmenu "Version" property and only create the GTK menu after the probe succeeds. Until then, keep the existing ContextMenu fallback so startup remains non-blocking and ordinary tray actions are unchanged.

This example below is when running Windows native Steam which renders its own menu.

<img width="708" height="545" alt="image" src="https://github.com/user-attachments/assets/f0b361d8-7f4b-4a54-b69d-82d6ce5af5f1" />

**Related issues**

**Checklist**
- [X] Code is formatted with `clang-format`
- [X] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [X] Tested against the affected module(s)
