### PR TITLE
feat(modules): add on-enter and on-leave events

### DIFF
--- a/include/AModule.hpp
+++ b/include/AModule.hpp
@@ -92,6 +92,11 @@ class AModule : public IModule {
   virtual bool handleToggle(GdkEventButton* const& ev);
   virtual bool handleMouseEnter(GdkEventCrossing* const& ev);
   virtual bool handleMouseLeave(GdkEventCrossing* const& ev);
+  // Called from AModule's handleMouseEnter and handleMouseLeave. A subclass
+  // that overrides those without chaining up gets no on-enter or on-leave
+  // unless it calls this itself, as Group does.
+  void handleCrossingEvent(GdkEventCrossing* const& ev, bool entering);
+
   virtual bool handleScroll(GdkEventScroll*);
   virtual bool handleRelease(GdkEventButton* const& ev);
 
@@ -110,9 +115,14 @@ class AModule : public IModule {
   const bool isTooltip;
   const bool isExpand;
   bool hasUserEvents_;
+  bool hovered_{false};
   gdouble distance_scrolled_y_;
   gdouble distance_scrolled_x_;
   sigc::connection cursor_timeout_conn_;
+  // Resolved in the constructor: jsoncpp throws on a non-object value, and an
+  // exception escaping a GTK signal handler aborts the bar.
+  const std::string on_enter_cmd_;
+  const std::string on_leave_cmd_;
   static const inline std::map<std::pair<uint, GdkEventType>, std::string> eventMap_{
       {std::make_pair(1, GdkEventType::GDK_BUTTON_PRESS), "on-click"},
       {std::make_pair(1, GdkEventType::GDK_BUTTON_RELEASE), "on-click-release"},

--- a/man/waybar-backlight.5.scd
+++ b/man/waybar-backlight.5.scd
@@ -65,6 +65,14 @@ The *backlight* module displays the current backlight level.
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when performing a scroll up on the module. This replaces the default behaviour of brightness control.

--- a/man/waybar-battery.5.scd
+++ b/man/waybar-battery.5.scd
@@ -102,6 +102,14 @@ The *battery* module displays the current capacity and state (eg. charging) of y
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-bluetooth.5.scd
+++ b/man/waybar-bluetooth.5.scd
@@ -88,6 +88,14 @@ Addressed by *bluetooth*
 	typeof: string ++
 	Command to execute when you right-click on the module.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-cpu-graph.5.scd
+++ b/man/waybar-cpu-graph.5.scd
@@ -44,6 +44,14 @@ The *cpu graph* module displays a line graph with the CPU utilization.
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-cpu.5.scd
+++ b/man/waybar-cpu.5.scd
@@ -66,6 +66,14 @@ The *cpu* module displays the current CPU utilization.
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-custom-graph.5.scd
+++ b/man/waybar-custom-graph.5.scd
@@ -80,6 +80,14 @@ Addressed by *custom-graph/<name>*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-custom.5.scd
+++ b/man/waybar-custom.5.scd
@@ -103,6 +103,14 @@ Addressed by *custom/<name>*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-disk.5.scd
+++ b/man/waybar-disk.5.scd
@@ -62,6 +62,14 @@ Addressed by *disk*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-dwl-window.5.scd
+++ b/man/waybar-dwl-window.5.scd
@@ -66,6 +66,14 @@ Addressed by *dwl/window*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-ext-workspaces.5.scd
+++ b/man/waybar-ext-workspaces.5.scd
@@ -71,6 +71,14 @@ Addressed by *ext/workspaces*
 	typeof: string ++
 	The action to perform on right-click. See *CLICK ACTIONS* for the possible values.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 # FORMAT REPLACEMENTS
 
 *{name}*: Name of workspace assigned by compositor.

--- a/man/waybar-hyprland-submap.5.scd
+++ b/man/waybar-hyprland-submap.5.scd
@@ -53,6 +53,14 @@ Addressed by *hyprland/submap*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-idle-inhibitor.5.scd
+++ b/man/waybar-idle-inhibitor.5.scd
@@ -55,6 +55,14 @@ screensaver, also known as "presentation mode".
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module. (increase the timeout if dynamic timeouts are enabled).

--- a/man/waybar-image.5.scd
+++ b/man/waybar-image.5.scd
@@ -58,6 +58,14 @@ For single *image*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-inhibitor.5.scd
+++ b/man/waybar-inhibitor.5.scd
@@ -59,6 +59,14 @@ See *systemd-inhibit*(1) for more information.
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-jack.5.scd
+++ b/man/waybar-jack.5.scd
@@ -91,6 +91,14 @@ Addressed by *jack*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.

--- a/man/waybar-load.5.scd
+++ b/man/waybar-load.5.scd
@@ -62,6 +62,14 @@ Addressed by *load*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-mango-workspaces.5.scd
+++ b/man/waybar-mango-workspaces.5.scd
@@ -48,6 +48,14 @@ Addressed by *mango/workspaces*
 	typeof: string ++
 	Command for right click. Same actions as *on-click*.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *overview-label*: ++
 	typeof: string ++
 	default: "OVERVIEW" ++

--- a/man/waybar-memory.5.scd
+++ b/man/waybar-memory.5.scd
@@ -67,6 +67,14 @@ Addressed by *memory*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-mpd.5.scd
+++ b/man/waybar-mpd.5.scd
@@ -137,6 +137,14 @@ Addressed by *mpd*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-mpris.5.scd
+++ b/man/waybar-mpris.5.scd
@@ -140,6 +140,14 @@ The *mpris* module displays currently playing media via libplayerctl.
 	default: next track ++
 	Overwrite default action toggles.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-click-backward*: ++
 	typeof: string ++
 	default: previous track ++

--- a/man/waybar-network.5.scd
+++ b/man/waybar-network.5.scd
@@ -101,6 +101,14 @@ Addressed by *network*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-pulseaudio.5.scd
+++ b/man/waybar-pulseaudio.5.scd
@@ -83,6 +83,14 @@ Additionally, you can control the volume by scrolling *up* or *down* while the c
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module. This replaces the default behaviour of volume control.

--- a/man/waybar-river-layout.5.scd
+++ b/man/waybar-river-layout.5.scd
@@ -55,6 +55,14 @@ Addressed by *river/layout*
 	typeof: string ++
 	Command to execute when you right-click on the module.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.

--- a/man/waybar-river-mode.5.scd
+++ b/man/waybar-river-mode.5.scd
@@ -53,6 +53,14 @@ Addressed by *river/mode*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-river-window.5.scd
+++ b/man/waybar-river-window.5.scd
@@ -49,6 +49,14 @@ Addressed by *river/window*
 	typeof: string ++
 	Command to execute when you right-click on the module.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *tooltip*: ++
 	typeof: bool ++
 	default: true ++

--- a/man/waybar-sndio.5.scd
+++ b/man/waybar-sndio.5.scd
@@ -60,6 +60,14 @@ cursor is over the module, and clicking on the module toggles mute.
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module. ++

--- a/man/waybar-sway-language.5.scd
+++ b/man/waybar-sway-language.5.scd
@@ -44,6 +44,14 @@ Addressed by *sway/language*
 	typeof: string ++
 	Command to execute when you right clicked on the module.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *menu*: ++
 	typeof: string ++
 	Action that popups the menu.

--- a/man/waybar-sway-mode.5.scd
+++ b/man/waybar-sway-mode.5.scd
@@ -53,6 +53,14 @@ Addressed by *sway/mode*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-sway-window.5.scd
+++ b/man/waybar-sway-window.5.scd
@@ -53,6 +53,14 @@ Addressed by *sway/window*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-temperature.5.scd
+++ b/man/waybar-temperature.5.scd
@@ -113,6 +113,14 @@ Addressed by *temperature*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module.

--- a/man/waybar-upower.5.scd
+++ b/man/waybar-upower.5.scd
@@ -69,6 +69,14 @@ compatible devices in the tooltip.
 	typeof: string ++
 	Command to execute when clicked on the module.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *show-icon*: ++
 	typeof: bool ++
 	default: true ++

--- a/man/waybar-wireplumber.5.scd
+++ b/man/waybar-wireplumber.5.scd
@@ -118,6 +118,14 @@ The *wireplumber* module displays the current volume reported by WirePlumber.
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *on-scroll-up*: ++
 	typeof: string ++
 	Command to execute when scrolling up on the module. This replaces the default behaviour of volume control.

--- a/man/waybar-wlr-taskbar.5.scd
+++ b/man/waybar-wlr-taskbar.5.scd
@@ -105,6 +105,14 @@ Addressed by *wlr/taskbar*
 	typeof: string ++
 	Command to execute when the module is updated.
 
+*on-enter*: ++
+	typeof: string ++
+	Command to execute when the mouse enters the module.
+
+*on-leave*: ++
+	typeof: string ++
+	Command to execute when the mouse leaves the module.
+
 *ignore-list*: ++
 	typeof: array ++
 	List of app_id/titles to be invisible.

--- a/src/AModule.cpp
+++ b/src/AModule.cpp
@@ -19,7 +19,9 @@ AModule::AModule(const Json::Value& config, const std::string& name, const std::
       isExpand{config_["expand"].isBool() ? config_["expand"].asBool() : false},
       distance_scrolled_y_(0.0),
       distance_scrolled_x_(0.0),
-      cursor_timeout_conn_() {
+      cursor_timeout_conn_(),
+      on_enter_cmd_{config_["on-enter"].isString() ? config_["on-enter"].asString() : ""},
+      on_leave_cmd_{config_["on-leave"].isString() ? config_["on-leave"].asString() : ""} {
   // Configure module action Map
   const Json::Value actions{config_["actions"]};
 
@@ -175,6 +177,8 @@ bool AModule::handleMouseEnter(GdkEventCrossing* const& e) {
     setCursor("pointer");
   }
 
+  handleCrossingEvent(e, true);
+
   return false;
 }
 
@@ -188,7 +192,38 @@ bool AModule::handleMouseLeave(GdkEventCrossing* const& e) {
     setCursor("default");
   }
 
+  handleCrossingEvent(e, false);
+
   return false;
+}
+
+// GTK sends a leave/enter pair carrying GDK_NOTIFY_INFERIOR when the pointer
+// crosses into a child with its own GdkWindow, and pointer grabs add more of
+// them. Ignore those and latch the rest, so a command runs once per hover.
+void AModule::handleCrossingEvent(GdkEventCrossing* const& e, bool entering) {
+  if (e != nullptr && e->detail == GDK_NOTIFY_INFERIOR) {
+    return;
+  }
+  if (hovered_ == entering) {
+    return;
+  }
+  hovered_ = entering;
+
+  const auto* eventName = entering ? "on-enter" : "on-leave";
+  // An exception escaping a GTK signal handler aborts the bar.
+  try {
+    this->AModule::doAction(eventName);
+    if (const auto& cmd = entering ? on_enter_cmd_ : on_leave_cmd_; !cmd.empty()) {
+      // A value naming a built-in action already ran through doAction (#3284).
+      const auto actionIt = eventActionMap_.find(eventName);
+      const bool isModuleAction = actionIt != eventActionMap_.cend() && cmd == actionIt->second;
+      if (!isModuleAction) {
+        pid_children_.push_back(util::command::forkExec(cmd));
+      }
+    }
+  } catch (const std::exception& err) {
+    spdlog::warn("Module {}: {} handler failed: {}", name_, eventName, err.what());
+  }
 }
 
 bool AModule::handleToggle(GdkEventButton* const& e) { return handleUserEvent(e); }

--- a/src/group.cpp
+++ b/src/group.cpp
@@ -174,6 +174,7 @@ void Group::hide_group() {
 }
 
 bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
+  handleCrossingEvent(e, true);
   if (!click_to_reveal) {
     if (reveal_delay > 0) {
       if (reveal_timeout_.connected()) {
@@ -194,6 +195,7 @@ bool Group::handleMouseEnter(GdkEventCrossing* const& e) {
 }
 
 bool Group::handleMouseLeave(GdkEventCrossing* const& e) {
+  handleCrossingEvent(e, false);
   if (!click_to_reveal && e->detail != GDK_NOTIFY_INFERIOR) {
     if (reveal_delay > 0 && reveal_timeout_.connected()) {
       reveal_timeout_.disconnect();


### PR DESCRIPTION
**What does this PR do?**

Adds `on-enter` and `on-leave` command hooks to `AModule`, so any module can run something when the pointer arrives and leaves.

`AModule` already receives GTK's enter- and leave-notify events. Today they drive the prelight state and the pointer cursor, and nothing else can hang off them. Issue #2002 has asked for this since 2023.

Dispatch follows `on-scroll-*`. Module actions go first through `doAction()`, then the user command. A module that only wants the CSS `:hover` state sees no change, since nothing runs unless the option is set.

Both options resolve in the constructor rather than on every crossing. Beyond avoiding repeated work, that matters to anyone backporting this to a build older than ae119543, where a `Group` holds a dangling `config_` and a JSON lookup from a crossing handler becomes a use-after-free. jsoncpp's type assert then throws inside a GTK signal handler and takes the bar down. I hit exactly that developing against 0.15.0.

A value naming a built-in action has already run through `doAction()`, so it does not also run as a shell command. `handleUserEvent` has carried that guard since #3284, and `handleCrossingEvent` mirrors it.

Two kinds of spurious crossing need handling. When the pointer moves between the event box and a child that owns a `GdkWindow`, such as a workspace button or a group's box, GTK sends a leave/enter pair carrying `GDK_NOTIFY_INFERIOR`, and `group.cpp` already guards its reveal logic against those. Pointer grabs, a menu popping up for instance, add further pairs. Inferior crossings are ignored and the rest latched on a `hovered_` flag, so each command runs once per hover.

A throw from a crossing handler would abort the bar, so the dispatch logs the module name and carries on, for the same reason `handleUserEvent` catches `fmt::format_error`.

`Group` overrides both handlers without chaining up to `AModule`'s, so it calls the shared helper directly.

One thing I left alone: `pid_children_` gains an entry per forked command and is never reaped, which `on-click` and `on-update` already do today. Hover fires far more often than clicking does, so if you want that bounded, say the word and I will do it here or in a separate PR.

**Naming, worth deciding before this merges**

This uses `on-enter` and `on-leave`, matching the existing per-module vocabulary (`on-click`, `on-scroll-up`, `on-update`) and GTK's own enter-notify and leave-notify names.

PR #5280 and issue #3475 instead propose `on-mouse-enter` and `on-mouse-exit` for the bar-level equivalent. If both land, Waybar ends up with two names for one idea and config files carry both spellings indefinitely. I would rather you pick than have me quietly match an unmerged PR. Renaming is small and I am happy to do it either way.

**Man pages**

The docs commit touches 33 files because the option applies to every module and there is no shared page for options common to all of them. Happy to trim that to a smaller set, or to add a shared page and point the module pages at it, if you would prefer either.

**Testing**

No automated test. Crossing events come from GTK, and the suite covers utils and Hyprland IPC.

Verified by hand in a nested headless sway driving a synthetic pointer. Commands fire once per hover across many modules, through two levels of group nesting, and across rapid enter and leave transitions, with no duplicate or missed runs. The #3284 guard was checked against a control on the same pointer path: 40 shell runs with the `actions` entry removed, 0 with it in place.

**Related issues**

Closes #2002
Related: #3475, #5280

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [x] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
