### PR TITLE
fix(tray): do not abort on a malformed `orders` entry

### DIFF
--- a/src/modules/sni/host.cpp
+++ b/src/modules/sni/host.cpp
@@ -30,14 +30,17 @@ Host::Host(std::size_t id, const Json::Value& config, const Bar& bar,
       on_reorder_(on_reorder),
       on_update_(on_update) {
   auto orders = config["orders"];
-  if (!orders.isNull()) {
+  if (orders.isObject()) {
     for (auto itr = orders.begin(); itr != orders.end(); ++itr) {
-      auto key = itr.name();
-      auto& value = *itr;
-      assert(value.isInt());
-
-      orders_[key] = value.asInt();
+      const auto& value = *itr;
+      if (!value.isInt()) {
+        spdlog::warn("tray: ignoring order for '{}': expected an integer", itr.name());
+        continue;
+      }
+      orders_[itr.name()] = value.asInt();
     }
+  } else if (!orders.isNull()) {
+    spdlog::warn("tray: ignoring 'orders': expected an object");
   }
 }
 


### PR DESCRIPTION
**What does this PR do?**

`Host`'s config parsing asserts that every value in `orders` is an integer:

```cpp
assert(value.isInt());
orders_[key] = value.asInt();
```

Waybar builds with `b_ndebug=false`, so the assert is live in release builds
too. A single typo in a user's config takes down the whole bar with no
actionable message:

```
$ waybar -c bad.json
[info] Tray: No ignore-list configured
waybar: ../src/modules/sni/host.cpp:39: waybar::modules::SNI::Host::Host(...): Assertion `value.isInt()' failed.
[1]    core dumped
```

Reproducer:

```json
"tray": { "orders": { "gammastep": "oops" } }
```

This skips the offending entry with a warning instead, and checks that `orders`
is an object before iterating it. User input should not be able to terminate
waybar.

After:

```
[warning] tray: ignoring order for 'gammastep': expected an integer
```

**Related issues**

None. Found while working on #4162 / #5297; independent of both.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`) — n/a, no config surface changes
- [x] Tested against the affected module(s) — `tray`, with a valid config, a
      non-integer value, and `orders` set to a non-object
