### PR TITLE
docs(states): wireplumber uses >=, not <=

### DIFF
--- a/man/waybar-states.5.scd
+++ b/man/waybar-states.5.scd
@@ -14,7 +14,7 @@ apply a class when the value matches the declared state value.
 Every entry (*state*) consists of a *<name>* (typeof: *string*) and a *<value>* (typeof: *integer*).
 
 - The state can be addressed as a CSS class in the *style.css*. The name of the CSS class is the *<name>* of the state.
-  Each class gets activated when the current value is equal to or less than the configured *<value>* for the *battery*, *pulseaudio* and *wireplumber* modules, or equal to or greater than the configured *<value>* for all other modules.
+  Each class gets activated when the current value is equal to or less than the configured *<value>* for the *battery* and *pulseaudio* modules, or equal to or greater than the configured *<value>* for all other modules (including *wireplumber*).
 
 - Also, each state can have its own *format*.
   Those can be configured via *format-<name>*, or if you want to differentiate a bit more, as *format-<status>-<state>*.


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Fixes an actual bug in `waybar-states(5)`. The documentation states that the `<=` threshold applies to `battery`, `pulseaudio` *and* `wireplumber`, while all other modules use `>=`. This is incorrect for `wireplumber`.

`ALabel::getState()` defaults to `lesser=false` (`>=`).

Tested `<=` behavior of `pulseaudio` in real time for 9 threshold values ​​(0/1/25/26/50/51/76/77/100) using `states` + `format-<name>` overrides - exactly matches. `wireplumber` was tested by reading `wireplumber.cpp` and `wireplumber.hpp` directly (no override).

**Related issues**
There is no related issue - this was discovered while configuring icons for each volume level on `pulseaudio` and checking the same doc statement with other modules it calls.

**Checklist**
- [ ] Code is formatted with `clang-format`
- [ ] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
