### PR TITLE
fix(battery): prefer Mains/USB supplies when auto-detecting the adapter

### DIFF
--- a/src/modules/battery.cpp
+++ b/src/modules/battery.cpp
@@ -114,6 +114,12 @@ void waybar::modules::Battery::refreshBatteries() {
     check_map[bat.first] = false;
   }
 
+  fs::path named_adapter;
+  fs::path mains_adapter;
+  fs::path usb_adapter;
+  fs::path online_adapter;
+  fs::path status_adapter;
+
   try {
     for (auto& node : fs::directory_iterator(data_dir_)) {
       if (!fs::is_directory(node)) {
@@ -154,14 +160,41 @@ void waybar::modules::Battery::refreshBatteries() {
           }
         }
       }
-      auto adap_defined = config_["adapter"].isString();
-      if (((adap_defined && dir_name == config_["adapter"].asString()) || !adap_defined) &&
-          (fs::exists(node.path() / "online") || fs::exists(node.path() / "status"))) {
-        adapter_ = node.path();
+      if (config_["adapter"].isString()) {
+        if (dir_name == config_["adapter"].asString() &&
+            (fs::exists(node.path() / "online") || fs::exists(node.path() / "status"))) {
+          named_adapter = node.path();
+        }
+      } else {
+        std::string type;
+        if (fs::exists(node.path() / "online")) {
+          std::ifstream{node.path() / "type"} >> type;
+          if (type == "Mains" && mains_adapter.empty()) {
+            mains_adapter = node.path();
+          } else if (type.starts_with("USB") && usb_adapter.empty()) {
+            usb_adapter = node.path();
+          } else if (online_adapter.empty()) {
+            online_adapter = node.path();
+          }
+        } else if (status_adapter.empty() && fs::exists(node.path() / "status")) {
+          status_adapter = node.path();
+        }
       }
     }
   } catch (fs::filesystem_error& e) {
     spdlog::warn("Battery directory tracking failed: {}", e.what());
+  }
+
+  if (!named_adapter.empty()) {
+    adapter_ = named_adapter;
+  } else if (!mains_adapter.empty()) {
+    adapter_ = mains_adapter;
+  } else if (!usb_adapter.empty()) {
+    adapter_ = usb_adapter;
+  } else if (!online_adapter.empty()) {
+    adapter_ = online_adapter;
+  } else if (!status_adapter.empty()) {
+    adapter_ = status_adapter;
   }
   if (warnFirstTime_ && batteries_.empty()) {
     if (config_["bat"].isString()) {


### PR DESCRIPTION
**What does this PR do?**

Fixes battery adapter auto-detection picking the battery itself as the adapter.

When no `"adapter"` is configured, `refreshBatteries()` assigns `adapter_` to the last node in `/sys/class/power_supply` that has `online` or `status`. Batteries match through `status`, so whether the real adapter or the battery wins depends on readdir order. A battery has no `online`, so when the battery wins, every `adapter_` check reads offline: the `Not charging` -> `Plugged` upgrade and `full-at-plugged` are silently dead.

Observed on a MacBookPro16,1 (kernel 7.2.0-1-cachyos-t2): `ADP1` (`ACPI0003:00`, type `Mains`, has `online`, no `status`) iterates before `BAT0` (`ACPI0002:00`, type `Battery`, has `status`, no `online`), so `BAT0` always won and the bar showed the discharging/not-charging format while plugged in. Pinning `"adapter": "ADP1"` was the only workaround.

The fix classifies candidates by `type` and picks in priority order:

1. node matching a configured `"adapter"` name (unchanged behavior)
2. `Mains`
3. `USB*` (prefix match, so legacy pre-4.19 types like `USB_PD` count)
4. any other online-capable supply (`Wireless`, `UPS`, missing `type` file)
5. status-only nodes, as a last resort

First match wins within each tier. If a pass finds nothing, `adapter_` keeps its previous value, as before.

Tested live on the machine above: before, Waybar picked `BAT0`, patched now picks `ADP1`, and `Plugged` works without a pin. Also compared old and new selection over nine mocked sysfs layouts (battery-only, Mains+battery, Mains+USB-C source nodes, legacy `USB_PD`, wireless charger, UPS-only, typeless online node, empty dir, two batteries): the new logic finds an adapter in every case the old one did, and picks the same node everywhere except the order-dependent broken cases. Battery-only machines still get the battery as `adapter_`, and the configured-name path is identical.

**Related issues**

None found

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`) — N/A, no new option; `adapter` docs already say "instead of auto detect"
- [x] Tested against the affected module(s)
