### PR TITLE
icon_loader: fix ctype usage

### DIFF
--- a/src/util/icon_loader.cpp
+++ b/src/util/icon_loader.cpp
@@ -187,8 +187,9 @@ Glib::RefPtr<Gio::DesktopAppInfo> IconLoader::get_app_info_from_app_id_list(
     }
 
     auto lower_app_id = app_id;
-    std::ranges::transform(lower_app_id, lower_app_id.begin(),
-                           [](char c) { return std::tolower(c); });
+    std::ranges::transform(lower_app_id, lower_app_id.begin(), [](char c) {
+      return static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    });
     app_info_ = get_desktop_app_info(lower_app_id);
     if (app_info_) {
       return app_info_;


### PR DESCRIPTION
<!-- Thanks for contributing to Waybar! Please fill in the sections below. -->

**What does this PR do?**
Fix ctype tolower() usage to avoid undefined behavior.
On NetBSD, this can cause a crash due to its strict ctype usage requirements.

**Related issues**
Not found.

**Checklist**
- [x] Code is formatted with `clang-format`
- [x] Builds locally (`ninja -C build`)
- [ ] Man page updated for any new/changed user-facing option (`man/`)
- [x] Tested against the affected module(s)
