### PR TITLE
feat: clang format options added on makefile and docker image for arc…

### DIFF
--- a/Dockerfiles/archlinux
+++ b/Dockerfiles/archlinux
@@ -3,5 +3,5 @@
 FROM archlinux:base-devel
 
 RUN pacman -Syu --noconfirm && \
-    pacman -S --noconfirm git meson base-devel libinput wayland wayland-protocols glib2-devel pixman libxkbcommon mesa gtkmm3 jsoncpp pugixml scdoc libpulse libdbusmenu-gtk3 libmpdclient gobject-introspection libxkbcommon playerctl iniparser fftw && \
+    pacman -S --noconfirm git meson base-devel libinput wayland wayland-protocols glib2-devel pixman libxkbcommon mesa gtkmm3 jsoncpp pugixml scdoc libpulse libdbusmenu-gtk3 libmpdclient gobject-introspection libxkbcommon playerctl iniparser fftw clang && \
     sed -Ei 's/#(en_(US|GB)\.UTF)/\1/' /etc/locale.gen && locale-gen

--- a/Makefile
+++ b/Makefile
@@ -27,5 +27,10 @@ test-detailed:
 	meson test -C build --verbose --print-errorlogs --test-args='--reporter console -s'
 .PHONY: test-detailed
 
+format:
+	git diff --name-only --diff-filter=ACMR | \
+		grep -E '\.(c|h|cpp|hpp)$$' | \
+		xargs -r clang-format -i
+
 clean:
 	rm -rf build


### PR DESCRIPTION
…hlinux

<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
clang package added on Arch Linux Dockerfile
format option added on Makefile

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
