### PR TITLE
Portable uptime usage, fallback to CLOCK_MONOTONIC

### DIFF
--- a/src/modules/user.cpp
+++ b/src/modules/user.cpp
@@ -62,10 +62,12 @@ long User::uptime_as_seconds() {
 #if HAVE_CPU_BSD
   struct timespec s_info;
   int flags = 0;
-#ifndef __OpenBSD__
+#ifdef CLOCK_UPTIME_PRECISE
   flags = CLOCK_UPTIME_PRECISE;
-#else
+#elif defined(CLOCK_UPTIME)
   flags = CLOCK_UPTIME;
+#else
+  flags = CLOCK_MONOTONIC;
 #endif
   if (0 == clock_gettime(flags, &s_info)) {
     uptime = s_info.tv_sec;


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
NetBSD doesn't provide CLOCK_UPTIME_PRECISE or CLOCK_UPTIME, so
fall back to CLOCK_MONOTONIC. Select the available clock using
CLOCK_UPTIME_PRECISE -> CLOCK_UPTIME -> CLOCK_MONOTONIC
as a compile-time fallback.

**Related issues**
#4404
Waybar is already available in pkgsrc, altough with a limited feature set.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
