### PR TITLE
feat: rfkill support added by default on make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 default: build
 
 build:
-	meson setup build
+	meson setup build -Drfkill=enabled
 	ninja -C build
 
 build-debug:


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Enable rfkill support on make build

<img width="451" height="41" alt="image" src="https://github.com/user-attachments/assets/0cfb5713-c347-4ea2-bc7f-86c2d840df36" />

**Related issues**
Closes #

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
