### PR TITLE
feat: active-by option added on hyprland config - allows the choice b…

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -170,18 +170,17 @@ class Workspaces : public AModule, public EventHandler {
 
   enum class SortMethod { ID, NAME, NUMBER, SPECIAL_CENTERED, DEFAULT };
   SortMethod m_sortBy = SortMethod::DEFAULT;
-  static inline const std::map<std::string, SortMethod> m_sortMap = {{"ID", SortMethod::ID},
-                                                 {"NAME", SortMethod::NAME},
-                                                 {"NUMBER", SortMethod::NUMBER},
-                                                 {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
-                                                 {"DEFAULT", SortMethod::DEFAULT}};
-  
+  static inline const std::map<std::string, SortMethod> m_sortMap = {
+      {"ID", SortMethod::ID},
+      {"NAME", SortMethod::NAME},
+      {"NUMBER", SortMethod::NUMBER},
+      {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
+      {"DEFAULT", SortMethod::DEFAULT}};
+
   enum class ActiveMethod { ID, NAME, DEFAULT };
   ActiveMethod m_activeBy = ActiveMethod::DEFAULT;
-  static inline const std::map<std::string, ActiveMethod> m_activeMap = {{"ID", ActiveMethod::ID},
-                                                 {"NAME", ActiveMethod::NAME},
-                                                 {"DEFAULT", ActiveMethod::DEFAULT}
-                                                };
+  static inline const std::map<std::string, ActiveMethod> m_activeMap = {
+      {"ID", ActiveMethod::ID}, {"NAME", ActiveMethod::NAME}, {"DEFAULT", ActiveMethod::DEFAULT}};
 
   std::string m_formatBefore;
   std::string m_formatAfter;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -92,6 +92,7 @@ class Workspaces : public AModule, public EventHandler {
   static auto populateBoolConfig(const Json::Value& config, const std::string& key, bool& member)
       -> void;
   auto populateSortByConfig(const Json::Value& config) -> void;
+  auto populateActiveByConfig(const Json::Value& config) -> void;
   auto populateIgnoreWorkspacesConfig(const Json::Value& config) -> void;
   auto populateFormatWindowSeparatorConfig(const Json::Value& config) -> void;
   auto populateWindowRewriteConfig(const Json::Value& config) -> void;
@@ -173,6 +174,13 @@ class Workspaces : public AModule, public EventHandler {
                                                  {"NUMBER", SortMethod::NUMBER},
                                                  {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
                                                  {"DEFAULT", SortMethod::DEFAULT}};
+  
+  enum class ActiveMethod { ID, NAME, DEFAULT };
+  ActiveMethod m_activeBy = ActiveMethod::DEFAULT;
+  static inline const std::map<std::string, ActiveMethod> m_activeMap = {{"ID", ActiveMethod::ID},
+                                                 {"NAME", ActiveMethod::NAME},
+                                                 {"DEFAULT", ActiveMethod::DEFAULT}
+                                                };
 
   std::string m_formatBefore;
   std::string m_formatAfter;

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -147,6 +147,13 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	default: false ++
 	If set to false workspaces group will be shown only in assigned output. Otherwise, all workspace groups are shown.
 
+*active-by*: ++
+	typeof: string ++
+	default: "default" ++
+	If set to id, workspaces will be set as active by id.
+	If set to name, workspaces will set as active by name.
+	If none of those, workspaces will set as active by default behavior.
+
 *active-only*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -637,6 +637,7 @@ auto Workspaces::parseConfig(const Json::Value& config) -> void {
 
   m_persistentWorkspaceConfig = config.get("persistent-workspaces", Json::Value());
   populateSortByConfig(config);
+  populateActiveByConfig(config);
   populateIgnoreWorkspacesConfig(config);
   populateFormatWindowSeparatorConfig(config);
 
@@ -687,6 +688,20 @@ auto Workspaces::populateSortByConfig(const Json::Value& config) -> void {
       m_sortBy = SortMethod::DEFAULT;
       spdlog::warn(
           "Invalid string representation for sort-by. Falling back to default sort method.");
+    }
+  }
+}
+
+auto Workspaces::populateActiveByConfig(const Json::Value& config) -> void {
+  const auto& configActiveBy = config["active-by"];
+  if (configActiveBy.isString()) {
+    auto activeByStr = configActiveBy.asString();
+    try {
+      m_activeBy = waybar::util::parseStringToEnum<ActiveMethod>(activeByStr, m_activeMap);
+    } catch (const std::invalid_argument& e) {
+      m_activeBy = ActiveMethod::DEFAULT;
+      spdlog::warn(
+          "Invalid string representation for active-by. Falling back to default active method.");
     }
   }
 }
@@ -1103,10 +1118,13 @@ void Workspaces::updateWorkspaceStates() {
 
   for (auto& workspace : m_workspaces) {
     bool isActiveByName =
-        !currentWorkspaceName.empty() && workspace->name() == currentWorkspaceName;
+        !currentWorkspaceName.empty() && 
+        workspace->name() == currentWorkspaceName;
 
     workspace->setActive(
-        workspace->id() == m_activeWorkspaceId || isActiveByName ||
+        ((m_activeBy == ActiveMethod::ID || m_activeBy == ActiveMethod::DEFAULT) &&
+          workspace->id() == m_activeWorkspaceId ) || 
+        (m_activeBy == ActiveMethod::NAME && isActiveByName) ||
         (workspace->isSpecial() && workspace->name() == m_activeSpecialWorkspaceName));
     if (workspace->isActive() && workspace->isUrgent()) {
       workspace->setUrgent(false);


### PR DESCRIPTION
…etween show as active by id or name

<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
active-by option added on Hyprland module - allows to set which prop will be used to mark a workspace as active

**Related issues**
Closes #4680

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
