### PR TITLE
feat/hyprland set workspace click action

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -48,6 +48,10 @@ class Workspaces : public AModule, public EventHandler {
   auto taskbarWithIcon() const -> bool { return m_taskbarWithIcon; }
   auto barScroll() const -> bool { return m_barScroll; }
 
+  std::string onClick() const { return m_onClick; }
+  std::string onClickMiddle() const { return m_onClickMiddle; }
+  std::string onClickRight() const { return m_onClickRight; }
+
   auto getBarOutput() const -> std::string { return m_bar.output->name; }
   auto formatBefore() const -> std::string { return m_formatBefore; }
   auto formatAfter() const -> std::string { return m_formatAfter; }
@@ -160,6 +164,11 @@ class Workspaces : public AModule, public EventHandler {
   bool m_moveToMonitor = false;
   bool m_uniqueIcons = false;
   bool m_barScroll = false;
+
+  std::string m_onClick = "";
+  std::string m_onClickMiddle = "";
+  std::string m_onClickRight = "";
+
   Json::Value m_persistentWorkspaceConfig;
 
   // Map for windows stored in workspaces not present in the current bar.

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -21,6 +21,24 @@ Addressed by *hyprland/workspaces*
 	typeof: object ++
 	Based on the workspace ID and state, the corresponding icon gets selected. See *icons*.
 
+*on-click*: ++
+	typeof: string ++
+	Command to execute when the module is clicked.
+	Default activates workspace
+	Set to disabled to deactivate click
+
+*on-click-middle*: ++
+	typeof: string ++
+	Command to execute when middle-clicked on the module using mouse scroll wheel.
+	Default activates workspace
+	Set to disabled to deactivate click
+
+*on-click-right*: ++
+	typeof: string ++
+	Command to execute when the module is right-clicked.
+	Default activates workspace
+	Set to disabled to deactivate click
+
 *window-rewrite*: ++
 	typeof: object ++
 	Regex rules to map window class to an icon or preferred method of representation for a workspace's window.

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -204,6 +204,20 @@ bool Workspace::handleLeave(GdkEventCrossing* /*event*/) {
 }
 bool Workspace::handleClicked(GdkEventButton* bt) const {
   if (bt->type == GDK_BUTTON_PRESS) {
+    std::string action;
+
+    if (bt->button == 1) {
+      action = m_workspaceManager.onClick();
+    } else if (bt->button == 2) {
+      action = m_workspaceManager.onClickMiddle();
+    } else if (bt->button == 3) {
+      action = m_workspaceManager.onClickRight();
+    }
+
+    if (action == "disabled") {
+      return true;
+    }
+
     try {
       if (id() > 0) {  // normal
         if (m_workspaceManager.moveToMonitor()) {

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -185,9 +185,23 @@ void Workspace::stopHoverCheck() {
   }
 }
 
-bool Workspace::handleEnter(GdkEventCrossing* /*event*/) {
-  m_button.get_style_context()->add_class("workspace-hover");
-  startHoverCheck();
+bool Workspace::handleEnter(GdkEventCrossing* event) {
+  auto gdk_window = m_button.get_window();
+  
+  if (m_workspaceManager.onClick() == "disabled") {
+    if (gdk_window) {
+      auto cursor = Gdk::Cursor::create(gdk_window->get_display(), "default");
+      gdk_window->set_cursor(cursor);
+    }
+  } else {
+    if (gdk_window) {
+      auto cursor = Gdk::Cursor::create(gdk_window->get_display(), "pointer");
+      gdk_window->set_cursor(cursor);
+    }
+    
+    m_button.get_style_context()->add_class("workspace-hover");
+    startHoverCheck();
+  }
   return false;
 }
 

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -638,6 +638,16 @@ void Workspaces::onConfigReloaded() {
 }
 
 auto Workspaces::parseConfig(const Json::Value& config) -> void {
+  if (config["on-click"].isString()) {
+    m_onClick = config["on-click"].asString();
+  }
+  if (config["on-click-middle"].isString()) {
+    m_onClickMiddle = config["on-click-middle"].asString();
+  }
+  if (config["on-click-right"].isString()) {
+    m_onClickRight = config["on-click-right"].asString();
+  }
+  
   const auto& configFormat = config["format"];
   m_formatBefore = configFormat.isString() ? configFormat.asString() : "{name}";
   m_withIcon = m_formatBefore.find("{icon}") != std::string::npos;
@@ -837,7 +847,7 @@ auto Workspaces::populateWorkspaceTaskbarConfig(const Json::Value& config) -> vo
     auto posStr = workspaceTaskbar["active-window-position"].asString();
     try {
       m_activeWindowPosition =
-        util::parseStringToEnum<ActiveWindowPosition>(posStr, m_activeWindowPositionMap);
+          util::parseStringToEnum<ActiveWindowPosition>(posStr, m_activeWindowPositionMap);
     } catch (const std::invalid_argument& e) {
       spdlog::warn(
           "Invalid string representation for active-window-position. Falling back to 'none'.");


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Add option to set click action on Hyprland workspaces
Just set on hyprland/workspaces:
"on-click": "disabled" to disable the workspaces click action
Default means no action is executed

**Related issues**
Closes #2832

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
