### PR TITLE
 feat: add bar mouse exit event

### DIFF
--- a/include/bar.hpp
+++ b/include/bar.hpp
@@ -96,6 +96,7 @@ class Bar : public sigc::trackable {
 
  private:
   void onMap(GdkEventAny*);
+  bool handleMouseLeave(GdkEventCrossing*);
   auto setupWidgets() -> void;
   void getModules(const Factory&, const std::string&, waybar::Group*);
   void setupAltFormatKeyForModule(const std::string& module_name);

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -99,6 +99,10 @@ Addressed by *custom/<name>*
 	typeof: string ++
 	Command to execute when you right-click on the module.
 
+*on-mouse-exit*: ++
+	typeof: string ++
+	Command to execute when the mouse exits the module.
+
 *on-update*: ++
 	typeof: string ++
 	Command to execute when the module is updated.

--- a/src/bar.cpp
+++ b/src/bar.cpp
@@ -9,6 +9,7 @@
 #include "client.hpp"
 #include "factory.hpp"
 #include "group.hpp"
+#include "util/command.hpp"
 #include "util/enum.hpp"
 #include "util/hosts_check.hpp"
 #include "util/kill_signal.hpp"
@@ -227,6 +228,10 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
   }
 
   window.signal_configure_event().connect_notify(sigc::mem_fun(*this, &Bar::onConfigure));
+  if (config["on-mouse-exit"].isString()) {
+    window.add_events(Gdk::LEAVE_NOTIFY_MASK);
+    window.signal_leave_notify_event().connect(sigc::mem_fun(*this, &Bar::handleMouseLeave));
+  }
   output->monitor->property_geometry().signal_changed().connect(
       sigc::mem_fun(*this, &Bar::onOutputGeometryChanged));
 
@@ -301,7 +306,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     auto strSigusr1 = configSigusr1.asString();
     try {
       onSigusr1 =
-        util::parseStringToEnum<util::KillSignalAction>(strSigusr1, util::userKillSignalActions);
+          util::parseStringToEnum<util::KillSignalAction>(strSigusr1, util::userKillSignalActions);
     } catch (const std::invalid_argument& e) {
       onSigusr1 = util::SIGNALACTION_DEFAULT_SIGUSR1;
       spdlog::warn(
@@ -313,7 +318,7 @@ waybar::Bar::Bar(struct waybar_output* w_output, const Json::Value& w_config)
     auto strSigusr2 = configSigusr2.asString();
     try {
       onSigusr2 =
-        util::parseStringToEnum<util::KillSignalAction>(strSigusr2, util::userKillSignalActions);
+          util::parseStringToEnum<util::KillSignalAction>(strSigusr2, util::userKillSignalActions);
     } catch (const std::invalid_argument& e) {
       onSigusr2 = util::SIGNALACTION_DEFAULT_SIGUSR2;
       spdlog::warn(
@@ -675,6 +680,15 @@ auto waybar::Bar::setupWidgets() -> void {
   for (auto const& module : modules_right_) {
     right_.pack_end(*module, module->expandEnabled(), module->expandEnabled());
   }
+}
+
+bool waybar::Bar::handleMouseLeave(GdkEventCrossing* event) {
+  if (event->detail == GDK_NOTIFY_INFERIOR) {
+    return false;
+  }
+
+  util::command::forkExec(config["on-mouse-exit"].asString());
+  return false;
 }
 
 void waybar::Bar::onConfigure(GdkEventConfigure* ev) {


### PR DESCRIPTION
**What does this PR do?**

Expose GTK leave notifications as the generic top-level on-mouse-exit bar option. Register the leave event mask on the Waybar window when configured and execute the configured command from Bar::handleMouseLeave.

This is useful for hiding the bar when the pointer leaves the entire bar:

```
"on-sigusr2": "HIDE",
"on-mouse-exit": "kill -USR2 \"$PPID\""
```

Coupled with waycorner to activate the bar on mouse y=0, I have a waybar that behaves pretty well.

**Related issues**

  - #3475 Execute custom command on entering/exiting Waybar area open. It requests on-mouse-enter and on-mouse-exit bar options for showing/hiding a second bar.

  - #3853 Feature: Auto-Hide (closed) requests revealing the bar on pointer movement and hiding it when the pointer leaves.

  - #3928 Idempotent and user-configurable kill signals (closed) discusses automatic hiding/showing and references issues #3853, #3456, #2330, and #1058.

**Checklist**
- [X] Code is formatted with `clang-format`
- [X] Builds locally (`ninja -C build`)
- [X] Man page updated for any new/changed user-facing option (`man/`)
- [X] Tested against the affected module(s)
