### PR TITLE
sni/watcher: accept combined "bus_name/object_path" item registrations (Electron 43.4.1+)

### DIFF
--- a/src/modules/sni/watcher.cpp
+++ b/src/modules/sni/watcher.cpp
@@ -87,10 +87,16 @@ gboolean Watcher::handleRegisterItem(Watcher* obj, GDBusMethodInvocation* invoca
                                      const gchar* service) {
   const gchar* bus_name = service;
   const gchar* object_path = "/StatusNotifierItem";
+  g_autofree gchar* bus_name_buf = nullptr;
 
   if (*service == '/') {
     bus_name = g_dbus_method_invocation_get_sender(invocation);
     object_path = service;
+  } else if (const gchar* slash = g_strstr_len(service, -1, "/")) {
+    // Electron >= 43.4.1 registers with a combined "bus_name/object_path" string
+    bus_name_buf = g_strndup(service, slash - service);
+    bus_name = bus_name_buf;
+    object_path = slash;
   }
   if (g_dbus_is_name(bus_name) == FALSE) {
     g_dbus_method_invocation_return_error(invocation, G_DBUS_ERROR, G_DBUS_ERROR_INVALID_ARGS,


### PR DESCRIPTION
Fixes #5240.

## Problem

Electron ≥ 43.4.1 (Chromium 150.0.7871.224) changed how its tray icon registers with the StatusNotifierWatcher: instead of a bare object path it now sends a combined `bus_name/object_path` string. Captured on the bus (`busctl --user monitor org.kde.StatusNotifierWatcher`), Signal-Desktop 8.25.0:

```
Member=RegisterStatusNotifierItem
  STRING "org.freedesktop.StatusNotifierItem-36777-1/StatusNotifierItem/1";
```

`Watcher::handleRegisterItem` only understands two shapes — a string starting with `/` (object path, resolved against the sender) or a plain bus name — so it runs `g_dbus_is_name()` on the whole combined string and rejects it:

```
ErrorName=org.freedesktop.DBus.Error.InvalidArgs
ErrorMessage="D-Bus bus name 'org.freedesktop.StatusNotifierItem-36777-1/StatusNotifierItem/1' is not valid"
```

On rejection Electron releases its bus name and destroys the tray icon permanently (it does not retry, not even when the watcher restarts), so the app shows no tray icon for the rest of its lifetime. Side-by-side comparison of the same app across the Electron bump:

| | Signal 8.23.0 (Electron 43.0.0) | Signal 8.25.0 (Electron 43.4.1) |
|---|---|---|
| Registers as | `/org/chromium/StatusNotifierItem/1` | `org.freedesktop.StatusNotifierItem-36777-1/StatusNotifierItem/1` |
| Result | accepted | rejected → icon torn down |

Slack (Electron 43.4.0) still registers with a bare bus name and works, so this will progressively hit every Electron app as they update past 43.4.1. KDE's StatusNotifierWatcher accepts the combined form.

## Fix

When the service string contains a `/` but does not start with one, split at the first `/` into bus name and object path. The two existing forms are handled exactly as before. As a bonus, `g_bus_watch_name()` now watches the actual bus name for these items, so they are pruned correctly when the owner exits.

## Testing

Running this patch on waybar 0.15.0 under Hyprland: Signal 8.25.0's icon registers, appears in the tray, and survives repeated window close/reopen (close-to-tray) cycles; Slack, Telegram, Bitwarden, udiskie and nm-applet items are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
