### PR TITLE
feat(tray): order unconfigured items alphabetically, log item keys

### DIFF
--- a/include/modules/sni/item.hpp
+++ b/include/modules/sni/item.hpp
@@ -13,6 +13,7 @@
 
 #include <functional>
 #include <set>
+#include <string>
 #include <string_view>
 
 #include "bar.hpp"
@@ -46,6 +47,10 @@ class Item : public sigc::trackable {
   Gtk::EventBox event_box;
   std::string category;
   std::string id;
+  // The key this item is addressed by in the tray config, and what items
+  // without a configured order are sorted by. Usually the SNI Id, but see the
+  // Chrome hack in setProperty().
+  std::string sort_key;
 
   std::string title;
   std::string icon_name;

--- a/man/waybar-tray.5.scd
+++ b/man/waybar-tray.5.scd
@@ -51,9 +51,34 @@ Addressed by *tray*
 
 *orders*: ++
 	typeof: object ++
-	Orders for items to be placed in tray. When not set, orders are controlled by DBus. ++
+	Explicit order values for items in the tray. ++
 	Key: name of item. ++
-	Value: integer, higher value means to place this item to the right.
+	Value: integer, higher value means to place this item to the right. ++
+	Items without an entry default to 0, so a negative value places an item
+	left of all unconfigured ones and a positive value places it right of
+	them.
+
+# ITEM KEYS AND DEFAULT ORDER
+
+An item is addressed by its key in *orders* and *icons*. The key is the
+item's SNI *Id*, except for Chrome-based applications, whose *Id* is not
+unique -- those are addressed by their tooltip text, lowercased.
+
+Since neither is visible anywhere in the UI, waybar logs the key of every
+item it registers on startup:
+
+```
+[info] tray: item key 'nm-applet'
+[info] tray: item key 'Rocket.Chat_status_icon_1'
+```
+
+Run waybar from a terminal to see them.
+
+Items that no entry in *orders* applies to are placed in alphabetical
+order of their key, after those with a negative order value and before
+those with a positive one. Ordering therefore does not depend on the
+order in which applications register on D-Bus, which is racy and differs
+between restarts and between outputs of the same bar.
 
 Note: custom *icons* only work with actual image files, not font-based icons. They
 might not work for some Electron apps (see https://github.com/electron/electron/issues/40936).

--- a/src/modules/sni/item.cpp
+++ b/src/modules/sni/item.cpp
@@ -162,6 +162,24 @@ ToolTip get_variant<ToolTip>(const Glib::VariantBase& value) {
   return result;
 }
 
+/**
+ * Announces the key an item is addressed by in the tray config. There is no
+ * other way for a user to learn it -- an Electron app's key is something like
+ * "Rocket.Chat_status_icon_1", which nobody guesses. Kept at info level for
+ * that reason, but logged only once per key: every bar runs its own Host with
+ * its own Item objects, so an unguarded log line fires once per output, and
+ * again on every Id property update.
+ */
+static void logItemKey(const std::string& key) {
+  static std::set<std::string> announced;
+  if (key.empty()) {
+    return;
+  }
+  if (announced.insert(key).second) {
+    spdlog::info("tray: item key '{}'", key);
+  }
+}
+
 void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
   try {
     spdlog::trace("Set tray item property: {}.{} = {}", id.empty() ? bus_name : id, name, value);
@@ -180,17 +198,22 @@ void Item::setProperty(const Glib::ustring& name, Glib::VariantBase& value) {
        * it might be my theme.
        */
       std::string icon_id = id;
+      // The key an item is addressed by in the tray config. setCustomIcon() below
+      // triggers a reorder, so this has to be in place before it is called.
+      sort_key = id;
       if (id == "chrome_status_icon_1") {
         Glib::VariantBase value;
         this->proxy_->get_cached_property(value, "ToolTip");
         tooltip = get_variant<ToolTip>(value);
         if (!tooltip.text.empty()) {
           icon_id = tooltip.text.lowercase();
+          sort_key = icon_id;
           setCustomIcon(icon_id);
         }
       } else {
         setCustomIcon(icon_id);
       }
+      logItemKey(sort_key);
 
       // Check if this item should be hidden
       if (IconManager::instance().isHidden(icon_id)) {

--- a/src/modules/sni/tray.cpp
+++ b/src/modules/sni/tray.cpp
@@ -3,6 +3,7 @@
 #include <spdlog/spdlog.h>
 
 #include <algorithm>
+#include <cctype>
 
 #include "modules/sni/icon_manager.hpp"
 
@@ -118,9 +119,19 @@ void Tray::onRemove(std::unique_ptr<Item>& item) {
 void Tray::reorderBox() {
   const bool reverse =
       config_["reverse-direction"].isBool() && config_["reverse-direction"].asBool();
-  // Stable sort keeps insertion order among items sharing the same order value.
-  std::stable_sort(items_.begin(), items_.end(),
-                   [](const Item* a, const Item* b) { return a->order_ < b->order_; });
+  // Items sharing an order value -- in particular every item without a
+  // configured one, which all sit at 0 -- are sorted by their key. Falling back
+  // to insertion order here would leave the tray layout up to the order in
+  // which applications happen to win the race to register on D-Bus, which
+  // differs between restarts and even between outputs of the same bar.
+  std::stable_sort(items_.begin(), items_.end(), [](const Item* a, const Item* b) {
+    if (a->order_ != b->order_) {
+      return a->order_ < b->order_;
+    }
+    return std::lexicographical_compare(
+        a->sort_key.begin(), a->sort_key.end(), b->sort_key.begin(), b->sort_key.end(),
+        [](unsigned char lhs, unsigned char rhs) { return std::tolower(lhs) < std::tolower(rhs); });
+  });
   for (std::size_t i = 0; i < items_.size(); ++i) {
     const int pos = reverse ? static_cast<int>(items_.size() - 1 - i) : static_cast<int>(i);
     box_.reorder_child(items_[i]->event_box, pos);


### PR DESCRIPTION
**What does this PR do?**

Closes two gaps around tray ordering.

### Ordering is only deterministic for configured items

`orders` pins the items you name. Everything else keeps the order in which the
applications happened to win the race to register on D-Bus, which is what #4162
is about — it differs between restarts, and as noted in that thread it differs
between the outputs of a single bar, so two monitors show two different trays.

To get a stable layout today you have to enumerate every item with an explicit
integer, including the ones you have no opinion about.

This sorts items sharing an order value by their key instead of leaving them at
insertion order. Items with no entry in `orders` all sit at 0, so they end up
alphabetical between the negative and the positive ones, and the default layout
is stable without any configuration at all.

### The key an item is addressed by is invisible

`orders` and `icons` address an item by its SNI `Id`, or by its lowercased
tooltip for Chrome-based apps whose `Id` is not unique. Neither appears anywhere
in the UI, and the man page only said "name of item" — so configuring Rocket.Chat
means guessing `Rocket.Chat_status_icon_1`.

This logs it once per key at info level:

```
[info] tray: item key 'nm-applet'
[info] tray: item key 'Rocket.Chat_status_icon_1'
```

Deduplicated on purpose: every bar runs its own `Host` with its own `Item`
objects, so an unguarded line fires once per output, and again on every `Id`
property update.

### Notes

No new config options; existing configs keep their exact layout.

`Item::sort_key` holds the key separately from the icon id. The two are only
incidentally the same string — the icon id is what gets looked up in `icons`,
and tying the sort order to it would mean an icon config change silently
reshuffles the tray.

**Related issues**

Closes #4162.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`) —
      `man/waybar-tray.5.scd` gained a section documenting the item keys and the
      default order
- [x] Tested against the affected module(s) — `tray`, live, six items
      (gammastep, nm-applet, Telegram and three Electron apps) on a two-output
      setup:
  - no `orders` at all → `Claude_status_icon_1`, `gammastep`, `nm-applet`,
    `Rocket.Chat_status_icon_1`, `TelegramDesktop`, `vesktop_status_icon_1`
  - `{"gammastep": -5, "nm-applet": 10, "Claude_status_icon_1": 20}` → gammastep,
    then the alphabetical remainder, then nm-applet, then Claude
  - each key logged exactly once across both outputs (twice before this change)
