### PR TITLE
feat: add num-tags for mango/workspaces

### DIFF
--- a/man/waybar-mango-workspaces.5.scd
+++ b/man/waybar-mango-workspaces.5.scd
@@ -53,6 +53,10 @@ Addressed by *mango/workspaces*
 	default: "OVERVIEW" ++
 	Label shown on the overview button when the overview is active.
 
+*num-tags*: ++
+	typeof: uint ++
+	The number of tags that should be displayed.
+
 *expand*: ++
 	typeof: bool ++
 	default: false ++

--- a/src/modules/mango/workspaces.cpp
+++ b/src/modules/mango/workspaces.cpp
@@ -103,17 +103,27 @@ void Workspaces::doUpdate() {
       }
     }
 
-    uint64_t num_tags =
-        config_["num-tags"].isUInt64() ? config_["num-tags"].asUInt64() : tags.size();
+    const auto num_tags = std::min<uint64_t>(
+        config_["num-tags"].isUInt64() ? config_["num-tags"].asUInt64() : tags.size(), tags.size());
 
-    for (const auto& tag : tags) {
-      uint64_t idx = tag["index"].asUInt64();
+    std::vector<const Json::Value*> ordered_tags;
+    ordered_tags.reserve(num_tags);
 
-      if (idx > num_tags) break;
+    for (Json::ArrayIndex i = 0; i < num_tags; ++i) {
+      const auto& tag = tags[i];
+      ordered_tags.push_back(&tag);
+    }
+
+    std::ranges::sort(ordered_tags, [](const Json::Value* a, const Json::Value* b) {
+      return (*a)["index"].asUInt64() < (*b)["index"].asUInt64();
+    });
+
+    for (const auto* tag : ordered_tags) {
+      uint64_t idx = (*tag)["index"].asUInt64();
 
       auto btn_it = buttons_.find(idx);
       Gtk::Button& button = (btn_it == buttons_.end()) ? addButton(idx) : btn_it->second;
-      updateButtonState(button, tag, monitor);
+      updateButtonState(button, *tag, monitor);
     }
   }
 }

--- a/src/modules/mango/workspaces.cpp
+++ b/src/modules/mango/workspaces.cpp
@@ -55,6 +55,7 @@ void Workspaces::doUpdate() {
   const auto& tags = monitor["tags"];
 
   bool overview_mode = false;
+
   if (monitor.isMember("active_tags") && monitor["active_tags"].isArray()) {
     const auto& active_tags = monitor["active_tags"];
     if (active_tags.size() == 1 && active_tags[0].asInt() == 0) {
@@ -90,9 +91,9 @@ void Workspaces::doUpdate() {
 
     for (auto btn_it = buttons_.begin(); btn_it != buttons_.end();) {
       uint64_t id = btn_it->first;
-      bool found = std::any_of(tags.begin(), tags.end(), [id](const Json::Value& tag) {
-        return tag["index"].asUInt64() == id;
-      });
+
+      bool found = std::ranges::any_of(
+          tags, [id](const Json::Value& tag) { return tag["index"].asUInt64() == id; });
 
       if (!found) {
         box_.remove(btn_it->second);
@@ -102,20 +103,17 @@ void Workspaces::doUpdate() {
       }
     }
 
+    uint64_t num_tags =
+        config_["num-tags"].isUInt64() ? config_["num-tags"].asUInt64() : tags.size();
+
     for (const auto& tag : tags) {
       uint64_t idx = tag["index"].asUInt64();
+
+      if (idx > num_tags) break;
+
       auto btn_it = buttons_.find(idx);
       Gtk::Button& button = (btn_it == buttons_.end()) ? addButton(idx) : btn_it->second;
       updateButtonState(button, tag, monitor);
-    }
-
-    std::vector<uint64_t> indices;
-    for (const auto& tag : tags) indices.push_back(tag["index"].asUInt64());
-    std::sort(indices.begin(), indices.end());
-    int pos = 0;
-    for (uint64_t idx : indices) {
-      box_.reorder_child(buttons_[idx], pos + 1);
-      pos++;
     }
   }
 }


### PR DESCRIPTION
**What does this PR do?**
Adds num-tags option to mango/workspaces similar to dwl/tags 

**Related issues**
None

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)

~~Little note. It also removes previous buttons sorting based on tags because while testing, tags were always pre-sorted.~~