### PR TITLE
group: add `align` option to control children alignment (#2834)

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -32,6 +32,7 @@ class Group : public AModule {
   bool empty_if_drawer_empty = false;
   int reveal_delay = 0;
   std::string add_class_to_drawer_children;
+  Gtk::Align align_ = Gtk::ALIGN_CENTER;
   bool handleMouseEnter(GdkEventCrossing* const& ev) override;
   bool handleMouseLeave(GdkEventCrossing* const& ev) override;
   bool handleToggle(GdkEventButton* const& ev) override;

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -349,6 +349,12 @@ A module group is defined by specifying a module named "group/some-group-name". 
 
 Valid options for the (optional) "orientation" property are: "horizontal", "vertical", "inherit", and "orthogonal" (default).
 
+*align*: ++
+	typeof: string ++
+	Valid options: "start", "center", "end" ++
+	default: "center" ++
+	Controls how the group's children are aligned within the group's box. This is useful when a group lives in `modules-left` but its children would otherwise appear centered. Set it to "start" to left-align the children.
+
 ## Group Drawers
 
 A group may hide all but one element, showing them only on mouse hover. In order to configure this, you can use the `drawer` property, whose value is an object with the following properties:

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -50,6 +50,18 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     throw std::runtime_error("Invalid orientation value: " + orientation);
   }
 
+  // default alignment of the group's children within its box
+  auto align = config_["align"].empty() ? "center" : config_["align"].asString();
+  if (align == "start") {
+    align_ = Gtk::ALIGN_START;
+  } else if (align == "center") {
+    align_ = Gtk::ALIGN_CENTER;
+  } else if (align == "end") {
+    align_ = Gtk::ALIGN_END;
+  } else {
+    throw std::runtime_error("Invalid align value: " + align);
+  }
+
   if (config_["drawer"].isObject()) {
     is_drawer = true;
 
@@ -268,6 +280,7 @@ void Group::addWidget(AModule* module) {
   Gtk::Widget& widget = *module;
 
   getBox().pack_start(widget, false, false);
+  widget.set_halign(align_);
 
   if (is_drawer && !is_first_widget) {
     widget.get_style_context()->add_class(add_class_to_drawer_children);


### PR DESCRIPTION
## Summary
Adds an optional `align` property to the group module to control how its
children are aligned within the group's box.

- Values: `start` | `center` | `end`
- Default: `center` (preserves current behavior)

This lets a group placed in `modules-left` left-align its contents instead of
centering them, as requested in #2834.

## Implementation
- `include/group.hpp`: add `Gtk::Align align_` (default `ALIGN_CENTER`).
- `src/group.cpp`: read `config_["align"]` in the constructor (throws on
  invalid value, matching the existing `orientation` handling), and apply
  `widget.set_halign(align_)` to each child in `addWidget()`.
- `man/waybar.5.scd.in`: document the new option.

## Notes
I could not build/test this locally (no build toolchain in my environment), so
this relies on CI. If maintainers would prefer `start` as the default to fully
resolve #2834 out of the box, I'm happy to flip the default.

Co-Authored-By: opencode <noreply@opencode.ai>