### PR TITLE
cpu_frequency: add NetBSD support

### DIFF
--- a/src/modules/cpu_frequency/bsd.cpp
+++ b/src/modules/cpu_frequency/bsd.cpp
@@ -8,7 +8,16 @@ std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
   size_t len;
   int32_t freq;
 
-#ifndef __OpenBSD__
+#if defined(__NetBSD__)
+  if (sysctlbyname("machdep.cpu.frequency.current", &freq, &len, NULL, 0) == 0) {
+    frequencies.push_back((float)freq);
+  }
+#elif defined(__OpenBSD__)
+  int getMhz[] = {CTL_HW, HW_CPUSPEED};
+  len = sizeof(freq);
+  sysctl(getMhz, 2, &freq, &len, NULL, 0);
+  frequencies.push_back((float)freq);
+#else
   char buffer[256];
   uint32_t i = 0;
   while (true) {
@@ -18,11 +27,6 @@ std::vector<float> waybar::modules::CpuFrequency::parseCpuFrequencies() {
     frequencies.push_back(freq);
     ++i;
   }
-#else
-  int getMhz[] = {CTL_HW, HW_CPUSPEED};
-  len = sizeof(freq);
-  sysctl(getMhz, 2, &freq, &len, NULL, 0);
-  frequencies.push_back((float)freq);
 #endif
 
   if (frequencies.empty()) {


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
NetBSD support for the cpu_frequency module.

**Related issues**
#4404
Waybar is already available in pkgsrc, altough with a limited feature set.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
