### PR TITLE
fix(hyprland/workspaces): handle workspace ID changes

### DIFF
--- a/include/modules/hyprland/workspace.hpp
+++ b/include/modules/hyprland/workspace.hpp
@@ -61,6 +61,7 @@ class Workspace {
   void setUrgent(bool value = true) { m_isUrgent = value; };
   void setVisible(bool value = true) { m_isVisible = value; };
   void setWindows(uint value) { m_windows = value; };
+  void setId(int value) { m_id = value; };
   void setName(std::string const& value) { m_name = value; };
   void setOutput(std::string const& value) { m_output = value; };
   bool containsWindow(WindowAddress const& addr) const {

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -169,11 +169,12 @@ class Workspaces : public AModule, public EventHandler {
 
   enum class SortMethod { ID, NAME, NUMBER, SPECIAL_CENTERED, DEFAULT };
   SortMethod m_sortBy = SortMethod::DEFAULT;
-  static inline const std::map<std::string, SortMethod> m_sortMap = {{"ID", SortMethod::ID},
-                                                 {"NAME", SortMethod::NAME},
-                                                 {"NUMBER", SortMethod::NUMBER},
-                                                 {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
-                                                 {"DEFAULT", SortMethod::DEFAULT}};
+  static inline const std::map<std::string, SortMethod> m_sortMap = {
+      {"ID", SortMethod::ID},
+      {"NAME", SortMethod::NAME},
+      {"NUMBER", SortMethod::NUMBER},
+      {"SPECIAL-CENTERED", SortMethod::SPECIAL_CENTERED},
+      {"DEFAULT", SortMethod::DEFAULT}};
 
   std::string m_formatBefore;
   std::string m_formatAfter;

--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -108,6 +108,7 @@ class Workspaces : public AModule, public EventHandler {
                           Json::Value const& clientsData = Json::Value::nullRef);
   void onWorkspaceMoved(std::string const& payload);
   void onWorkspaceRenamed(std::string const& payload);
+  void onWorkspaceIdChanged(std::string const& payload);
   static std::optional<int> parseWorkspaceId(std::string const& workspaceIdStr);
 
   // monitor events

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -312,6 +312,8 @@ void Workspaces::onEvent(const std::string& ev) {
       onSpecialWorkspaceActivated(payload);
     } else if (eventName == "destroyworkspacev2") {
       onWorkspaceDestroyed(payload);
+    } else if (eventName == "changeworkspaceid") {
+      onWorkspaceIdChanged(payload);
     } else if (eventName == "createworkspacev2") {
       onWorkspaceCreated(payload);
     } else if (eventName == "focusedmonv2") {
@@ -447,6 +449,35 @@ void Workspaces::onWorkspaceRenamed(std::string const& payload) {
     }
   }
   sortWorkspaces();
+}
+
+void Workspaces::onWorkspaceIdChanged(std::string const& payload) {
+  spdlog::debug("Workspace ID changed: {}", payload);
+
+  const auto [oldIdStr, newIdStr] = splitDoublePayload(payload);
+
+  const auto oldId = parseWorkspaceId(oldIdStr);
+  const auto newId = parseWorkspaceId(newIdStr);
+
+  if (!oldId.has_value() || !newId.has_value()) {
+    spdlog::warn("Invalid workspace ID change payload: {}", payload);
+    return;
+  }
+
+  for (auto& workspace : m_workspaces) {
+    if (workspace->id() == *oldId) {
+      spdlog::debug("Changing workspace ID from {} to {}", *oldId, *newId);
+      workspace->setId(*newId);
+      break;
+    }
+  }
+
+  if (m_activeWorkspaceId == *oldId) {
+    m_activeWorkspaceId = *newId;
+  }
+
+  sortWorkspaces();
+  updateWindowCount();
 }
 
 void Workspaces::onMonitorFocused(std::string const& payload) {
@@ -827,6 +858,7 @@ auto Workspaces::registerIpc() -> void {
   m_ipc.registerForIPC("createworkspacev2", this);
   m_ipc.registerForIPC("destroyworkspacev2", this);
   m_ipc.registerForIPC("focusedmonv2", this);
+  m_ipc.registerForIPC("changeworkspaceid", this);
   m_ipc.registerForIPC("moveworkspacev2", this);
   m_ipc.registerForIPC("renameworkspace", this);
   m_ipc.registerForIPC("openwindow", this);


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Refresh the bar when Hyprland workspace ID changes

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
