### PR TITLE
clock: add {month_name} placeholder with standalone month support

### DIFF
--- a/include/modules/clock.hpp
+++ b/include/modules/clock.hpp
@@ -9,6 +9,7 @@ namespace waybar::modules {
 const std::string kCldPlaceholder{"calendar"};
 const std::string kTZPlaceholder{"tz_list"};
 const std::string kOrdPlaceholder{"ordinal_date"};
+const std::string kMonthPlaceholder{"month_name"};
 
 enum class CldMode { MONTH, YEAR };
 enum class WS { LEFT, RIGHT, HIDDEN };
@@ -67,11 +68,16 @@ class Clock final : public ALabel {
   std::string tzText_{""};                      // time zones text to print
   std::string tzTooltipFormat_{""};             // optional timezone tooltip format
   util::SleeperThread thread_;
-
+ 
   // ordinal date in tooltip
   const bool ordInTooltip_;
   std::string ordText_{""};
+
+  const bool monInTooltip_;  // month in tooltip
+  std::string monText_{""};                     // month text to print
+
   auto get_ordinal_date(const date::year_month_day& today) -> std::string;
+  auto get_month_name(const date::year_month& ym) -> std::string;
 
   auto getTZtext(date::sys_seconds now) -> std::string;
   auto first_day_of_week() -> date::weekday;

--- a/man/waybar-clock.5.scd
+++ b/man/waybar-clock.5.scd
@@ -100,6 +100,10 @@ $XDG_CONFIG_HOME/waybar/config ++
 :[ string
 :[ same as format
 :[ Tooltip on hover
+|[ *month_name*
+:[ string
+:[ Placeholder
+:[ This is intended to add an ability to use a modifier %OB as chrono does not support them, in calendar
 |[ *menu*
 :[ string
 :[

--- a/src/modules/clock.cpp
+++ b/src/modules/clock.cpp
@@ -34,7 +34,8 @@ waybar::modules::Clock::Clock(const std::string& id, const Json::Value& config)
       tzTooltipFormat_{config_["timezone-tooltip-format"].isString()
                            ? config_["timezone-tooltip-format"].asString()
                            : ""},
-      ordInTooltip_{m_tlpFmt_.find("{" + kOrdPlaceholder + "}") != std::string::npos} {
+      ordInTooltip_{m_tlpFmt_.find("{" + kOrdPlaceholder + "}") != std::string::npos},
+      monInTooltip_{m_tlpFmt_.find("{" + kMonthPlaceholder + "}") != std::string::npos} {
   m_tlpText_ = m_tlpFmt_;
 
   if (config_["timezones"].isArray() && !config_["timezones"].empty()) {
@@ -219,9 +220,10 @@ auto waybar::modules::Clock::update() -> void {
 
     if (tzInTooltip_) tzText_ = getTZtext(now.get_sys_time());
     if (cldInTooltip_) cldText_ = get_calendar(today, shiftedDay, tz);
+    if (monInTooltip_) monText_ = get_month_name(shiftedDay.year() / shiftedDay.month());
     if (ordInTooltip_) ordText_ = get_ordinal_date(shiftedDay);
     try {
-      if (tzInTooltip_ || cldInTooltip_ || ordInTooltip_) {
+      if (tzInTooltip_ || cldInTooltip_ || ordInTooltip_ || monInTooltip_) {
         // std::vformat doesn't support named arguments.
         m_tlpText_ =
             std::regex_replace(m_tlpFmt_, std::regex("\\{" + kTZPlaceholder + "\\}"), tzText_);
@@ -230,6 +232,8 @@ auto waybar::modules::Clock::update() -> void {
             fmt_lib::vformat(m_locale_, cldText_, fmt_lib::make_format_args(shiftedNow)));
         m_tlpText_ =
             std::regex_replace(m_tlpText_, std::regex("\\{" + kOrdPlaceholder + "\\}"), ordText_);
+        m_tlpText_ =
+            std::regex_replace(m_tlpText_, std::regex("\\{" + kMonthPlaceholder + "\\}"), monText_);
       } else {
         m_tlpText_ = m_tlpFmt_;
       }
@@ -678,4 +682,17 @@ auto waybar::modules::Clock::get_ordinal_date(const year_month_day& today) -> st
       res << "th";
   }
   return res.str();
+}
+
+/* Falling back to use strftime() for %OB specifier support that missing on chrono/date C++20 library */
+auto waybar::modules::Clock::get_month_name(const date::year_month& ym) -> std::string {
+  const auto tp = date::sys_days{ym / date::day{1}};
+  const std::time_t t = std::chrono::system_clock::to_time_t(tp);
+  std::tm tm{};
+  gmtime_r(&t, &tm);
+
+  std::ostringstream oss;
+  oss.imbue(m_locale_);
+  oss << std::put_time(&tm, "%OB");
+  return oss.str();
 }


### PR DESCRIPTION
This adds a support for POSIX %OB modifier of strftime() for clock/calendar module through a new placeholder {month_name}.

Introduce a new `{month_name}` placeholder for the clock module tooltip. Unlike the standard library formatting which wraps month names in a date context (often forcing genitive case in inflected languages like Slavic, Baltic, or Finno-Ugric), this placeholder utilizes the POSIX `%OB` modifier to retrieve the standalone (nominative) month name.

It can resolve #5241, #3890.

Mine clock module config section looks as follows:
```
    "clock": {
        "format"  : "{:%H:%M%n%d.%m.%Y}",
        "justify" : "center",
        "tooltip-format": "<span color='#ecc6d9'><b>{month_name} {:%Y}</b></span>\n<tt><small>{calendar}</small></tt>",
        "calendar": {
            "mode"          : "month",
            "mode-mon-col"  : 3,
            "weeks-pos"     : "right",
            "on-scroll"     : 1,
            "format": {
                "months":     "", //"<span color='#ffead3'><b>{}</b></span>",
                "days":       "<span color='#ecc6d9'><b>{}</b></span>",
                "weeks":      "<span color='#ffcc66'><b>Н.{}</b></span>",
                "weekdays":   "<span color='#ffcc66'><b>{}</b></span>",
                "today":      "<span color='#00a000'><b><u>{}</u></b></span>"
            },
        },
    }, 
```