### PR TITLE
fix(hyprland/language): ensuring exact match of the device name

### DIFF
--- a/src/modules/hyprland/language.cpp
+++ b/src/modules/hyprland/language.cpp
@@ -171,7 +171,8 @@ void Language::initLanguage() {
   try {
     auto searcher = kbName.empty()
                         ? inputDevices
-                        : inputDevices.substr(inputDevices.find(kbName) + kbName.length());
+                        : inputDevices.substr(inputDevices.find(std::format("\t{}\n", kbName)) +
+                                              kbName.length() + 2);
     searcher = searcher.substr(searcher.find("keymap:") + 8);
     searcher = searcher.substr(0, searcher.find_first_of("\n\t"));
 


### PR DESCRIPTION
**What does this PR do?**
When `Language::initLanguage()` search for the configured `keyboard-name`, adds a `\t` before and a `\n` after to ensure it does not match other devices that are super-strings.

I created an issue detailing the problem with my configuration as an example.

**Related issues**
Closes #5277

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Tested against the affected module(s)
