### PR TITLE
fix(tooltips): only update the tooltip of the hovered module

### DIFF
--- a/include/ALabel.hpp
+++ b/include/ALabel.hpp
@@ -88,6 +88,8 @@ class ALabel : public AModule {
   static void handleGtkMenuEvent(GtkMenuItem* menuitem, gpointer data);
 
  private:
+  bool pointerOverModule() const;
+
   // Raw UTF-8 bytes, not Glib::ustring: ustring::operator== collates with
   // g_utf8_collate(), which gives private-use codepoints (nerd-font icons)
   // no collation weight, so two different icons compare equal.

--- a/src/ALabel.cpp
+++ b/src/ALabel.cpp
@@ -177,6 +177,19 @@ bool ALabel::setLabelMarkup(const Glib::ustring& markup) {
   return true;
 }
 
+bool ALabel::pointerOverModule() const {
+  auto gdk_window = event_box_.get_window();
+  if (!gdk_window || !event_box_.get_mapped()) {
+    return false;
+  }
+  int x = 0;
+  int y = 0;
+  Gdk::ModifierType mask;
+  gdk_window->get_device_position(gdk_window->get_display()->get_default_seat()->get_pointer(), x,
+                                  y, mask);
+  return x >= 0 && y >= 0 && x < gdk_window->get_width() && y < gdk_window->get_height();
+}
+
 bool ALabel::setTooltipMarkup(const Glib::ustring& markup) {
   if (last_tooltip_markup_ == markup.raw()) {
     return false;
@@ -184,7 +197,13 @@ bool ALabel::setTooltipMarkup(const Glib::ustring& markup) {
 
   last_tooltip_markup_ = markup.raw();
   if (active_tooltip_) {
-    active_tooltip_->set_markup(markup);
+    // leave-notify is not always delivered when the pointer moves between
+    // adjacent modules, so active_tooltip_ may belong to another module.
+    if (pointerOverModule()) {
+      active_tooltip_->set_markup(markup);
+    } else {
+      active_tooltip_.reset();
+    }
   }
   return true;
 }


### PR DESCRIPTION
Since #5212 every module pokes `active_tooltip_->set_markup()` on update. That reference is cleared on leave-notify, which is not always delivered when the pointer moves between adjacent modules, so a fast-updating module overwrites the tooltip of whichever module is actually hovered.

Check the pointer position instead of trusting leave-notify.

<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**

Hovering one module sometimes flashes a neighbor's tooltip contents. With a lot of custom modules with `interval: 1` this creates a significant problem. `active_tooltip_` is only cleared on `leave-notify`, which is not always delivered when the pointer moves between adjacent modules, so a fast-updating module overwrites the tooltip of whichever module is actually hovered.

This gates the update on the live pointer position instead of trusting `leave-notify`, and drops the stale reference when the pointer is elsewhere.

Tested for several days on NixOS 26.05 and Fedora 43 (both on sway 1.12) with a several custom modules with `interval: 1`.

**Related issues**

No issue filed. The behavior was introduced by #5212.

**Checklist**

- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`) - n/a. No new options
- [x] Tested against the affected module(s)
