### PR TITLE
privacy: disconnect pending timeouts on destruction

### DIFF
--- a/include/modules/privacy/privacy.hpp
+++ b/include/modules/privacy/privacy.hpp
@@ -17,6 +17,7 @@ namespace waybar::modules::privacy {
 class Privacy : public AModule {
  public:
   Privacy(const std::string&, const Json::Value&, Gtk::Orientation, const std::string& pos);
+  ~Privacy() override;
   auto update() -> void override;
 
  private:

--- a/src/modules/privacy/privacy.cpp
+++ b/src/modules/privacy/privacy.cpp
@@ -119,6 +119,15 @@ Privacy::Privacy(const std::string& id, const Json::Value& config, Gtk::Orientat
       sigc::mem_fun(*this, &Privacy::onGeoCluePrivacyNodesChanged));
 }
 
+Privacy::~Privacy() {
+  // Both timeouts are attached to the global main context, which outlives this
+  // module when the bar is reloaded. sigc::connection's destructor does not
+  // disconnect, and the members are torn down after the backends they use, so a
+  // pending timeout would dispatch onto freed memory.
+  geoclue_timeout_conn.disconnect();
+  visibility_conn.disconnect();
+}
+
 void Privacy::onPWPrivacyNodesChanged() {
   mutex_.lock();
   nodes_audio_out.clear();


### PR DESCRIPTION
**What does this PR do?**

Disconnect the privacy module's pending GeoClue and visibility timeout
connections when the module is destroyed.

The timeout callbacks are attached to GLib's main context. During a
`SIGUSR2` reload, the `Privacy` object can be destroyed while the GeoClue
timeout remains pending. If it runs afterwards, it dereferences freed
memory and Waybar crashes in `Privacy::locationTimeout()`.

Add a destructor that disconnects both timeout connections before the
object is torn down.

The unpatched binary crashed after four reloads spaced 1.5 seconds apart.
The patched binary survived ten reloads without a new coredump.

**Related issues**

None.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`) — N/A, no user-facing change
- [x] Tested against the affected module(s)