### PR TITLE
fix: fix module backlight format using clang

### DIFF
--- a/src/modules/backlight.cpp
+++ b/src/modules/backlight.cpp
@@ -124,7 +124,8 @@ bool waybar::modules::Backlight::handleScroll(GdkEventScroll* e) {
       return true;
     }
     if (current - step < min_brightness) {
-      backend.set_scaled_brightness(preferred_device_, static_cast<int>(std::round(min_brightness)));
+      backend.set_scaled_brightness(preferred_device_,
+                                    static_cast<int>(std::round(min_brightness)));
       return true;
     }
   }


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Just run the formatter on backlight module

**Related issues**
This was interfering on lint step 
<img width="614" height="769" alt="image" src="https://github.com/user-attachments/assets/eb8c0450-c0a0-4bb5-b6fd-35cc1bcf4202" />

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
