### PR TITLE
ext/worksapces: sort buttons when workspace changes group

### DIFF
--- a/src/modules/ext/workspace_manager.cpp
+++ b/src/modules/ext/workspace_manager.cpp
@@ -301,6 +301,7 @@ void WorkspaceGroup::handle_output_leave(wl_output* output) {
 
 void WorkspaceGroup::handle_workspace_enter(ext_workspace_handle_v1* handle) {
   workspaces_.push_back(handle);
+  workspaces_manager_.set_needs_sorting();
 }
 
 void WorkspaceGroup::handle_workspace_leave(ext_workspace_handle_v1* handle) {
@@ -308,6 +309,7 @@ void WorkspaceGroup::handle_workspace_leave(ext_workspace_handle_v1* handle) {
   if (it != workspaces_.end()) {
     workspaces_.erase(it);
   }
+  workspaces_manager_.set_needs_sorting();
 }
 
 void WorkspaceGroup::handle_removed() {


### PR DESCRIPTION
handle_workspace_enter/leave never called set_needs_sorting. As a result, moving a workspace to a different output's group appended new buttons to the end of the box instead of placing them in sorted order.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
