### PR TITLE
fix(niri/workspaces): center workspace labels when taskbar is disabled

### DIFF
--- a/src/modules/niri/workspace.cpp
+++ b/src/modules/niri/workspace.cpp
@@ -211,51 +211,49 @@ void Workspace::rebuildTaskbar(const std::vector<Json::Value>& my_windows) {
 // ── Icon loading ─────────────────────────────────────────────────────────────
 
 Glib::RefPtr<Gdk::Pixbuf> Workspace::loadIcon(const std::string& app_id, int size) {
-    if (app_id.empty()) return {};
-    auto app_info = Gio::DesktopAppInfo::create(app_id + ".desktop");
-        
-    if (app_info) {
-        auto icon = app_info->get_icon();
-        if (icon) {
-          auto theme = Gtk::IconTheme::get_default();
-          auto icon_info = theme->lookup_icon(icon, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
-        
-          if (icon_info) {
-              try {
-                  
-                  return icon_info.load_icon(); 
-              } catch (...) {
-                
-              }
-          }
+  if (app_id.empty()) return {};
+  auto app_info = Gio::DesktopAppInfo::create(app_id + ".desktop");
+
+  if (app_info) {
+    auto icon = app_info->get_icon();
+    if (icon) {
+      auto theme = Gtk::IconTheme::get_default();
+      auto icon_info = theme->lookup_icon(icon, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
+
+      if (icon_info) {
+        try {
+          return icon_info.load_icon();
+        } catch (...) {
+        }
       }
     }
+  }
 
-    auto theme = Gtk::IconTheme::get_default();
-    
-    auto tryLoad = [&](const std::string& name) -> Glib::RefPtr<Gdk::Pixbuf> {
-        if (!theme->has_icon(name)) return {};
-        try {
-            return theme->load_icon(name, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
-        } catch (...) {
-            return {};
-        }
-    };
+  auto theme = Gtk::IconTheme::get_default();
 
-    if (auto pb = tryLoad(app_id)) return pb;
-
-    std::string lower = app_id;
-    std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-    if (auto pb = tryLoad(lower)) return pb;
-
-    auto dot = app_id.rfind('.');
-    if (dot != std::string::npos) {
-        std::string last = app_id.substr(dot + 1);
-        std::transform(last.begin(), last.end(), last.begin(), ::tolower);
-        if (auto pb = tryLoad(last)) return pb;
+  auto tryLoad = [&](const std::string& name) -> Glib::RefPtr<Gdk::Pixbuf> {
+    if (!theme->has_icon(name)) return {};
+    try {
+      return theme->load_icon(name, size, Gtk::ICON_LOOKUP_FORCE_SIZE);
+    } catch (...) {
+      return {};
     }
+  };
 
-    return {};
+  if (auto pb = tryLoad(app_id)) return pb;
+
+  std::string lower = app_id;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  if (auto pb = tryLoad(lower)) return pb;
+
+  auto dot = app_id.rfind('.');
+  if (dot != std::string::npos) {
+    std::string last = app_id.substr(dot + 1);
+    std::transform(last.begin(), last.end(), last.begin(), ::tolower);
+    if (auto pb = tryLoad(last)) return pb;
+  }
+
+  return {};
 }
 
 }  // namespace waybar::modules::niri

--- a/src/modules/niri/workspace.cpp
+++ b/src/modules/niri/workspace.cpp
@@ -1,11 +1,11 @@
 #include "modules/niri/workspace.hpp"
 
 #include <gdkmm/pixbuf.h>
+#include <giomm/desktopappinfo.h>
+#include <giomm/icon.h>
 #include <gtkmm/icontheme.h>
 #include <gtkmm/image.h>
 #include <spdlog/spdlog.h>
-#include <giomm/desktopappinfo.h>
-#include <giomm/icon.h>
 
 #include "modules/niri/backend.hpp"
 #include "modules/niri/workspaces.hpp"
@@ -18,7 +18,7 @@ Workspace::Workspace(const Json::Value& workspace_data, Workspaces& manager)
       box_(Gtk::ORIENTATION_HORIZONTAL, 0),
       taskbar_box_(Gtk::ORIENTATION_HORIZONTAL, 0) {
   button_.add(box_);
-  box_.pack_start(label_, false, false, 0);
+  box_.pack_start(label_, true, true, 0);
   box_.pack_start(taskbar_box_, false, false, 0);
 
   button_.set_relief(Gtk::RELIEF_NONE);


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
The workspace taskbar PR (#4997) broke the centering of the number labels in the buttons when the taskbar is disabled. The label used to be a direct child of the button, now it's inside a box. I have changed it to fill/expand inside the box, so it is centered again. 

<img width="314" height="195" alt="image" src="https://github.com/user-attachments/assets/2a7902bf-f72f-4515-b093-a85dc0783710" />

* 0.15.0
* 6d60c8e02be67bb85bb9b1ea803f2fbcf0722002, no taskbar
* 6d60c8e02be67bb85bb9b1ea803f2fbcf0722002, taskbar
* this PR, no taskbar
* this PR, taskbar

The file also had interesting formatting, so the bottom of the diff looks a bit weird, I didn't do any modifications there apart from styling.

**Related issues**
Didn't find one

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
