### PR TITLE
hyprland/workspaces: Highlight workspaces visible on other monitors

### DIFF
--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -373,6 +373,7 @@ Additional to workspace name matching, the following *format-icons* can be set.
 - *#workspaces*
 - *#workspaces button*
 - *#workspaces button.active*
+- *#workspaces button.visible*
 - *#workspaces button.empty*
 - *#workspaces button.visible*
 - *#workspaces button.persistent*

--- a/resources/style.css
+++ b/resources/style.css
@@ -63,6 +63,10 @@ button:hover {
     background: rgba(0, 0, 0, 0.2);
 }
 
+#workspaces button.visible {
+    background-color: rgba(100, 114, 125, 0.5);
+}
+
 #workspaces button.focused, #workspaces button.active {
     background-color: #64727D;
     box-shadow: inset 0 -3px #ffffff;

--- a/src/modules/hyprland/workspace.cpp
+++ b/src/modules/hyprland/workspace.cpp
@@ -412,6 +412,7 @@ void Workspace::update(const std::string& workspace_icon, const std::string& wor
 
   auto styleContext = m_button.get_style_context();
   addOrRemoveClass(styleContext, isActive(), "active");
+  addOrRemoveClass(styleContext, isVisible(), "visible");
   addOrRemoveClass(styleContext, isSpecial(), "special");
   addOrRemoveClass(styleContext, isSpecial(), name());
   addOrRemoveClass(styleContext, isEmpty(), "empty");


### PR DESCRIPTION
**What does this PR do?**

hyprland/workspaces: Highlight workspaces visible on other monitors

**Related issues**

Closes #5268

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)

<hr>

I'm not good with colors. If you have an idea for a color that would work better, feel free to edit.
