### PR TITLE
memory: fix get_free_memory() on NetBSD

### DIFF
--- a/src/modules/memory/bsd.cpp
+++ b/src/modules/memory/bsd.cpp
@@ -73,9 +73,15 @@ static uint64_t get_free_memory() {
   if (sysctl(mib, miblen, &uvmexp, &sz, NULL, 0)) {
     throw std::runtime_error("sysctl vm.uvmexp failed");
   }
+#ifdef VM_UVMEXP2
+  uint64_t total = get_total_memory();
+  uint64_t used = static_cast<uint64_t>(uvmexp.active + uvmexp.wired) * uvmexp.pagesize;
+  return used < total ? total - used : 0;
+#else
   return static_cast<uint64_t>(uvmexp.free + uvmexp.inactive + uvmexp.filepages +
                                uvmexp.execpages) *
          uvmexp.pagesize;
+#endif
 #endif
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
On NetBSD, uvmexp_sysctl.inactive includes both inactive file and exec pages, while .filepages and .execpages count both inactive and active file/exec pages. As a result, the calculated MemAvailable can sometimes be higher than MemTotal.

It is safer to calculate the used memory as .active + .wired, and then subtract it from MemTotal to get the free memory.

**Related issues**
#4404

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
