### PR TITLE
fix(inhibitor): use a private system bus connection and reconnect when closed

### DIFF
--- a/include/modules/inhibitor.hpp
+++ b/include/modules/inhibitor.hpp
@@ -19,7 +19,7 @@ class Inhibitor : public ALabel {
  private:
   auto handleToggle(::GdkEventButton* const& e) -> bool override;
 
-  const std::unique_ptr<::GDBusConnection, void (*)(::GDBusConnection*)> dbus_;
+  std::unique_ptr<::GDBusConnection, void (*)(::GDBusConnection*)> dbus_;
   const std::string inhibitors_;
   int handle_ = -1;
 };

--- a/src/modules/inhibitor.cpp
+++ b/src/modules/inhibitor.cpp
@@ -8,26 +8,46 @@ namespace {
 
 using DBus = std::unique_ptr<GDBusConnection, void (*)(GDBusConnection*)>;
 
-auto dbus() -> DBus {
-  GError* error = nullptr;
-  GDBusConnection* connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
-
-  if (error) {
-    spdlog::error("g_bus_get_sync() failed: {}", error->message);
-    g_error_free(error);
-    connection = nullptr;
-  }
-
-  auto destructor = [](GDBusConnection* connection) {
+auto destroyDBus(GDBusConnection* connection) -> void {
+  if (!g_dbus_connection_is_closed(connection)) {
     GError* error = nullptr;
     g_dbus_connection_close_sync(connection, nullptr, &error);
     if (error) {
       spdlog::error("g_bus_connection_close_sync failed(): {}", error->message);
       g_error_free(error);
     }
-  };
+  }
+  g_object_unref(connection);
+}
 
-  return DBus{connection, destructor};
+// A connection of our own rather than the shared one from g_bus_get_sync(): the
+// destructor below closes it, and closing the shared connection would close it
+// for the whole process, with g_bus_get_sync() handing the same closed
+// connection back to every later caller.
+auto dbus() -> DBus {
+  GError* error = nullptr;
+  gchar* address = g_dbus_address_get_for_bus_sync(G_BUS_TYPE_SYSTEM, nullptr, &error);
+
+  if (error) {
+    spdlog::error("g_dbus_address_get_for_bus_sync() failed: {}", error->message);
+    g_error_free(error);
+    return DBus{nullptr, destroyDBus};
+  }
+
+  GDBusConnection* connection = g_dbus_connection_new_for_address_sync(
+      address,
+      static_cast<GDBusConnectionFlags>(G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+                                        G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION),
+      nullptr, nullptr, &error);
+  g_free(address);
+
+  if (error) {
+    spdlog::error("g_dbus_connection_new_for_address_sync() failed: {}", error->message);
+    g_error_free(error);
+    connection = nullptr;
+  }
+
+  return DBus{connection, destroyDBus};
 }
 
 auto getLocks(const DBus& bus, const std::string& inhibitors) -> int {
@@ -135,7 +155,10 @@ auto Inhibitor::handleToggle(GdkEventButton* const& e) -> bool {
       ::close(handle_);
       handle_ = -1;
     } else {
-      handle_ = ::getLocks(dbus_, inhibitors_);
+      if (dbus_ == nullptr || g_dbus_connection_is_closed(dbus_.get())) {
+        dbus_ = ::dbus();
+      }
+      handle_ = dbus_ == nullptr ? -1 : ::getLocks(dbus_, inhibitors_);
       if (handle_ == -1) {
         spdlog::error("cannot get inhibitor locks");
       }


### PR DESCRIPTION
**What does this PR do?**

The inhibitor module took its connection from `g_bus_get_sync()`, which returns the process-wide *shared* system bus, and its destructor called `g_dbus_connection_close_sync()` on it. Destroying an Inhibitor therefore closes the shared connection for the whole process, and GLib keeps handing that same closed connection back to every later `g_bus_get_sync()` caller, so the Inhibitor built for the next bar starts life holding a dead connection with no way to get a live one. Every toggle then fails with `The connection is closed` until waybar is restarted.

A bar is destroyed and rebuilt whenever its output goes away and comes back (`Client::handleDeferredMonitorRemoval`), which is what happens across suspend/resume. That is why #5260 shows up after a sleep.

This opens a private system bus connection that the module owns and may legitimately close, and re-establishes it when it is found closed.

**Related issues**

Closes #5260

**How to reproduce and verify**

No suspend needed, cycling the output is enough. Bar with only the inhibitor module, `systemd-inhibit --list` as ground truth for whether the lock was really taken, clicks injected through the compositor rather than by hand:

```
niri msg output eDP-1 off; sleep 3; niri msg output eDP-1 on
```

| step | `master` (d561b9d) | this branch |
|---|---|---|
| click the module | lock held | lock held |
| click again | released | released |
| output off, then on | bar removed, bar reconfigured | bar removed, bar reconfigured |
| click the module | **no lock** | **lock held** |
| log at that click | `g_dbus_connection_call_with_unix_fd_list_sync() failed: The connection is closed` + `cannot get inhibitor locks` | nothing |

**Why the connection can never be re-acquired on master**

A short GIO program on the same machine: take the shared system bus, close it the way the destructor does, iterate the main context, ask for it again. GLib returns the identical pointer with `is_closed = 1`, so "just call `g_bus_get_sync()` again" is not a fix. That is what makes a private connection the right shape here.

**Second case, a genuine peer-side drop**

Running waybar against a pass-through dbus proxy and killing the proxy, again with only the inhibitor module configured:

| | `master` | this branch |
|---|---|---|
| bus connection dropped | waybar **exits** (`g_bus_get_sync()` connections have `exit-on-close`) | waybar stays up |
| click after the bus is back | n/a | lock held |

Worth stating precisely: waybar surviving that drop is a property of this test config. Other modules still take the shared bus through `g_bus_get_sync()`, so a real config with them present will still exit on a bus drop. Nothing here changes that, it only stops the inhibitor from breaking the shared connection for everyone else.

**Checklist**

- [x] Code is formatted with `clang-format` (`--dry-run --Werror` clean on both touched files)
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (not applicable, no config surface changes)
- [x] Tested against the affected module(s) (`meson test -C build`: 3/3 ok, plus the two live A/B runs above)

Tested on NixOS 26.11, GLib 2.88.3, GTK 3, niri 26.04, single output.
