### PR TITLE
sink the GVariant to prevent freeing a floating variant

### DIFF
--- a/src/modules/wireplumber.cpp
+++ b/src/modules/wireplumber.cpp
@@ -824,7 +824,7 @@ bool waybar::modules::Wireplumber::handleScroll(GdkEventScroll* e) {
 
   if (newVol != volume_) {
     if (mixer_api_ == nullptr) return true;
-    GVariant* variant = g_variant_new_double(newVol);
+    GVariant* variant = g_variant_ref_sink(g_variant_new_double(newVol));
     gboolean ret;
     g_signal_emit_by_name(mixer_api_, "set-volume", node_id_, variant, &ret);
     g_variant_unref(variant);


### PR DESCRIPTION
**What does this PR do?**
This fixes the following error:
`(waybar:27880): GLib-CRITICAL **: 10:48:56.748: g_atomic_ref_count_dec: assertion 'old_value > 0' failed`
when changing volume in the wireplumber widget.

**Related issues**
None that I'm aware of.

**Checklist**
- [ N/A ] Code is formatted with `clang-format`
- [ ✅️ ] Builds locally (`ninja -C build`)
- [ N/A ] Man page updated for any new/changed user-facing option (`man/`)
- [ ✅️ ] Tested against the affected module(s)
