### PR TITLE
feat: hyprland inactive-on-special option added

### DIFF
--- a/include/modules/hyprland/workspaces.hpp
+++ b/include/modules/hyprland/workspaces.hpp
@@ -47,6 +47,7 @@ class Workspaces : public AModule, public EventHandler {
   auto enableTaskbar() const -> bool { return m_enableTaskbar; }
   auto taskbarWithIcon() const -> bool { return m_taskbarWithIcon; }
   auto barScroll() const -> bool { return m_barScroll; }
+  auto inactiveOnSpecial() const -> bool { return m_inactiveOnSpecial; }
 
   auto getBarOutput() const -> std::string { return m_bar.output->name; }
   auto formatBefore() const -> std::string { return m_formatBefore; }
@@ -160,6 +161,7 @@ class Workspaces : public AModule, public EventHandler {
   bool m_moveToMonitor = false;
   bool m_uniqueIcons = false;
   bool m_barScroll = false;
+  bool m_inactiveOnSpecial = false;
   Json::Value m_persistentWorkspaceConfig;
 
   // Map for windows stored in workspaces not present in the current bar.

--- a/man/waybar-hyprland-workspaces.5.scd
+++ b/man/waybar-hyprland-workspaces.5.scd
@@ -147,6 +147,11 @@ This setting is ignored if *workspace-taskbar.enable* is set to true.
 	default: false ++
 	If set to false workspaces group will be shown only in assigned output. Otherwise, all workspace groups are shown.
 
+*inactive-on-special*:++
+	typeof: bool ++
+	default: false ++
+	If set true, all workspaces will be marked as inactive when a special workspace is active on the current monitor
+
 *active-only*: ++
 	typeof: bool ++
 	default: false ++
@@ -239,7 +244,6 @@ they are written in the config:
 
 When the config contains only "vague" rules, they are matched against window
 *classes* only. This is both for backwards compatibility and for performance:
-matching against the title requires listening to window title changes via
 Hyprland's IPC, which is unnecessary when no title rule is in use.
 
 When the config contains *at least one* "title-only" or "hybrid" rule, then all

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -665,6 +665,7 @@ auto Workspaces::parseConfig(const Json::Value& config) -> void {
   populateBoolConfig(config, "move-to-monitor", m_moveToMonitor);
   populateBoolConfig(config, "unique-icons", m_uniqueIcons);
   populateBoolConfig(config, "enable-bar-scroll", m_barScroll);
+  populateBoolConfig(config, "inactive-on-special", m_inactiveOnSpecial);
 
   m_persistentWorkspaceConfig = config.get("persistent-workspaces", Json::Value());
   populateSortByConfig(config);
@@ -837,7 +838,7 @@ auto Workspaces::populateWorkspaceTaskbarConfig(const Json::Value& config) -> vo
     auto posStr = workspaceTaskbar["active-window-position"].asString();
     try {
       m_activeWindowPosition =
-        util::parseStringToEnum<ActiveWindowPosition>(posStr, m_activeWindowPositionMap);
+          util::parseStringToEnum<ActiveWindowPosition>(posStr, m_activeWindowPositionMap);
     } catch (const std::invalid_argument& e) {
       spdlog::warn(
           "Invalid string representation for active-window-position. Falling back to 'none'.");
@@ -1134,12 +1135,27 @@ void Workspaces::updateWorkspaceStates() {
       currentWorkspace.isMember("name") ? currentWorkspace["name"].asString() : "";
 
   for (auto& workspace : m_workspaces) {
+    auto updatedWorkspace = std::ranges::find_if(updatedWorkspaces, [&workspace](const auto& w) {
+      return w["id"].asInt() == workspace->id();
+    });
+    std::string monitor = updatedWorkspace != updatedWorkspaces.end()
+                              ? (*updatedWorkspace)["monitor"].asString()
+                              : workspace->output();
+
     bool isActiveByName =
         !currentWorkspaceName.empty() && workspace->name() == currentWorkspaceName;
 
-    workspace->setActive(
-        workspace->id() == m_activeWorkspaceId || isActiveByName ||
-        (workspace->isSpecial() && workspace->name() == m_activeSpecialWorkspaceName));
+    bool isActive = workspace->id() == m_activeWorkspaceId || isActiveByName ||
+                    (workspace->isSpecial() && workspace->name() == m_activeSpecialWorkspaceName);
+
+    if (m_inactiveOnSpecial && !workspace->isSpecial() &&
+        std::ranges::any_of(updatedWorkspaces, [&monitor](const auto& w) {
+          return w["id"].asInt() < 0 && w["monitor"].asString() == monitor;
+        })) {
+      isActive = false;
+    }
+
+    workspace->setActive(isActive);
     if (workspace->isActive() && workspace->isUrgent()) {
       workspace->setUrgent(false);
     }
@@ -1153,9 +1169,6 @@ void Workspaces::updateWorkspaceStates() {
     if (m_withTooltip) {
       workspaceTooltip = workspace->selectString(m_tooltipMap);
     }
-    auto updatedWorkspace = std::ranges::find_if(updatedWorkspaces, [&workspace](const auto& w) {
-      return w["id"].asInt() == workspace->id();
-    });
     if (updatedWorkspace != updatedWorkspaces.end()) {
       workspace->setOutput((*updatedWorkspace)["monitor"].asString());
     }

--- a/src/modules/hyprland/workspaces.cpp
+++ b/src/modules/hyprland/workspaces.cpp
@@ -1149,8 +1149,10 @@ void Workspaces::updateWorkspaceStates() {
                     (workspace->isSpecial() && workspace->name() == m_activeSpecialWorkspaceName);
 
     if (m_inactiveOnSpecial && !workspace->isSpecial() &&
-        std::ranges::any_of(updatedWorkspaces, [&monitor](const auto& w) {
-          return w["id"].asInt() < 0 && w["monitor"].asString() == monitor;
+        std::ranges::any_of(updatedWorkspaces, [&monitor, this](const auto& w) {
+          return w["id"].asInt() < 0 && 
+                 w["name"].asString() == "special:" + m_activeSpecialWorkspaceName && 
+                 w["monitor"].asString() == monitor;
         })) {
       isActive = false;
     }


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
When inactive-on-special is enabled, mark all others workspaces as inactive when a special workspace is active on monitor

**Related issues**
Closes #

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
