### PR TITLE
fix: don't block startup on the desktop portal

### DIFF
--- a/include/util/portal.hpp
+++ b/include/util/portal.hpp
@@ -25,6 +25,7 @@ class Portal : private Gio::DBus::Proxy {
   Appearance currentMode;
   void on_signal(const Glib::ustring& sender_name, const Glib::ustring& signal_name,
                  const Glib::VariantContainerBase& parameters);
+  void onAppearanceReceived(Glib::RefPtr<Gio::AsyncResult>& result);
 };
 
 }  // namespace waybar

--- a/src/util/portal.cpp
+++ b/src/util/portal.cpp
@@ -35,17 +35,36 @@ auto fmt::formatter<waybar::Appearance>::format(waybar::Appearance c, format_con
 
 waybar::Portal::Portal()
     : Gio::DBus::Proxy(Gio::DBus::Connection::get_sync(Gio::DBus::BusType::BUS_TYPE_SESSION),
-                       PORTAL_BUS_NAME, PORTAL_OBJ_PATH, PORTAL_INTERFACE),
+                       PORTAL_BUS_NAME, PORTAL_OBJ_PATH, PORTAL_INTERFACE,
+                       Glib::RefPtr<Gio::DBus::InterfaceInfo>(),
+                       Gio::DBus::PROXY_FLAGS_DO_NOT_AUTO_START),
       currentMode(Appearance::UNKNOWN) {
+  // Without DO_NOT_AUTO_START the proxy asks the bus to spawn the portal and
+  // waits for it, so a slow portal delays the whole bar. Watch for the name
+  // instead, which also covers a portal that only shows up later.
+  // (A lambda, not sigc::mem_fun: Gio::DBus::Proxy is a private base here, so
+  // sigc::trackable is not accessible.)
+  connect_property_changed("g-name-owner", [this]() { refreshAppearance(); });
   refreshAppearance();
 };
 
 void waybar::Portal::refreshAppearance() {
+  if (get_name_owner().empty()) {
+    // Nothing is serving the portal yet; the g-name-owner handler will call us
+    // back if something does.
+    return;
+  }
   auto params = Glib::Variant<std::tuple<Glib::ustring, Glib::ustring>>::create(
       {PORTAL_NAMESPACE, PORTAL_KEY});
+  call(
+      std::string(PORTAL_INTERFACE) + ".Read",
+      [this](Glib::RefPtr<Gio::AsyncResult>& result) { onAppearanceReceived(result); }, params);
+}
+
+void waybar::Portal::onAppearanceReceived(Glib::RefPtr<Gio::AsyncResult>& result) {
   Glib::VariantBase response;
   try {
-    response = call_sync(std::string(PORTAL_INTERFACE) + ".Read", params);
+    response = call_finish(result);
   } catch (const Glib::Error& e) {
     spdlog::info("Unable to receive desktop appearance: {}", std::string(e.what()));
     return;


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Waybar reads org.freedesktop.appearance color-scheme through org.freedesktop.portal.Settings to pick a light or dark stylesheet. Both halves of that read are synchronous and sit ahead of setupCss(), so the bar cannot draw until the portal answers:

  - the Gio::DBus::Proxy is constructed with default flags, so it asks the bus to *spawn* the portal and waits for the activation, and
  - the Read itself uses call_sync() with the default 25 s timeout.

A portal that is slow to activate therefore delays the whole bar. This is a long-standing complaint (#1266, #2675, #3140, #3714); every answer in those threads is a workaround such as masking a portal backend or rewriting the activation environment, because Waybar itself has no way to opt out.

Pass DO_NOT_AUTO_START so Waybar stops being the thing that launches the portal, skip the call when the name has no owner, and issue the Read asynchronously. The result is delivered through the existing signal_appearance_changed() path that Client already connects to setupCss(), so a late answer still restyles the bar. Watching g-name-owner covers a portal that only appears after Waybar starts.

Reproduced with a user drop-in that makes activation slow:

  mkdir -p ~/.config/systemd/user/xdg-desktop-portal.service.d
  printf '[Service]\nExecStartPre=/bin/sleep 30\n' > \
    ~/.config/systemd/user/xdg-desktop-portal.service.d/slow.conf
  systemctl --user daemon-reload
  systemctl --user stop xdg-desktop-portal.service
  waybar -c min.jsonc -s min.css

Time between the "Using configuration file" and "Using CSS file" log lines, which is the window where no bar is on screen:

  before   25.001 s
  after     0.001 s

Also verified on the session bus that no Settings.Read is issued while the portal has no owner, that exactly one is issued once it appears, and that Waybar no longer triggers the portal's D-Bus activation.

Trade-off worth naming: getStyle() now runs before the reply arrives, so a user with style-light.css/style-dark.css gets style.css first and the appearance-specific sheet a moment later, through the existing signal_appearance_changed() -> setupCss() path. Measured here that second pass lands 11 ms after the first, i.e. inside one frame. Changing the system appearance while Waybar runs is unaffected and produces the same log sequence as before the patch.

**Related issues**
Closes #1266, #2675, #3140, #3714

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)