### PR TITLE
fix(tray): create the dbus menu once the probe succeeds

### DIFF
--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -593,6 +593,9 @@ void Item::menuProbeReady(Glib::RefPtr<Gio::AsyncResult>& result, const std::str
   try {
     proxy_->get_connection()->call_finish(result);
     has_dbus_menu_ = true;
+    // Dbusmenu synchronizes its layout asynchronously. Create the GTK menu as soon as the probe
+    // succeeds so it has time to populate before the first click.
+    makeMenu();
   } catch (const Glib::Error&) {
   }
 }


### PR DESCRIPTION
**What does this PR do?**

Tray context menus open empty on the first click and only work on the second.

b58018bc swapped the `makeMenu()` call in the `Menu` property handler for an async probe, but `menuProbeReady()` never calls `makeMenu()`. `handleClick()` is now the only call site, so the menu gets created and popped in the same block. Dbusmenu loads its layout asynchronously, so the first click gets a menu with no root item yet:

```
LIBDBUSMENU-GLIB-CRITICAL: dbusmenu_menuitem_send_about_to_show: assertion 'DBUSMENU_IS_MENUITEM(mi)' failed
*** BUG *** In pixman_region32_init_rect: Invalid rectangle passed
```

That empty menu is the small blank popup users see. The second click works because the layout has arrived.

It is a re-regression of 01ad3d96 ("fix(tray): pre-create dbusmenu for tray items", 2019), which fixed the same assertion by creating the menu at property-set time.

Calling `makeMenu()` when the probe succeeds restores that timing. Items that do not export `com.canonical.dbusmenu` still fail the probe and still fall back to `ContextMenu`.

The diff is @awsms's from #5285, credited in the commit. They also suggested reverting b58018bc outright. I have no strong view, happy to switch this to a revert if you prefer.

**Related issues**

Closes #5285

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated. Not applicable, no user-facing option changed.
- [x] Tested against the affected module(s)

**Testing**

Hyprland, three SNI items (KDE Connect, Nextcloud, an Electron app).

Before: empty popup on the first click, full menu on the second, with the two log lines above.
After: full menu on the first click, log clean.
