### PR TITLE
Fix crash with `keyboard-state` on keyboard removal

### DIFF
--- a/include/modules/keyboard_state.hpp
+++ b/include/modules/keyboard_state.hpp
@@ -41,7 +41,8 @@ class KeyboardState : public AModule {
 
   struct libinput* libinput_;
   std::unordered_map<std::string, struct libinput_device*> libinput_devices_;
-  std::mutex devices_mutex_;  // protects libinput_devices_
+  std::mutex devices_mutex_;  // protects libinput_devices_ and libinput_ context (libinput is not
+                              // thread-safe)
   std::set<int> binding_keys;
 
   util::SleeperThread libinput_thread_, hotplug_thread_;

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -211,61 +211,90 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
     dp.emit();
     while (1) {
       struct pollfd fd = {libinput_get_fd(libinput_), POLLIN, 0};
-      poll(&fd, 1, -1);
-      libinput_dispatch(libinput_);
-      struct libinput_event* event;
-      while ((event = libinput_get_event(libinput_))) {
-        auto type = libinput_event_get_type(event);
-        if (type == LIBINPUT_EVENT_KEYBOARD_KEY) {
-          auto keyboard_event = libinput_event_get_keyboard_event(event);
-          auto state = libinput_event_keyboard_get_key_state(keyboard_event);
-          if (state == LIBINPUT_KEY_STATE_RELEASED) {
-            uint32_t key = libinput_event_keyboard_get_key(keyboard_event);
-            if (binding_keys.contains(key)) {
-              dp.emit();
+      int ret = poll(&fd, 1, -1);
+      if (ret < 0) {
+        if (errno == EINTR) continue;
+        spdlog::error("keyboard-state: poll failed: {}", strerror(errno));
+        continue;
+      }
+      // libinput is not thread-safe: all libinput_* calls must be serialized
+      // with hotplug add/remove via devices_mutex_. Defer pthread_cancel while
+      // holding the mutex to avoid leaking the lock on forced unwind.
+      {
+        waybar::util::CancellationGuard guard;
+        std::lock_guard<std::mutex> lock(devices_mutex_);
+        libinput_dispatch(libinput_);
+        struct libinput_event* event;
+        while ((event = libinput_get_event(libinput_))) {
+          auto type = libinput_event_get_type(event);
+          if (type == LIBINPUT_EVENT_KEYBOARD_KEY) {
+            auto* keyboard_event = libinput_event_get_keyboard_event(event);
+            auto state = libinput_event_keyboard_get_key_state(keyboard_event);
+            if (state == LIBINPUT_KEY_STATE_RELEASED) {
+              uint32_t key = libinput_event_keyboard_get_key(keyboard_event);
+              if (binding_keys.contains(key)) {
+                dp.emit();
+              }
             }
           }
+          libinput_event_destroy(event);
         }
-        libinput_event_destroy(event);
       }
     }
   };
 
   hotplug_thread_ = [this] {
     int fd;
-    fd = inotify_init();
+    fd = inotify_init1(IN_CLOEXEC);
     if (fd < 0) {
-      spdlog::error("Failed to initialize inotify: {}", strerror(errno));
+      fd = inotify_init();
+      if (fd < 0) {
+        spdlog::error("Failed to initialize inotify: {}", strerror(errno));
+        return;
+      }
+    }
+    int wd = inotify_add_watch(fd, devices_path_.c_str(), IN_CREATE | IN_DELETE);
+    if (wd < 0) {
+      spdlog::error("Failed to add inotify watch for {}: {}", devices_path_, strerror(errno));
+      close(fd);
       return;
     }
-    inotify_add_watch(fd, devices_path_.c_str(), IN_CREATE | IN_DELETE);
     while (1) {
       int BUF_LEN = 1024 * (sizeof(struct inotify_event) + 16);
       char buf[BUF_LEN];
-      int length = read(fd, buf, 1024);
+      int length = read(fd, buf, BUF_LEN);
       if (length < 0) {
+        if (errno == EINTR) continue;
         spdlog::error("Failed to read inotify: {}", strerror(errno));
+        close(fd);
         return;
       }
+      if (length == 0) continue;
       for (int i = 0; i < length;) {
         struct inotify_event* event = (struct inotify_event*)&buf[i];
+        // event->name may be empty on some IN_DELETE events; skip those
+        i += sizeof(struct inotify_event) + event->len;
+        if (event->len == 0) continue;
         std::string dev_path = devices_path_ + event->name;
         if (event->mask & IN_CREATE) {
           // Wait for device setup
           int timeout = 10;
           while (timeout--) {
             try {
-              int fd = openFile(dev_path, O_NONBLOCK | O_CLOEXEC | O_RDONLY);
-              closeFile(fd);
+              int dev_fd = openFile(dev_path, O_NONBLOCK | O_CLOEXEC | O_RDONLY);
+              closeFile(dev_fd);
               break;
             } catch (const errno_error& e) {
-              if (e.code == EACCES) {
+              if (e.code == EACCES || e.code == ENOENT) {
                 sleep(1);
+              } else {
+                break;
               }
             }
           }
           tryAddDevice(dev_path);
         } else if (event->mask & IN_DELETE) {
+          waybar::util::CancellationGuard guard;
           std::lock_guard<std::mutex> lock(devices_mutex_);
           auto it = libinput_devices_.find(dev_path);
           if (it != libinput_devices_.end()) {
@@ -281,16 +310,26 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
             libinput_device_unref(device);
           }
         }
-        i += sizeof(struct inotify_event) + event->len;
       }
     }
   };
 }
 
 waybar::modules::KeyboardState::~KeyboardState() {
+  // Stop background threads before touching libinput, which is not thread-safe.
+  // SleeperThread::stop() cancels the blocking poll()/read() and marks do_run false.
+  libinput_thread_.stop();
+  hotplug_thread_.stop();
+  waybar::util::CancellationGuard guard;
   std::lock_guard<std::mutex> lock(devices_mutex_);
   for (const auto& [_, dev_ptr] : libinput_devices_) {
     libinput_path_remove_device(dev_ptr);
+    libinput_device_unref(dev_ptr);
+  }
+  libinput_devices_.clear();
+  if (libinput_) {
+    libinput_unref(libinput_);
+    libinput_ = nullptr;
   }
 }
 
@@ -394,6 +433,7 @@ auto waybar::modules ::KeyboardState::tryAddDevice(const std::string& dev_path) 
     }
     if (supportsLockStates(dev)) {
       spdlog::info("Found device {} at '{}'", libevdev_get_name(dev), dev_path);
+      waybar::util::CancellationGuard guard;
       std::lock_guard<std::mutex> lock(devices_mutex_);
       if (libinput_devices_.find(dev_path) == libinput_devices_.end()) {
         auto device = libinput_path_add_device(libinput_, dev_path.c_str());

--- a/src/modules/keyboard_state.cpp
+++ b/src/modules/keyboard_state.cpp
@@ -201,6 +201,7 @@ waybar::modules::KeyboardState::KeyboardState(const std::string& id, const Bar& 
     std::string dev_path = devices_path_ + ep->d_name;
     tryAddDevice(dev_path);
   }
+  closedir(dev_dir);
 
   if (libinput_devices_.empty()) {
     throw errno_error(errno, "Failed to find keyboard device");


### PR DESCRIPTION
**What does this PR do?**
Fixes crash in `keyboard-state` on keyboard removal (`SIGABRT` `waybar: ../libinput/src/util-list.c:139: list_remove`). `libinput` is not thread-safe but `libinput_thread_` (`poll`/`dispatch`/`get_event`) and `hotplug_thread_` (`path_add_device`/`path_remove_device`) accessed the same context without synchronization, corrupting the internal `wl_list` on unplug (also triggered by duplicate `IN_DELETE`). Follow-up to `d3bfec13` (#5143).

* Serialize all `libinput` calls via `devices_mutex_` (comment now documents it protects both map and context). Hold mutex for `dispatch`/`get_event` and for `add`/`remove`, deferring `pthread_cancel` with `waybar::util::CancellationGuard` while the mutex is held so `SleeperThread::stop()` cannot leak the lock via `__forced_unwind` (`CONTRIBUTING.md: Signals & Threading` / `Thread Safety`).
* Stop both `SleeperThread`s in destructor before touching `libinput`, then `path_remove_device` + `device_unref` per entry and `libinput_unref`; use `SafeSignal`/`dp.emit()` for GTK thread marshalling.
* Fix `inotify` handling: `read` was truncated (`BUF_LEN ~32KB` but `read(...,1024)`), now `read(...,BUF_LEN)`, check `inotify_add_watch`, handle `EINTR`/empty `len`, retry `ENOENT` as well as `EACCES` in `IN_CREATE` wait loop and fail fast otherwise, fix `len==0` infinite loop by advancing `i` before `continue` and `close(fd)` on error.
* Fix `DIR*` leak: `closedir(dev_dir)` after initial scan.

No user-facing option changed, so no `man/` update.

**Related issues**
Closes #5276
Follow-up to #5143

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`meson setup --wipe build` / `ninja -C build` / `meson test` 3/3, `makepkg --noextract` via `yay` path → `waybar-git-0.15.0.r974.gfdf0c0f-1`)
- [x] Man page updated for any new/changed user-facing option (`man/`) — N/A (no new option)
- [x] Tested against the affected module(s) — `keyboard-state` with `{"modules-right":["keyboard-state"]}` on Hyprland 0.56.2, USB unplug no longer aborts (`[info] Keyboard /dev/input/event4 has been removed.`), `./build/waybar --version` `0.15.0-974-gfdf0c0f1` and AUR package `r974` verified

---

**Note to maintainers**

The proposed solution is a compromise between keeping a similar approach to what was previously there and addressing the issue at hand. I don't think it's the ideal solution, though. I'd say my opinion carries low weight because this is not really an area I've much experience. I used an LLM to identify and fix the issue and here go a few points that seem to me like the best path moving forward, to be eventually (if ever) implemented:

* **1 libinput owner thread, no mutex**: don't share `libinput*` – either `libinput_udev_create_context`+`libinput_udev_assign_seat("seat0")` with its internal `udev_monitor` (no `inotify` on `/dev/input`, no `opendir` scan) *or* single `poll()` on both `libinput_get_fd()` and `inotify_fd` in one thread. Removes need for `devices_mutex_`/`CancellationGuard`.
* **Integrate with GLib main loop**: `Glib::signal_io().connect(libinput_get_fd)` / `GSource` instead of raw `poll` thread; marshal to GTK via `waybar::SafeSignal`/`Glib::Dispatcher` only.
* **Cooperative shutdown**: `std::jthread`+`stop_token` / `eventfd`/`pipe` to wake `poll`, `join()` in `~KeyboardState` before `libinput_unref`; no `pthread_cancel`, no `CancellationGuard`.
* **RAII**: `unique_ptr<libinput, libinput_unref>`, `unique_ptr<libinput_device,...>`, `ScopedFd` for `inotify`/`dev_fd`, `std::vector<char>` not VLA, `closedir` already done now but scope-guarded.
* **Optional**: drop `libinput_path_*` entirely and use `wl_seat` keyboard state from compositor (no `/dev/input` access, no `LIBINPUT_DEVICE_CAP_KEYBOARD` / `CAPS_LOCK` filtering in module) – canonical Wayland way.