### PR TITLE
wlr/taskbar: reload icon when the widget scale factor changes

### DIFF
--- a/src/modules/wlr/taskbar.cpp
+++ b/src/modules/wlr/taskbar.cpp
@@ -200,6 +200,15 @@ Task::Task(const waybar::Bar& bar, const Json::Value& config, Taskbar* tbar,
   button.signal_drag_data_get().connect(sigc::mem_fun(*this, &Task::handle_drag_data_get), false);
   button.signal_drag_data_received().connect(sigc::mem_fun(*this, &Task::handle_drag_data_received),
                                              false);
+
+  /* Re-rasterize the icon if the bar ends up on an output with a different scale
+   * than the one GTK guessed while the widget was not yet realized. */
+  icon_.property_scale_factor().signal_changed().connect([this] {
+    if (!with_icon_) return;
+    int icon_size = config_["icon-size"].isInt() ? config_["icon-size"].asInt() : 16;
+    spdlog::debug("Task ({}) scale factor changed, reloading icon", id_);
+    if (tbar_->icon_loader().image_load_icon(icon_, app_info_, icon_size)) icon_.show();
+  });
 }
 
 Task::~Task() {


### PR DESCRIPTION
## Problem

`wlr/taskbar` rasterizes each task's icon once, in `Task::handle_app_id()` / `handle_title()`, at `icon-size × icon_.get_scale_factor()` (`IconLoader::image_load_icon`). It is never re-rendered afterwards.

When a bar is created (waybar start, config reload, or an output being hotplugged) every already-existing toplevel gets its `Task` built before the bar's surface has entered its output. At that point `gtk_widget_get_scale_factor()` falls back to the scale of **monitor 0** (GTK 3 `gtkwidget.c`). On a mixed-DPI setup that guess is wrong for any bar that isn't on monitor 0, so the icon is rasterized at the wrong scale and stays blurry until the application is restarted. Windows opened *after* the bar has settled get a correct, crisp icon — which makes the symptom look random.

Repro: laptop panel at scale 2 (or a fractional scale Hyprland rounds up to 2) plus an external monitor at scale 1 that is the first output, open a few windows, then restart waybar or replug the external monitor. Icons of the pre-existing windows are blurry on the HiDPI bar; newly opened windows are sharp.

## Fix

Connect to the image's `scale-factor` property and reload the icon when it changes. GTK emits this once the surface enters its output (and on any later scale change), so tasks created during the window where the scale is still a guess get re-rasterized at the right size. No-op for bars whose guess was already right.

Tested on Hyprland with eDP-1 @1.5 + HDMI-A-1 @1 (waybar 0.15.0 + this patch, and current master builds).