### PR TITLE
group: allow replacing the drawer leader when expanded

### DIFF
--- a/include/group.hpp
+++ b/include/group.hpp
@@ -24,10 +24,14 @@ class Group : public AModule {
  protected:
   Gtk::Box box;
   Gtk::Box revealer_box;
+  Gtk::Box leader_revealer_box;
   Gtk::Revealer revealer;
+  Gtk::Revealer leader_revealer;
   bool is_first_widget = true;
   bool is_drawer = false;
   bool click_to_reveal = false;
+  bool hide_leader_when_expanded = false;
+  bool drawer_left_to_right = true;
   std::string always_visible_class;
   bool empty_if_drawer_empty = false;
   int reveal_delay = 0;

--- a/man/waybar.5.scd.in
+++ b/man/waybar.5.scd.in
@@ -383,6 +383,11 @@ A group may hide all but one element, showing them only on mouse hover. In order
 	default: false ++
 	Defines whether the drawer should initialize in an expanded state.
 
+*hide-leader-when-expanded*: ++
+	typeof: bool ++
+	default: false ++
+	Hides the group leader while the drawer is expanded.
+
 *transition-left-to-right*: ++
 	typeof: bool ++
 	default: true ++

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -28,7 +28,8 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
              bool vertical)
     : AModule(config, name, id, true, false),
       box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0},
-      revealer_box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0} {
+      revealer_box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0},
+      leader_revealer_box{vertical ? Gtk::ORIENTATION_VERTICAL : Gtk::ORIENTATION_HORIZONTAL, 0} {
   box.set_name(name_);
   box.get_style_context()->add_class("empty");
   if (!id.empty()) {
@@ -63,11 +64,13 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     const bool left_to_right = (drawer_config["transition-left-to-right"].isBool()
                                     ? drawer_config["transition-left-to-right"].asBool()
                                     : true);
+    drawer_left_to_right = left_to_right;
     const bool reveal_by_default =
         (drawer_config["reveal-by-default"].isBool() ? drawer_config["reveal-by-default"].asBool()
                                                      : false);
 
     click_to_reveal = drawer_config["click-to-reveal"].asBool();
+    hide_leader_when_expanded = drawer_config["hide-leader-when-expanded"].asBool();
     always_visible_class = (drawer_config["always-visible-class"].isString()
                                 ? drawer_config["always-visible-class"].asString()
                                 : "");
@@ -84,6 +87,11 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
 
     revealer.set_transition_type(transition_type);
     revealer.set_transition_duration(transition_duration);
+    leader_revealer.set_transition_type(
+        vertical ? Gtk::RevealerTransitionType::REVEALER_TRANSITION_TYPE_SLIDE_DOWN
+                 : Gtk::RevealerTransitionType::REVEALER_TRANSITION_TYPE_SLIDE_RIGHT);
+    leader_revealer.set_transition_duration(transition_duration);
+    leader_revealer.set_reveal_child(true);
     if ((click_to_reveal && reveal_by_default) || start_expanded) {
       box.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
       revealer.set_reveal_child(true);
@@ -92,8 +100,10 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     }
 
     revealer.get_style_context()->add_class("drawer");
+    leader_revealer.get_style_context()->add_class("drawer-leader");
 
     revealer.add(revealer_box);
+    leader_revealer.add(leader_revealer_box);
 
     if (left_to_right) {
       box.pack_end(revealer);
@@ -116,6 +126,9 @@ Group::~Group() {
 void Group::show_group() {
   box.set_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   revealer.set_reveal_child(true);
+  if (hide_leader_when_expanded) {
+    leader_revealer.set_reveal_child(false);
+  }
   box.get_style_context()->add_class("expanded");
 }
 
@@ -168,6 +181,9 @@ void Group::manage_visibility(AModule* module) {
 }
 
 void Group::hide_group() {
+  if (hide_leader_when_expanded) {
+    leader_revealer.set_reveal_child(true);
+  }
   box.unset_state_flags(Gtk::StateFlags::STATE_FLAG_PRELIGHT);
   revealer.set_reveal_child(false);
   box.get_style_context()->remove_class("expanded");
@@ -267,7 +283,16 @@ Gtk::Box& Group::getBox() { return is_drawer ? (is_first_widget ? box : revealer
 void Group::addWidget(AModule* module) {
   Gtk::Widget& widget = *module;
 
-  getBox().pack_start(widget, false, false);
+  if (is_drawer && is_first_widget && hide_leader_when_expanded) {
+    leader_revealer_box.pack_start(widget, false, false);
+    if (drawer_left_to_right) {
+      box.pack_start(leader_revealer, false, false);
+    } else {
+      box.pack_end(leader_revealer, false, false);
+    }
+  } else {
+    getBox().pack_start(widget, false, false);
+  }
 
   if (is_drawer && !is_first_widget) {
     widget.get_style_context()->add_class(add_class_to_drawer_children);

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -110,6 +110,12 @@ Group::Group(const std::string& name, const std::string& id, const Json::Value& 
     } else {
       box.pack_start(revealer);
     }
+
+    revealer.property_child_revealed().signal_changed().connect([this]() {
+      if (revealer.get_child_revealed()) {
+        event_box_.trigger_tooltip_query();
+      }
+    });
   }
 
   event_box_.add(box);


### PR DESCRIPTION
This change adds the `hide-leader-when-expanded` option to drawer groups.

It allows the first module to serve as a compact representation of the drawer's contents. When the drawer expands, the leader is hidden and replaced by the child modules. When the drawer collapses, the leader becomes visible again.

My use case is a media group composed of:

- A ten-bar CAVA audio visualizer shown while the drawer is collapsed.
- Four media controls.
- Controls that occupy approximately the same horizontal space as the visualizer.

The configuration looks like this:

```json
"group/cava-media": {
    "orientation": "inherit",
    "drawer": {
        "transition-duration": 180,
        "transition-left-to-right": false,
        "hide-leader-when-expanded": true,
        "children-class": "cava-media-control"
    },
    "modules": [
        "custom/cava",
        "custom/media-previous",
        "custom/media-stop",
        "custom/media-play-pause",
        "custom/media-next"
    ]
}
```

While collapsed, the group displays only the CAVA visualizer:

```text
⡀⣀⣄⣤⣦⣶⣷⣿⣶⣄
```

When the pointer enters the group, the visualizer is replaced by the media controls:

```text
󰒮  󰓛  󰐎  󰒭
```

Without this option, a drawer keeps its first module visible and reveals its children beside it. That is appropriate when the first module is a permanent button or indicator, but it does not support cases where the expanded content is intended to be an alternative view of the same space.

The option defaults to `false`, so existing configurations retain their current behavior.

The second commit fixes tooltip behavior during this replacement. Hiding the leader changes the widget under a stationary pointer. GTK does not always initiate another tooltip query in that situation, so a newly revealed child's tooltip may not appear until the pointer leaves and enters the group again.

To address this, the group triggers a tooltip query once the drawer's reveal transition has completed. This allows the revealed widget to display its tooltip without repeatedly querying during the animation.

I tested horizontal drawers in both transition directions. When `hide-leader-when-expanded` is not configured, existing drawer behavior remains unchanged.
