### PR TITLE
fix(hyprland/language): ignore empty/unknown layouts from virtual keyboards

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -155,8 +155,22 @@ void Language::onEvent(const std::string& ev) {
 
   layoutName = waybar::util::sanitize_string(layoutName);
 
+  if (layoutName.empty()) {
+    // Virtual keyboards (e.g. wtype) can emit activelayout events without a layout name;
+    // ignore them instead of blanking the module (#2079).
+    return;
+  }
+
+  auto newLayout = getLayout(layoutName);
+  if (newLayout.full_name.empty()) {
+    // Layout name not found in the xkb registry, e.g. reported by a virtual keyboard that
+    // isn't a real physical layout. Keep showing the last known good layout (#2079).
+    spdlog::debug("hyprland language onevent: unknown layout '{}', ignoring", layoutName);
+    return;
+  }
+
   // CSS class swap happens in update() on the main thread (#4665).
-  layout_ = getLayout(layoutName);
+  layout_ = newLayout;
 
   spdlog::debug("hyprland language onevent with {}", layoutName);
 


### PR DESCRIPTION
## Problem

`hyprland/language` goes blank after any virtual keyboard input (e.g. [wtype](https://github.com/atx/wtype)) is used, and stays blank until the layout is changed manually via a real keyboard shortcut.

Reported in #2079, which is about `sway/language` but has a comment confirming the same symptom on `hyprland/language`:

> Similar issue with the Hyprland language module.
> After using wtype, there is no language listed, until I manually change the layout to some other using my keyboard language change shortcut.

The only workaround mentioned there is setting `keyboard-name` to filter to a specific physical device, which isn't always convenient and isn't available on `sway/language`.

## Root cause

`Language::onEvent` in `src/modules/hyprland/language.cpp` parses the `activelayout>>kbname,layoutname` event and unconditionally overwrites `layout_` with the result of `getLayout(layoutName)`. Virtual keyboards like wtype's send `activelayout` events with an empty or unrecognized layout name. `getLayout()` falls through its search loop for such names and returns an empty `Layout{"", "", "", ""}`, which blanks the module's label/tooltip until a real layout change event comes in.

This is the same root cause already fixed for `sway/language`:
- #1125 — ignore sway IPC events where `xkb_active_layout_name` is empty.
- #5039 — guard `set_current_layout` so an unknown/unmatched layout name doesn't blank `layout_`, preserving the last known good layout.

## Fix

Apply the same two guards to `hyprland/language::onEvent`:
1. Ignore the event outright if the parsed layout name is empty.
2. If `getLayout()` doesn't find a match (unknown layout, e.g. reported by a virtual keyboard), keep the last known good `layout_` instead of overwriting it with an empty one.

Real layout changes are unaffected — `layout_` still updates normally whenever `getLayout()` resolves a real layout.

## Test plan
- [x] `meson setup build && ninja waybar` builds cleanly with the change (no warnings/errors introduced)
- [x] `clang-format --dry-run --Werror` passes on the changed file
- [ ] Manual repro on a Hyprland session: run `wtype` and confirm the module keeps showing the last real layout instead of going blank

🤖 Generated with [Claude Code](https://claude.com/claude-code)